### PR TITLE
feat: RAG server changes for consistency

### DIFF
--- a/presets/ragengine/main.py
+++ b/presets/ragengine/main.py
@@ -60,7 +60,9 @@ async def index_documents(request: IndexRequest): # TODO: Research async/sync wh
 @app.post("/query", response_model=QueryResponse)
 async def query_index(request: QueryRequest):
     try:
-        llm_params = request.llm_params or {} # Default to empty dict if no params provided
+        llm_params = {}        
+        for key, value in request.model_extra.items():
+            llm_params[key] = value  
         rerank_params = request.rerank_params or {} # Default to empty dict if no params provided
         return rag_ops.query(request.index_name, request.query, request.top_k, llm_params, rerank_params)
     except Exception as e:

--- a/presets/ragengine/models.py
+++ b/presets/ragengine/models.py
@@ -3,7 +3,7 @@
 
 from typing import Dict, List, Optional
 
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 class Document(BaseModel):
     text: str
@@ -22,7 +22,7 @@ class QueryRequest(BaseModel):
     index_name: str
     query: str
     top_k: int = 10
-    llm_params: Optional[Dict] = None  # Accept a dictionary for parameters
+    model_config = ConfigDict(extra='allow')
     rerank_params: Optional[Dict] = None # Accept a dictionary for parameters
 
 class ListDocumentsResponse(BaseModel):

--- a/presets/ragengine/vector_store/base.py
+++ b/presets/ragengine/vector_store/base.py
@@ -111,6 +111,9 @@ class BaseVectorStore(ABC):
         """
         if index_name not in self.index_map:
             raise ValueError(f"No such index: '{index_name}' exists.")
+        if self.llm.model == "":
+            self.llm.set_model()
+
         self.llm.set_params(llm_params)
 
         node_postprocessors = []


### PR DESCRIPTION
**Reason for Change**:
context:
OpenAI style inference API have /v1/models API but Kaito transformer inference does not have this. And Kaito vllm inference need the model as in input.

- Add query model ID step from inference deployment
- Add Error detection if no model ID is needed
- Remove llm_params from QueryRequest for easier input and consistency

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: