### PR TITLE
fix: Update the go package module

### DIFF
--- a/PROJECT
+++ b/PROJECT
@@ -6,7 +6,7 @@ domain: io
 layout:
 - go.kubebuilder.io/v4
 projectName: kdm
-repo: github.com/kdm
+repo: github.com/azure/kdm
 resources:
 - api:
     crdVersion: v1
@@ -15,6 +15,6 @@ resources:
   domain: io
   group: kdm
   kind: Workspace
-  path: github.com/kdm/api/v1alpha1
+  path: github.com/azure/kdm/api/v1alpha1
   version: v1alpha1
 version: "3"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,8 +23,8 @@ import (
 	"time"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
-	"github.com/kdm/pkg/controllers"
-	"github.com/kdm/pkg/webhooks"
+	"github.com/azure/kdm/pkg/controllers"
+	"github.com/azure/kdm/pkg/webhooks"
 	"k8s.io/klog/v2"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/signals"
@@ -42,7 +42,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	kdmv1alpha1 "github.com/kdm/api/v1alpha1"
+	kdmv1alpha1 "github.com/azure/kdm/api/v1alpha1"
 	//+kubebuilder:scaffold:imports
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/kdm
+module github.com/azure/kdm
 
 go 1.20
 

--- a/pkg/controllers/workspace_controller.go
+++ b/pkg/controllers/workspace_controller.go
@@ -3,15 +3,16 @@ package controllers
 import (
 	"context"
 	"fmt"
-	appsv1 "k8s.io/api/apps/v1"
 	"time"
 
+	appsv1 "k8s.io/api/apps/v1"
+
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
+	kdmv1alpha1 "github.com/azure/kdm/api/v1alpha1"
+	"github.com/azure/kdm/pkg/inference"
+	"github.com/azure/kdm/pkg/k8sresources"
+	"github.com/azure/kdm/pkg/machine"
 	"github.com/go-logr/logr"
-	kdmv1alpha1 "github.com/kdm/api/v1alpha1"
-	"github.com/kdm/pkg/inference"
-	"github.com/kdm/pkg/k8sresources"
-	"github.com/kdm/pkg/machine"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/controllers/workspace_gc_finalizer.go
+++ b/pkg/controllers/workspace_gc_finalizer.go
@@ -3,8 +3,8 @@ package controllers
 import (
 	"context"
 
-	kdmv1alpha1 "github.com/kdm/api/v1alpha1"
-	"github.com/kdm/pkg/utils"
+	kdmv1alpha1 "github.com/azure/kdm/api/v1alpha1"
+	"github.com/azure/kdm/pkg/utils"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/pkg/controllers/workspace_status.go
+++ b/pkg/controllers/workspace_status.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"sort"
 
-	kdmv1alpha1 "github.com/kdm/api/v1alpha1"
+	kdmv1alpha1 "github.com/azure/kdm/api/v1alpha1"
 	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/inference/preset-inference-types.go
+++ b/pkg/inference/preset-inference-types.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"time"
 
-	kdmv1alpha1 "github.com/kdm/api/v1alpha1"
+	kdmv1alpha1 "github.com/azure/kdm/api/v1alpha1"
 )
 
 const (

--- a/pkg/inference/preset-inferences.go
+++ b/pkg/inference/preset-inferences.go
@@ -6,8 +6,8 @@ import (
 	"strconv"
 	"time"
 
-	kdmv1alpha1 "github.com/kdm/api/v1alpha1"
-	"github.com/kdm/pkg/k8sresources"
+	kdmv1alpha1 "github.com/azure/kdm/api/v1alpha1"
+	"github.com/azure/kdm/pkg/k8sresources"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/k8sresources/manifests.go
+++ b/pkg/k8sresources/manifests.go
@@ -3,9 +3,10 @@ package k8sresources
 import (
 	"context"
 	"fmt"
+
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	kdmv1alpha1 "github.com/kdm/api/v1alpha1"
+	kdmv1alpha1 "github.com/azure/kdm/api/v1alpha1"
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/machine/machine.go
+++ b/pkg/machine/machine.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
-	kdmv1alpha1 "github.com/kdm/api/v1alpha1"
+	kdmv1alpha1 "github.com/azure/kdm/api/v1alpha1"
 	"github.com/samber/lo"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"

--- a/pkg/webhooks/webhooks.go
+++ b/pkg/webhooks/webhooks.go
@@ -11,7 +11,7 @@ import (
 	"knative.dev/pkg/webhook/resourcesemantics"
 	"knative.dev/pkg/webhook/resourcesemantics/validation"
 
-	kdmv1alpha1 "github.com/kdm/api/v1alpha1"
+	kdmv1alpha1 "github.com/azure/kdm/api/v1alpha1"
 )
 
 func NewWebhooks() []knativeinjection.ControllerConstructor {


### PR DESCRIPTION
The current package module name doesn't include the organization name which introduces issues while trying to use the go package.