### PR TITLE
Create the workspace service for custom models

### DIFF
--- a/pkg/utils/test/testUtils.go
+++ b/pkg/utils/test/testUtils.go
@@ -70,6 +70,33 @@ var (
 			},
 		},
 	}
+	MockWorkspaceCustomModel = &v1alpha1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testCustomWorkspace",
+			Namespace: "kaito",
+		},
+		Resource: v1alpha1.ResourceSpec{
+			Count:        &gpuNodeCount,
+			InstanceType: "Standard_NC12s_v3",
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"apps": "test",
+				},
+			},
+		},
+		Inference: &v1alpha1.InferenceSpec{
+			Template: &corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test-container",
+							Image: "fake.kaito.com/kaito-image:0.0.1",
+						},
+					},
+				},
+			},
+		},
+	}
 )
 
 var (


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->

This change updates the `ensureService` function in the workspace controller to create the workspace service for custom models instead of only doing it for preset models. 

The logic today only goes into the service creation code if there is a preset, but it is only using the preset information to see if the model supports distributed inference. To add support for custom models, we can just default the distributed inference support to false and always create the service preset or not. 

It seems fair to me to only support distributed inference on the preset models as that requires more setup. With this change custom models can at least have basic support without any manual Kubernetes resource creation.

Fixes #744.

**Requirements**

- [X] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

Fixes #744 

**Notes for Reviewers**: