### PR TITLE
chore: bump gpu-provisioner in terraform sample

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -6,7 +6,7 @@ variable "location" {
 
 variable "kaito_gpu_provisioner_version" {
   type        = string
-  default     = "0.2.1"
+  default     = "0.3.1"
   description = "kaito gpu provisioner version"
 }
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->
Bumping gpu-provisioner version to latest 0.3.1