### PR TITLE
fix: Use runner 0 for git checkout

### DIFF
--- a/.github/workflows/preset-image-build.yml
+++ b/.github/workflows/preset-image-build.yml
@@ -31,7 +31,7 @@ permissions:
 
 jobs:
   setup:
-    runs-on: self-hosted
+    runs-on: [self-hosted, username:runner-0]
     outputs:
       image_tag: ${{ steps.set_tag.outputs.image_tag }}
       FALCON_MODIFIED: ${{ steps.check_modified_paths.outputs.FALCON_MODIFIED }}

--- a/presets/test/docker.yaml
+++ b/presets/test/docker.yaml
@@ -27,7 +27,7 @@ spec:
       volumes:
       - name: host-volume
         hostPath:
-          path: /actions-runner/_work/kdm/kdm
+          path: /home/runner-0/runner/_work/kaito/kaito
           type: Directory
       - name: llama-volume
         hostPath: 


### PR DESCRIPTION
currently anyone of the four runners can checkout the latest git repo. If we tie it to runner #0, then we have a reliable path the most up to date repo is for the docker pod. 