### PR TITLE
fix: ensure check inference workload status

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,13 @@ helm install workspace ./charts/kaito/workspace
 export NODE_RESOURCE_GROUP=$(az aks show -n $MY_CLUSTER -g $RESOURCE_GROUP --query nodeResourceGroup | tr -d '"')
 export LOCATION=$(az aks show -n $MY_CLUSTER -g $RESOURCE_GROUP --query location | tr -d '"')
 export TENANT_ID=$(az account show | jq -r ".tenantId")
-yq -i '(.controller.env[] | select(.name=="ARM_SUBSCRIPTION_ID"))       .value = env(SUBSCRIPTION_ID)     ./charts/kaito/gpu-provisioner/values.yaml
-yq -i '(.controller.env[] | select(.name=="LOCATION"))                  .value = env(LOCATION)            ./charts/kaito/gpu-provisioner/values.yaml
-yq -i '(.controller.env[] | select(.name=="ARM_RESOURCE_GROUP"))        .value = env(RESOURCE_GROUP)      ./charts/kaito/gpu-provisioner/values.yaml
-yq -i '(.controller.env[] | select(.name=="AZURE_NODE_RESOURCE_GROUP")) .value = env(NODE_RESOURCE_GROUP) ./charts/kaito/gpu-provisioner/values.yaml
-yq -i '(.controller.env[] | select(.name=="AZURE_CLUSTER_NAME"))        .value = env(MY_CLUSTER)          ./charts/kaito/gpu-provisioner/values.yaml
-yq -i '(.workloadIdentity.clientId)                                            = env(IDENTITY_CLIENT_ID)  ./charts/kaito/gpu-provisioner/values.yaml
-yq -i '(.workloadIdentity.tenantId)                                            = env(TENANT_ID)           ./charts/kaito/gpu-provisioner/values.yaml
+yq -i '(.controller.env[] | select(.name=="ARM_SUBSCRIPTION_ID"))       .value = env(SUBSCRIPTION)'        ./charts/kaito/gpu-provisioner/values.yaml
+yq -i '(.controller.env[] | select(.name=="LOCATION"))                  .value = env(LOCATION)'            ./charts/kaito/gpu-provisioner/values.yaml
+yq -i '(.controller.env[] | select(.name=="ARM_RESOURCE_GROUP"))        .value = env(RESOURCE_GROUP)'      ./charts/kaito/gpu-provisioner/values.yaml
+yq -i '(.controller.env[] | select(.name=="AZURE_NODE_RESOURCE_GROUP")) .value = env(NODE_RESOURCE_GROUP)' ./charts/kaito/gpu-provisioner/values.yaml
+yq -i '(.controller.env[] | select(.name=="AZURE_CLUSTER_NAME"))        .value = env(MY_CLUSTER)'          ./charts/kaito/gpu-provisioner/values.yaml
+yq -i '(.workloadIdentity.clientId)                                            = env(IDENTITY_CLIENT_ID)'  ./charts/kaito/gpu-provisioner/values.yaml
+yq -i '(.workloadIdentity.tenantId)                                            = env(TENANT_ID)'           ./charts/kaito/gpu-provisioner/values.yaml
 helm install gpu-provisioner ./charts/kaito/gpu-provisioner 
 
 ```
@@ -52,7 +52,7 @@ helm install gpu-provisioner ./charts/kaito/gpu-provisioner
 This allows `gpu-provisioner` controller to use `kaitoprovisioner` identity via an access token.
 ```bash
 export AKS_OIDC_ISSUER=$(az aks show -n $MY_CLUSTER -g $RESOURCE_GROUP --subscription $SUBSCRIPTION --query "oidcIssuerProfile.issuerUrl" | tr -d '"')
-az identity federated-credential create --name kaito-federatedcredential --identity-name kaitoprovisioner -g $RESOURCE_GROUP --issuer $AKS_OIDC_ISSUER --subject system:serviceaccount:"kaito:gpu-provisioner" --audience api://AzureADTokenExchange --subscription $SUBSCRIPTION
+az identity federated-credential create --name kaito-federatedcredential --identity-name kaitoprovisioner -g $RESOURCE_GROUP --issuer $AKS_OIDC_ISSUER --subject system:serviceaccount:"gpu-provisioner:gpu-provisioner" --audience api://AzureADTokenExchange --subscription $SUBSCRIPTION
 ```
 Note that before doing this step, the `gpu-provisioner` controller pod will constantly fail with the following message in the log:
 ```

--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -69,7 +69,7 @@ func (i *InferenceSpec) validateCreate() (errs *apis.FieldError) {
 	if i.Preset != nil && i.Template != nil {
 		errs = errs.Also(apis.ErrGeneric("preset and template cannot be set at the same time"))
 	}
-	if i.Preset.PresetMeta.AccessMode == "private" && i.Preset.PresetOptions.Image == "" {
+	if i.Preset != nil && i.Preset.PresetMeta.AccessMode == "private" && i.Preset.PresetOptions.Image == "" {
 		errs = errs.Also(apis.ErrGeneric("When AccessMode is private, an image must be provided in PresetOptions"))
 	}
 	// Note: we don't enforce private access mode to have image secrets, incase anonymous pulling is enabled

--- a/pkg/inference/preset-inference-types.go
+++ b/pkg/inference/preset-inference-types.go
@@ -30,15 +30,11 @@ const (
 var (
 	registryName = os.Getenv("PRESET_REGISTRY_NAME")
 
-	presetLlama2AChatImage = registryName + fmt.Sprintf("/%s:0.0.1", kaitov1alpha1.PresetLlama2AChat)
-	presetLlama2BChatImage = registryName + fmt.Sprintf("/%s:0.0.1", kaitov1alpha1.PresetLlama2BChat)
-	presetLlama2CChatImage = registryName + fmt.Sprintf("/%s:0.0.1", kaitov1alpha1.PresetLlama2CChat)
+	presetFalcon7bImage         = registryName + fmt.Sprintf("/kaito-%s:0.0.1", kaitov1alpha1.PresetFalcon7BModel)
+	presetFalcon7bInstructImage = registryName + fmt.Sprintf("/kaito-%s:0.0.1", kaitov1alpha1.PresetFalcon7BInstructModel)
 
-	presetFalcon7bImage         = registryName + fmt.Sprintf("/%s:0.0.1", kaitov1alpha1.PresetFalcon7BModel)
-	presetFalcon7bInstructImage = registryName + fmt.Sprintf("/%s:0.0.1", kaitov1alpha1.PresetFalcon7BInstructModel)
-
-	presetFalcon40bImage         = registryName + fmt.Sprintf("/%s:0.0.1", kaitov1alpha1.PresetFalcon40BModel)
-	presetFalcon40bInstructImage = registryName + fmt.Sprintf("/%s:0.0.1", kaitov1alpha1.PresetFalcon40BInstructModel)
+	presetFalcon40bImage         = registryName + fmt.Sprintf("/kaito-%s:0.0.1", kaitov1alpha1.PresetFalcon40BModel)
+	presetFalcon40bInstructImage = registryName + fmt.Sprintf("/kaito-%s:0.0.1", kaitov1alpha1.PresetFalcon40BInstructModel)
 
 	baseCommandPresetLlama = "cd /workspace/llama/llama-2 && torchrun"
 	// llamaTextInferenceFile       = "inference-api.py" TODO: To support Text Generation Llama Models
@@ -101,7 +97,7 @@ var (
 
 		kaitov1alpha1.PresetLlama2AChat: {
 			ModelName:              "LLaMa2",
-			Image:                  presetLlama2AChatImage,
+			Image:                  "",
 			ImagePullSecrets:       defaultImagePullSecrets,
 			AccessMode:             defaultAccessMode,
 			DiskStorageRequirement: "34Gi",
@@ -117,7 +113,7 @@ var (
 		},
 		kaitov1alpha1.PresetLlama2BChat: {
 			ModelName:              "LLaMa2",
-			Image:                  presetLlama2BChatImage,
+			Image:                  "",
 			ImagePullSecrets:       defaultImagePullSecrets,
 			AccessMode:             defaultAccessMode,
 			DiskStorageRequirement: "46Gi",
@@ -133,7 +129,7 @@ var (
 		},
 		kaitov1alpha1.PresetLlama2CChat: {
 			ModelName:              "LLaMa2",
-			Image:                  presetLlama2CChatImage,
+			Image:                  "",
 			ImagePullSecrets:       defaultImagePullSecrets,
 			AccessMode:             defaultAccessMode,
 			DiskStorageRequirement: "158Gi",

--- a/pkg/inference/preset-inferences.go
+++ b/pkg/inference/preset-inferences.go
@@ -6,11 +6,9 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"time"
 
 	kaitov1alpha1 "github.com/azure/kaito/api/v1alpha1"
 	"github.com/azure/kaito/pkg/resources"
-	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -92,11 +90,11 @@ func setTorchParams(ctx context.Context, kubeClient client.Client, wObj *kaitov1
 }
 
 func CreatePresetInference(ctx context.Context, workspaceObj *kaitov1alpha1.Workspace,
-	inferenceObj PresetInferenceParam, kubeClient client.Client) error {
+	inferenceObj PresetInferenceParam, kubeClient client.Client) (client.Object, error) {
 	if inferenceObj.TorchRunParams != nil {
 		if err := setTorchParams(ctx, kubeClient, workspaceObj, inferenceObj); err != nil {
 			klog.ErrorS(err, "failed to update torch params", "workspace", workspaceObj)
-			return err
+			return nil, err
 		}
 	}
 
@@ -112,58 +110,13 @@ func CreatePresetInference(ctx context.Context, workspaceObj *kaitov1alpha1.Work
 		depObj = resources.GenerateDeploymentManifest(ctx, workspaceObj, inferenceObj.Image, inferenceObj.ImagePullSecrets, *workspaceObj.Resource.Count, commands,
 			containerPorts, livenessProbe, readinessProbe, resourceReq, tolerations, volume, volumeMount)
 	default:
-		return fmt.Errorf("Model not recognized: %s", inferenceObj.ModelName)
+		return nil, fmt.Errorf("Model not recognized: %s", inferenceObj.ModelName)
 	}
 	err := resources.CreateResource(ctx, depObj, kubeClient)
-	if err != nil {
-		return err
+	if client.IgnoreAlreadyExists(err) != nil {
+		return nil, err
 	}
-
-	if err := checkResourceStatus(depObj, kubeClient, inferenceObj.DeploymentTimeout); err != nil {
-		return err
-	}
-	return nil
-}
-
-func checkResourceStatus(obj client.Object, kubeClient client.Client, timeoutDuration time.Duration) error {
-	// Use Context for timeout
-	ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
-	defer cancel()
-
-	ticker := time.NewTicker(1 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-
-		case <-ticker.C:
-			key := client.ObjectKey{
-				Name:      obj.GetName(),
-				Namespace: obj.GetNamespace(),
-			}
-			err := kubeClient.Get(ctx, key, obj)
-			if err != nil {
-				return err
-			}
-
-			switch k8sResource := obj.(type) {
-			case *appsv1.Deployment:
-				if k8sResource.Status.ReadyReplicas == *k8sResource.Spec.Replicas {
-					klog.InfoS("deployment status is ready", "deployment", k8sResource.Name)
-					return nil
-				}
-			case *appsv1.StatefulSet:
-				if k8sResource.Status.ReadyReplicas == *k8sResource.Spec.Replicas {
-					klog.InfoS("statefulset status is ready", "statefulset", k8sResource.Name)
-					return nil
-				}
-			default:
-				return fmt.Errorf("unsupported resource type")
-			}
-		}
-	}
+	return depObj, nil
 }
 
 func prepareInferenceParameters(ctx context.Context, inferenceObj PresetInferenceParam) ([]string, corev1.ResourceRequirements) {

--- a/pkg/inference/template_inference.go
+++ b/pkg/inference/template_inference.go
@@ -4,22 +4,17 @@ package inference
 
 import (
 	"context"
-	"time"
 
 	kaitov1alpha1 "github.com/azure/kaito/api/v1alpha1"
 	"github.com/azure/kaito/pkg/resources"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func CreateTemplateInference(ctx context.Context, workspaceObj *kaitov1alpha1.Workspace, kubeClient client.Client) error {
+func CreateTemplateInference(ctx context.Context, workspaceObj *kaitov1alpha1.Workspace, kubeClient client.Client) (client.Object, error) {
 	depObj := resources.GenerateDeploymentManifestWithPodTemplate(ctx, workspaceObj)
 	err := resources.CreateResource(ctx, client.Object(depObj), kubeClient)
 	if client.IgnoreAlreadyExists(err) != nil {
-		return err
+		return nil, err
 	}
-
-	if err := checkResourceStatus(depObj, kubeClient, 10*time.Minute); err != nil {
-		return err
-	}
-	return nil
+	return depObj, nil
 }

--- a/pkg/resources/resources_test.go
+++ b/pkg/resources/resources_test.go
@@ -1,6 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
-package inference
+package resources
 
 import (
 	"testing"
@@ -33,7 +33,7 @@ func TestCheckResourceStatus(t *testing.T) {
 		}
 
 		cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(dep).Build()
-		err := checkResourceStatus(dep, cl, 2*time.Second)
+		err := CheckResourceStatus(dep, cl, 2*time.Second)
 		assert.Nil(t, err)
 	})
 
@@ -48,7 +48,7 @@ func TestCheckResourceStatus(t *testing.T) {
 		}
 
 		cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(dep).Build()
-		err := checkResourceStatus(dep, cl, 1*time.Millisecond)
+		err := CheckResourceStatus(dep, cl, 1*time.Millisecond)
 		assert.Error(t, err)
 	})
 
@@ -63,7 +63,7 @@ func TestCheckResourceStatus(t *testing.T) {
 		}
 
 		cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(ss).Build()
-		err := checkResourceStatus(ss, cl, 2*time.Second)
+		err := CheckResourceStatus(ss, cl, 2*time.Second)
 		assert.Nil(t, err)
 	})
 
@@ -78,7 +78,7 @@ func TestCheckResourceStatus(t *testing.T) {
 		}
 
 		cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(ss).Build()
-		err := checkResourceStatus(ss, cl, 1*time.Millisecond)
+		err := CheckResourceStatus(ss, cl, 1*time.Millisecond)
 		assert.Error(t, err)
 	})
 
@@ -96,14 +96,14 @@ func TestCheckResourceStatus(t *testing.T) {
 		// Create the fake client without adding the dep object
 		cl := fake.NewClientBuilder().WithScheme(scheme).Build()
 
-		err := checkResourceStatus(dep, cl, 2*time.Second)
+		err := CheckResourceStatus(dep, cl, 2*time.Second)
 		assert.Error(t, err)
 	})
 
 	t.Run("Should return error for unsupported resource type", func(t *testing.T) {
 		unsupportedResource := &appsv1.DaemonSet{}
 		cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(unsupportedResource).Build()
-		err := checkResourceStatus(unsupportedResource, cl, 2*time.Second)
+		err := CheckResourceStatus(unsupportedResource, cl, 2*time.Second)
 		assert.Error(t, err)
 		assert.Equal(t, "unsupported resource type", err.Error())
 	})


### PR DESCRIPTION
This PR mainly does the following:

1) Ensure always check workload status when the workload already exists. (e.g., workspace controller restart)
2) A large code refactoring for apply inference workflow.
3) Fix a nil pointer access bug in validation.
4) Remove llama related image path.
5) Fix falcon image name with kaito as name prefix.