### PR TITLE
feat: port preset name validation to v1beta1 webhook

### DIFF
--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -294,9 +294,9 @@ func (r *ResourceSpec) validateCreateWithInference(inference *InferenceSpec) (er
 	var presetName string
 	if inference.Preset != nil {
 		presetName = strings.ToLower(string(inference.Preset.Name))
-		// since inference.Preset exists, we must validate preset name
+		// Since inference.Preset exists, we must validate preset name.
 		if !plugin.IsValidPreset(presetName) {
-			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("Unsupported inference preset name %s", presetName), "presetName"))
+			// Return to skip the rest of checks, the Inference spec validation will return proper err msg.
 			return errs
 		}
 	}
@@ -415,6 +415,8 @@ func (i *InferenceSpec) validateCreate(ctx context.Context, namespace string) (e
 		// Validate preset name
 		if !plugin.IsValidPreset(presetName) {
 			errs = errs.Also(apis.ErrInvalidValue(fmt.Sprintf("Unsupported inference preset name %s", presetName), "presetName"))
+			// Need to return here. Otherwise, a panic will be hit when doing following checks.
+			return errs
 		}
 		// Validate private preset has private image specified
 		if plugin.KaitoModelRegister.MustGet(string(i.Preset.Name)).GetInferenceParameters().ImageAccessMode == string(ModelImageAccessModePrivate) &&

--- a/api/v1alpha1/workspace_validation_test.go
+++ b/api/v1alpha1/workspace_validation_test.go
@@ -369,10 +369,10 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 				InstanceType: "Standard_NC6s_v3",
 				Count:        pointerToInt(2),
 			},
-			errContent:         "Unsupported inference preset name",
+			errContent:         "",
 			preset:             true,
 			presetNameOverride: "Invalid-Preset-Name",
-			expectErrs:         true,
+			expectErrs:         false,
 		},
 	}
 
@@ -559,7 +559,7 @@ func TestInferenceSpecValidateCreate(t *testing.T) {
 					},
 				},
 			},
-			errContent: "model is not registered",
+			errContent: "Unsupported inference preset name",
 			expectErrs: true,
 		},
 		{

--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -16,17 +16,8 @@ const (
 	// WorkspaceConditionTypeInferenceStatus is the state when Inference service has been ready.
 	WorkspaceConditionTypeInferenceStatus = ConditionType("InferenceReady")
 
-	// RAGEneineConditionTypeServiceStatus is the state when service has been ready.
-	RAGEneineConditionTypeServiceStatus = ConditionType("ServiceReady")
-
-	// RAGConditionTypeServiceStatus is the state when RAG Engine service has been ready.
-	RAGConditionTypeServiceStatus = ConditionType("RAGEngineServiceReady")
-
 	// WorkspaceConditionTypeTuningJobStatus is the state when the tuning job starts normally.
 	WorkspaceConditionTypeTuningJobStatus ConditionType = ConditionType("JobStarted")
-
-	//RAGEngineConditionTypeDeleting is the RAGEngine state when starts to get deleted.
-	RAGEngineConditionTypeDeleting = ConditionType("RAGEngineDeleting")
 
 	//WorkspaceConditionTypeDeleting is the Workspace state when starts to get deleted.
 	WorkspaceConditionTypeDeleting = ConditionType("WorkspaceDeleting")
@@ -35,6 +26,4 @@ const (
 	//For inference, the "True" condition means the inference service is ready to serve requests.
 	//For fine tuning, the "True" condition means the tuning job completes successfully.
 	WorkspaceConditionTypeSucceeded ConditionType = ConditionType("WorkspaceSucceeded")
-
-	RAGEngineConditionTypeSucceeded ConditionType = ConditionType("RAGEngineSucceeded")
 )

--- a/api/v1beta1/labels.go
+++ b/api/v1beta1/labels.go
@@ -22,20 +22,11 @@ const (
 	// LabelWorkspaceName is the label for workspace name.
 	LabelWorkspaceName = KAITOPrefix + "workspace"
 
-	// LabelRAGEngineName is the label for ragengine name.
-	LabelRAGEngineName = KAITOPrefix + "ragengine"
-
 	// LabelWorkspaceName is the label for workspace namespace.
 	LabelWorkspaceNamespace = KAITOPrefix + "workspacenamespace"
 
-	// LabelRAGEngineNamespace is the label for ragengine namespace.
-	LabelRAGEngineNamespace = KAITOPrefix + "ragenginenamespace"
-
 	// WorkspaceRevisionAnnotation is the Annotations for revision number
 	WorkspaceRevisionAnnotation = "workspace.kaito.io/revision"
-
-	// RAGEngineRevisionAnnotation is the Annotations for revision number
-	RAGEngineRevisionAnnotation = "ragengine.kaito.io/revision"
 
 	// AnnotationWorkspaceRuntime is the annotation for runtime selection.
 	AnnotationWorkspaceRuntime = KAITOPrefix + "runtime"

--- a/api/v1beta1/workspace_validation_test.go
+++ b/api/v1beta1/workspace_validation_test.go
@@ -224,6 +224,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		modelPerGPUMemory   string
 		modelTotalGPUMemory string
 		preset              bool
+		presetNameOverride  string
 		errContent          string // Content expect error to include, if any
 		expectErrs          bool
 		validateTuning      bool // To indicate if we are testing tuning validation
@@ -362,6 +363,17 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 			expectErrs:     true,
 			validateTuning: true,
 		},
+		{
+			name: "Invalid Preset Name",
+			resourceSpec: &ResourceSpec{
+				InstanceType: "Standard_NC6s_v3",
+				Count:        pointerToInt(2),
+			},
+			errContent:         "",
+			preset:             true,
+			presetNameOverride: "Invalid-Preset-Name",
+			expectErrs:         false,
+		},
 	}
 
 	t.Setenv("CLOUD_PROVIDER", consts.AzureCloudName)
@@ -386,10 +398,15 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 				var spec InferenceSpec
 
 				if tc.preset {
+					presetName := ModelName("test-validation")
+					if tc.presetNameOverride != "" {
+						presetName = ModelName(tc.presetNameOverride)
+					}
+
 					spec = InferenceSpec{
 						Preset: &PresetSpec{
 							PresetMeta: PresetMeta{
-								Name: ModelName("test-validation"),
+								Name: presetName,
 							},
 						},
 					}
@@ -542,7 +559,7 @@ func TestInferenceSpecValidateCreate(t *testing.T) {
 					},
 				},
 			},
-			errContent: "model is not registered",
+			errContent: "Unsupported inference preset name",
 			expectErrs: true,
 		},
 		{

--- a/charts/kaito/workspace/templates/deployment.yaml
+++ b/charts/kaito/workspace/templates/deployment.yaml
@@ -36,7 +36,7 @@ spec:
             - --feature-gates={{ include "utils.joinKeyValuePairs" .Values.featureGates }}
           env:
             - name: WEBHOOK_SERVICE
-              value: {{ include "kaito.fullname" . }}
+              value: {{ include "kaito.fullname" . }}-svc
             - name: WEBHOOK_PORT
               value: "{{ .Values.webhook.port }}"
             - name: SYSTEM_NAMESPACE

--- a/pkg/utils/test/testUtils.go
+++ b/pkg/utils/test/testUtils.go
@@ -230,7 +230,7 @@ var (
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        "testRAGEngine",
 			Namespace:   "kaito",
-			Annotations: map[string]string{v1beta1.RAGEngineRevisionAnnotation: "1"},
+			Annotations: map[string]string{v1alpha1.RAGEngineRevisionAnnotation: "1"},
 		},
 		Spec: &v1alpha1.RAGEngineSpec{
 			Compute: &v1alpha1.ResourceSpec{


### PR DESCRIPTION
**Reason for Change**:
This change ports the preset name validation fix from v1apha1 to v1beta1 webhook.  This fix is omitted during v1beta1 api promotion process.

**Notes for Reviewers**:

The original fix does not completely resolve the problem. The inferenceSpec.validateCreate will also hit panic if preset name is wrong. In this PR, we slightly change the validation logic. The resourceSpec.validateCreate does not report the error and inferenceSpec.validateCreate will fail fast in case the preset name is wrong. 

The reason why resourceSpec.validateCreate does not report the error is because:
1) The err will be caught by the inferenceSpec.validateCreate 100%.
2) The err msg indicates resource.presetName field is wrong, which can be confusing.

The logic changes are backported to v1alpha1 webhook validation.

This change also removes all constants used by ragengine in v1beta1 module.

Manual tests:

```
$ kubectl apply -f ws-beta.yaml
Error from server (BadRequest): error when creating "ws-beta.yaml": admission webhook "validation.workspace.kaito.sh" denied the request: validation failed: invalid value: Unsupported inference preset name phi-x: inference.presetName

$ kubectl apply -f ws-alpha.yaml
Error from server (BadRequest): error when creating "ws-alpha.yaml": admission webhook "validation.workspace.kaito.sh" denied the request: validation failed: invalid value: Unsupported inference preset name phi-x: inference.presetName
```

