### PR TITLE
fix: optimize the use of crd status

### DIFF
--- a/api/v1alpha1/workspace_condition_types.go
+++ b/api/v1alpha1/workspace_condition_types.go
@@ -7,23 +7,11 @@ const (
 	// WorkspaceConditionTypeMachineStatus is the state when checking machine status.
 	WorkspaceConditionTypeMachineStatus = ConditionType("MachineReady")
 
-	// WorkspaceConditionTypeMachineProvisioned is the state when Machine has been created.
-	WorkspaceConditionTypeMachineProvisioned = ConditionType("MachineProvisioned")
-
-	// WorkspaceConditionTypeMachineDeleted is the state when Machine has been deleted.
-	WorkspaceConditionTypeMachineDeleted = ConditionType("MachineDeleted")
-
 	// WorkspaceConditionTypeResourceStatus is the state when Resource has been created.
-	WorkspaceConditionTypeResourceStatus = ConditionType("ResourceStatus")
-
-	// WorkspaceConditionTypeResourceDeleted is the state when Resource has been deleted.
-	WorkspaceConditionTypeResourceDeleted = ConditionType("ResourceDeleted")
+	WorkspaceConditionTypeResourceStatus = ConditionType("ResourceReady")
 
 	// WorkspaceConditionTypeInferenceStatus is the state when Inference has been created.
-	WorkspaceConditionTypeInferenceStatus = ConditionType("InferenceStatus")
-
-	// WorkspaceConditionTypeInferenceDeleted is the state when Inference has been deleted.
-	WorkspaceConditionTypeInferenceDeleted = ConditionType("InferenceDeleted")
+	WorkspaceConditionTypeInferenceStatus = ConditionType("InferenceReady")
 
 	//WorkspaceConditionTypeDeleting is the Workspace state when starts to get deleted.
 	WorkspaceConditionTypeDeleting = ConditionType("WorkspaceDeleting")

--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -91,9 +91,9 @@ type WorkspaceStatus struct {
 // +kubebuilder:resource:path=workspaces,scope=Namespaced,categories=workspace,shortName={wk,wks}
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Instance",type="string",JSONPath=".resource.instanceType",description=""
-// +kubebuilder:printcolumn:name="ResourceReady",type="string",JSONPath=".status.condition[?(@.type==\"ResourceStatus\")].status",description=""
-// +kubebuilder:printcolumn:name="InferenceReady",type="string",JSONPath=".status.condition[?(@.type==\"InferenceStatus\")].status",description=""
-// +kubebuilder:printcolumn:name="WorkspaceStatus",type="string",JSONPath=".status.condition[?(@.type==\"WorkspaceReady\")].status",description=""
+// +kubebuilder:printcolumn:name="ResourceReady",type="string",JSONPath=".status.condition[?(@.type==\"ResourceReady\")].status",description=""
+// +kubebuilder:printcolumn:name="InferenceReady",type="string",JSONPath=".status.condition[?(@.type==\"InferenceReady\")].status",description=""
+// +kubebuilder:printcolumn:name="WorkspaceReady",type="string",JSONPath=".status.condition[?(@.type==\"WorkspaceReady\")].status",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 type Workspace struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/config/crd/bases/kdm.io_workspaces.yaml
+++ b/config/crd/bases/kdm.io_workspaces.yaml
@@ -23,14 +23,14 @@ spec:
     - jsonPath: .resource.instanceType
       name: Instance
       type: string
-    - jsonPath: .status.condition[?(@.type=="ResourceStatus")].status
+    - jsonPath: .status.condition[?(@.type=="ResourceReady")].status
       name: ResourceReady
       type: string
-    - jsonPath: .status.condition[?(@.type=="InferenceStatus")].status
+    - jsonPath: .status.condition[?(@.type=="InferenceReady")].status
       name: InferenceReady
       type: string
     - jsonPath: .status.condition[?(@.type=="WorkspaceReady")].status
-      name: WorkspaceStatus
+      name: WorkspaceReady
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -27,8 +27,8 @@ const (
 )
 
 var (
-	//	machineStatusCheckInterval is the interval to check the machine status.
-	machineStatusCheckInterval = 180 * time.Second
+	//	machineStatusTimeoutInterval is the interval to check the machine status.
+	machineStatusTimeoutInterval = 240 * time.Second
 )
 
 // GenerateMachineManifest generates a machine object from	the given workspace.
@@ -194,7 +194,7 @@ func ListMachines(ctx context.Context, workspaceObj *kdmv1alpha1.Workspace, kube
 func CheckMachineStatus(ctx context.Context, machineObj *v1alpha5.Machine, kubeClient client.Client) error {
 	klog.InfoS("CheckMachineStatus", "machine", klog.KObj(machineObj))
 	timeClock := clock.RealClock{}
-	tick := timeClock.NewTicker(machineStatusCheckInterval)
+	tick := timeClock.NewTicker(machineStatusTimeoutInterval)
 	defer tick.Stop()
 
 	for {


### PR DESCRIPTION
We only need status to indicate long-run operations. Creating machine cr is going to be quick, hence removing the WorkspaceConditionTypeMachineProvisioned status.