### PR TITLE
chore: RAG pipeline leaking cluster patch

### DIFF
--- a/.github/actions/e2e-base-setup/action.yml
+++ b/.github/actions/e2e-base-setup/action.yml
@@ -1,0 +1,206 @@
+name: "e2e-base-setup"
+description: "Composite action for e2e base setup"
+
+inputs:
+  git_sha:
+    description: "Git commit SHA"
+    required: true
+  node_provisioner:
+    description: "Provisioner type"
+    required: false
+    default: "gpuprovisioner"
+  tag:
+    description: "Tag"
+    required: false
+  isRelease:
+    description: "Is Release"
+    required: false
+    default: "false"
+  registry:
+    description: "Registry"
+    required: false
+  region:
+    description: "the azure location to run the e2e test in"
+    required: false
+    default: "eastus"
+  k8s_version:
+    description: "Kubernetes version"
+    required: false
+    default: "1.30.0"
+
+outputs:
+  cluster_name:
+    description: "Cluster name"
+  registry:
+    description: "Registry value"
+  run_llama_13b:
+    description: "Whether to run llama 13b"
+
+env:
+  GO_VERSION: "1.23"
+
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      with:
+        ref: ${{ inputs.git_sha }}
+
+    - name: Set e2e Resource and Cluster Name
+      shell: bash
+      run: |
+        rand=$(git rev-parse --short ${{ inputs.git_sha }})
+        if [ -z "$rand" ]; then
+          rand=$RANDOM
+        fi
+
+        echo "VERSION=${rand}" >> $GITHUB_ENV
+        echo "CLUSTER_NAME=${{ inputs.node_provisioner }}${rand}" >> $GITHUB_ENV
+        echo "REGISTRY=${{ inputs.node_provisioner }}${rand}.azurecr.io" >> $GITHUB_ENV
+        echo "RUN_LLAMA_13B=false" >> $GITHUB_ENV
+
+    - name: Set Registry
+      if: ${{ inputs.isRelease == 'true' }}
+      shell: bash
+      run: |
+        echo "REGISTRY=${{ inputs.registry }}" >> $GITHUB_ENV
+        echo "VERSION=$(echo ${{ inputs.tag }} | tr -d v)" >> $GITHUB_ENV
+
+    - name: Remove existing Go modules directory
+      shell: bash
+      run: sudo rm -rf ~/go/pkg/mod
+
+    - name: Set up Go 1.23
+      uses: actions/setup-go@v5.2.0
+      with:
+        go-version: "1.23"
+
+    - name: Install Azure CLI latest
+      shell: bash
+      run: |
+        if ! which az > /dev/null; then
+          echo "Azure CLI not found. Installing..."
+          curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+        else
+          echo "Azure CLI already installed."
+        fi
+
+    - name: Azure CLI Login
+      shell: bash
+      run: |
+        az login --identity
+
+    - name: Install Helm
+      uses: azure/setup-helm@v4
+
+    - name: Create Resource Group
+      shell: bash
+      run: |
+        make create-rg
+      env:
+        AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}
+
+    - name: Create ACR
+      shell: bash
+      run: |
+        make create-acr
+      env:
+        AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}
+        AZURE_ACR_NAME: ${{ env.CLUSTER_NAME }}
+
+    - name: Create Azure Identity
+      uses: azure/CLI@v2.1.0
+      with:
+        inlineScript: |
+          az identity create --name "${{ inputs.node_provisioner }}Identity" --resource-group "${{ env.CLUSTER_NAME }}"
+
+    - name: Generate APIs
+      shell: bash
+      run: |
+        make generate
+
+    - name: build KAITO image
+      if: ${{ inputs.isRelease == 'false' }}
+      shell: bash
+      run: |
+        make docker-build-workspace
+
+    - name: create cluster
+      shell: bash
+      run: |
+        if [ "${{ inputs.node_provisioner }}" == "gpuprovisioner" ]; then
+          make create-aks-cluster
+        else
+          make create-aks-cluster-for-karpenter
+        fi
+      env:
+        AZURE_ACR_NAME: ${{ env.CLUSTER_NAME }}
+        AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}
+        AZURE_CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
+        AZURE_LOCATION: ${{ inputs.region }}
+        AKS_K8S_VERSION: ${{ inputs.k8s_version }}
+
+    - name: Create Identities and Permissions for ${{ inputs.node_provisioner }}
+      shell: bash
+      run: |
+        AZURE_SUBSCRIPTION_ID=$E2E_SUBSCRIPTION_ID \
+        make generate-identities
+      env:
+        AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}
+        AZURE_CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
+        TEST_SUITE: ${{ inputs.node_provisioner }}
+
+    - name: Install gpu-provisioner helm chart
+      if: ${{ inputs.node_provisioner == 'gpuprovisioner' }}
+      shell: bash
+      run: |
+        AZURE_TENANT_ID=$E2E_TENANT_ID \
+        AZURE_SUBSCRIPTION_ID=$E2E_SUBSCRIPTION_ID \
+        make gpu-provisioner-helm
+      env:
+        AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}
+        AZURE_CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
+
+    - name: Install KAITO Workspace helm chart
+      shell: bash
+      run: |
+        make az-patch-install-helm
+        kubectl wait --for=condition=available deploy "kaito-workspace" -n kaito-workspace --timeout=300s
+      env:
+        AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}
+        AZURE_CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
+        REGISTRY: ${{ env.REGISTRY }}
+        VERSION: ${{ env.VERSION }}
+        TEST_SUITE: ${{ inputs.node_provisioner }}
+
+    - name: Set up E2E ACR Credentials and Secret
+      shell: bash
+      run: |
+        ACR_USERNAME=$(az acr credential show --name "${{ env.CLUSTER_NAME }}" --resource-group "${{ env.CLUSTER_NAME }}" --query "username" -o tsv)
+        ACR_PASSWORD=$(az acr credential show --name "${{ env.CLUSTER_NAME }}" --resource-group "${{ env.CLUSTER_NAME }}" --query "passwords[0].value" -o tsv)
+
+        if [ -z "$ACR_USERNAME" ] || [ -z "$ACR_PASSWORD" ]; then
+          echo "Failed to retrieve ACR credentials"
+          exit 1
+        fi
+
+        kubectl create secret docker-registry "${{ env.CLUSTER_NAME }}-acr-secret" \
+          --docker-server="${{ env.CLUSTER_NAME }}.azurecr.io" \
+          --docker-username="${ACR_USERNAME}" \
+          --docker-password="${ACR_PASSWORD}"
+
+    # Add Private-Hosted ACR secret for private models like llama
+    - name: Add Private-Hosted ACR Secret Credentials
+      shell: bash
+      run: |
+        E2E_AMRT_SECRET_NAME=$(echo "$E2E_AMRT_SECRET_NAME" | sed 's/[\"'\'']//g')
+        if kubectl get secret "$E2E_AMRT_SECRET_NAME" >/dev/null 2>&1; then
+          echo "Secret $E2E_AMRT_SECRET_NAME already exists. Skipping creation."
+        else
+          kubectl create secret docker-registry "$E2E_AMRT_SECRET_NAME" \
+            --docker-server="$E2E_ACR_AMRT_USERNAME.azurecr.io" \
+            --docker-username="$E2E_ACR_AMRT_USERNAME" \
+            --docker-password="$E2E_ACR_AMRT_PASSWORD"
+          echo "Secret $E2E_AMRT_SECRET_NAME created successfully."
+        fi

--- a/.github/workflows/e2e-workflow.yml
+++ b/.github/workflows/e2e-workflow.yml
@@ -122,6 +122,11 @@ jobs:
           AI_MODELS_REGISTRY_SECRET=$E2E_AMRT_SECRET_NAME \
           GINKGO_LABEL=FastCheck \
           make kaito-workspace-e2e-test
+        env:
+          AZURE_CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
+          E2E_ACR_REGISTRY: ${{ env.CLUSTER_NAME }}.azurecr.io
+          E2E_ACR_REGISTRY_SECRET: ${{ env.CLUSTER_NAME }}-acr-secret
+
 
       - name: Cleanup e2e resources
         if: ${{ always() }}
@@ -131,4 +136,4 @@ jobs:
         with:
           inlineScript: |
             set +e
-            az group delete --name "${AZURE_CLUSTER_NAME}" --yes --no-wait || true
+            az group delete --name "${AZURE_RESOURCE_GROUP}" --yes --no-wait || true

--- a/.github/workflows/e2e-workflow.yml
+++ b/.github/workflows/e2e-workflow.yml
@@ -26,36 +26,44 @@ on:
         default: "1.30.0"
 
 jobs:
-  base-setup:
-    uses: ./.github/workflows/e2e-base-setup.yaml
-    with:
-      git_sha: ${{ inputs.git_sha }}
-      node_provisioner: ${{ inputs.node_provisioner }}
-      tag: ${{ inputs.tag }}
-      isRelease: ${{ inputs.isRelease }}
-      registry: ${{ inputs.registry }}
-      region: ${{ inputs.region }}
-      k8s_version: ${{ inputs.k8s_version }}
-
   e2e-tests:
     runs-on: [ "self-hosted", "hostname:kaito-e2e-github-runner" ]
     name: e2e-tests-${{ inputs.node_provisioner }}
-    needs: base-setup
+    environment: e2e-test
     permissions:
       contents: read
       id-token: write # This is required for requesting the JWT
     
     env:
-      AZURE_CLUSTER_NAME: ${{ needs.base-setup.outputs.cluster_name }}
-      RUN_LLAMA_13B: ${{ needs.base-setup.outputs.run_llama_13b }}
       TEST_SUITE: ${{ inputs.node_provisioner }}
-      E2E_ACR_REGISTRY: ${{ needs.base-setup.outputs.cluster_name }}.azurecr.io
-      E2E_ACR_REGISTRY_SECRET: ${{ needs.base-setup.outputs.cluster_name }}-acr-secret
       GO_VERSION: "1.23"
       KARPENTER_NAMESPACE: "karpenter"
       GPU_PROVISIONER_NAMESPACE: "gpu-provisioner"
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.git_sha }}
+
+      - name: Run e2e-base-setup composite action
+        id: base-setup
+        uses: ./.github/actions/e2e-base-setup
+        with:
+          git_sha: ${{ inputs.git_sha }}
+          node_provisioner: ${{ inputs.node_provisioner }}
+          tag: ${{ inputs.tag }}
+          isRelease: ${{ inputs.isRelease }}
+          region: ${{ inputs.region }}
+          k8s_version: ${{ inputs.k8s_version }}
+
       - name: Set Registry
         if: ${{ inputs.isRelease }}
         run: |
@@ -67,14 +75,14 @@ jobs:
         run: |
           make docker-build-adapter
         env:
-          REGISTRY: ${{ env.E2E_ACR_REGISTRY }}
+          REGISTRY: ${{ env.CLUSTER_NAME }}.azurecr.io
 
       - name: build dataset image
         shell: bash
         run: |
           make docker-build-dataset
         env:
-          REGISTRY: ${{ env.E2E_ACR_REGISTRY }}
+          REGISTRY: ${{ env.CLUSTER_NAME }}.azurecr.io
       
       - name: Remove existing Go modules directory
         run: sudo rm -rf ~/go/pkg/mod
@@ -102,6 +110,10 @@ jobs:
           AI_MODELS_REGISTRY=$E2E_ACR_AMRT_USERNAME.azurecr.io \
           AI_MODELS_REGISTRY_SECRET=$E2E_AMRT_SECRET_NAME \
           make kaito-workspace-e2e-test
+        env:
+          AZURE_CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
+          E2E_ACR_REGISTRY: ${{ env.CLUSTER_NAME }}.azurecr.io
+          E2E_ACR_REGISTRY_SECRET: ${{ env.CLUSTER_NAME }}-acr-secret
 
       - name: Run fast e2e test
         if: ${{ !inputs.isRelease }}
@@ -113,6 +125,8 @@ jobs:
 
       - name: Cleanup e2e resources
         if: ${{ always() }}
+        env:
+          AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}
         uses: azure/CLI@v2.1.0
         with:
           inlineScript: |

--- a/.github/workflows/ragengine-e2e-workflow.yml
+++ b/.github/workflows/ragengine-e2e-workflow.yml
@@ -26,36 +26,43 @@ on:
         default: "1.30.0"
 
 jobs:
-  base-setup:
-    uses: ./.github/workflows/e2e-base-setup.yaml
-    with:
-      git_sha: ${{ inputs.git_sha }}
-      node_provisioner: ${{ inputs.node_provisioner }}
-      tag: ${{ inputs.tag }}
-      isRelease: ${{ inputs.isRelease }}
-      registry: ${{ inputs.registry }}
-      region: ${{ inputs.region }}
-      k8s_version: ${{ inputs.k8s_version }}
-
   e2e-tests:
     runs-on: [ "self-hosted", "hostname:kaito-e2e-github-runner" ]
-    name: e2e-tests-${{ inputs.node_provisioner }}
-    needs: base-setup
+    environment: e2e-test
     permissions:
       contents: read
-      id-token: write # This is required for requesting the JWT
+      id-token: write
     
     env:
-      AZURE_CLUSTER_NAME: ${{ needs.base-setup.outputs.cluster_name }}
-      AZURE_RESOURCE_GROUP: ${{ needs.base-setup.outputs.cluster_name }}
-      TEST_SUITE: ${{ inputs.node_provisioner }}
-      E2E_ACR_REGISTRY: ${{ needs.base-setup.outputs.cluster_name }}.azurecr.io
-      E2E_ACR_REGISTRY_SECRET: ${{ needs.base-setup.outputs.cluster_name }}-acr-secret
+      TEST_SUITE: ${{ inputs.node_provisioner }}      
       GO_VERSION: "1.23"
       KARPENTER_NAMESPACE: "karpenter"
       GPU_PROVISIONER_NAMESPACE: "gpu-provisioner"
 
     steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0080882f6c36860b6ba35c610c98ce87d4e2f26f # v2.10.2
+        with:
+          egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ inputs.git_sha }}
+      
+      - name: Run e2e-base-setup composite action
+        id: base-setup
+        uses: ./.github/actions/e2e-base-setup
+        with:
+          git_sha: ${{ inputs.git_sha }}
+          node_provisioner: ${{ inputs.node_provisioner }}
+          tag: ${{ inputs.tag }}
+          isRelease: ${{ inputs.isRelease }}
+          region: ${{ inputs.region }}
+          k8s_version: ${{ inputs.k8s_version }}
+
       - name: Set Registry
         if: ${{ inputs.isRelease }}
         run: |
@@ -68,7 +75,7 @@ jobs:
         run: |
           make docker-build-ragengine
         env:
-          REGISTRY: ${{ env.E2E_ACR_REGISTRY }}
+          REGISTRY: ${{ env.CLUSTER_NAME }}.azurecr.io
       
       - name: Remove existing Go modules directory
         run: sudo rm -rf ~/go/pkg/mod
@@ -76,7 +83,7 @@ jobs:
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5.2.0
         with:
-          go-version: ${{ env.GO_VERSION  }}
+          go-version: ${{ env.GO_VERSION }}
 
       - name: Install Helm
         uses: azure/setup-helm@v4
@@ -87,18 +94,26 @@ jobs:
           make az-patch-install-ragengine-helm
           kubectl wait --for=condition=available deploy "kaito-ragengine" -n kaito-ragengine --timeout=300s
         env:
-          REGISTRY: ${{ env.E2E_ACR_REGISTRY }}
+          REGISTRY: ${{ env.CLUSTER_NAME }}.azurecr.io
+          AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}
+          AZURE_CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
       
       - name: Run e2e test
         run: |
           AI_MODELS_REGISTRY=$E2E_ACR_AMRT_USERNAME.azurecr.io \
           AI_MODELS_REGISTRY_SECRET=$E2E_AMRT_SECRET_NAME \
           make kaito-ragengine-e2e-test
+        env:
+          AZURE_CLUSTER_NAME: ${{ env.CLUSTER_NAME }}
+          E2E_ACR_REGISTRY: ${{ env.CLUSTER_NAME }}.azurecr.io
+          E2E_ACR_REGISTRY_SECRET: ${{ env.CLUSTER_NAME }}-acr-secret
 
       - name: Cleanup e2e resources
         if: ${{ always() }}
+        env:
+          AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}
         uses: azure/CLI@v2.1.0
         with:
           inlineScript: |
             set +e
-            az group delete --name "${AZURE_CLUSTER_NAME}" --yes --no-wait || true
+            az group delete --name "${AZURE_RESOURCE_GROUP}" --yes --no-wait || true

--- a/.github/workflows/ragengine-e2e.yml
+++ b/.github/workflows/ragengine-e2e.yml
@@ -1,0 +1,34 @@
+name: ragengine-e2e-test
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    paths:
+      - 'test/**'
+      - 'pkg/ragengine/**'
+      - '.github/**'
+
+env:
+  GO_VERSION: "1.22"
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  contents: read # This is required for actions/checkout
+
+jobs:
+  run-e2e:
+    strategy:
+      fail-fast: false
+      matrix:
+        node-provisioner: [gpuprovisioner] # WIP: azkarpenter]
+    permissions:
+      contents: read
+      id-token: write
+      statuses: write
+    uses: ./.github/workflows/ragengine-e2e-workflow.yml
+    with:
+      git_sha: ${{ github.event.pull_request.head.sha }}
+      node_provisioner: ${{ matrix.node-provisioner }}

--- a/pkg/ragengine/controllers/preset-rag.go
+++ b/pkg/ragengine/controllers/preset-rag.go
@@ -98,8 +98,8 @@ func CreatePresetRAG(ctx context.Context, ragEngineObj *v1alpha1.RAGEngine, revi
 
 	}
 	commands := utils.ShellCmd("python3 main.py")
-	// TODO: provide this image
-	image := "mcr.microsoft.com/aks/kaito/kaito-rag-service:0.0.1"
+
+	image := "aimodelsregistrytest.azurecr.io/kaito-rag-service:0.1.2" //TODO: Change to the mcr image when release
 
 	imagePullSecretRefs := []corev1.LocalObjectReference{}
 

--- a/pkg/ragengine/controllers/preset-rag_test.go
+++ b/pkg/ragengine/controllers/preset-rag_test.go
@@ -31,7 +31,7 @@ func TestCreatePresetRAG(t *testing.T) {
 				c.On("Create", mock.IsType(context.TODO()), mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(nil)
 			},
 			expectedCmd:   "/bin/sh -c python3 main.py",
-			expectedImage: "aimodelsregistrytest.azurecr.io/kaito-rag-service:0.0.7", //TODO: Change to the mcr image when release
+			expectedImage: "aimodelsregistrytest.azurecr.io/kaito-rag-service:0.1.2", //TODO: Change to the mcr image when release
 		},
 	}
 

--- a/pkg/ragengine/controllers/preset-rag_test.go
+++ b/pkg/ragengine/controllers/preset-rag_test.go
@@ -31,7 +31,7 @@ func TestCreatePresetRAG(t *testing.T) {
 				c.On("Create", mock.IsType(context.TODO()), mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(nil)
 			},
 			expectedCmd:   "/bin/sh -c python3 main.py",
-			expectedImage: "mcr.microsoft.com/aks/kaito/kaito-rag-service:0.0.1",
+			expectedImage: "aimodelsregistrytest.azurecr.io/kaito-rag-service:0.0.7", //TODO: Change to the mcr image when release
 		},
 	}
 

--- a/test/rage2e/rag_test.go
+++ b/test/rage2e/rag_test.go
@@ -484,7 +484,7 @@ func createAndValidateQueryPod(ragengineObj *kaitov1alpha1.RAGEngine) error {
 				return false
 			}
 
-			searchQuerySuccess := "'text': '\\\\nKaito is an operator that automates the AI/ML model inference or tuning workload in a Kubernetes cluster.\\\\n"
+			searchQuerySuccess := "\\nKaito is an operator that automates the AI/ML model inference or tuning workload in a Kubernetes cluster.\\n\\n\\n"
 
 			return strings.Contains(logs, searchQuerySuccess)
 		}, 2*time.Minute, utils.PollInterval).Should(BeTrue(), "Failed to wait for query logs to be ready")
@@ -542,7 +542,7 @@ func GenerateQueryPodManifest(namespace, serviceName string) *v1.Pod { // TODO: 
     }
 }'`
 
-	indexPod := &v1.Pod{
+	queryPod := &v1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "querypod",
 			Namespace: namespace,
@@ -560,5 +560,5 @@ func GenerateQueryPodManifest(namespace, serviceName string) *v1.Pod { // TODO: 
 		},
 	}
 
-	return indexPod
+	return queryPod
 }


### PR DESCRIPTION
**Reason for Change**:
1. Use composite steps for avoiding cleaning step is not run when interrupted.
2. Add RAG pipeline back when rag engine related codes are changed.
3. Use the image aimodelsregistrytest.azurecr.io/kaito-rag-service:0.0.7 for now, will change it back when MCR image is good
4. Changed the image in the unit test too

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: