### PR TITLE
fix: machine and nodeclaim can not supported at the same time

### DIFF
--- a/pkg/ragengine/controllers/ragengine_gc_finalizer.go
+++ b/pkg/ragengine/controllers/ragengine_gc_finalizer.go
@@ -21,19 +21,6 @@ import (
 func (c *RAGEngineReconciler) garbageCollectRAGEngine(ctx context.Context, ragEngineObj *kaitov1alpha1.RAGEngine) (ctrl.Result, error) {
 	klog.InfoS("garbageCollectRAGEngine", "ragengine", klog.KObj(ragEngineObj))
 
-	// Check if there are any machines associated with this ragengine.
-	mList, err := machine.ListMachines(ctx, ragEngineObj, c.Client)
-	if err != nil {
-		return ctrl.Result{}, err
-	}
-	// We should delete all the machines that are created by this ragengine
-	for i := range mList.Items {
-		if deleteErr := c.Delete(ctx, &mList.Items[i], &client.DeleteOptions{}); deleteErr != nil {
-			klog.ErrorS(deleteErr, "failed to delete the machine", "machine", klog.KObj(&mList.Items[i]))
-			return ctrl.Result{}, deleteErr
-		}
-	}
-
 	if featuregates.FeatureGates[consts.FeatureFlagKarpenter] {
 		// Check if there are any nodeClaims associated with this ragengine.
 		ncList, err := nodeclaim.ListNodeClaim(ctx, ragEngineObj, c.Client)
@@ -45,6 +32,19 @@ func (c *RAGEngineReconciler) garbageCollectRAGEngine(ctx context.Context, ragEn
 		for i := range ncList.Items {
 			if deleteErr := c.Delete(ctx, &ncList.Items[i], &client.DeleteOptions{}); deleteErr != nil {
 				klog.ErrorS(deleteErr, "failed to delete the nodeClaim", "nodeClaim", klog.KObj(&ncList.Items[i]))
+				return ctrl.Result{}, deleteErr
+			}
+		}
+	} else {
+		// Check if there are any machines associated with this ragengine.
+		mList, err := machine.ListMachines(ctx, ragEngineObj, c.Client)
+		if err != nil {
+			return ctrl.Result{}, err
+		}
+		// We should delete all the machines that are created by this ragengine
+		for i := range mList.Items {
+			if deleteErr := c.Delete(ctx, &mList.Items[i], &client.DeleteOptions{}); deleteErr != nil {
+				klog.ErrorS(deleteErr, "failed to delete the machine", "machine", klog.KObj(&mList.Items[i]))
 				return ctrl.Result{}, deleteErr
 			}
 		}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->
We need to select Machine or NodeClaim to connect gpu-provisioner component to provide GPU resource.
this means Machine and NodeClaim can not supported at the same time.

In this pull request, improve some sequence process of Machine and NodeClaim into `if condition`.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: