### PR TITLE
llm-reference-preset: Add workflow to build & push

### DIFF
--- a/.github/workflows/publish-ghcr-llm-reference-preset.yml
+++ b/.github/workflows/publish-ghcr-llm-reference-preset.yml
@@ -1,0 +1,43 @@
+name: LLM Reference Preset GHCR Image - Build & Push
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout the code
+      uses: actions/checkout@v4
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Docker meta
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ env.REGISTRY }}/kaito-project/kaito/llm-reference-preset
+        tags: |
+          type=semver,pattern={{version}}
+
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        file: docs/custom-model-integration/Dockerfile.reference
+        push: true
+        build-args: |
+          MODEL_TYPE=text-generation
+          VERSION=${{ fromJSON(steps.meta.outputs.json).labels['org.opencontainers.image.version'] }}
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
This commit adds an image to build and push image to GHCR for `llm-reference-preset`, this workflow is triggered when a tag is pushed with `v*` pattern.

**Reason for Change**:

To automatically build image on every release for `llm-reference-preset`.

**Issue Fixed**:

Fixes #731

**Notes for Reviewers**:

The image won't be built until there is another release.