### PR TITLE
feat: support multi-node distributed inference for vLLM

### DIFF
--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -3,6 +3,9 @@ FROM python:3.12-slim AS base
 ARG MODEL_TYPE
 ARG VERSION
 
+# https://docs.ray.io/en/latest/cluster/usage-stats.html
+ENV RAY_USAGE_STATS_ENABLED="1"
+
 # Set the working directory
 WORKDIR /workspace
 

--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -11,7 +11,7 @@ COPY kaito/presets/workspace/dependencies/requirements.txt /workspace/requiremen
 RUN pip install --no-cache-dir -r /workspace/requirements.txt
 
 # Required for torch.compile
-RUN apt-get update -y && apt-get install --no-install-recommends gcc libc-dev perl -y && \
+RUN apt-get update -y && apt-get install --no-install-recommends curl gcc libc-dev perl -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # 1. Huggingface transformers
@@ -24,7 +24,14 @@ COPY kaito/presets/workspace/inference/${MODEL_TYPE}/inference_api.py \
     /workspace/tfs/
 
 # 2. vLLM
-COPY kaito/presets/workspace/inference/vllm/inference_api.py /workspace/vllm/inference_api.py
+COPY kaito/presets/workspace/inference/vllm/inference_api.py \
+    kaito/presets/workspace/inference/vllm/multi-node-health-check.py \
+    /workspace/vllm/
+
+RUN VLLM_VERSION=$(grep 'vllm==' /workspace/requirements.txt | cut -d'=' -f3) && \
+    curl -o /workspace/vllm/multi-node-serving.sh \
+    https://raw.githubusercontent.com/vllm-project/vllm/refs/tags/v${VLLM_VERSION}/examples/online_serving/multi-node-serving.sh && \
+    chmod +x /workspace/vllm/multi-node-serving.sh
 
 # Chat template
 ADD kaito/presets/workspace/inference/chat_templates /workspace/chat_templates

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -13,6 +13,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kaito-project/kaito/pkg/sku"
 	"github.com/kaito-project/kaito/pkg/utils"
@@ -116,7 +117,6 @@ type PresetParam struct {
 	TotalGPUMemoryRequirement     string         // Total GPU memory required for the Preset. Used for inference.
 	PerGPUMemoryRequirement       string         // GPU memory required per GPU. Used for inference.
 	TuningPerGPUMemoryRequirement map[string]int // Min GPU memory per tuning method (batch size 1). Used for tuning.
-	WorldSize                     int            // Defines the number of processes required for distributed inference.
 
 	RuntimeParam
 
@@ -142,12 +142,15 @@ type HuggingfaceTransformersParam struct {
 }
 
 type VLLMParam struct {
+	RayLeaderBaseCommand string
+	RayLeaderParams      map[string]string
+	RayWorkerBaseCommand string
+	RayWorkerParams      map[string]string
+	// BaseCommand is the command used to start the inference server.
 	BaseCommand string
 	// The model name used in the openai serving API.
 	// see https://platform.openai.com/docs/api-reference/chat/create#chat-create-model.
 	ModelName string
-	// Parameters for distributed inference.
-	DistributionParams map[string]string
 	// Parameters for running the model training/inference.
 	ModelRunParams map[string]string
 	// Indicates if vllm supports LoRA (Low-Rank Adaptation) for this model.
@@ -191,17 +194,21 @@ func (v *VLLMParam) DeepCopy() VLLMParam {
 		return VLLMParam{}
 	}
 	out := *v
-	out.DistributionParams = maps.Clone(v.DistributionParams)
+	out.RayLeaderParams = maps.Clone(v.RayLeaderParams)
+	out.RayWorkerParams = maps.Clone(v.RayWorkerParams)
 	out.ModelRunParams = maps.Clone(v.ModelRunParams)
 	return out
 }
 
 // RuntimeContext defines the runtime context for a model.
 type RuntimeContext struct {
-	RuntimeName  RuntimeName
-	GPUConfig    *sku.GPUConfig
-	ConfigVolume *corev1.VolumeMount
-	SKUNumGPUs   int
+	RuntimeName          RuntimeName
+	GPUConfig            *sku.GPUConfig
+	ConfigVolume         *corev1.VolumeMount
+	SKUNumGPUs           int
+	NumNodes             int
+	WorkspaceMetadata    metav1.ObjectMeta
+	DistributedInference bool
 	RuntimeContextExtraArguments
 }
 
@@ -245,6 +252,8 @@ func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
 		p.VLLM.ModelRunParams["served-model-name"] = p.VLLM.ModelName
 	}
 	if !p.DisableTensorParallelism {
+		// Tensor Parallelism (TP) is set to the number of GPUs on a given node per vLLM guidance:
+		// https://docs.vllm.ai/en/latest/serving/distributed_serving.html.
 		p.VLLM.ModelRunParams["tensor-parallel-size"] = strconv.Itoa(rc.SKUNumGPUs)
 	}
 	if !p.VLLM.DisallowLoRA && rc.AdaptersEnabled {
@@ -262,8 +271,42 @@ func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
 	if rc.ConfigVolume != nil {
 		p.VLLM.ModelRunParams["kaito-config-file"] = path.Join(rc.ConfigVolume.MountPath, ConfigfileNameVLLM)
 	}
-	modelCommand := utils.BuildCmdStr(p.VLLM.BaseCommand, p.VLLM.ModelRunParams)
-	return utils.ShellCmd(modelCommand)
+
+	if !rc.DistributedInference {
+		modelCommand := utils.BuildCmdStr(p.VLLM.BaseCommand, p.VLLM.ModelRunParams)
+		return utils.ShellCmd(modelCommand)
+	}
+
+	// Pipeline Parallelism (PP) is set to the number of nodes for multi-node inference per vLLM guidance:
+	// https://docs.vllm.ai/en/latest/serving/distributed_serving.html.
+	p.VLLM.ModelRunParams["pipeline-parallel-size"] = strconv.Itoa(rc.NumNodes)
+
+	// If PP > 1, we need to setup multi-node Ray cluster and assume pod index 0 is the leader of the cluster.
+	// - leader: start as ray leader along with the model run command
+	// - worker: start as ray worker - don't need to provide the model run command
+	if p.VLLM.RayLeaderParams == nil {
+		p.VLLM.RayLeaderParams = make(map[string]string)
+	}
+	p.VLLM.RayLeaderParams["ray_cluster_size"] = strconv.Itoa(rc.NumNodes)
+	p.VLLM.RayLeaderParams["ray_port"] = "6379"
+
+	if p.VLLM.RayWorkerParams == nil {
+		p.VLLM.RayWorkerParams = make(map[string]string)
+	}
+	p.VLLM.RayWorkerParams["ray_address"] = utils.GetRayLeaderHost(rc.WorkspaceMetadata)
+	p.VLLM.RayWorkerParams["ray_port"] = "6379"
+
+	rayLeaderCommand := utils.BuildCmdStr(p.VLLM.RayLeaderBaseCommand, p.VLLM.RayLeaderParams)
+	modelRunCommand := utils.BuildCmdStr(p.VLLM.BaseCommand, p.VLLM.ModelRunParams)
+	result := utils.BuildIfElseCmdStr(
+		`[ "${POD_INDEX}" = "0" ]`,                                      // initiate as ray leader if the pod index is 0, otherwise initiate as ray worker
+		strings.Join([]string{rayLeaderCommand, modelRunCommand}, "; "), // command if true, concatenate the ray leader command and model run command
+		map[string]string{},                                             // no parameters needed since the command is already built above
+		p.VLLM.RayWorkerBaseCommand,                                     // command if false
+		p.VLLM.RayWorkerParams,                                          // parameters for the false command
+	)
+
+	return utils.ShellCmd(result)
 }
 
 func (p *PresetParam) Validate(rc RuntimeContext) error {

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -117,6 +117,12 @@ func BuildCmdStr(baseCommand string, runParams ...map[string]string) string {
 	return updatedBaseCommand
 }
 
+func BuildIfElseCmdStr(condition string, trueCmd string, trueCmdParams map[string]string, falseCmd string, falseCmdParams map[string]string) string {
+	trueCmdStr := BuildCmdStr(trueCmd, trueCmdParams)
+	falseCmdStr := BuildCmdStr(falseCmd, falseCmdParams)
+	return fmt.Sprintf("if %s; then %s; else %s; fi", condition, trueCmdStr, falseCmdStr)
+}
+
 func ShellCmd(command string) []string {
 	return []string{
 		"/bin/sh",
@@ -313,4 +319,10 @@ func ParseHuggingFaceModelVersion(version string) (repoId string, revision strin
 	}
 
 	return "", "", fmt.Errorf(errInvalidModelVersionURL, version)
+}
+
+// getRayLeaderHost constructs the leader host for the Ray cluster.
+func GetRayLeaderHost(meta metav1.ObjectMeta) string {
+	return fmt.Sprintf("%s-0.%s-headless.%s.svc.cluster.local",
+		meta.Name, meta.Name, meta.Namespace)
 }

--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -231,3 +231,173 @@ func TestParseHuggingFaceModelVersion(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildIfElseCmdStr(t *testing.T) {
+	tests := []struct {
+		name           string
+		condition      string
+		trueCmd        string
+		trueCmdParams  map[string]string
+		falseCmd       string
+		falseCmdParams map[string]string
+		expected       string
+	}{
+		{
+			name:      "Both commands with parameters",
+			condition: "[ -f /path/to/file ]",
+			trueCmd:   "echo 'File exists'",
+			trueCmdParams: map[string]string{
+				"flag1": "",
+			},
+			falseCmd: "echo 'File does not exist'",
+			falseCmdParams: map[string]string{
+				"param2": "value2",
+			},
+			expected: "if [ -f /path/to/file ]; then echo 'File exists' --flag1; else echo 'File does not exist' --param2=value2; fi",
+		},
+		{
+			name:      "True command with parameters, false command without",
+			condition: "check_condition",
+			trueCmd:   "do_true_action",
+			trueCmdParams: map[string]string{
+				"arg": "true_arg",
+			},
+			falseCmd:       "do_false_action",
+			falseCmdParams: map[string]string{},
+			expected:       "if check_condition; then do_true_action --arg=true_arg; else do_false_action; fi",
+		},
+		{
+			name:           "False command with parameters, true command without",
+			condition:      "another_check",
+			trueCmd:        "simple_true",
+			trueCmdParams:  map[string]string{},
+			falseCmd:       "complex_false",
+			falseCmdParams: map[string]string{"opt": "false_opt"},
+			expected:       "if another_check; then simple_true; else complex_false --opt=false_opt; fi",
+		},
+		{
+			name:           "Neither command with parameters",
+			condition:      "basic_test",
+			trueCmd:        "run_if_true",
+			trueCmdParams:  map[string]string{},
+			falseCmd:       "run_if_false",
+			falseCmdParams: map[string]string{},
+			expected:       "if basic_test; then run_if_true; else run_if_false; fi",
+		},
+		{
+			name:           "Empty true command",
+			condition:      "test_empty_true",
+			trueCmd:        "",
+			trueCmdParams:  map[string]string{},
+			falseCmd:       "fallback",
+			falseCmdParams: map[string]string{"p": "v"},
+			expected:       "if test_empty_true; then ; else fallback --p=v; fi",
+		},
+		{
+			name:      "Empty false command",
+			condition: "test_empty_false",
+			trueCmd:   "primary",
+			trueCmdParams: map[string]string{
+				"a": "b",
+			},
+			falseCmd:       "",
+			falseCmdParams: map[string]string{},
+			expected:       "if test_empty_false; then primary --a=b; else ; fi",
+		},
+		{
+			name:           "Empty condition",
+			condition:      "",
+			trueCmd:        "true_cmd",
+			trueCmdParams:  map[string]string{},
+			falseCmd:       "false_cmd",
+			falseCmdParams: map[string]string{},
+			expected:       "if ; then true_cmd; else false_cmd; fi",
+		},
+		{
+			name:           "Nil parameters map",
+			condition:      "nil_test",
+			trueCmd:        "true_cmd",
+			trueCmdParams:  nil,
+			falseCmd:       "false_cmd",
+			falseCmdParams: nil,
+			expected:       "if nil_test; then true_cmd; else false_cmd; fi",
+		},
+		{
+			name:          "Nil true parameters map",
+			condition:     "nil_true_params",
+			trueCmd:       "true_cmd",
+			trueCmdParams: nil,
+			falseCmd:      "false_cmd",
+			falseCmdParams: map[string]string{
+				"f_param": "f_val",
+			},
+			expected: "if nil_true_params; then true_cmd; else false_cmd --f_param=f_val; fi",
+		},
+		{
+			name:      "Nil false parameters map",
+			condition: "nil_false_params",
+			trueCmd:   "true_cmd",
+			trueCmdParams: map[string]string{
+				"t_param": "t_val",
+			},
+			falseCmd:       "false_cmd",
+			falseCmdParams: nil,
+			expected:       "if nil_false_params; then true_cmd --t_param=t_val; else false_cmd; fi",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actual := BuildIfElseCmdStr(tt.condition, tt.trueCmd, tt.trueCmdParams, tt.falseCmd, tt.falseCmdParams)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestGetRayLeaderHost(t *testing.T) {
+	tests := []struct {
+		name         string
+		meta         metav1.ObjectMeta
+		expectedHost string
+	}{
+		{
+			name: "Standard case",
+			meta: metav1.ObjectMeta{
+				Name:      "my-ray-cluster",
+				Namespace: "default",
+			},
+			expectedHost: "my-ray-cluster-0.my-ray-cluster-headless.default.svc.cluster.local",
+		},
+		{
+			name: "Different name and namespace",
+			meta: metav1.ObjectMeta{
+				Name:      "another-app",
+				Namespace: "kube-system",
+			},
+			expectedHost: "another-app-0.another-app-headless.kube-system.svc.cluster.local",
+		},
+		{
+			name: "Name with hyphens",
+			meta: metav1.ObjectMeta{
+				Name:      "test-ray-app-v1",
+				Namespace: "production",
+			},
+			expectedHost: "test-ray-app-v1-0.test-ray-app-v1-headless.production.svc.cluster.local",
+		},
+		{
+			name: "Namespace with hyphens",
+			meta: metav1.ObjectMeta{
+				Name:      "simple",
+				Namespace: "my-custom-namespace",
+			},
+			expectedHost: "simple-0.simple-headless.my-custom-namespace.svc.cluster.local",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			actualHost := GetRayLeaderHost(tt.meta)
+			assert.Equal(t, tt.expectedHost, actualHost)
+		})
+	}
+}

--- a/pkg/utils/test/testModel.go
+++ b/pkg/utils/test/testModel.go
@@ -19,7 +19,8 @@ func (*baseTestModel) GetInferenceParameters() *model.PresetParam {
 		Metadata: model.Metadata{
 			Tag: "base-test-model",
 		},
-		GPUCountRequirement: "1",
+		GPUCountRequirement:       "1",
+		TotalGPUMemoryRequirement: "8Gi",
 		RuntimeParam: model.RuntimeParam{
 			VLLM: model.VLLMParam{
 				BaseCommand:    "python3 /workspace/vllm/inference_api.py",
@@ -69,7 +70,8 @@ func (*testNoTensorParallelModel) GetInferenceParameters() *model.PresetParam {
 		Metadata: model.Metadata{
 			Tag: "test-no-tensor-parallel-model",
 		},
-		GPUCountRequirement: "1",
+		GPUCountRequirement:       "1",
+		TotalGPUMemoryRequirement: "8Gi",
 		RuntimeParam: model.RuntimeParam{
 			DisableTensorParallelism: true,
 			VLLM: model.VLLMParam{
@@ -97,7 +99,7 @@ type testModelDownload struct {
 }
 
 func (*testModelDownload) SupportDistributedInference() bool {
-	return false
+	return true
 }
 
 func (*testModelDownload) GetInferenceParameters() *model.PresetParam {
@@ -106,7 +108,8 @@ func (*testModelDownload) GetInferenceParameters() *model.PresetParam {
 			Version:           "https://huggingface.co/test-repo/test-model/commit/test-revision",
 			DownloadAtRuntime: true,
 		},
-		GPUCountRequirement: "1",
+		GPUCountRequirement:       "1",
+		TotalGPUMemoryRequirement: "64Gi",
 		RuntimeParam: model.RuntimeParam{
 			VLLM: model.VLLMParam{
 				BaseCommand:    "python3 /workspace/vllm/inference_api.py",
@@ -115,6 +118,7 @@ func (*testModelDownload) GetInferenceParameters() *model.PresetParam {
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       "accelerate launch",
 				InferenceMainFile: "/workspace/tfs/inference_api.py",
+				AccelerateParams:  emptyParams,
 				ModelRunParams:    emptyParams,
 			},
 		},
@@ -127,7 +131,8 @@ func (*testNoLoraSupportModel) GetInferenceParameters() *model.PresetParam {
 		Metadata: model.Metadata{
 			Tag: "test-no-lora-support-model",
 		},
-		GPUCountRequirement: "1",
+		GPUCountRequirement:       "1",
+		TotalGPUMemoryRequirement: "8Gi",
 		RuntimeParam: model.RuntimeParam{
 			DisableTensorParallelism: true,
 			VLLM: model.VLLMParam{

--- a/pkg/workspace/inference/preset-inference-types.go
+++ b/pkg/workspace/inference/preset-inference-types.go
@@ -11,6 +11,12 @@ const (
 	DefaultNumMachines  = "1"
 	DefaultMachineRank  = "0"
 	DefaultGPUIds       = "all"
+
+	DefaultVLLMRayLeaderBaseCommand        = "/workspace/vllm/multi-node-serving.sh leader"
+	DefaultVLLMRayWorkerBaseCommand        = "/workspace/vllm/multi-node-serving.sh worker"
+	DefaultVLLMMultiNodeHealthCheckCommand = "python3 /workspace/vllm/multi-node-health-check.py"
+	DefaultVLLMCommand                     = "python3 /workspace/vllm/inference_api.py"
+	DefaultTransformersMainFile            = "/workspace/tfs/inference_api.py"
 )
 
 var (
@@ -20,9 +26,6 @@ var (
 		"machine_rank":  DefaultMachineRank,
 		"gpu_ids":       DefaultGPUIds,
 	}
-
-	DefaultVLLMCommand          = "python3 /workspace/vllm/inference_api.py"
-	DefaultTransformersMainFile = "/workspace/tfs/inference_api.py"
 
 	DefaultImagePullSecrets = []corev1.LocalObjectReference{}
 )

--- a/pkg/workspace/inference/preset-inferences.go
+++ b/pkg/workspace/inference/preset-inferences.go
@@ -6,14 +6,15 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kaito-project/kaito/api/v1beta1"
-	"github.com/kaito-project/kaito/pkg/model"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
@@ -30,10 +31,9 @@ const (
 var (
 	containerPorts = []corev1.ContainerPort{{
 		ContainerPort: int32(Port5000),
-	},
-	}
+	}}
 
-	livenessProbe = &corev1.Probe{
+	defaultLivenessProbe = &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Port: intstr.FromInt(Port5000),
@@ -44,7 +44,7 @@ var (
 		PeriodSeconds:       10,
 	}
 
-	readinessProbe = &corev1.Probe{
+	defaultReadinessProbe = &corev1.Probe{
 		ProbeHandler: corev1.ProbeHandler{
 			HTTPGet: &corev1.HTTPGetAction{
 				Port: intstr.FromInt(Port5000),
@@ -70,7 +70,7 @@ var (
 	}
 )
 
-func GetInferenceImageInfo(ctx context.Context, workspaceObj *v1beta1.Workspace, presetObj *model.PresetParam) (string, []corev1.LocalObjectReference) {
+func GetInferenceImageInfo(ctx context.Context, workspaceObj *v1beta1.Workspace, presetObj *pkgmodel.PresetParam) (string, []corev1.LocalObjectReference) {
 	imagePullSecretRefs := []corev1.LocalObjectReference{}
 	// Check if the workspace preset's access mode is private
 	if len(workspaceObj.Inference.Adapters) > 0 {
@@ -121,6 +121,8 @@ func CreatePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspace,
 
 	// resource requirements
 	var skuNumGPUs int
+	// initially respect the user setting by deploying the model on the same number of nodes as the user requested
+	numNodes := *workspaceObj.Resource.Count
 	gpuConfig, err := utils.GetGPUConfigBySKU(workspaceObj.Resource.InstanceType)
 	if err != nil {
 		gpuConfig, err = utils.TryGetGPUConfigFromNode(ctx, kubeClient, workspaceObj.Status.WorkerNodes)
@@ -131,6 +133,17 @@ func CreatePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspace,
 	}
 	if gpuConfig != nil {
 		skuNumGPUs = gpuConfig.GPUCount
+		// Calculate the minimum number of nodes required to satisfy the model's total GPU memory requirement.
+		// The goal is to maximize GPU utilization and not spread the model across too many nodes.
+		totalGPUMemoryRequired := resource.MustParse(inferenceParam.TotalGPUMemoryRequirement)
+		totalGPUMemoryPerNode := resource.NewScaledQuantity(int64(gpuConfig.GPUCount*gpuConfig.GPUMemGB), resource.Giga)
+		minimumNodes := 0
+		for ; totalGPUMemoryRequired.Sign() > 0; totalGPUMemoryRequired.Sub(*totalGPUMemoryPerNode) {
+			minimumNodes++
+		}
+		if minimumNodes < numNodes {
+			numNodes = minimumNodes
+		}
 	}
 	resourceReq := corev1.ResourceRequirements{
 		Requests: corev1.ResourceList{
@@ -181,10 +194,13 @@ func CreatePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspace,
 	// inference command
 	runtimeName := v1beta1.GetWorkspaceRuntimeName(workspaceObj)
 	commands := inferenceParam.GetInferenceCommand(pkgmodel.RuntimeContext{
-		RuntimeName:  runtimeName,
-		GPUConfig:    gpuConfig,
-		ConfigVolume: &cmVolumeMount,
-		SKUNumGPUs:   skuNumGPUs,
+		RuntimeName:          runtimeName,
+		GPUConfig:            gpuConfig,
+		ConfigVolume:         &cmVolumeMount,
+		SKUNumGPUs:           skuNumGPUs,
+		NumNodes:             numNodes,
+		WorkspaceMetadata:    workspaceObj.ObjectMeta,
+		DistributedInference: model.SupportDistributedInference(),
 		RuntimeContextExtraArguments: pkgmodel.RuntimeContextExtraArguments{
 			AdaptersEnabled: len(workspaceObj.Inference.Adapters) > 0,
 		},
@@ -193,16 +209,67 @@ func CreatePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspace,
 	image, imagePullSecrets := GetInferenceImageInfo(ctx, workspaceObj, inferenceParam)
 
 	var depObj client.Object
-	if model.SupportDistributedInference() {
-		depObj = manifests.GenerateStatefulSetManifest(workspaceObj, image, imagePullSecrets, *workspaceObj.Resource.Count, commands,
+	if model.SupportDistributedInference() && runtimeName == pkgmodel.RuntimeNameVLLM {
+		// 60 seconds initial delay for liveness probe to allow workers to join the cluster
+		livenessProbe := getDistributedInferenceProbe(probeTypeLiveness, workspaceObj, 60, 10, 5)
+		readinessProbe := getDistributedInferenceProbe(probeTypeReadiness, workspaceObj, 0, 10, 1)
+		depObj = manifests.GenerateStatefulSetManifest(workspaceObj, image, imagePullSecrets, numNodes, commands,
 			containerPorts, livenessProbe, readinessProbe, resourceReq, tolerations, volumes, volumeMounts, envVars)
 	} else {
-		depObj = manifests.GenerateDeploymentManifest(workspaceObj, revisionNum, image, imagePullSecrets, *workspaceObj.Resource.Count, commands,
-			containerPorts, livenessProbe, readinessProbe, resourceReq, tolerations, volumes, volumeMounts, envVars)
+		depObj = manifests.GenerateDeploymentManifest(workspaceObj, revisionNum, image, imagePullSecrets, numNodes, commands,
+			containerPorts, defaultLivenessProbe, defaultReadinessProbe, resourceReq, tolerations, volumes, volumeMounts, envVars)
 	}
 	err = resources.CreateResource(ctx, depObj, kubeClient)
 	if client.IgnoreAlreadyExists(err) != nil {
 		return nil, err
 	}
 	return depObj, nil
+}
+
+type probeType string
+
+const (
+	probeTypeLiveness  probeType = "liveness"
+	probeTypeReadiness probeType = "readiness"
+)
+
+// getDistributedInferenceProbe returns a container probe configuration for the distributed inference workload.
+func getDistributedInferenceProbe(probeType probeType, wObj *v1beta1.Workspace, initialDelaySeconds, periodSeconds, timeoutSeconds int32) *corev1.Probe {
+	args := map[string]string{
+		"leader-address": utils.GetRayLeaderHost(wObj.ObjectMeta),
+	}
+	switch probeType {
+	case probeTypeLiveness:
+		args["ray-port"] = "6379"
+	case probeTypeReadiness:
+		args["vllm-port"] = strconv.Itoa(Port5000)
+	}
+
+	// for distributed inference, we cannot use the default http probe since only the leader pod
+	// exposes the health check endpoint. We need to use presets/workspace/inference/vllm/multi-node-health-check.py
+	// to check the health of both the leader and worker pods.
+	cmd := utils.BuildCmdStr(
+		fmt.Sprintf("%s %s", DefaultVLLMMultiNodeHealthCheckCommand, probeType),
+		args,
+	)
+	probe := &corev1.Probe{
+		ProbeHandler: corev1.ProbeHandler{
+			Exec: &corev1.ExecAction{
+				Command: utils.ShellCmd(cmd),
+			},
+		},
+		InitialDelaySeconds: initialDelaySeconds,
+		PeriodSeconds:       periodSeconds,
+		TimeoutSeconds:      timeoutSeconds,
+
+		// lowering the failure threshold from 3 (default) to 1 and setting the
+		// termination grace period to 1 second to ensure that the pod is terminated
+		// immediately if the health check fails to minimize downtime.
+		FailureThreshold: 1,
+	}
+	if probeType == probeTypeLiveness {
+		probe.TerminationGracePeriodSeconds = lo.ToPtr(int64(1))
+	}
+
+	return probe
 }

--- a/pkg/workspace/inference/preset-inferences_test.go
+++ b/pkg/workspace/inference/preset-inferences_test.go
@@ -5,10 +5,12 @@ package inference
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/mock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -18,7 +20,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/pkg/utils/test"
-	"github.com/kaito-project/kaito/presets/workspace/models"
+	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
 
 var ValidStrength string = "0.5"
@@ -37,7 +39,6 @@ func TestCreatePresetInference(t *testing.T) {
 		expectedVolume  string
 		expectedEnvVars []corev1.EnvVar
 	}{
-
 		"test-model/vllm": {
 			workspace: test.MockWorkspaceWithPresetVLLM,
 			nodeCount: 1,
@@ -146,11 +147,15 @@ func TestCreatePresetInference(t *testing.T) {
 			modelName: "test-model-download",
 			callMocks: func(c *test.MockClient) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
-				c.On("Create", mock.IsType(context.TODO()), mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Service{}), mock.Anything).Return(nil)
+				c.On("Create", mock.IsType(context.TODO()), mock.IsType(&appsv1.StatefulSet{}), mock.Anything).Return(nil)
 			},
-			workload:      "Deployment",
-			expectedImage: "test-registry/kaito-base:" + models.MustGet("base").Tag,
-			expectedCmd:   "/bin/sh -c python3 /workspace/vllm/inference_api.py --gpu-memory-utilization=0.90 --kaito-config-file=/mnt/config/inference_config.yaml --model=test-repo/test-model --code-revision=test-revision --tensor-parallel-size=2",
+			workload: "StatefulSet",
+			expectedImage: func() string {
+				baseImage := metadata.MustGet("base")
+				return fmt.Sprintf("test-registry/kaito-base:%s", baseImage.Tag)
+			}(),
+			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=1 --ray_port=6379; python3 /workspace/vllm/inference_api.py --model=test-repo/test-model --code-revision=test-revision --gpu-memory-utilization=0.90 --kaito-config-file=/mnt/config/inference_config.yaml --pipeline-parallel-size=1 --tensor-parallel-size=2; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
 			expectedEnvVars: []corev1.EnvVar{{
 				Name: "HF_TOKEN",
 				ValueFrom: &corev1.EnvVarSource{
@@ -159,6 +164,85 @@ func TestCreatePresetInference(t *testing.T) {
 						LocalObjectReference: corev1.LocalObjectReference{
 							Name: "test-secret",
 						},
+					},
+				},
+			}, {
+				Name: "POD_INDEX",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: fmt.Sprintf("metadata.labels['%s']", appsv1.PodIndexLabel),
+					},
+				},
+			}},
+		},
+
+		"test-model-download-distributed/vllm": {
+			workspace: test.MockWorkspaceWithPresetDownloadVLLM,
+			nodeCount: 2,
+			modelName: "test-model-download",
+			callMocks: func(c *test.MockClient) {
+				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Service{}), mock.Anything).Return(nil)
+				c.On("Create", mock.IsType(context.TODO()), mock.IsType(&appsv1.StatefulSet{}), mock.Anything).Return(nil)
+			},
+			workload: "StatefulSet",
+			expectedImage: func() string {
+				baseImage := metadata.MustGet("base")
+				return fmt.Sprintf("test-registry/kaito-base:%s", baseImage.Tag)
+			}(),
+			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=2 --ray_port=6379; python3 /workspace/vllm/inference_api.py --model=test-repo/test-model --code-revision=test-revision --gpu-memory-utilization=0.90 --kaito-config-file=/mnt/config/inference_config.yaml --pipeline-parallel-size=2 --tensor-parallel-size=2; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
+			expectedEnvVars: []corev1.EnvVar{{
+				Name: "HF_TOKEN",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key: "HF_TOKEN",
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "test-secret",
+						},
+					},
+				},
+			}, {
+				Name: "POD_INDEX",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: fmt.Sprintf("metadata.labels['%s']", appsv1.PodIndexLabel),
+					},
+				},
+			}},
+		},
+
+		"test-model-download-distributed/vllm (more nodes than required)": {
+			// Using Standard_NC12s_v3, which has 32GB GPU memory per node.
+			// The preset requires 64GB GPU memory for the model, so only 2 nodes are needed.
+			workspace: test.MockWorkspaceWithPresetDownloadVLLM,
+			nodeCount: 4, // 4 nodes but only 2 are needed
+			modelName: "test-model-download",
+			callMocks: func(c *test.MockClient) {
+				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Service{}), mock.Anything).Return(nil)
+				c.On("Create", mock.IsType(context.TODO()), mock.IsType(&appsv1.StatefulSet{}), mock.Anything).Return(nil)
+			},
+			workload: "StatefulSet",
+			expectedImage: func() string {
+				baseImage := metadata.MustGet("base")
+				return fmt.Sprintf("test-registry/kaito-base:%s", baseImage.Tag)
+			}(),
+			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=2 --ray_port=6379; python3 /workspace/vllm/inference_api.py --model=test-repo/test-model --code-revision=test-revision --gpu-memory-utilization=0.90 --kaito-config-file=/mnt/config/inference_config.yaml --pipeline-parallel-size=2 --tensor-parallel-size=2; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
+			expectedEnvVars: []corev1.EnvVar{{
+				Name: "HF_TOKEN",
+				ValueFrom: &corev1.EnvVarSource{
+					SecretKeyRef: &corev1.SecretKeySelector{
+						Key: "HF_TOKEN",
+						LocalObjectReference: corev1.LocalObjectReference{
+							Name: "test-secret",
+						},
+					},
+				},
+			}, {
+				Name: "POD_INDEX",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{
+						FieldPath: fmt.Sprintf("metadata.labels['%s']", appsv1.PodIndexLabel),
 					},
 				},
 			}},
@@ -172,9 +256,11 @@ func TestCreatePresetInference(t *testing.T) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
 				c.On("Create", mock.IsType(context.TODO()), mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(nil)
 			},
-			workload:      "Deployment",
-			expectedImage: "test-registry/kaito-base:" + models.MustGet("base").Tag,
-			expectedCmd:   "/bin/sh -c accelerate launch /workspace/tfs/inference_api.py --pretrained_model_name_or_path=test-repo/test-model --revision=test-revision",
+			workload: "Deployment",
+			expectedImage: func() string {
+				return fmt.Sprintf("test-registry/kaito-base:%s", metadata.MustGet("base").Tag)
+			}(),
+			expectedCmd: "/bin/sh -c accelerate launch /workspace/tfs/inference_api.py --pretrained_model_name_or_path=test-repo/test-model --revision=test-revision",
 			expectedEnvVars: []corev1.EnvVar{{
 				Name: "HF_TOKEN",
 				ValueFrom: &corev1.EnvVarSource{
@@ -303,11 +389,92 @@ func TestCreatePresetInference(t *testing.T) {
 	}
 }
 
+func TestGetDistributedInferenceProbe(t *testing.T) {
+	testcases := map[string]struct {
+		probeType           probeType
+		workspace           *v1beta1.Workspace
+		initialDelaySeconds int32
+		periodSeconds       int32
+		timeoutSeconds      int32
+		expectedProbe       *corev1.Probe
+	}{
+		"Liveness": {
+			probeType: probeTypeLiveness,
+			workspace: &v1beta1.Workspace{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-workspace",
+					Namespace: "test-ns",
+				},
+			},
+			initialDelaySeconds: 30,
+			periodSeconds:       5,
+			timeoutSeconds:      5,
+			expectedProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					Exec: &corev1.ExecAction{
+						Command: []string{"/bin/sh", "-c", "python3 /workspace/vllm/multi-node-health-check.py liveness --leader-address=test-workspace-0.test-workspace-headless.test-ns.svc.cluster.local --ray-port=6379"},
+					},
+				},
+				InitialDelaySeconds:           30,
+				PeriodSeconds:                 5,
+				TimeoutSeconds:                5,
+				TerminationGracePeriodSeconds: lo.ToPtr(int64(1)),
+				FailureThreshold:              1,
+			},
+		},
+		"Readiness": {
+			probeType: probeTypeReadiness,
+			workspace: &v1beta1.Workspace{
+				ObjectMeta: v1.ObjectMeta{
+					Name:      "test-workspace",
+					Namespace: "test-ns",
+				},
+			},
+			initialDelaySeconds: 30,
+			periodSeconds:       5,
+			timeoutSeconds:      5,
+			expectedProbe: &corev1.Probe{
+				ProbeHandler: corev1.ProbeHandler{
+					Exec: &corev1.ExecAction{
+						Command: []string{"/bin/sh", "-c", "python3 /workspace/vllm/multi-node-health-check.py readiness --leader-address=test-workspace-0.test-workspace-headless.test-ns.svc.cluster.local --vllm-port=5000"},
+					},
+				},
+				InitialDelaySeconds: 30,
+				PeriodSeconds:       5,
+				TimeoutSeconds:      5,
+				FailureThreshold:    1,
+			},
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			actualProbe := probeType.getDistributedInferenceProbe(tc.tc.workspace, tc.initialDelaySeconds, tc.periodSeconds, tc.timeoutSeconds)
+			if actualProbe.Exec != nil && tc.expectedProbe.Exec != nil {
+				expected := toParameterMap(tc.expectedProbe.Exec.Command)
+				actual := toParameterMap(actualProbe.Exec.Command)
+				if !reflect.DeepEqual(expected, actual) {
+					t.Errorf("Exec command mismatch: expected %+v, got %+v", expected, actual)
+				}
+			}
+			if actualProbe.HTTPGet != nil && tc.expectedProbe.HTTPGet != nil {
+				if !reflect.DeepEqual(actualProbe.HTTPGet, tc.expectedProbe.HTTPGet) {
+					t.Errorf("HTTPGet mismatch: expected %+v, got %+v", tc.expectedProbe.HTTPGet, actualProbe.HTTPGet)
+				}
+			}
+		})
+	}
+}
+
 func toParameterMap(in []string) map[string]string {
 	ret := make(map[string]string)
 	for _, eachToken := range in {
 		for _, each := range strings.Split(eachToken, " ") {
 			each = strings.TrimSpace(each)
+			each = strings.Trim(each, ";")
+			if len(each) == 0 {
+				continue
+			}
 			r := strings.Split(each, "=")
 			k := r[0]
 			var v string

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -71,6 +71,18 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 					Port:       80,
 					TargetPort: intstr.FromInt32(5000),
 				},
+				{
+					Name:       "ray",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       6379,
+					TargetPort: intstr.FromInt32(6379),
+				},
+				{
+					Name:       "dashboard",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       8265,
+					TargetPort: intstr.FromInt32(8265),
+				},
 			},
 			Selector: selector,
 			// Added this to allow pods to discover each other
@@ -100,6 +112,14 @@ func GenerateStatefulSetManifest(workspaceObj *kaitov1beta1.Workspace, imageName
 	labelselector := &v1.LabelSelector{
 		MatchLabels: selector,
 	}
+	envVars = append(envVars, corev1.EnvVar{
+		Name: "POD_INDEX",
+		ValueFrom: &corev1.EnvVarSource{
+			FieldRef: &corev1.ObjectFieldSelector{
+				FieldPath: fmt.Sprintf("metadata.labels['%s']", appsv1.PodIndexLabel),
+			},
+		},
+	})
 
 	ss := &appsv1.StatefulSet{
 		ObjectMeta: v1.ObjectMeta{

--- a/presets/workspace/dependencies/requirements.txt
+++ b/presets/workspace/dependencies/requirements.txt
@@ -14,6 +14,10 @@ numpy<3.0,>=1.25.0
 sentencepiece==0.2.0
 jinja2>=3.1.0
 
+# For accessing Ray dashboard. ray[default] version should be consistent with the one in vllm/vllm-openai:<vllm-version>.
+# Check with `docker run --entrypoint "" vllm/vllm-openai:<vllm-version> pip freeze | grep ray`
+ray[default]==2.43.0
+
 # Utility libraries
 datasets==2.19.1
 peft==0.11.1

--- a/presets/workspace/inference/vllm/multi-node-health-check.py
+++ b/presets/workspace/inference/vllm/multi-node-health-check.py
@@ -1,0 +1,57 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+import argparse
+import logging
+import os
+import sys
+
+
+def liveness(args):
+    from ray.util.state import list_actors, list_jobs
+    gcs = f"{args.leader_address}:{args.ray_port}"
+
+    # Checking the Ray job's entrypoint is the best we can do to identify the VLLM inference job
+    inference_job = next(filter(lambda job: job.entrypoint.startswith("python3 /workspace/vllm/inference_api.py"), list_jobs(address=gcs)), None)
+    assert inference_job is not None, "Inference job not found in Ray jobs"
+
+    has_dead_actors = False
+    for actor in list_actors(address=gcs, filters=[("job_id", "=", inference_job.job_id), ("state", "!=", "ALIVE")]):
+        logging.error(f"Ray actor {actor.actor_id} is {actor.state}: {actor.death_cause}")
+        has_dead_actors = True
+
+    if has_dead_actors:
+        sys.exit(1)
+
+
+def readiness(args):
+    import requests
+    vllm_health_endpoint = f"http://{args.leader_address}:{args.vllm_port}/health"
+    try:
+        response = requests.get(vllm_health_endpoint)
+        if response.status_code != 200:
+            sys.exit(1)
+    except requests.exceptions.RequestException as e:
+        print(f"Get \"{vllm_health_endpoint}\": {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Health check for VLLM multi-node setup")
+    parser.add_argument("probe", type=str, choices=["liveness", "readiness"], help="Type of health check probe")
+    parser.add_argument("--leader-address", type=str, required=True, help="Leader address of the Ray cluster")
+    parser.add_argument("--ray-port", type=int, default=6379, help="Ray port of the cluster")
+    parser.add_argument("--vllm-port", type=int, default=5000, help="VLLM port for the API server")
+    args = parser.parse_args()
+
+    is_leader = os.environ.get("POD_INDEX") == "0"
+
+    # only run liveness probe on the leader node because restarting workers would require
+    # restarting the leader node as well. In other words, we are delegating the worker's
+    # liveness check to the leader node.
+    if args.probe == "liveness" and is_leader:
+        assert args.ray_port is not None, "Ray port must be specified for liveness probe"
+        liveness(args)
+    elif args.probe == "readiness":
+        assert args.vllm_port is not None, "VLLM port must be specified for readiness probe"
+        readiness(args)

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -3,7 +3,7 @@ models:
   - name: base
     type: text-generation
     runtime: tfs
-    tag: 0.0.3
+    tag: 0.0.2
     # Tag history:
     # 0.0.3 - add depdenencies to support vLLM multi-node distributed inference
     # 0.0.2 - bump vLLM to 0.8.5. Tool chat template added.

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -4,7 +4,10 @@ models:
     type: text-generation
     runtime: tfs
     tag: 0.0.3
+    # Tag history:
+    # 0.0.3 - add depdenencies to support vLLM multi-node distributed inference
     # 0.0.2 - bump vLLM to 0.8.5. Tool chat template added.
+    # 0.0.1 - Initial Release
 
   # Llama
   - name: llama-3.1-8b-instruct

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -3,7 +3,7 @@ models:
   - name: base
     type: text-generation
     runtime: tfs
-    tag: 0.0.2
+    tag: 0.0.3
     # 0.0.2 - bump vLLM to 0.8.5. Tool chat template added.
 
   # Llama


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->

**Reason for Change:**
Enables Kaito to support multi-node distributed inference for large models (e.g., 400B+ parameters) using the vLLM runtime, addressing the gap in deploying models that exceed single-node GPU memory capacity. Adds validation to prevent HuggingFace Transformers from being used for multi-node distributed inference, as it no longer supports this setup.

**Changes:**
- **api/v1beta1/workspace_validation.go**:
  - Updated `validateCreateWithInference` to accept `runtime` parameter and validate that HuggingFace Transformers is not used for multi-node distributed inference when model GPU memory exceeds single-node capacity.
- **api/v1beta1/workspace_validation_test.go**:
  - Updated `testModelDownload` to support distributed inference and set GPU memory requirements (`32Gi` total, `16Gi` per GPU).
  - Added test cases for vLLM distributed inference and HuggingFace Transformers multi-node validation error.
- **docker/presets/models/tfs/Dockerfile**:
  - Added `curl` to install `multi-node-serving.sh` and `multi-node-health-check.py` for vLLM multi-node support.
  - Copied `multi-node-health-check.py` to `/workspace/vllm/`.
- **pkg/model/interface.go**:
  - Removed `WorldSize` and `DistributionParams` from `PresetParam` and `VLLMParam`.
  - Added `RayLeaderBaseCommand`, `RayLeaderParams`, `RayWorkerBaseCommand`, and `RayWorkerParams` to `VLLMParam` for Ray cluster setup.
  - Updated `buildVLLMInferenceCommand` to handle distributed inference with Ray leader/worker logic using `BuildIfElseCmdStr`.
  - Added `NumNodes`, `WorkspaceMetadata`, and `DistributedInference` to `RuntimeContext`.
- **pkg/utils/common.go**:
  - Added `BuildIfElseCmdStr` to construct conditional commands for Ray leader/worker.
  - Added `GetRayLeaderHost` to generate Ray leader host address.
- **pkg/utils/common_test.go**:
  - Added tests for `BuildIfElseCmdStr` and `GetRayLeaderHost` covering various scenarios.
- **pkg/utils/test/testModel.go**:
  - Updated test models (`baseTestModel`, `testNoTensorParallelModel`, `testModelDownload`, `testNoLoraSupportModel`) to include `TotalGPUMemoryRequirement`.
  - Enabled distributed inference for `testModelDownload`.
- **pkg/workspace/inference/preset-inference-types.go**:
  - Added constants for vLLM Ray commands (`DefaultVLLMRayLeaderBaseCommand`, `DefaultVLLMRayWorkerBaseCommand`, `DefaultVLLMMultiNodeHealthCheckCommand`).
- **pkg/workspace/inference/preset-inferences.go**:
  - Updated `CreatePresetInference` to calculate minimum nodes required based on model GPU memory and node capacity.
  - Added `getDistributedInferenceProbe` to configure liveness/readiness probes for vLLM multi-node setups using `multi-node-health-check.py`.
  - Used `StatefulSet` with custom probes for vLLM distributed inference.
- **pkg/workspace/inference/preset-inferences_test.go**:
  - Added tests for vLLM distributed inference, including single-node and multi-node scenarios.
  - Tested node minimization logic for cases where user requests more nodes than required.
- **pkg/workspace/manifests/manifests.go**:
  - Added Ray-specific ports (6379, 8265) to `GenerateServiceManifest`.
  - Added `POD_INDEX` env var to `StatefulSet` for leader/worker identification.
- **presets/workspace/dependencies/requirements.txt**:
  - Added `ray[default]==2.43.0` to support Ray dashboard and align with vLLM's Ray version.
- **presets/workspace/inference/vllm/multi-node-health-check.py**:
  - Added script to check liveness (Ray actors) on leader node and readiness (vLLM API health) on all nodes.


- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

#912 

**Notes for Reviewers**:

