### PR TITLE
fix: Filepath in custom-deployment-template.yaml

### DIFF
--- a/docs/custom-model-integration/custom-deployment-template.yaml
+++ b/docs/custom-model-integration/custom-deployment-template.yaml
@@ -22,7 +22,7 @@ inference:
           - "1"
           - "--gpu_ids"
           - "all"
-          - "inference_api.py"
+          - "tfs/inference_api.py"
           - "--pipeline"
           - "text-generation"
           - "--torch_dtype"


### PR DESCRIPTION
Fix the `inference_api.py` filepath used in custom-deployment-template.yaml

https://github.com/kaito-project/kaito/issues/753