### PR TITLE
docs: Update to use Standard_NC24ads_A100_v4 as default SKU in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ kind: Workspace
 metadata:
   name: workspace-phi-3-5-mini
 resource:
-  instanceType: "Standard_NC6s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: phi-3-5
@@ -65,8 +65,8 @@ The workspace status can be tracked by running the following command. When the W
 
 ```sh
 $ kubectl get workspace workspace-phi-3-5-mini
-NAME                     INSTANCE           RESOURCEREADY   INFERENCEREADY   JOBSTARTED   WORKSPACESUCCEEDED   AGE
-workspace-phi-3-5-mini   Standard_NC6s_v3   True            True                          True                 4h15m
+NAME                     INSTANCE                   RESOURCEREADY   INFERENCEREADY   JOBSTARTED   WORKSPACESUCCEEDED   AGE
+workspace-phi-3-5-mini   Standard_NC24ads_A100_v4   True            True                          True                 4h15m
 ```
 
 Next, one can find the inference service's cluster ip and use a temporal `curl` pod to test the service endpoint in the cluster.

--- a/docs/custom-model-integration/custom-deployment-template.yaml
+++ b/docs/custom-model-integration/custom-deployment-template.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-custom-llm
 resource:
-  instanceType: "Standard_NC12s_v3" # Replace with the required VM SKU based on model requirements
+  instanceType: "Standard_NC24ads_A100_v4" # Replace with the required VM SKU based on model requirements
   labelSelector:
     matchLabels:
       apps: custom-llm

--- a/docs/custom-model-integration/reference-image-deployment.yaml
+++ b/docs/custom-model-integration/reference-image-deployment.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-custom-llm
 resource:
-  instanceType: "Standard_NC12s_v3" # Replace with the required VM SKU based on model requirements
+  instanceType: "Standard_NC24ads_A100_v4" # Replace with the required VM SKU based on model requirements
   labelSelector:
     matchLabels:
       apps: custom-llm

--- a/docs/inference/README.md
+++ b/docs/inference/README.md
@@ -12,7 +12,7 @@ kind: Workspace
 metadata:
   name: workspace-falcon-7b
 resource:
-  instanceType: "Standard_NC6s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: falcon-7b
@@ -54,7 +54,7 @@ metadata:
   annotations:
     kaito.sh/runtime: "transformers"
 resource:
-  instanceType: "Standard_NC12s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: falcon-7b
@@ -73,7 +73,7 @@ kind: Workspace
 metadata:
   name: workspace-falcon-7b
 resource:
-  instanceType: "Standard_NC12s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: falcon-7b

--- a/examples/inference/kaito_workspace_falcon_7b-instruct.yaml
+++ b/examples/inference/kaito_workspace_falcon_7b-instruct.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-falcon-7b-instruct
 resource:
-  instanceType: "Standard_NC12s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: falcon-7b-instruct

--- a/examples/inference/kaito_workspace_falcon_7b.yaml
+++ b/examples/inference/kaito_workspace_falcon_7b.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-falcon-7b
 resource:
-  instanceType: "Standard_NC12s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: falcon-7b

--- a/examples/inference/kaito_workspace_falcon_7b_with_adapters.yaml
+++ b/examples/inference/kaito_workspace_falcon_7b_with_adapters.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-falcon-7b
 resource:
-  instanceType: "Standard_NC12s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: falcon-7b

--- a/examples/inference/kaito_workspace_llama2_13b-chat.yaml
+++ b/examples/inference/kaito_workspace_llama2_13b-chat.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-llama-2-13b-chat
 resource:
-  instanceType: "Standard_NC12s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: llama-2-13b-chat

--- a/examples/inference/kaito_workspace_llama2_13b.yaml
+++ b/examples/inference/kaito_workspace_llama2_13b.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-llama-2-13b
 resource:
-  instanceType: "Standard_NC12s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: llama-2-13b

--- a/examples/inference/kaito_workspace_llama2_7b-chat.yaml
+++ b/examples/inference/kaito_workspace_llama2_7b-chat.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-llama-2-7b-chat
 resource:
-  instanceType: "Standard_NC12s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: llama-2-7b-chat

--- a/examples/inference/kaito_workspace_llama2_7b.yaml
+++ b/examples/inference/kaito_workspace_llama2_7b.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-llama-2-7b
 resource:
-  instanceType: "Standard_NC12s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: llama-2-7b

--- a/examples/inference/kaito_workspace_mistral_7b-instruct.yaml
+++ b/examples/inference/kaito_workspace_mistral_7b-instruct.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-mistral-7b-instruct
 resource:
-  instanceType: "Standard_NC12s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: mistral-7b-instruct

--- a/examples/inference/kaito_workspace_mistral_7b.yaml
+++ b/examples/inference/kaito_workspace_mistral_7b.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-mistral-7b
 resource:
-  instanceType: "Standard_NC12s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: mistral-7b

--- a/examples/inference/kaito_workspace_phi_2.yaml
+++ b/examples/inference/kaito_workspace_phi_2.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-phi-2
 resource:
-  instanceType: "Standard_NC6s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: phi-2

--- a/examples/inference/kaito_workspace_phi_3.5-instruct.yaml
+++ b/examples/inference/kaito_workspace_phi_3.5-instruct.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-phi-3-5-mini
 resource:
-  instanceType: "Standard_NC6s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: phi-3-5

--- a/examples/inference/kaito_workspace_phi_3_mini_128k.yaml
+++ b/examples/inference/kaito_workspace_phi_3_mini_128k.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-phi-3-mini
 resource:
-  instanceType: "Standard_NC6s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: phi-3

--- a/examples/inference/kaito_workspace_phi_3_mini_4k.yaml
+++ b/examples/inference/kaito_workspace_phi_3_mini_4k.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-phi-3-mini
 resource:
-  instanceType: "Standard_NC6s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: phi-3

--- a/examples/inference/kaito_workspace_phi_3_with_adapters.yaml
+++ b/examples/inference/kaito_workspace_phi_3_with_adapters.yaml
@@ -3,7 +3,7 @@ kind: Workspace
 metadata:
   name: workspace-phi-3-mini-adapter
 resource:
-  instanceType: "Standard_NC6s_v3"
+  instanceType: "Standard_NC24ads_A100_v4"
   labelSelector:
     matchLabels:
       apps: phi-3-adapter


### PR DESCRIPTION
v3 GPU SKUs have been deprecated by Azure. Hence, using v4 GPU as a default SKU in the documentation. 