### PR TITLE
fix: ignore instanceType when selecting preferred nodes

### DIFF
--- a/.github/workflows/e2e-workflow.yml
+++ b/.github/workflows/e2e-workflow.yml
@@ -85,7 +85,7 @@ jobs:
           go-version: ${{ env.GO_VERSION  }}
 
       - name: Az login
-        uses: azure/login@6c251865b4e6290e7b78be643ea2d005bc51f69a # v2.1.1
+        uses: azure/login@v2.2.0
         with:
           client-id: ${{ secrets.E2E_CLIENT_ID }}
           tenant-id: ${{ secrets.E2E_TENANT_ID }}

--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -34,8 +34,7 @@ type ResourceSpec struct {
 	LabelSelector *metav1.LabelSelector `json:"labelSelector"`
 
 	// PreferredNodes is an optional node list specified by the user.
-	// If a node in the list does not have the required labels or
-	// the required instanceType, it will be ignored.
+	// If a node in the list does not have the required labels, it will be ignored.
 	// +optional
 	PreferredNodes []string `json:"preferredNodes,omitempty"`
 }

--- a/pkg/controllers/workspace_controller_test.go
+++ b/pkg/controllers/workspace_controller_test.go
@@ -751,28 +751,34 @@ func TestApplyInferenceWithTemplate(t *testing.T) {
 }
 
 func TestGetAllQualifiedNodes(t *testing.T) {
+	deletedNode := corev1.Node{
+		ObjectMeta: v1.ObjectMeta{
+			Name: "node4",
+			Labels: map[string]string{
+				corev1.LabelInstanceTypeStable: "Standard_NC12s_v3",
+			},
+			DeletionTimestamp: &v1.Time{Time: time.Now()},
+		},
+	}
+
 	testcases := map[string]struct {
 		callMocks     func(c *test.MockClient)
+		workspace     *v1alpha1.Workspace
 		expectedError error
+		expectedNodes []string
 	}{
 		"Fails to get qualified nodes because can't list nodes": {
 			callMocks: func(c *test.MockClient) {
 				c.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(errors.New("Failed to list nodes"))
 			},
+			workspace:     test.MockWorkspaceDistributedModel,
 			expectedError: errors.New("Failed to list nodes"),
+			expectedNodes: nil,
 		},
 		"Gets all qualified nodes": {
 			callMocks: func(c *test.MockClient) {
 				nodeList := test.MockNodeList
-				deletedNode := corev1.Node{
-					ObjectMeta: v1.ObjectMeta{
-						Name: "node4",
-						Labels: map[string]string{
-							corev1.LabelInstanceTypeStable: "Standard_NC12s_v3",
-						},
-						DeletionTimestamp: &v1.Time{Time: time.Now()},
-					},
-				}
+
 				nodeList.Items = append(nodeList.Items, deletedNode)
 
 				relevantMap := c.CreateMapWithType(nodeList)
@@ -786,14 +792,88 @@ func TestGetAllQualifiedNodes(t *testing.T) {
 
 				c.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
 			},
+			workspace:     test.MockWorkspaceDistributedModel,
 			expectedError: nil,
+			expectedNodes: []string{"node1"},
+		},
+		"Gets all qualified nodes with preferred": {
+			callMocks: func(c *test.MockClient) {
+				nodeList := test.MockNodeList
+
+				nodeList.Items = append(nodeList.Items, deletedNode)
+
+				nodesFromOtherVendor := []corev1.Node{
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "node-p1",
+							Labels: map[string]string{
+								corev1.LabelInstanceTypeStable: "vendor1",
+							},
+						},
+						Status: corev1.NodeStatus{
+							Conditions: []corev1.NodeCondition{
+								{
+									Type:   corev1.NodeReady,
+									Status: corev1.ConditionTrue,
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "node-p2",
+							Labels: map[string]string{
+								corev1.LabelInstanceTypeStable: "vendor2",
+							},
+						},
+						Status: corev1.NodeStatus{
+							Conditions: []corev1.NodeCondition{
+								{
+									Type:   corev1.NodeReady,
+									Status: corev1.ConditionFalse,
+								},
+							},
+						},
+					},
+					{
+						ObjectMeta: v1.ObjectMeta{
+							Name: "node-p3",
+							Labels: map[string]string{
+								corev1.LabelInstanceTypeStable: "vendor1",
+							},
+						},
+						Status: corev1.NodeStatus{
+							Conditions: []corev1.NodeCondition{
+								{
+									Type:   corev1.NodeReady,
+									Status: corev1.ConditionTrue,
+								},
+							},
+						},
+					},
+				}
+				nodeList.Items = append(nodeList.Items, nodesFromOtherVendor...)
+
+				relevantMap := c.CreateMapWithType(nodeList)
+				//insert node objects into the map
+				for _, obj := range test.MockNodeList.Items {
+					n := obj
+					objKey := client.ObjectKeyFromObject(&n)
+
+					relevantMap[objKey] = &n
+				}
+
+				c.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+			},
+			workspace:     test.MockWorkspaceWithPreferredNodes,
+			expectedError: nil,
+			expectedNodes: []string{"node1", "node-p1"},
 		},
 	}
 
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
 			mockClient := test.NewClient()
-			mockWorkspace := test.MockWorkspaceDistributedModel
 			reconciler := &WorkspaceReconciler{
 				Client: mockClient,
 				Scheme: test.NewTestScheme(),
@@ -802,15 +882,17 @@ func TestGetAllQualifiedNodes(t *testing.T) {
 
 			tc.callMocks(mockClient)
 
-			nodes, err := reconciler.getAllQualifiedNodes(ctx, mockWorkspace)
-			if tc.expectedError == nil {
-				assert.Check(t, err == nil, "Not expected to return error")
-				assert.Check(t, nodes != nil, "Response node array should not be nil")
-				assert.Check(t, len(nodes) == 1, "One out of three nodes should be qualified")
-			} else {
+			nodes, err := reconciler.getAllQualifiedNodes(ctx, tc.workspace)
+
+			if tc.expectedError != nil {
 				assert.Equal(t, tc.expectedError.Error(), err.Error())
 				assert.Check(t, nodes == nil, "Response node array should be nil")
+				return
 			}
+
+			assert.Check(t, err == nil, "Not expected to return error")
+			assert.Check(t, nodes != nil, "Response node array should not be nil")
+			assert.Check(t, len(nodes) == len(tc.expectedNodes), "Unexpected qualified nodes")
 		})
 	}
 }

--- a/pkg/utils/test/testUtils.go
+++ b/pkg/utils/test/testUtils.go
@@ -47,6 +47,29 @@ var (
 			},
 		},
 	}
+	MockWorkspaceWithPreferredNodes = &v1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testWorkspace",
+			Namespace: "kaito",
+		},
+		Resource: v1alpha1.ResourceSpec{
+			Count:        &gpuNodeCount,
+			InstanceType: "Standard_NC12s_v3",
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"apps": "test",
+				},
+			},
+			PreferredNodes: []string{"node-p1", "node-p2"},
+		},
+		Inference: &v1alpha1.InferenceSpec{
+			Preset: &v1alpha1.PresetSpec{
+				PresetMeta: v1alpha1.PresetMeta{
+					Name: "test-distributed-model",
+				},
+			},
+		},
+	}
 )
 
 var (


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->

ignore instanceType when selecting preferred nodes

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: