### PR TITLE
chore: Curb the permissions for publishing data to third party dashboards.

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,8 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
 
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -19,6 +19,8 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
 
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@3041bf56c941b39c61721a86cd11f3bb1338122a # v5.2.0

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -20,6 +20,8 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
 
       - name: 'Checkout Repository'
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/e2e-base-setup.yaml
+++ b/.github/workflows/e2e-base-setup.yaml
@@ -51,6 +51,8 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -21,6 +21,8 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -28,6 +28,8 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/markdown-link-check.yml
+++ b/.github/workflows/markdown-link-check.yml
@@ -17,6 +17,8 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: gaurav-nelson/github-action-markdown-link-check@5c5dfc0ac2e225883c0e5f03a85311ec2830d368 # v1

--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -16,6 +16,8 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
 
       - uses: thehanimo/pr-title-checker@7fbfe05602bdd86f926d3fb3bccb6f3aed43bc70 # v1.4.3
         with:

--- a/.github/workflows/publish-rag-controller-gh-image.yml
+++ b/.github/workflows/publish-rag-controller-gh-image.yml
@@ -36,6 +36,8 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/publish-rag-service-gh-image.yml
+++ b/.github/workflows/publish-rag-service-gh-image.yml
@@ -36,6 +36,8 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/publish-workspace-gh-image.yml
+++ b/.github/workflows/publish-workspace-gh-image.yml
@@ -36,6 +36,8 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
 
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/unit-tests-ragengine.yml
+++ b/.github/workflows/unit-tests-ragengine.yml
@@ -28,6 +28,8 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
 
       - name: Check out the code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -28,6 +28,8 @@ jobs:
         uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
         with:
           egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
 
       - name: Check out the code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION
### **Possible Enhance Security by Disabling Sudo & Telemetry in Workflows**  

This PR updates workflows in the this repository to enable the following security configurations by default:  

- **`disable-sudo: true`** → Prevents unnecessary privilege escalations.  
- **`disable-telemetry: true`** → Disables telemetry to enhance privacy.  

These settings provide a **baseline security enhancement**, but users can **opt to enable full-level access** based on their workflow needs and understanding.  

These flags serve as a good starting point.  

📌 **References:**  

- [Disable Telemetry](https://docs.stepsecurity.io/harden-runner/how-tos/disable-telemetry/)  
- [Disable Sudo](https://docs.stepsecurity.io/harden-runner/how-tos/disable-sudo/)  

Thank you so much for letting me add this to your repo, please accept if this feels good. 