### PR TITLE
fix: include torch params in inference command

### DIFF
--- a/pkg/inference/preset-llama2-inferences.go
+++ b/pkg/inference/preset-llama2-inferences.go
@@ -235,7 +235,6 @@ func buildCommand(baseCommand string, torchRunParams map[string]string) []string
 	updatedBaseCommand := baseCommand
 	for key, value := range torchRunParams {
 		updatedBaseCommand = fmt.Sprintf("%s --%s=%s", updatedBaseCommand, key, value)
-		fmt.Println(updatedBaseCommand)
 	}
 
 	commands := []string{


### PR DESCRIPTION
Currently torch command only includes the last parameter. This explains demo 13b had more output than 7b even though they had same torch params. one had max batch size applied other had max seq len - super quick fix
