### PR TITLE
fix: Excluding Metadata to LLM during Response Synthesis & Updating default top_k

### DIFF
--- a/presets/ragengine/models.py
+++ b/presets/ragengine/models.py
@@ -28,7 +28,7 @@ class IndexRequest(BaseModel):
 class QueryRequest(BaseModel):
     index_name: str
     query: str
-    top_k: int = 10
+    top_k: int = 5
     # Accept a dictionary for our LLM parameters
     llm_params: Optional[Dict[str, Any]] = Field(
         default_factory=dict,

--- a/presets/ragengine/vector_store/base.py
+++ b/presets/ragengine/vector_store/base.py
@@ -191,7 +191,7 @@ class BaseVectorStore(ABC):
         """Common logic for adding a single document."""
         if index_name not in self.index_map:
             raise ValueError(f"No such index: '{index_name}' exists.")
-        llama_doc = LlamaDocument(id_=doc_id, text=document.text, metadata=document.metadata)
+        llama_doc = LlamaDocument(id_=doc_id, text=document.text, metadata=document.metadata, excluded_llm_metadata_keys=[key for key in document.metadata.keys()])
 
         if self.use_rwlock:
             async with self.rwlock.writer_lock:


### PR DESCRIPTION
**Reason for Change**:
https://docs.llamaindex.ai/en/stable/module_guides/loading/documents_and_nodes/usage_documents/
"Typically, a document might have many metadata keys, but you might not want all of them visible to the LLM during response synthesis."