### PR TITLE
fix: GitHub runner name needs quotes

### DIFF
--- a/.github/workflows/preset-image-build.yml
+++ b/.github/workflows/preset-image-build.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   setup:
-    runs-on: [self-hosted, username:runner-0]
+    runs-on: [self-hosted, 'username:runner-0']
     outputs:
       image_tag: ${{ steps.set_tag.outputs.image_tag }}
       FALCON_MODIFIED: ${{ steps.check_modified_paths.outputs.FALCON_MODIFIED }}


### PR DESCRIPTION
Runner name needs quotes, otherwise throws this error: 
`The workflow is not valid. .github/workflows/preset-image-build.yml: (Line: 32, Col: 28, Idx: 547) - (Line: 32, Col: 36, Idx: 555): While scanning a plain scalar, find unexpected ':'.
`