### PR TITLE
feat: add inference config api

### DIFF
--- a/api/v1alpha1/params_validation.go
+++ b/api/v1alpha1/params_validation.go
@@ -216,7 +216,7 @@ func getStructInstances(s any) map[string]any {
 	return instances
 }
 
-func validateConfigMapSchema(cm *corev1.ConfigMap) *apis.FieldError {
+func validateTuningConfigMapSchema(cm *corev1.ConfigMap) *apis.FieldError {
 	trainingConfigData, ok := cm.Data["training_config.yaml"]
 	if !ok {
 		return apis.ErrMissingField("training_config.yaml in ConfigMap")
@@ -263,7 +263,7 @@ func (r *TuningSpec) validateConfigMap(ctx context.Context, namespace string, me
 			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("Failed to get ConfigMap '%s' in namespace '%s': %v", r.Config, namespace, err), "config"))
 		}
 	} else {
-		if err := validateConfigMapSchema(&cm); err != nil {
+		if err := validateTuningConfigMapSchema(&cm); err != nil {
 			errs = errs.Also(err)
 		}
 		if err := validateMethodViaConfigMap(&cm, methodLowerCase); err != nil {

--- a/api/v1alpha1/workspace_types.go
+++ b/api/v1alpha1/workspace_types.go
@@ -82,6 +82,10 @@ type InferenceSpec struct {
 	// +kubebuilder:validation:Schemaless
 	// +optional
 	Template *v1.PodTemplateSpec `json:"template,omitempty"`
+	// Config specifies the name of a custom ConfigMap that contains inference arguments.
+	// If specified, the ConfigMap must be in the same namespace as the Workspace custom resource.
+	// +optional
+	Config string `json:"config,omitempty"`
 	// Adapters are integrated into the base model for inference.
 	// Users can specify multiple adapters for the model and the respective weight of using each of them.
 	// +optional

--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -29,9 +29,10 @@ const (
 	N_SERIES_PREFIX = "Standard_N"
 	D_SERIES_PREFIX = "Standard_D"
 
-	DefaultLoraConfigMapTemplate  = "lora-params-template"
-	DefaultQloraConfigMapTemplate = "qlora-params-template"
-	MaxAdaptersNumber             = 10
+	DefaultLoraConfigMapTemplate   = "lora-params-template"
+	DefaultQloraConfigMapTemplate  = "qlora-params-template"
+	DefaultInferenceConfigTemplate = "inference-params-template"
+	MaxAdaptersNumber              = 10
 )
 
 func (w *Workspace) SupportedVerbs() []admissionregistrationv1.OperationType {

--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -12,12 +12,16 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/kaito-project/kaito/pkg/k8sclient"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
@@ -54,7 +58,7 @@ func (w *Workspace) Validate(ctx context.Context) (errs *apis.FieldError) {
 		if w.Inference != nil {
 			// TODO: Add Adapter Spec Validation - Including DataSource Validation for Adapter
 			errs = errs.Also(w.Resource.validateCreateWithInference(w.Inference).ViaField("resource"),
-				w.Inference.validateCreate().ViaField("inference"))
+				w.Inference.validateCreate(ctx, w.Namespace).ViaField("inference"))
 		}
 		if w.Tuning != nil {
 			// TODO: Add validate resource based on Tuning Spec
@@ -391,7 +395,7 @@ func (r *ResourceSpec) validateUpdate(old *ResourceSpec) (errs *apis.FieldError)
 	return errs
 }
 
-func (i *InferenceSpec) validateCreate() (errs *apis.FieldError) {
+func (i *InferenceSpec) validateCreate(ctx context.Context, namespace string) (errs *apis.FieldError) {
 	// Check if both Preset and Template are not set
 	if i.Preset == nil && i.Template == nil {
 		errs = errs.Also(apis.ErrMissingField("Preset or Template must be specified"))
@@ -427,6 +431,35 @@ func (i *InferenceSpec) validateCreate() (errs *apis.FieldError) {
 	if len(i.Adapters) > 0 {
 		nameMap := make(map[string]bool)
 		errs = errs.Also(validateDuplicateName(i.Adapters, nameMap))
+	}
+
+	if i.Config != "" {
+		errs = errs.Also(i.validateConfigMap(ctx, namespace))
+	}
+
+	return errs
+}
+
+func (i *InferenceSpec) validateConfigMap(ctx context.Context, namespace string) (errs *apis.FieldError) {
+	var cm corev1.ConfigMap
+	if k8sclient.Client == nil {
+		errs = errs.Also(apis.ErrGeneric("Failed to obtain client from context.Context"))
+		return errs
+	}
+	err := k8sclient.Client.Get(ctx, client.ObjectKey{Name: i.Config, Namespace: namespace}, &cm)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("ConfigMap '%s' specified in 'config' not found in namespace '%s'", i.Config, namespace), "config"))
+		} else {
+			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("Failed to get ConfigMap '%s' in namespace '%s': %v", i.Config, namespace, err), "config"))
+		}
+		return errs
+	}
+
+	// basic check here, it's hard to validate the content of the configmap in controller
+	_, ok := cm.Data["inference_config.yaml"]
+	if !ok {
+		return apis.ErrMissingField("inference_config.yaml in ConfigMap")
 	}
 
 	return errs

--- a/charts/kaito/workspace/crds/kaito.sh_workspaces.yaml
+++ b/charts/kaito/workspace/crds/kaito.sh_workspaces.yaml
@@ -94,6 +94,11 @@ spec:
                       type: string
                   type: object
                 type: array
+              config:
+                description: |-
+                  Config specifies the name of a custom ConfigMap that contains inference arguments.
+                  If specified, the ConfigMap must be in the same namespace as the Workspace custom resource.
+                type: string
               preset:
                 description: Preset describes the base model that will be deployed
                   with preset configurations.

--- a/config/crd/bases/kaito.sh_workspaces.yaml
+++ b/config/crd/bases/kaito.sh_workspaces.yaml
@@ -94,6 +94,11 @@ spec:
                       type: string
                   type: object
                 type: array
+              config:
+                description: |-
+                  Config specifies the name of a custom ConfigMap that contains inference arguments.
+                  If specified, the ConfigMap must be in the same namespace as the Workspace custom resource.
+                type: string
               preset:
                 description: Preset describes the base model that will be deployed
                   with preset configurations.

--- a/pkg/utils/test/testUtils.go
+++ b/pkg/utils/test/testUtils.go
@@ -4,6 +4,8 @@
 package test
 
 import (
+	"os"
+
 	"github.com/aws/karpenter-core/pkg/apis/v1alpha5"
 	"github.com/kaito-project/kaito/api/v1alpha1"
 	"github.com/kaito-project/kaito/pkg/model"
@@ -947,4 +949,22 @@ func NotFoundError() error {
 
 func IsAlreadyExistsError() error {
 	return &apierrors.StatusError{ErrStatus: metav1.Status{Reason: metav1.StatusReasonAlreadyExists}}
+}
+
+// Saves state of current env, and returns function to restore to saved state
+func SaveEnv(key string) func() {
+	envVal, envExists := os.LookupEnv(key)
+	return func() {
+		if envExists {
+			err := os.Setenv(key, envVal)
+			if err != nil {
+				return
+			}
+		} else {
+			err := os.Unsetenv(key)
+			if err != nil {
+				return
+			}
+		}
+	}
 }

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -749,6 +749,7 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1a
 				if !model.SupportDistributedInference() {
 					deployment := existingObj.(*appsv1.Deployment)
 					if deployment.Annotations[kaitov1alpha1.WorkspaceRevisionAnnotation] != revisionStr {
+						// TODO: respect updates to other fields
 						var volumes []corev1.Volume
 						var volumeMounts []corev1.VolumeMount
 						shmVolume, shmVolumeMount := utils.ConfigSHMVolume(*wObj.Resource.Count)

--- a/pkg/workspace/controllers/workspace_controller_test.go
+++ b/pkg/workspace/controllers/workspace_controller_test.go
@@ -624,6 +624,7 @@ func TestApplyInferenceWithPreset(t *testing.T) {
 		},
 		"Create preset inference because inference workload did not exist": {
 			callMocks: func(c *test.MockClient) {
+				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
 				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(test.NotFoundError()).Times(4)
 				c.On("Get", mock.Anything, mock.Anything, mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(nil).Run(func(args mock.Arguments) {
 					depObj := &appsv1.Deployment{}
@@ -692,9 +693,10 @@ func TestApplyInferenceWithPreset(t *testing.T) {
 			}
 			ctx := context.Background()
 
+			os.Setenv("CLOUD_PROVIDER", consts.AzureCloudName)
 			err := reconciler.applyInference(ctx, &tc.workspace)
 			if tc.expectedError == nil {
-				assert.Check(t, err == nil, "Not expected to return error")
+				assert.Check(t, err == nil, fmt.Sprintf("Not expected to return error: %v", err))
 			} else {
 				assert.Equal(t, tc.expectedError.Error(), err.Error())
 			}

--- a/pkg/workspace/inference/preset-inferences.go
+++ b/pkg/workspace/inference/preset-inferences.go
@@ -17,7 +17,6 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/workspace/manifests"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/klog/v2"
@@ -132,7 +131,15 @@ func CreatePresetInference(ctx context.Context, workspaceObj *kaitov1alpha1.Work
 	model model.Model, kubeClient client.Client) (client.Object, error) {
 	inferenceParam := model.GetInferenceParameters().DeepCopy()
 
-	configVolume, err := EnsureInferenceConfigMap(ctx, workspaceObj, kubeClient)
+	configVolume, err := resources.EnsureConfigOrCopyFromDefault(ctx, kubeClient,
+		client.ObjectKey{
+			Name:      workspaceObj.Inference.Config,
+			Namespace: workspaceObj.Namespace,
+		},
+		client.ObjectKey{
+			Name: kaitov1alpha1.DefaultInferenceConfigTemplate,
+		},
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -202,71 +209,4 @@ func CreatePresetInference(ctx context.Context, workspaceObj *kaitov1alpha1.Work
 		return nil, err
 	}
 	return depObj, nil
-}
-
-// EnsureInferenceConfigMap handles two scenarios:
-// 1. User provided config (workspaceObj.Inference.Config):
-//   - Check if it exists in the target namespace
-//   - If not found, return error as this is user-specified
-//
-// 2. No user config specified:
-//   - Use the default config template (inference-params-template)
-//   - Check if it exists in the target namespace
-//   - If not, copy from release namespace to target namespace
-func EnsureInferenceConfigMap(ctx context.Context, workspaceObj *kaitov1alpha1.Workspace,
-	kubeClient client.Client) (*corev1.ConfigMap, error) {
-
-	// If user specified a config, use that
-	if workspaceObj.Inference.Config != "" {
-		userCM := &corev1.ConfigMap{}
-		err := resources.GetResource(ctx, workspaceObj.Inference.Config, workspaceObj.Namespace, kubeClient, userCM)
-		if err != nil {
-			if errors.IsNotFound(err) {
-				return nil, fmt.Errorf("user specified ConfigMap %s not found in namespace %s",
-					workspaceObj.Inference.Config, workspaceObj.Namespace)
-			}
-			return nil, err
-		}
-
-		return userCM, nil
-	}
-
-	// Otherwise use default template
-	configMapName := kaitov1alpha1.DefaultInferenceConfigTemplate
-
-	// Check if default configmap already exists in target namespace
-	existingCM := &corev1.ConfigMap{}
-	err := resources.GetResource(ctx, configMapName, workspaceObj.Namespace, kubeClient, existingCM)
-	if err != nil {
-		if !errors.IsNotFound(err) {
-			return nil, err
-		}
-	} else {
-		klog.Infof("Default ConfigMap already exists in target namespace: %s, no action taken.", workspaceObj.Namespace)
-		return existingCM, nil
-	}
-
-	// Copy default template from release namespace if not found
-	releaseNamespace, err := utils.GetReleaseNamespace()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get release namespace: %v", err)
-	}
-
-	templateCM := &corev1.ConfigMap{}
-	err = resources.GetResource(ctx, configMapName, releaseNamespace, kubeClient, templateCM)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get default ConfigMap from template namespace: %v", err)
-	}
-
-	templateCM.Namespace = workspaceObj.Namespace
-	templateCM.ResourceVersion = "" // Clear metadata not needed for creation
-	templateCM.UID = ""             // Clear UID
-
-	err = resources.CreateResource(ctx, templateCM, kubeClient)
-	if err != nil {
-		return nil, fmt.Errorf("failed to create default ConfigMap in target namespace %s: %v",
-			workspaceObj.Namespace, err)
-	}
-
-	return templateCM, nil
 }

--- a/pkg/workspace/inference/preset-inferences_test.go
+++ b/pkg/workspace/inference/preset-inferences_test.go
@@ -15,13 +15,10 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/test"
 
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 var ValidStrength string = "0.5"
@@ -242,95 +239,4 @@ func toParameterMap(in []string) map[string]string {
 		}
 	}
 	return ret
-}
-
-func TestEnsureInferenceConfigMap(t *testing.T) {
-	testcases := map[string]struct {
-		setupEnv      func()
-		callMocks     func(c *test.MockClient)
-		workspaceObj  *v1alpha1.Workspace
-		expectedError string
-	}{
-		"Config already exists in workspace namespace": {
-			setupEnv: func() {
-				os.Setenv(consts.DefaultReleaseNamespaceEnvVar, "release-namespace")
-			},
-			callMocks: func(c *test.MockClient) {
-				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
-			},
-			workspaceObj: &v1alpha1.Workspace{
-				Inference: &v1alpha1.InferenceSpec{
-					Config: "inference-config-template",
-				},
-			},
-			expectedError: "",
-		},
-		"Error finding release namespace": {
-			callMocks: func(c *test.MockClient) {
-				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(errors.NewNotFound(schema.GroupResource{}, "inference-config-template"))
-			},
-			workspaceObj: &v1alpha1.Workspace{
-				Inference: &v1alpha1.InferenceSpec{},
-			},
-			expectedError: "failed to get release namespace: failed to determine release namespace from file /var/run/secrets/kubernetes.io/serviceaccount/namespace and env var RELEASE_NAMESPACE",
-		},
-		"Config doesn't exist in namespace": {
-			setupEnv: func() {
-				os.Setenv(consts.DefaultReleaseNamespaceEnvVar, "release-namespace")
-			},
-			callMocks: func(c *test.MockClient) {
-				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(errors.NewNotFound(schema.GroupResource{}, "inference-config-template"))
-			},
-			workspaceObj: &v1alpha1.Workspace{
-				Inference: &v1alpha1.InferenceSpec{
-					Config: "inference-config-template",
-				},
-			},
-			expectedError: "user specified ConfigMap inference-config-template not found in namespace workspace-namespace",
-		},
-		"Generate default config": {
-			setupEnv: func() {
-				os.Setenv(consts.DefaultReleaseNamespaceEnvVar, "release-namespace")
-			},
-			callMocks: func(c *test.MockClient) {
-				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).
-					Return(errors.NewNotFound(schema.GroupResource{}, "inference-params-template")).Times(4)
-
-				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).
-					Run(func(args mock.Arguments) {
-						cm := args.Get(2).(*corev1.ConfigMap)
-						cm.Name = "inference-params-template"
-					}).Return(nil)
-
-				c.On("Create", mock.IsType(context.Background()), mock.MatchedBy(func(cm *corev1.ConfigMap) bool {
-					return cm.Name == "inference-params-template" && cm.Namespace == "workspace-namespace"
-				}), mock.Anything).Return(nil)
-			},
-			workspaceObj: &v1alpha1.Workspace{
-				Inference: &v1alpha1.InferenceSpec{},
-			},
-			expectedError: "",
-		},
-	}
-
-	for name, tc := range testcases {
-		t.Run(name, func(t *testing.T) {
-			cleanupEnv := test.SaveEnv(consts.DefaultReleaseNamespaceEnvVar)
-			defer cleanupEnv()
-
-			if tc.setupEnv != nil {
-				tc.setupEnv()
-			}
-			mockClient := test.NewClient()
-			tc.callMocks(mockClient)
-			tc.workspaceObj.SetNamespace("workspace-namespace")
-			_, err := EnsureInferenceConfigMap(context.Background(), tc.workspaceObj, mockClient)
-			if tc.expectedError != "" {
-				assert.EqualError(t, err, tc.expectedError)
-			} else {
-				assert.NoError(t, err)
-			}
-			mockClient.AssertExpectations(t)
-		})
-	}
 }

--- a/pkg/workspace/tuning/preset-tuning_test.go
+++ b/pkg/workspace/tuning/preset-tuning_test.go
@@ -28,24 +28,6 @@ func normalize(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }
 
-// Saves state of current env, and returns function to restore to saved state
-func saveEnv(key string) func() {
-	envVal, envExists := os.LookupEnv(key)
-	return func() {
-		if envExists {
-			err := os.Setenv(key, envVal)
-			if err != nil {
-				return
-			}
-		} else {
-			err := os.Unsetenv(key)
-			if err != nil {
-				return
-			}
-		}
-	}
-}
-
 func TestGetInstanceGPUCount(t *testing.T) {
 	os.Setenv("CLOUD_PROVIDER", consts.AzureCloudName)
 
@@ -224,7 +206,7 @@ func TestEnsureTuningConfigMap(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			cleanupEnv := saveEnv(consts.DefaultReleaseNamespaceEnvVar)
+			cleanupEnv := test.SaveEnv(consts.DefaultReleaseNamespaceEnvVar)
 			defer cleanupEnv()
 
 			if tc.setupEnv != nil {

--- a/pkg/workspace/tuning/preset-tuning_test.go
+++ b/pkg/workspace/tuning/preset-tuning_test.go
@@ -14,13 +14,9 @@ import (
 
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	"github.com/kaito-project/kaito/pkg/model"
-	"github.com/kaito-project/kaito/pkg/utils/test"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/resource"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/utils/pointer"
 )
 
@@ -152,76 +148,6 @@ func TestGetDataSrcImageInfo(t *testing.T) {
 			resultImage, resultSecrets := GetDataSrcImageInfo(context.Background(), tc.wObj)
 			assert.Equal(t, tc.expectedImage, resultImage)
 			assert.Equal(t, tc.expectedSecrets, resultSecrets)
-		})
-	}
-}
-
-func TestEnsureTuningConfigMap(t *testing.T) {
-	testcases := map[string]struct {
-		setupEnv      func()
-		callMocks     func(c *test.MockClient)
-		workspaceObj  *kaitov1alpha1.Workspace
-		expectedError string
-	}{
-		"Config already exists in workspace namespace": {
-			setupEnv: func() {
-				os.Setenv(consts.DefaultReleaseNamespaceEnvVar, "release-namespace")
-			},
-			callMocks: func(c *test.MockClient) {
-				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
-			},
-			workspaceObj: &kaitov1alpha1.Workspace{
-				Tuning: &kaitov1alpha1.TuningSpec{
-					Config: "config-template",
-				},
-			},
-			expectedError: "",
-		},
-		"Error finding release namespace": {
-			callMocks: func(c *test.MockClient) {
-				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(errors.NewNotFound(schema.GroupResource{}, "config-template"))
-			},
-			workspaceObj: &kaitov1alpha1.Workspace{
-				Tuning: &kaitov1alpha1.TuningSpec{
-					Config: "config-template",
-				},
-			},
-			expectedError: "failed to get release namespace: failed to determine release namespace from file /var/run/secrets/kubernetes.io/serviceaccount/namespace and env var RELEASE_NAMESPACE",
-		},
-		"Config doesn't exist in template namespace": {
-			setupEnv: func() {
-				os.Setenv(consts.DefaultReleaseNamespaceEnvVar, "release-namespace")
-			},
-			callMocks: func(c *test.MockClient) {
-				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(errors.NewNotFound(schema.GroupResource{}, "config-template"))
-			},
-			workspaceObj: &kaitov1alpha1.Workspace{
-				Tuning: &kaitov1alpha1.TuningSpec{
-					Config: "config-template",
-				},
-			},
-			expectedError: "failed to get ConfigMap from template namespace:  \"config-template\" not found",
-		},
-	}
-
-	for name, tc := range testcases {
-		t.Run(name, func(t *testing.T) {
-			cleanupEnv := test.SaveEnv(consts.DefaultReleaseNamespaceEnvVar)
-			defer cleanupEnv()
-
-			if tc.setupEnv != nil {
-				tc.setupEnv()
-			}
-			mockClient := test.NewClient()
-			tc.callMocks(mockClient)
-			tc.workspaceObj.SetNamespace("workspace-namespace")
-			_, err := EnsureTuningConfigMap(context.Background(), tc.workspaceObj, mockClient)
-			if tc.expectedError != "" {
-				assert.EqualError(t, err, tc.expectedError)
-			} else {
-				assert.NoError(t, err)
-			}
-			mockClient.AssertExpectations(t)
 		})
 	}
 }

--- a/presets/workspace/models/falcon/model.go
+++ b/presets/workspace/models/falcon/model.go
@@ -38,10 +38,10 @@ var (
 	PresetFalcon40BInstructModel = PresetFalcon40BModel + "-instruct"
 
 	PresetFalconTagMap = map[string]string{
-		"Falcon7B":          "0.0.7",
-		"Falcon7BInstruct":  "0.0.7",
-		"Falcon40B":         "0.0.8",
-		"Falcon40BInstruct": "0.0.8",
+		"Falcon7B":          "0.0.8",
+		"Falcon7BInstruct":  "0.0.8",
+		"Falcon40B":         "0.0.9",
+		"Falcon40BInstruct": "0.0.9",
 	}
 
 	baseCommandPresetFalconInference = "accelerate launch"

--- a/presets/workspace/models/mistral/model.go
+++ b/presets/workspace/models/mistral/model.go
@@ -27,8 +27,8 @@ var (
 	PresetMistral7BInstructModel = PresetMistral7BModel + "-instruct"
 
 	PresetMistralTagMap = map[string]string{
-		"Mistral7B":         "0.0.8",
-		"Mistral7BInstruct": "0.0.8",
+		"Mistral7B":         "0.0.9",
+		"Mistral7BInstruct": "0.0.9",
 	}
 
 	baseCommandPresetMistralInference = "accelerate launch"

--- a/presets/workspace/models/phi2/model.go
+++ b/presets/workspace/models/phi2/model.go
@@ -22,7 +22,7 @@ var (
 	PresetPhi2Model = "phi-2"
 
 	PresetPhiTagMap = map[string]string{
-		"Phi2": "0.0.6",
+		"Phi2": "0.0.7",
 	}
 
 	baseCommandPresetPhiInference = "accelerate launch"

--- a/presets/workspace/models/phi3/model.go
+++ b/presets/workspace/models/phi3/model.go
@@ -42,11 +42,11 @@ var (
 	PresetPhi3_5MiniInstruct  = "phi-3.5-mini-instruct"
 
 	PresetPhiTagMap = map[string]string{
-		"Phi3Mini4kInstruct":     "0.0.3",
-		"Phi3Mini128kInstruct":   "0.0.3",
-		"Phi3Medium4kInstruct":   "0.0.3",
-		"Phi3Medium128kInstruct": "0.0.3",
-		"Phi3_5MiniInstruct":     "0.0.1",
+		"Phi3Mini4kInstruct":     "0.0.4",
+		"Phi3Mini128kInstruct":   "0.0.4",
+		"Phi3Medium4kInstruct":   "0.0.4",
+		"Phi3Medium128kInstruct": "0.0.4",
+		"Phi3_5MiniInstruct":     "0.0.2",
 	}
 
 	baseCommandPresetPhiInference = "accelerate launch"

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -680,6 +680,7 @@ var _ = Describe("Workspace Preset", func() {
 		time.Sleep(30 * time.Second)
 
 		validateAssociatedService(workspaceObj)
+		validateInferenceConfig(workspaceObj)
 
 		validateInferenceResource(workspaceObj, int32(numOfNode), false)
 
@@ -699,6 +700,7 @@ var _ = Describe("Workspace Preset", func() {
 		time.Sleep(30 * time.Second)
 
 		validateAssociatedService(workspaceObj)
+		validateInferenceConfig(workspaceObj)
 
 		validateInferenceResource(workspaceObj, int32(numOfNode), false)
 
@@ -718,6 +720,7 @@ var _ = Describe("Workspace Preset", func() {
 		time.Sleep(30 * time.Second)
 
 		validateAssociatedService(workspaceObj)
+		validateInferenceConfig(workspaceObj)
 
 		validateInferenceResource(workspaceObj, int32(numOfNode), false)
 
@@ -741,6 +744,7 @@ var _ = Describe("Workspace Preset", func() {
 		time.Sleep(30 * time.Second)
 
 		validateAssociatedService(workspaceObj)
+		validateInferenceConfig(workspaceObj)
 
 		validateInferenceResource(workspaceObj, int32(numOfNode), false)
 
@@ -768,6 +772,7 @@ var _ = Describe("Workspace Preset", func() {
 		time.Sleep(30 * time.Second)
 
 		validateAssociatedService(workspaceObj)
+		validateInferenceConfig(workspaceObj)
 
 		validateInferenceResource(workspaceObj, int32(numOfNode), true)
 
@@ -805,6 +810,7 @@ var _ = Describe("Workspace Preset", func() {
 		time.Sleep(30 * time.Second)
 
 		validateAssociatedService(workspaceObj)
+		validateInferenceConfig(workspaceObj)
 
 		validateInferenceResource(workspaceObj, int32(numOfNode), false)
 
@@ -860,4 +866,28 @@ func validateCreateNode(workspaceObj *kaitov1alpha1.Workspace, numOfNode int) {
 	} else {
 		utils.ValidateMachineCreation(ctx, workspaceObj, numOfNode)
 	}
+}
+
+// validateInferenceConfig validates that the inference config exists and contains data
+func validateInferenceConfig(workspaceObj *kaitov1alpha1.Workspace) {
+	By("Checking the inference config exists", func() {
+		Eventually(func() bool {
+			configMap := &v1.ConfigMap{}
+			configName := kaitov1alpha1.DefaultInferenceConfigTemplate
+			if workspaceObj.Inference.Config != "" {
+				configName = workspaceObj.Inference.Config
+			}
+			err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+				Namespace: workspaceObj.Namespace,
+				Name:      configName,
+			}, configMap)
+
+			if err != nil {
+				GinkgoWriter.Printf("Error fetching config: %v\n", err)
+				return false
+			}
+
+			return len(configMap.Data) > 0
+		}, 10*time.Minute, utils.PollInterval).Should(BeTrue(), "Failed to wait for inference config to be ready")
+	})
 }

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		time.Sleep(30 * time.Second)
 
 		validateAssociatedService(workspaceObj)
+		validateInferenceConfig(workspaceObj)
 
 		validateInferenceResource(workspaceObj, int32(numOfNode), false)
 
@@ -59,6 +60,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		time.Sleep(30 * time.Second)
 
 		validateAssociatedService(workspaceObj)
+		validateInferenceConfig(workspaceObj)
 
 		validateInferenceResource(workspaceObj, int32(numOfNode), false)
 
@@ -78,6 +80,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		time.Sleep(30 * time.Second)
 
 		validateAssociatedService(workspaceObj)
+		validateInferenceConfig(workspaceObj)
 
 		validateInferenceResource(workspaceObj, int32(numOfNode), false)
 
@@ -97,6 +100,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		time.Sleep(30 * time.Second)
 
 		validateAssociatedService(workspaceObj)
+		validateInferenceConfig(workspaceObj)
 
 		validateInferenceResource(workspaceObj, int32(numOfNode), false)
 
@@ -117,6 +121,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		time.Sleep(30 * time.Second)
 
 		validateAssociatedService(workspaceObj)
+		validateInferenceConfig(workspaceObj)
 
 		validateInferenceResource(workspaceObj, int32(numOfNode), false)
 


### PR DESCRIPTION
**Reason for Change**:

- API change: add config to `workspace.inference.config`
- generate a default config if no user config specified by copying from release-namespace

**Requirements**

- [x] added unit tests and e2e tests (if applicable).
