### PR TITLE
fix: DeepSeek Model Naming

### DIFF
--- a/pkg/workspace/inference/preset-inference-types.go
+++ b/pkg/workspace/inference/preset-inference-types.go
@@ -54,7 +54,7 @@ var (
 		"gpu_ids":       DefaultGPUIds,
 	}
 
-	DefaultVLLMCommand         = "python3 /workspace/vllm/inference_api.py"
+	DefaultVLLMCommand          = "python3 /workspace/vllm/inference_api.py"
 	DefaultTransformersMainFile = "/workspace/tfs/inference_api.py"
 
 	DefaultImagePullSecrets = []corev1.LocalObjectReference{}

--- a/pkg/workspace/inference/preset-inference-types.go
+++ b/pkg/workspace/inference/preset-inference-types.go
@@ -55,7 +55,7 @@ var (
 	}
 
 	DefaultVLLMCommand         = "python3 /workspace/vllm/inference_api.py"
-	DefautTransformersMainFile = "/workspace/tfs/inference_api.py"
+	DefaultTransformersMainFile = "/workspace/tfs/inference_api.py"
 
 	DefaultImagePullSecrets = []corev1.LocalObjectReference{}
 )

--- a/presets/workspace/models/deepseek/model.go
+++ b/presets/workspace/models/deepseek/model.go
@@ -69,7 +69,7 @@ func (*llama8b) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "deepseek-r1-distill-llama-8b",
+				ModelName:      PresetDeepSeekR1DistillLlama8BModel,
 				ModelRunParams: deepseekLlama8bRunParamsVLLM,
 			},
 			// vllm requires the model specification to be exactly divisible by
@@ -111,7 +111,7 @@ func (*qwen14b) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "deepseek-r1-distill-qwen-14b",
+				ModelName:      PresetDeepSeekR1DistillQwen14BModel,
 				ModelRunParams: deepseekQwen14bRunParamsVLLM,
 			},
 			// vllm requires the model specification to be exactly divisible by

--- a/presets/workspace/models/deepseek/model.go
+++ b/presets/workspace/models/deepseek/model.go
@@ -64,12 +64,12 @@ func (*llama8b) GetInferenceParameters() *model.PresetParam {
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetDeepseekInference,
 				TorchRunParams:    inference.DefaultAccelerateParams,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    deepseekLlama8bRunParams,
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "/workspace/vllm/weights",
+				ModelName:      "deepseek-r1-distill-llama-8b",
 				ModelRunParams: deepseekLlama8bRunParamsVLLM,
 			},
 			// vllm requires the model specification to be exactly divisible by
@@ -106,12 +106,12 @@ func (*qwen14b) GetInferenceParameters() *model.PresetParam {
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetDeepseekInference,
 				TorchRunParams:    inference.DefaultAccelerateParams,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    deepseekQwen14bRunParams,
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "/workspace/vllm/weights",
+				ModelName:      "deepseek-r1-distill-qwen-14b",
 				ModelRunParams: deepseekQwen14bRunParamsVLLM,
 			},
 			// vllm requires the model specification to be exactly divisible by

--- a/presets/workspace/models/falcon/model.go
+++ b/presets/workspace/models/falcon/model.go
@@ -73,7 +73,7 @@ func (*falcon7b) GetInferenceParameters() *model.PresetParam {
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetFalconInference,
 				TorchRunParams:    inference.DefaultAccelerateParams,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    falconRunParams,
 			},
 			VLLM: model.VLLMParam{
@@ -135,7 +135,7 @@ func (*falcon7bInst) GetInferenceParameters() *model.PresetParam {
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetFalconInference,
 				TorchRunParams:    inference.DefaultAccelerateParams,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    falconRunParams,
 			},
 			VLLM: model.VLLMParam{
@@ -180,7 +180,7 @@ func (*falcon40b) GetInferenceParameters() *model.PresetParam {
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetFalconInference,
 				TorchRunParams:    inference.DefaultAccelerateParams,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    falconRunParams,
 			},
 			VLLM: model.VLLMParam{
@@ -235,7 +235,7 @@ func (*falcon40bInst) GetInferenceParameters() *model.PresetParam {
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetFalconInference,
 				TorchRunParams:    inference.DefaultAccelerateParams,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    falconRunParams,
 			},
 			VLLM: model.VLLMParam{

--- a/presets/workspace/models/mistral/model.go
+++ b/presets/workspace/models/mistral/model.go
@@ -61,7 +61,7 @@ func (*mistral7b) GetInferenceParameters() *model.PresetParam {
 				TorchRunParams:    inference.DefaultAccelerateParams,
 				ModelRunParams:    mistralRunParams,
 				BaseCommand:       baseCommandPresetMistralInference,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
@@ -118,7 +118,7 @@ func (*mistral7bInst) GetInferenceParameters() *model.PresetParam {
 				TorchRunParams:    inference.DefaultAccelerateParams,
 				ModelRunParams:    mistralRunParams,
 				BaseCommand:       baseCommandPresetMistralInference,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,

--- a/presets/workspace/models/phi2/model.go
+++ b/presets/workspace/models/phi2/model.go
@@ -53,7 +53,7 @@ func (*phi2) GetInferenceParameters() *model.PresetParam {
 				TorchRunParams:    inference.DefaultAccelerateParams,
 				ModelRunParams:    phiRunParams,
 				BaseCommand:       baseCommandPresetPhiInference,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,

--- a/presets/workspace/models/phi3/model.go
+++ b/presets/workspace/models/phi3/model.go
@@ -77,7 +77,7 @@ func (*phi3Mini4KInst) GetInferenceParameters() *model.PresetParam {
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetPhiInference,
 				TorchRunParams:    inference.DefaultAccelerateParams,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    phiRunParams,
 			},
 			VLLM: model.VLLMParam{
@@ -130,7 +130,7 @@ func (*phi3Mini128KInst) GetInferenceParameters() *model.PresetParam {
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetPhiInference,
 				TorchRunParams:    inference.DefaultAccelerateParams,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    phiRunParams,
 			},
 			VLLM: model.VLLMParam{
@@ -181,7 +181,7 @@ func (*phi3_5MiniInst) GetInferenceParameters() *model.PresetParam {
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetPhiInference,
 				TorchRunParams:    inference.DefaultAccelerateParams,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    phiRunParams,
 			},
 			VLLM: model.VLLMParam{
@@ -234,7 +234,7 @@ func (*Phi3Medium4kInstruct) GetInferenceParameters() *model.PresetParam {
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetPhiInference,
 				TorchRunParams:    inference.DefaultAccelerateParams,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    phiRunParams,
 			},
 			VLLM: model.VLLMParam{
@@ -287,7 +287,7 @@ func (*Phi3Medium128kInstruct) GetInferenceParameters() *model.PresetParam {
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetPhiInference,
 				TorchRunParams:    inference.DefaultAccelerateParams,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    phiRunParams,
 			},
 			VLLM: model.VLLMParam{

--- a/presets/workspace/models/qwen/model.go
+++ b/presets/workspace/models/qwen/model.go
@@ -53,7 +53,7 @@ func (*qwen2_5Coder7BInstruct) GetInferenceParameters() *model.PresetParam {
 				TorchRunParams:    inference.DefaultAccelerateParams,
 				ModelRunParams:    qwenRunParams,
 				BaseCommand:       baseCommandPresetQwenInference,
-				InferenceMainFile: inference.DefautTransformersMainFile,
+				InferenceMainFile: inference.DefaultTransformersMainFile,
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,


### PR DESCRIPTION
**Reason for Change**:
Nit on model naming and typo