### PR TITLE
ci: Make publish helm chart and create release workflows sequential

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -2,7 +2,7 @@ name: publish_helm_chart
 
 on:
   repository_dispatch:
-    types: [ create-release ]
+    types: [ publish-helm-chart ]
   workflow_dispatch:
 
 permissions:
@@ -36,3 +36,15 @@ jobs:
           charts_dir: charts/kaito
           target_dir: charts/kaito
           linting: off
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: [ publish-helm ]
+    steps:
+      - name: 'Dispatch release tag to create a release'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: create-release
+          client-payload: '{"tag": "${{ github.event.client_payload.tag }}"}'
+

--- a/.github/workflows/publish-workspace-mcr-image.yml
+++ b/.github/workflows/publish-workspace-mcr-image.yml
@@ -46,13 +46,13 @@ jobs:
           VERSION: ${{ needs.get-tag.outputs.release-tag }}
           REGISTRY: ${{ secrets.KAITO_MCR_REGISTRY }}/public/aks/kaito
 
-  create-release:
+  publish-helm-chart:
     runs-on: ubuntu-latest
     needs: [ build-publish-mcr-image ]
     steps:
-      - name: 'Dispatch release tag'
+      - name: 'Dispatch release tag for helm chart'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: create-release
+          event-type: publish-helm-chart
           client-payload: '{"tag": "${{ github.event.client_payload.tag }}"}'


### PR DESCRIPTION
**Reason for Change**:
As part of tighten the security for Kaito pipelines, we enforced approval-based for all workflows that perform writing to the repo. One of the side effects of this was a required approval for the auto triggered 'pages build and deployment' workflow which was missing - and it will get canceled when creating a new release - and caused the helm github page repo to not get updated (#808).

As a solution to that, we will change the Make publish helm chart and create release workflows to run sequentially instead of parallel, so new release won't get created until all (including github pages) are updated successfully.


**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: