### PR TITLE
fix: patch imagePullSecrets validation in e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -291,6 +291,7 @@ gpu-provisioner-helm:  ## Update Azure client env vars and settings in helm valu
 	helm install $(GPU_PROVISIONER_NAMESPACE) \
 	--values gpu-provisioner-values.yaml \
 	--set settings.azure.clusterName=$(AZURE_CLUSTER_NAME) \
+	--namespace $(GPU_PROVISIONER_NAMESPACE) --create-namespace \
 	https://github.com/Azure/gpu-provisioner/raw/gh-pages/charts/gpu-provisioner-$(GPU_PROVISIONER_VERSION).tgz
 
 	kubectl wait --for=condition=available deploy "gpu-provisioner" -n gpu-provisioner --timeout=300s

--- a/test/e2e/inference_with_adapters_test.go
+++ b/test/e2e/inference_with_adapters_test.go
@@ -30,6 +30,9 @@ var validAdapters1 = []kaitov1alpha1.AdapterSpec{
 		Source: &kaitov1alpha1.DataSource{
 			Name:  imageName1,
 			Image: fullImageName1,
+			ImagePullSecrets: []string{
+				aiModelsRegistrySecret,
+			},
 		},
 		Strength: &DefaultStrength,
 	},
@@ -40,9 +43,6 @@ var validAdapters2 = []kaitov1alpha1.AdapterSpec{
 		Source: &kaitov1alpha1.DataSource{
 			Name:  imageName2,
 			Image: fullImageName2,
-			ImagePullSecrets: []string{
-				aiModelsRegistrySecret,
-			},
 		},
 		Strength: &DefaultStrength,
 	},
@@ -85,13 +85,15 @@ func validateInitContainers(workspaceObj *kaitov1alpha1.Workspace, expectedInitC
 				return false
 			}
 
-			if dep.Spec.Template.Spec.ImagePullSecrets == nil || len(dep.Spec.Template.Spec.ImagePullSecrets) == 0 {
-				return false
-			}
 			if len(initContainers) != len(expectedInitContainers) {
 				return false
 			}
 			initContainer, expectedInitContainer := initContainers[0], expectedInitContainers[0]
+			if expectedInitContainer.Name == imageName1 { //only the first adapter need to check imagePullSecrets
+				if dep.Spec.Template.Spec.ImagePullSecrets == nil || len(dep.Spec.Template.Spec.ImagePullSecrets) == 0 {
+					return false
+				}
+			}
 
 			// GinkgoWriter.Printf("Resource '%s' not ready. Ready replicas: %d\n", workspaceObj.Name, readyReplicas)
 			return initContainer.Image == expectedInitContainer.Image && initContainer.Name == expectedInitContainer.Name


### PR DESCRIPTION
**Reason for Change**:
patch imagePullSecrets validation in e2e test, only the second image need this check

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: