### PR TITLE
llama2-Dockerfile: Update Python to 3.9-slim

### DIFF
--- a/docker/presets/models/llama-2/Dockerfile
+++ b/docker/presets/models/llama-2/Dockerfile
@@ -4,7 +4,7 @@
 #              --build-arg VERSION={{VERSION}} \
 #              --build-arg MODEL_TYPE={{MODEL_TYPE}} \
 
-FROM python:3.8-slim@sha256:95bfecec648356cdd0b28c8b00ce00009baff10c99d1126a82d1aca716453a1a
+FROM python:3.9-slim@sha256:caaf1af9e23adc6149e5d20662b267ead9505868ff07c7673dc4a7166951cfea
 WORKDIR /workspace
 
 # Install git
@@ -12,7 +12,7 @@ RUN apt-get update && \
     apt-get install -y git && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
-    
+
 RUN git clone https://github.com/facebookresearch/llama.git
 
 WORKDIR /workspace/llama


### PR DESCRIPTION
**Reason for Change**:

This updates the Python version to 3.9-slim in the Dockerfile for the Llama 2 model, so that the new features specific to Python 3.9 can be used by the inference_api.py.

**Issue Fixed**:

Fixes #797
