### PR TITLE
chore: add replacement for k8s.io/cri-client to v0.30.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -129,6 +129,7 @@ replace (
 	k8s.io/component-helpers => k8s.io/component-helpers v0.30.1
 	k8s.io/controller-manager => k8s.io/controller-manager v0.30.1
 	k8s.io/cri-api => k8s.io/cri-api v0.30.1
+	k8s.io/cri-client => k8s.io/cri-client v0.30.1
 	k8s.io/csi-translation-lib => k8s.io/csi-translation-lib v0.30.1
 	k8s.io/dynamic-resource-allocation => k8s.io/dynamic-resource-allocation v0.30.1
 	k8s.io/endpointslice => k8s.io/endpointslice v0.30.1


### PR DESCRIPTION
### **User description**
**Reason for Change**:
`go list -m all` was failing with `go: k8s.io/cri-client@v0.0.0: invalid version: unknown revision v0.0.0`, making Goland fail to inspect the project.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
Fixes #938

**Notes for Reviewers**:
`k8s.io/cri-client` was replaced with version `v0.30.1`, like all other K8s dependencies.

___

### **PR Type**
bug_fix


___

### **Description**
- Fixed `go list -m all` failing due to invalid version for `k8s.io/cri-client`.

- Added replacement for `k8s.io/cri-client` to version `v0.30.1`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug_fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>go.mod</strong><dd><code>Update `k8s.io/cri-client` version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

go.mod

- Added replacement for `k8s.io/cri-client` to `v0.30.1`.


</details>


  </td>
  <td><a href="https://github.com/kaito-project/kaito/pull/939/files#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>