### PR TITLE
ci: Add upload/download artifact to get pr context

### DIFF
--- a/.github/actions/download-artifact/action.yml
+++ b/.github/actions/download-artifact/action.yml
@@ -1,0 +1,33 @@
+## ref: https://github.com/Azure/karpenter/blob/988bc0685d50a20884b1161722c9aafe3de50239/.github/actions/download-artifact/action.yml
+name: DownloadArtifacts
+description: 'Downloads and unarchives artifacts for a workflow that runs on workflow_run so that it can use its data'
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/github-script@v6
+      with:
+        script: |
+          let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             run_id: context.payload.workflow_run.id,
+          });
+          let matchArtifact = allArtifacts.data.artifacts.filter((artifact) => {
+            return artifact.name == "artifacts"
+          })[0];
+          let download = await github.rest.actions.downloadArtifact({
+             owner: context.repo.owner,
+             repo: context.repo.repo,
+             artifact_id: matchArtifact.id,
+             archive_format: 'zip',
+          });
+          let fs = require('fs');
+          fs.writeFileSync(`/tmp/artifacts.zip`, Buffer.from(download.data));
+    - run: |
+        mkdir -p /tmp/artifacts
+        unzip /tmp/artifacts.zip -d /tmp/artifacts
+      shell: bash
+    - run: |
+        echo "Downloaded artifacts:"
+        ls -ablh /tmp/artifacts
+      shell: bash

--- a/.github/actions/upload-artifact/action.yml
+++ b/.github/actions/upload-artifact/action.yml
@@ -1,0 +1,10 @@
+## ref: https://github.com/Azure/karpenter/blob/988bc0685d50a20884b1161722c9aafe3de50239/.github/actions/upload-artifact/action.yml
+name: UploadArtifacts
+description: 'Uploads artifacts of a workflow as an archive of a directory so that another workflow that runs on workflow_run can download and use it'
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/upload-artifact@v3
+      with:
+        name: artifacts
+        path: /tmp/artifacts

--- a/.github/workflows/build-publish-image.yml
+++ b/.github/workflows/build-publish-image.yml
@@ -102,3 +102,9 @@ jobs:
           OUTPUT_TYPE=type=registry make docker-build-kdm
         env:
           VERSION: ${{ env.IMG_TAG }}
+      - name: Save registry and tag as an artifact for other workflows that run on workflow_run to download them
+        run: |
+          mkdir -p /tmp/artifacts
+          echo ${{ needs.create-tag.outputs.tag }} >> /tmp/artifacts/tag.txt
+          cat /tmp/artifacts/tag.txt
+      - uses: ./.github/actions/upload-artifact

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,6 +18,10 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-20.04
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@8ca2b8b2ece13480cda6dacd3511b49857a23c09 # v2.5.1
+        with:
+          egress-policy: audit
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v4
         with:
@@ -27,18 +31,17 @@ jobs:
         with:
           fetch-depth: 0
           submodules: true
-      - name: Download Image Tags
-        uses: dawidd6/action-download-artifact@v2
+      - uses: ./.github/actions/download-artifact
+      - name: Parse artifacts and assign GA environment variables
+        run: |
+          tag=$(tail -n 1 /tmp/artifacts/tag.txt)
+          echo "IMG_TAG=$tag" >> $GITHUB_ENV
+      - name: Checkout the repository at the given SHA from the artifact
+        uses: actions/checkout@v4
         with:
-          name: image_tags
-          run_id: ${{ github.event.workflow_run.id }}        
-          path: ${{ github.workspace }}
-      - name: Read Image Tags
-        run: |
-          echo "IMAGE_TAG=$(cat ${{ github.workspace }}/IMAGE_TAG)" >> $GITHUB_ENV
-      - name: Get tag
-        run: |
-          git tag ${{ env.IMAGE_TAG }}
+          submodules: true
+          fetch-depth: 0
+          ref: ${{ env.IMG_TAG }}
       - name: Goreleaser
         uses: goreleaser/goreleaser-action@v4
         with:


### PR DESCRIPTION
- Add upload and download artifacts to get PR context and be able to use it in workflows using `workflow_run`
- Add Harder Runner security step 