### PR TITLE
chore: restruct workspace controller code - part 4

### DIFF
--- a/cmd/ragengine/main.go
+++ b/cmd/ragengine/main.go
@@ -18,7 +18,7 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/kaito-project/kaito/pkg/ragengine/controllers"
-	"github.com/kaito-project/kaito/pkg/webhooks"
+	"github.com/kaito-project/kaito/pkg/ragengine/webhooks"
 	"k8s.io/api/apps/v1beta1"
 	"k8s.io/klog/v2"
 	"knative.dev/pkg/injection/sharedmain"

--- a/cmd/workspace/main.go
+++ b/cmd/workspace/main.go
@@ -21,8 +21,8 @@ import (
 	"sigs.k8s.io/karpenter/pkg/apis/v1beta1"
 
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
-	"github.com/kaito-project/kaito/pkg/webhooks"
 	"github.com/kaito-project/kaito/pkg/workspace/controllers"
+	"github.com/kaito-project/kaito/pkg/workspace/webhooks"
 	"k8s.io/klog/v2"
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/webhook"

--- a/pkg/ragengine/webhooks/webhooks.go
+++ b/pkg/ragengine/webhooks/webhooks.go
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+package webhooks
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"knative.dev/pkg/configmap"
+	"knative.dev/pkg/controller"
+	knativeinjection "knative.dev/pkg/injection"
+	"knative.dev/pkg/webhook/certificates"
+	"knative.dev/pkg/webhook/resourcesemantics"
+	"knative.dev/pkg/webhook/resourcesemantics/validation"
+
+	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
+)
+
+func NewRAGEngineWebhooks() []knativeinjection.ControllerConstructor {
+	return []knativeinjection.ControllerConstructor{
+		certificates.NewController,
+		NewRAGEngineCRDValidationWebhook,
+	}
+}
+
+func NewRAGEngineCRDValidationWebhook(ctx context.Context, _ configmap.Watcher) *controller.Impl {
+	return validation.NewAdmissionController(ctx,
+		"validation.ragengine.kaito.sh",
+		"/validate/ragengine.kaito.sh",
+		RAGEngineResources,
+		func(ctx context.Context) context.Context { return ctx },
+		true,
+	)
+}
+
+var RAGEngineResources = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
+	kaitov1alpha1.GroupVersion.WithKind("RAGEngine"): &kaitov1alpha1.RAGEngine{},
+}

--- a/pkg/workspace/webhooks/webhooks.go
+++ b/pkg/workspace/webhooks/webhooks.go
@@ -36,24 +36,3 @@ func NewWorkspaceCRDValidationWebhook(ctx context.Context, _ configmap.Watcher) 
 var WorkspaceResources = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
 	kaitov1alpha1.GroupVersion.WithKind("Workspace"): &kaitov1alpha1.Workspace{},
 }
-
-func NewRAGEngineWebhooks() []knativeinjection.ControllerConstructor {
-	return []knativeinjection.ControllerConstructor{
-		certificates.NewController,
-		NewRAGEngineCRDValidationWebhook,
-	}
-}
-
-func NewRAGEngineCRDValidationWebhook(ctx context.Context, _ configmap.Watcher) *controller.Impl {
-	return validation.NewAdmissionController(ctx,
-		"validation.ragengine.kaito.sh",
-		"/validate/ragengine.kaito.sh",
-		RAGEngineResources,
-		func(ctx context.Context) context.Context { return ctx },
-		true,
-	)
-}
-
-var RAGEngineResources = map[schema.GroupVersionKind]resourcesemantics.GenericCRD{
-	kaitov1alpha1.GroupVersion.WithKind("RAGEngine"): &kaitov1alpha1.RAGEngine{},
-}


### PR DESCRIPTION
Split webhook.go for workspace and ragengine controller individually. 