### PR TITLE
fix: Adding Preset name validation in validateCreateWithInference

### DIFF
--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -294,6 +294,11 @@ func (r *ResourceSpec) validateCreateWithInference(inference *InferenceSpec) (er
 	var presetName string
 	if inference.Preset != nil {
 		presetName = strings.ToLower(string(inference.Preset.Name))
+		// since inference.Preset exists, we must validate preset name
+		if !plugin.IsValidPreset(presetName) {
+			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("Unsupported inference preset name %s", presetName), "presetName"))
+			return errs
+		}
 	}
 	instanceType := string(r.InstanceType)
 

--- a/api/v1alpha1/workspace_validation_test.go
+++ b/api/v1alpha1/workspace_validation_test.go
@@ -224,6 +224,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		modelPerGPUMemory   string
 		modelTotalGPUMemory string
 		preset              bool
+		presetNameOverride  string
 		errContent          string // Content expect error to include, if any
 		expectErrs          bool
 		validateTuning      bool // To indicate if we are testing tuning validation
@@ -362,6 +363,17 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 			expectErrs:     true,
 			validateTuning: true,
 		},
+		{
+			name: "Invalid Preset Name",
+			resourceSpec: &ResourceSpec{
+				InstanceType: "Standard_NC6s_v3",
+				Count:        pointerToInt(2),
+			},
+			errContent:         "Unsupported inference preset name",
+			preset:             true,
+			presetNameOverride: "Invalid-Preset-Name",
+			expectErrs:         true,
+		},
 	}
 
 	t.Setenv("CLOUD_PROVIDER", consts.AzureCloudName)
@@ -386,10 +398,15 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 				var spec InferenceSpec
 
 				if tc.preset {
+					presetName := ModelName("test-validation")
+					if tc.presetNameOverride != "" {
+						presetName = ModelName(tc.presetNameOverride)
+					}
+
 					spec = InferenceSpec{
 						Preset: &PresetSpec{
 							PresetMeta: PresetMeta{
-								Name: ModelName("test-validation"),
+								Name: presetName,
 							},
 						},
 					}


### PR DESCRIPTION
**Reason for Change**:
Adding Preset name validation in validateCreateWithInference

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Fixes #903 
**Notes for Reviewers**: