### PR TITLE
test: add ut for resources/manifests.go

### DIFF
--- a/pkg/resources/manifests_test.go
+++ b/pkg/resources/manifests_test.go
@@ -1,0 +1,183 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package resources
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+
+	"testing"
+
+	kaitov1alpha1 "github.com/azure/kaito/api/v1alpha1"
+	"github.com/azure/kaito/pkg/utils"
+	v1 "k8s.io/api/core/v1"
+)
+
+func TestGenerateStatefulSetManifest(t *testing.T) {
+	options := []bool{true, false}
+
+	for _, useHeadlessSvc := range options {
+		t.Run(fmt.Sprintf("generate statefulset with headlessSvc %v", useHeadlessSvc), func(t *testing.T) {
+
+			workspace := utils.MockWorkspace
+
+			obj := GenerateStatefulSetManifest(context.TODO(), workspace,
+				"",  //imageName
+				nil, //imagePullSecretRefs
+				*workspace.Resource.Count,
+				nil, //commands
+				nil, //containerPorts
+				nil, //livenessProbe
+				nil, //readinessProbe
+				v1.ResourceRequirements{},
+				nil, //tolerations
+				nil, //volumes
+				nil, //volumeMount
+				useHeadlessSvc)
+
+			if useHeadlessSvc && obj.Spec.ServiceName != fmt.Sprintf("%s-headless", workspace.Name) {
+				t.Errorf("headless service name is wrong in statefullset spec")
+			}
+
+			appSelector := map[string]string{
+				kaitov1alpha1.LabelWorkspaceName: workspace.Name,
+			}
+
+			if !reflect.DeepEqual(appSelector, obj.Spec.Selector.MatchLabels) {
+				t.Errorf("workload selector is wrong")
+			}
+			if !reflect.DeepEqual(appSelector, obj.Spec.Template.ObjectMeta.Labels) {
+				t.Errorf("template label is wrong")
+			}
+
+			nodeReq := obj.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions
+
+			for key, value := range workspace.Resource.LabelSelector.MatchLabels {
+				if !kvInNodeRequirement(key, value, nodeReq) {
+					t.Errorf("nodel affinity is wrong")
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateDeploymentManifest(t *testing.T) {
+	t.Run("generate deployment", func(t *testing.T) {
+
+		workspace := utils.MockWorkspace
+
+		obj := GenerateDeploymentManifest(context.TODO(), workspace,
+			"",  //imageName
+			nil, //imagePullSecretRefs
+			*workspace.Resource.Count,
+			nil, //commands
+			nil, //containerPorts
+			nil, //livenessProbe
+			nil, //readinessProbe
+			v1.ResourceRequirements{},
+			nil, //tolerations
+			nil, //volumes
+			nil, //volumeMount
+		)
+
+		appSelector := map[string]string{
+			kaitov1alpha1.LabelWorkspaceName: workspace.Name,
+		}
+
+		if !reflect.DeepEqual(appSelector, obj.Spec.Selector.MatchLabels) {
+			t.Errorf("workload selector is wrong")
+		}
+		if !reflect.DeepEqual(appSelector, obj.Spec.Template.ObjectMeta.Labels) {
+			t.Errorf("template label is wrong")
+		}
+
+		nodeReq := obj.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions
+
+		for key, value := range workspace.Resource.LabelSelector.MatchLabels {
+			if !kvInNodeRequirement(key, value, nodeReq) {
+				t.Errorf("nodel affinity is wrong")
+			}
+		}
+	})
+}
+
+func TestGenerateDeploymentManifestWithPodTemplate(t *testing.T) {
+	t.Run("generate deployment with pod template", func(t *testing.T) {
+
+		workspace := utils.MockWorkspaceWithInferenceTemplate
+
+		obj := GenerateDeploymentManifestWithPodTemplate(context.TODO(), workspace)
+
+		appSelector := map[string]string{
+			kaitov1alpha1.LabelWorkspaceName: workspace.Name,
+		}
+
+		if !reflect.DeepEqual(appSelector, obj.Spec.Selector.MatchLabels) {
+			t.Errorf("workload selector is wrong")
+		}
+		if !reflect.DeepEqual(appSelector, obj.Spec.Template.ObjectMeta.Labels) {
+			t.Errorf("template label is wrong")
+		}
+
+		nodeReq := obj.Spec.Template.Spec.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms[0].MatchExpressions
+
+		for key, value := range workspace.Resource.LabelSelector.MatchLabels {
+			if !kvInNodeRequirement(key, value, nodeReq) {
+				t.Errorf("nodel affinity is wrong")
+			}
+		}
+	})
+}
+
+func kvInNodeRequirement(key, val string, nodeReq []v1.NodeSelectorRequirement) bool {
+	for _, each := range nodeReq {
+		if each.Key == key && each.Values[0] == val && each.Operator == v1.NodeSelectorOpIn {
+			return true
+		}
+	}
+	return false
+}
+
+func TestGenerateServiceManifest(t *testing.T) {
+	options := []bool{true, false}
+
+	for _, isStatefulSet := range options {
+		t.Run(fmt.Sprintf("generate service, isStatefulSet %v", isStatefulSet), func(t *testing.T) {
+			workspace := utils.MockWorkspace
+			obj := GenerateServiceManifest(context.TODO(), workspace, v1.ServiceTypeClusterIP, isStatefulSet)
+
+			svcSelector := map[string]string{
+				kaitov1alpha1.LabelWorkspaceName: workspace.Name,
+			}
+			if isStatefulSet {
+				svcSelector["statefulset.kubernetes.io/pod-name"] = fmt.Sprintf("%s-0", workspace.Name)
+			}
+			if !reflect.DeepEqual(svcSelector, obj.Spec.Selector) {
+				t.Errorf("svc selector is wrong")
+			}
+		})
+	}
+}
+
+func TestGenerateHeadlessServiceManifest(t *testing.T) {
+
+	t.Run("generate headless service", func(t *testing.T) {
+		workspace := utils.MockWorkspace
+		obj := GenerateHeadlessServiceManifest(context.TODO(), workspace)
+
+		svcSelector := map[string]string{
+			kaitov1alpha1.LabelWorkspaceName: workspace.Name,
+		}
+		if !reflect.DeepEqual(svcSelector, obj.Spec.Selector) {
+			t.Errorf("svc selector is wrong")
+		}
+		if obj.Spec.ClusterIP != "None" {
+			t.Errorf("svc ClusterIP is wrong")
+		}
+		if obj.Name != fmt.Sprintf("%s-headless", workspace.Name) {
+			t.Errorf("svc Name is wrong")
+		}
+	})
+}

--- a/pkg/utils/testUtils.go
+++ b/pkg/utils/testUtils.go
@@ -6,13 +6,18 @@ package utils
 import (
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/azure/kaito/api/v1alpha1"
-	"github.com/azure/kaito/pkg/resources"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+)
+
+const (
+	LabelKeyNvidia    = "accelerator"
+	LabelValueNvidia  = "nvidia"
+	CapacityNvidiaGPU = "nvidia.com/gpu"
 )
 
 var (
@@ -124,7 +129,7 @@ var (
 				Name: "node1",
 				Labels: map[string]string{
 					corev1.LabelInstanceTypeStable: "Standard_NC12s_v3",
-					resources.LabelKeyNvidia:       resources.LabelValueNvidia,
+					LabelKeyNvidia:                 LabelValueNvidia,
 				},
 			},
 			Status: corev1.NodeStatus{
@@ -135,7 +140,7 @@ var (
 					},
 				},
 				Capacity: corev1.ResourceList{
-					resources.CapacityNvidiaGPU: resource.MustParse("1"),
+					CapacityNvidiaGPU: resource.MustParse("1"),
 				},
 			},
 		},


### PR DESCRIPTION
We don't test cases where the input parameters are directly applied in the manifests without modifications.