### PR TITLE
fix: disable tensor parallel for falcon7b

### DIFF
--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -100,8 +100,7 @@ func (h *HuggingfaceTransformersParam) DeepCopy() HuggingfaceTransformersParam {
 	if h == nil {
 		return HuggingfaceTransformersParam{}
 	}
-	out := HuggingfaceTransformersParam{}
-	out = *h
+	out := *h
 	out.TorchRunParams = make(map[string]string, len(h.TorchRunParams))
 	for k, v := range h.TorchRunParams {
 		out.TorchRunParams[k] = v
@@ -121,8 +120,7 @@ func (v *VLLMParam) DeepCopy() VLLMParam {
 	if v == nil {
 		return VLLMParam{}
 	}
-	out := VLLMParam{}
-	out = *v
+	out := *v
 	out.DistributionParams = make(map[string]string, len(v.DistributionParams))
 	for k, v := range v.DistributionParams {
 		out.DistributionParams[k] = v

--- a/pkg/utils/test/testModel.go
+++ b/pkg/utils/test/testModel.go
@@ -10,14 +10,15 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 )
 
-type testModel struct{}
+type baseTestModel struct{}
 
-func (*testModel) GetInferenceParameters() *model.PresetParam {
+func (*baseTestModel) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
 		GPUCountRequirement: "1",
 		RuntimeParam: model.RuntimeParam{
 			VLLM: model.VLLMParam{
 				BaseCommand: "python3 /workspace/vllm/inference_api.py",
+				ModelName:   "mymodel",
 			},
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       "accelerate launch",
@@ -27,27 +28,42 @@ func (*testModel) GetInferenceParameters() *model.PresetParam {
 		ReadinessTimeout: time.Duration(30) * time.Minute,
 	}
 }
-func (*testModel) GetTuningParameters() *model.PresetParam {
+func (*baseTestModel) GetTuningParameters() *model.PresetParam {
 	return &model.PresetParam{
 		GPUCountRequirement: "1",
 		ReadinessTimeout:    time.Duration(30) * time.Minute,
 	}
 }
+func (*baseTestModel) SupportDistributedInference() bool {
+	return true
+}
+func (*baseTestModel) SupportTuning() bool {
+	return true
+}
+
+type testModel struct {
+	baseTestModel
+}
+
 func (*testModel) SupportDistributedInference() bool {
 	return false
 }
-func (*testModel) SupportTuning() bool {
-	return true
+
+type testDistributedModel struct {
+	baseTestModel
 }
 
-type testDistributedModel struct{}
+type testNoTensorParallelModel struct {
+	baseTestModel
+}
 
-func (*testDistributedModel) GetInferenceParameters() *model.PresetParam {
+func (*testNoTensorParallelModel) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
 		GPUCountRequirement: "1",
 		RuntimeParam: model.RuntimeParam{
 			VLLM: model.VLLMParam{
-				BaseCommand: "python3 /workspace/vllm/inference_api.py",
+				BaseCommand:               "python3 /workspace/vllm/inference_api.py",
+				TensorParallelUnsupported: true,
 			},
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       "accelerate launch",
@@ -57,30 +73,23 @@ func (*testDistributedModel) GetInferenceParameters() *model.PresetParam {
 		ReadinessTimeout: time.Duration(30) * time.Minute,
 	}
 }
-func (*testDistributedModel) GetTuningParameters() *model.PresetParam {
-	return &model.PresetParam{
-		GPUCountRequirement: "1",
-		ReadinessTimeout:    time.Duration(30) * time.Minute,
-	}
-}
-func (*testDistributedModel) SupportDistributedInference() bool {
-	return true
-}
-func (*testDistributedModel) SupportTuning() bool {
-	return true
+func (*testNoTensorParallelModel) SupportDistributedInference() bool {
+	return false
 }
 
 func RegisterTestModel() {
-	var test testModel
 	plugin.KaitoModelRegister.Register(&plugin.Registration{
 		Name:     "test-model",
-		Instance: &test,
+		Instance: &testModel{},
 	})
 
-	var testDistributed testDistributedModel
 	plugin.KaitoModelRegister.Register(&plugin.Registration{
 		Name:     "test-distributed-model",
-		Instance: &testDistributed,
+		Instance: &testDistributedModel{},
 	})
 
+	plugin.KaitoModelRegister.Register(&plugin.Registration{
+		Name:     "test-no-tensor-parallel-model",
+		Instance: &testNoTensorParallelModel{},
+	})
 }

--- a/pkg/utils/test/testModel.go
+++ b/pkg/utils/test/testModel.go
@@ -61,9 +61,9 @@ func (*testNoTensorParallelModel) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
 		GPUCountRequirement: "1",
 		RuntimeParam: model.RuntimeParam{
+			DisableTensorParallelism: true,
 			VLLM: model.VLLMParam{
-				BaseCommand:               "python3 /workspace/vllm/inference_api.py",
-				TensorParallelUnsupported: true,
+				BaseCommand: "python3 /workspace/vllm/inference_api.py",
 			},
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       "accelerate launch",

--- a/presets/workspace/models/falcon/model.go
+++ b/presets/workspace/models/falcon/model.go
@@ -80,6 +80,11 @@ func (*falcon7b) GetInferenceParameters() *model.PresetParam {
 				BaseCommand:    inference.DefaultVLLMCommand,
 				ModelName:      "falcon-7b",
 				ModelRunParams: falconRunParamsVLLM,
+				// vllm requires the model specification to be exactly divisible by
+				// the number of GPUs(tensor parallel level).
+				// falcon-7b have 71 attention heads, which is a prime number.
+				// So, give up tensor parallel inference.
+				TensorParallelUnsupported: true,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
@@ -137,6 +142,11 @@ func (*falcon7bInst) GetInferenceParameters() *model.PresetParam {
 				BaseCommand:    inference.DefaultVLLMCommand,
 				ModelName:      "falcon-7b-instruct",
 				ModelRunParams: falconRunParamsVLLM,
+				// vllm requires the model specification to be exactly divisible by
+				// the number of GPUs(tensor parallel level).
+				// falcon-7b-instruct have 71 attention heads, which is a prime number.
+				// So, give up tensor parallel inference.
+				TensorParallelUnsupported: true,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,

--- a/presets/workspace/models/falcon/model.go
+++ b/presets/workspace/models/falcon/model.go
@@ -80,12 +80,12 @@ func (*falcon7b) GetInferenceParameters() *model.PresetParam {
 				BaseCommand:    inference.DefaultVLLMCommand,
 				ModelName:      "falcon-7b",
 				ModelRunParams: falconRunParamsVLLM,
-				// vllm requires the model specification to be exactly divisible by
-				// the number of GPUs(tensor parallel level).
-				// falcon-7b have 71 attention heads, which is a prime number.
-				// So, give up tensor parallel inference.
-				TensorParallelUnsupported: true,
 			},
+			// vllm requires the model specification to be exactly divisible by
+			// the number of GPUs(tensor parallel level).
+			// falcon-7b have 71 attention heads, which is a prime number.
+			// So, give up tensor parallel inference.
+			DisableTensorParallelism: true,
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
 		Tag:              PresetFalconTagMap["Falcon7B"],
@@ -142,12 +142,12 @@ func (*falcon7bInst) GetInferenceParameters() *model.PresetParam {
 				BaseCommand:    inference.DefaultVLLMCommand,
 				ModelName:      "falcon-7b-instruct",
 				ModelRunParams: falconRunParamsVLLM,
-				// vllm requires the model specification to be exactly divisible by
-				// the number of GPUs(tensor parallel level).
-				// falcon-7b-instruct have 71 attention heads, which is a prime number.
-				// So, give up tensor parallel inference.
-				TensorParallelUnsupported: true,
 			},
+			// vllm requires the model specification to be exactly divisible by
+			// the number of GPUs(tensor parallel level).
+			// falcon-7b-instruct have 71 attention heads, which is a prime number.
+			// So, give up tensor parallel inference.
+			DisableTensorParallelism: true,
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
 		Tag:              PresetFalconTagMap["Falcon7BInstruct"],


### PR DESCRIPTION
**Reason for Change**:

vllm requires the model specification to be exactly divisible by
the number of GPUs (tensor parallel level).
while falcon-7b-instruct have 71 attention heads, which is a prime number.
So, give up tensor parallel inference for it.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).
