### PR TITLE
Avoid creating GPU provisioner in the default namespace

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -83,7 +83,7 @@ curl -sO https://raw.githubusercontent.com/Azure/gpu-provisioner/main/hack/deplo
 chmod +x ./configure-helm-values.sh && ./configure-helm-values.sh $MY_CLUSTER $RESOURCE_GROUP $IDENTITY_NAME
 
 helm install gpu-provisioner --values gpu-provisioner-values.yaml --set settings.azure.clusterName=$MY_CLUSTER --wait \
-https://github.com/Azure/gpu-provisioner/raw/gh-pages/charts/gpu-provisioner-$GPU_PROVISIONER_VERSION.tgz
+https://github.com/Azure/gpu-provisioner/raw/gh-pages/charts/gpu-provisioner-$GPU_PROVISIONER_VERSION.tgz --namespace gpu-provisioner --create-namespace
 ```
 
 #### Create the federated credential


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->
I discussed an issue that the default installation of Kaito failed to work as it could create the GPU provisioner in a default name space and customers need to manually change the namespace to "default" to ensure the GPU provisioner pod is in running status

**Requirements**
Fix the document for the helm install command. The command is validated in the latest AKS cluster and discussed with Fei.
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: 