### PR TITLE
feat: reimplement pull and push of images with skopeo and oras

### DIFF
--- a/api/v1alpha1/workspace_validation_test.go
+++ b/api/v1alpha1/workspace_validation_test.go
@@ -1167,8 +1167,8 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 		{
 			name: "All fields valid",
 			tuningSpec: &TuningSpec{
-				Input:  &DataSource{Name: "valid-input", Image: "AZURE_ACR.azurecr.io/test:0.0.0"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0", ImagePushSecret: "secret"},
+				Input:  &DataSource{Name: "valid-input", Image: "kaito.azurecr.io/test:0.0.0"},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0", ImagePushSecret: "secret"},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: TuningMethodLora,
 			},
@@ -1178,8 +1178,8 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 		{
 			name: "Verify QLoRA Config",
 			tuningSpec: &TuningSpec{
-				Input:  &DataSource{Name: "valid-input", Image: "AZURE_ACR.azurecr.io/test:0.0.0"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0", ImagePushSecret: "secret"},
+				Input:  &DataSource{Name: "valid-input", Image: "kaito.azurecr.io/test:0.0.0"},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0", ImagePushSecret: "secret"},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: TuningMethodQLora,
 			},
@@ -1189,7 +1189,7 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 		{
 			name: "Missing Input",
 			tuningSpec: &TuningSpec{
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0", ImagePushSecret: ""},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0", ImagePushSecret: ""},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: TuningMethodLora,
 			},
@@ -1210,7 +1210,7 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 			name: "Missing Preset",
 			tuningSpec: &TuningSpec{
 				Input:  &DataSource{Name: "valid-input"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0", ImagePushSecret: ""},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0", ImagePushSecret: ""},
 				Method: TuningMethodLora,
 			},
 			wantErr:   true,
@@ -1220,7 +1220,7 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 			name: "Invalid Preset",
 			tuningSpec: &TuningSpec{
 				Input:  &DataSource{Name: "valid-input"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0", ImagePushSecret: ""},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0", ImagePushSecret: ""},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("invalid-preset")}},
 				Method: TuningMethodLora,
 			},
@@ -1231,7 +1231,7 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 			name: "Invalid Method",
 			tuningSpec: &TuningSpec{
 				Input:  &DataSource{Name: "valid-input"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0", ImagePushSecret: ""},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0", ImagePushSecret: ""},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: "invalid-method",
 			},
@@ -1241,8 +1241,8 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 		{
 			name: "Invalid Input Source Casing",
 			tuningSpec: &TuningSpec{
-				Input:  &DataSource{Name: "valid-input", Image: "AZURE_ACR.azurecr.io/INPUT:0.0.0"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/output:0.0.0", ImagePushSecret: "secret"},
+				Input:  &DataSource{Name: "valid-input", Image: "kaito.azurecr.io/INPUT:0.0.0"},
+				Output: &DataDestination{Image: "kaito.azurecr.io/output:0.0.0", ImagePushSecret: "secret"},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: TuningMethodLora,
 			},
@@ -1252,8 +1252,8 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 		{
 			name: "Invalid Output Destination Casing",
 			tuningSpec: &TuningSpec{
-				Input:  &DataSource{Name: "valid-input", Image: "AZURE_ACR.azurecr.io/input:0.0.0"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/OUTPUT:0.0.0", ImagePushSecret: "secret"},
+				Input:  &DataSource{Name: "valid-input", Image: "kaito.azurecr.io/input:0.0.0"},
+				Output: &DataDestination{Image: "kaito.azurecr.io/OUTPUT:0.0.0", ImagePushSecret: "secret"},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: TuningMethodLora,
 			},
@@ -1295,13 +1295,13 @@ func TestTuningSpecValidateUpdate(t *testing.T) {
 			name: "No changes",
 			oldTuning: &TuningSpec{
 				Input:  &DataSource{Name: "input1"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0"},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0"},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: TuningMethodLora,
 			},
 			newTuning: &TuningSpec{
 				Input:  &DataSource{Name: "input1"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0"},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0"},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: TuningMethodLora,
 			},
@@ -1368,7 +1368,7 @@ func TestDataSourceValidateCreate(t *testing.T) {
 		{
 			name: "Volume specified only",
 			dataSource: &DataSource{
-				Image: "AZURE_ACR.azurecr.io/test:0.0.0",
+				Image: "kaito.azurecr.io/test:0.0.0",
 			},
 			wantErr: false,
 		},
@@ -1385,7 +1385,7 @@ func TestDataSourceValidateCreate(t *testing.T) {
 				Image:            "data-image:latest",
 				ImagePullSecrets: []string{"imagePushSecret"},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "Image without Tag Specified",
@@ -1393,7 +1393,16 @@ func TestDataSourceValidateCreate(t *testing.T) {
 				Image:            "aimodels.azurecr.io/data-image",
 				ImagePullSecrets: []string{"imagePushSecret"},
 			},
-			wantErr: true,
+			wantErr: false,
+		},
+		{
+			name: "Invalid image",
+			dataSource: &DataSource{
+				Image:            "!ValidImage",
+				ImagePullSecrets: []string{"imagePushSecret"},
+			},
+			wantErr:  true,
+			errField: "invalid reference format",
 		},
 		{
 			name:       "None specified",
@@ -1472,6 +1481,16 @@ func TestDataSourceValidateUpdate(t *testing.T) {
 			wantErr:   true,
 			errFields: []string{"Name"},
 		},
+		{
+			name:      "Invalid image",
+			oldSource: &DataSource{},
+			newSource: &DataSource{
+				Image:            "!ValidImage",
+				ImagePullSecrets: []string{"imagePushSecret"},
+			},
+			wantErr:   true,
+			errFields: []string{"invalid reference format"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1528,7 +1547,7 @@ func TestDataDestinationValidateCreate(t *testing.T) {
 				Image:           "data-image:latest",
 				ImagePushSecret: "imagePushSecret",
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "Image without Tag Specified",
@@ -1536,7 +1555,16 @@ func TestDataDestinationValidateCreate(t *testing.T) {
 				Image:           "aimodels.azurecr.io/data-image",
 				ImagePushSecret: "imagePushSecret",
 			},
-			wantErr: true,
+			wantErr: false,
+		},
+		{
+			name: "Invalid image",
+			dataDestination: &DataDestination{
+				Image:           "!ValidImage",
+				ImagePushSecret: "imagePushSecret",
+			},
+			wantErr:  true,
+			errField: "invalid reference format",
 		},
 		// {
 		// 	name: "Both fields specified",
@@ -1586,6 +1614,16 @@ func TestDataDestinationValidateUpdate(t *testing.T) {
 				ImagePushSecret: "old-secret",
 			},
 			wantErr: false,
+		},
+		{
+			name:    "Invalid image",
+			oldDest: &DataDestination{},
+			newDest: &DataDestination{
+				Image:           "!ValidImage",
+				ImagePushSecret: "imagePushSecret",
+			},
+			wantErr:   true,
+			errFields: []string{"invalid reference format"},
 		},
 	}
 

--- a/api/v1beta1/workspace_validation_test.go
+++ b/api/v1beta1/workspace_validation_test.go
@@ -1167,8 +1167,8 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 		{
 			name: "All fields valid",
 			tuningSpec: &TuningSpec{
-				Input:  &DataSource{Name: "valid-input", Image: "AZURE_ACR.azurecr.io/test:0.0.0"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0", ImagePushSecret: "secret"},
+				Input:  &DataSource{Name: "valid-input", Image: "kaito.azurecr.io/test:0.0.0"},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0", ImagePushSecret: "secret"},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: TuningMethodLora,
 			},
@@ -1178,8 +1178,8 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 		{
 			name: "Verify QLoRA Config",
 			tuningSpec: &TuningSpec{
-				Input:  &DataSource{Name: "valid-input", Image: "AZURE_ACR.azurecr.io/test:0.0.0"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0", ImagePushSecret: "secret"},
+				Input:  &DataSource{Name: "valid-input", Image: "kaito.azurecr.io/test:0.0.0"},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0", ImagePushSecret: "secret"},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: TuningMethodQLora,
 			},
@@ -1189,7 +1189,7 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 		{
 			name: "Missing Input",
 			tuningSpec: &TuningSpec{
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0", ImagePushSecret: ""},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0", ImagePushSecret: ""},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: TuningMethodLora,
 			},
@@ -1210,7 +1210,7 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 			name: "Missing Preset",
 			tuningSpec: &TuningSpec{
 				Input:  &DataSource{Name: "valid-input"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0", ImagePushSecret: ""},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0", ImagePushSecret: ""},
 				Method: TuningMethodLora,
 			},
 			wantErr:   true,
@@ -1220,7 +1220,7 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 			name: "Invalid Preset",
 			tuningSpec: &TuningSpec{
 				Input:  &DataSource{Name: "valid-input"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0", ImagePushSecret: ""},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0", ImagePushSecret: ""},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("invalid-preset")}},
 				Method: TuningMethodLora,
 			},
@@ -1231,7 +1231,7 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 			name: "Invalid Method",
 			tuningSpec: &TuningSpec{
 				Input:  &DataSource{Name: "valid-input"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0", ImagePushSecret: ""},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0", ImagePushSecret: ""},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: "invalid-method",
 			},
@@ -1241,8 +1241,8 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 		{
 			name: "Invalid Input Source Casing",
 			tuningSpec: &TuningSpec{
-				Input:  &DataSource{Name: "valid-input", Image: "AZURE_ACR.azurecr.io/INPUT:0.0.0"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/output:0.0.0", ImagePushSecret: "secret"},
+				Input:  &DataSource{Name: "valid-input", Image: "kaito.azurecr.io/INPUT:0.0.0"},
+				Output: &DataDestination{Image: "kaito.azurecr.io/output:0.0.0", ImagePushSecret: "secret"},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: TuningMethodLora,
 			},
@@ -1252,8 +1252,8 @@ func TestTuningSpecValidateCreate(t *testing.T) {
 		{
 			name: "Invalid Output Destination Casing",
 			tuningSpec: &TuningSpec{
-				Input:  &DataSource{Name: "valid-input", Image: "AZURE_ACR.azurecr.io/input:0.0.0"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/OUTPUT:0.0.0", ImagePushSecret: "secret"},
+				Input:  &DataSource{Name: "valid-input", Image: "kaito.azurecr.io/input:0.0.0"},
+				Output: &DataDestination{Image: "kaito.azurecr.io/OUTPUT:0.0.0", ImagePushSecret: "secret"},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: TuningMethodLora,
 			},
@@ -1295,13 +1295,13 @@ func TestTuningSpecValidateUpdate(t *testing.T) {
 			name: "No changes",
 			oldTuning: &TuningSpec{
 				Input:  &DataSource{Name: "input1"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0"},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0"},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: TuningMethodLora,
 			},
 			newTuning: &TuningSpec{
 				Input:  &DataSource{Name: "input1"},
-				Output: &DataDestination{Image: "AZURE_ACR.azurecr.io/test:0.0.0"},
+				Output: &DataDestination{Image: "kaito.azurecr.io/test:0.0.0"},
 				Preset: &PresetSpec{PresetMeta: PresetMeta{Name: ModelName("test-validation")}},
 				Method: TuningMethodLora,
 			},
@@ -1368,7 +1368,7 @@ func TestDataSourceValidateCreate(t *testing.T) {
 		{
 			name: "Volume specified only",
 			dataSource: &DataSource{
-				Image: "AZURE_ACR.azurecr.io/test:0.0.0",
+				Image: "kaito.azurecr.io/test:0.0.0",
 			},
 			wantErr: false,
 		},
@@ -1385,7 +1385,7 @@ func TestDataSourceValidateCreate(t *testing.T) {
 				Image:            "data-image:latest",
 				ImagePullSecrets: []string{"imagePushSecret"},
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "Image without Tag Specified",
@@ -1393,7 +1393,16 @@ func TestDataSourceValidateCreate(t *testing.T) {
 				Image:            "aimodels.azurecr.io/data-image",
 				ImagePullSecrets: []string{"imagePushSecret"},
 			},
-			wantErr: true,
+			wantErr: false,
+		},
+		{
+			name: "Invalid image",
+			dataSource: &DataSource{
+				Image:            "!ValidImage",
+				ImagePullSecrets: []string{"imagePushSecret"},
+			},
+			wantErr:  true,
+			errField: "invalid reference format",
 		},
 		{
 			name:       "None specified",
@@ -1472,6 +1481,16 @@ func TestDataSourceValidateUpdate(t *testing.T) {
 			wantErr:   true,
 			errFields: []string{"Name"},
 		},
+		{
+			name:      "Invalid image",
+			oldSource: &DataSource{},
+			newSource: &DataSource{
+				Image:            "!ValidImage",
+				ImagePullSecrets: []string{"imagePushSecret"},
+			},
+			wantErr:   true,
+			errFields: []string{"invalid reference format"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1528,7 +1547,7 @@ func TestDataDestinationValidateCreate(t *testing.T) {
 				Image:           "data-image:latest",
 				ImagePushSecret: "imagePushSecret",
 			},
-			wantErr: true,
+			wantErr: false,
 		},
 		{
 			name: "Image without Tag Specified",
@@ -1536,7 +1555,16 @@ func TestDataDestinationValidateCreate(t *testing.T) {
 				Image:           "aimodels.azurecr.io/data-image",
 				ImagePushSecret: "imagePushSecret",
 			},
-			wantErr: true,
+			wantErr: false,
+		},
+		{
+			name: "Invalid image",
+			dataDestination: &DataDestination{
+				Image:           "!ValidImage",
+				ImagePushSecret: "imagePushSecret",
+			},
+			wantErr:  true,
+			errField: "invalid reference format",
 		},
 		// {
 		// 	name: "Both fields specified",
@@ -1586,6 +1614,16 @@ func TestDataDestinationValidateUpdate(t *testing.T) {
 				ImagePushSecret: "old-secret",
 			},
 			wantErr: false,
+		},
+		{
+			name:    "Invalid image",
+			oldDest: &DataDestination{},
+			newDest: &DataDestination{
+				Image:           "!ValidImage",
+				ImagePushSecret: "imagePushSecret",
+			},
+			wantErr:   true,
+			errFields: []string{"invalid reference format"},
 		},
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/Azure/karpenter-provider-azure v0.7.0
 	github.com/aws/karpenter-provider-aws v1.0.6
 	github.com/awslabs/operatorpkg v0.0.0-20240805231134-67d0acfb6306
+	github.com/distribution/reference v0.5.0
 	github.com/go-logr/logr v1.4.2
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/onsi/gomega v1.36.2
@@ -72,6 +73,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/patrickmn/go-cache v2.1.0+incompatible // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -148,6 +148,8 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/distribution/reference v0.5.0 h1:/FUIFXtfc/x2gpa5/VGfiGLuOIdYa1t65IKK2OFGvA0=
+github.com/distribution/reference v0.5.0/go.mod h1:BbU0aIcezP1/5jX/8MP0YiH4SdvB5Y4f/wlDRiLyi3E=
 github.com/emicklei/go-restful/v3 v3.12.1 h1:PJMDIM/ak7btuL8Ex0iYET9hxM3CI2sjZtzpL63nKAU=
 github.com/emicklei/go-restful/v3 v3.12.1/go.mod h1:6n3XBCmQQb25CM2LCACGz8ukIrRry+4bhvbpWn3mrbc=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
@@ -371,6 +373,8 @@ github.com/onsi/ginkgo/v2 v2.22.2 h1:/3X8Panh8/WwhU/3Ssa6rCKqPLuAkVY2I0RoyDLySlU
 github.com/onsi/ginkgo/v2 v2.22.2/go.mod h1:oeMosUL+8LtarXBHu/c0bx2D/K9zyQ6uX3cTyztHwsk=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
 github.com/onsi/gomega v1.36.2/go.mod h1:DdwyADRjrc825LhMEkD76cHR5+pUnjhUN8GlHlRPHzY=
+github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
+github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=

--- a/pkg/workspace/image/README.md
+++ b/pkg/workspace/image/README.md
@@ -1,0 +1,31 @@
+# Kaito Adapter Image Format Specification
+
+This document describes the specification for Kaito-compatible adapter images. It assumes the reader is familiar with the [OCI Image Format Specification](https://github.com/opencontainers/image-spec).
+
+## Image Layout
+
+A Kaito-compatible adapter image consists of any OCI image with the file structure below. Files added to the image but not specified here are simply ignored. The image can use any base and have as many layers as needed.
+```
+/
+└── data
+    ├── adapter_config.json
+    └── adapter_model.safetensors
+```
+
+A minimal and conformant image can be created by building the following Dockerfile:
+
+```dockerfile
+FROM scratch
+COPY adapter_config.json       /data/
+COPY adapter_model.safetensors /data/
+```
+
+## Building Platform-Independent Images
+
+To build a platform-independent image compatible with Kaito, you can leverage [pusher.sh](pusher.sh). Simply run `./pusher.sh ${PATH_TO_DATA_DIRECTORY} ${IMAGE_REFERENCE}` to build and push a platform-independent image containing the files in the specified directory.
+
+The following example pushes `~/Documents/kaito/adapter/data` to `ghcr.io/kaito-project/kaito/adapter` with tag `1.2.3`:
+
+```bash
+./pusher.sh ~/Documents/kaito/adapter/data ghcr.io/kaito-project/kaito/adapter:1.2.3
+```

--- a/pkg/workspace/image/puller.go
+++ b/pkg/workspace/image/puller.go
@@ -1,0 +1,66 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package image
+
+import (
+	"bytes"
+	_ "embed"
+	"log"
+	"text/template"
+
+	"github.com/distribution/reference"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	//go:embed puller.sh
+	pullerSHTextData string
+
+	pullerSHTemplate *template.Template
+)
+
+func init() {
+	t, err := template.New("puller.sh").Option("missingkey=zero").Parse(pullerSHTextData)
+	if err != nil {
+		panic(err)
+	}
+
+	pullerSHTemplate = t
+}
+
+func renderPullerSH(imgRef string, volDir string) string {
+	normalizedImgRef, err := reference.ParseDockerRef(imgRef)
+	if err != nil {
+		log.Printf("failed to normalize image reference `%s`: %v", imgRef, err)
+	}
+	if normalizedImgRef != nil {
+		imgRef = normalizedImgRef.String()
+	}
+
+	data := map[string]string{
+		"imgRef": imgRef,
+		"volDir": volDir,
+	}
+
+	var buf bytes.Buffer
+	if err := pullerSHTemplate.Execute(&buf, data); err != nil {
+		panic(err)
+	}
+
+	return buf.String()
+}
+
+func NewPullerContainer(inputImage string, outputDirectory string) *corev1.Container {
+	return &corev1.Container{
+		Name:  "puller",
+		Image: "quay.io/skopeo/stable:v1.18.0-immutable",
+		Command: []string{
+			"/bin/sh",
+			"-c",
+		},
+		Args: []string{
+			renderPullerSH(inputImage, outputDirectory),
+		},
+	}
+}

--- a/pkg/workspace/image/puller.sh
+++ b/pkg/workspace/image/puller.sh
@@ -1,0 +1,58 @@
+#!/bin/sh
+set -ex
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+TMPDIR="$(mktemp -d)"
+
+IMG_REF="${1}"
+[ ! -z "${IMG_REF}" ] || IMG_REF='{{ .imgRef }}'
+
+VOL_DIR="${2}"
+[ ! -z "${VOL_DIR}" ] || VOL_DIR='{{ .volDir }}'
+
+#{{`
+
+pull() {
+    LAYOUT_DIR="${TMPDIR}/layout"
+
+    local DOCKER_CONFIG_D="${HOME}/.docker/config.d"
+    [ ! -e "${DOCKER_CONFIG_D}" ] || local REGISTRY_AUTH_FILES="$(find -L "${DOCKER_CONFIG_D}" -type 'f' -printf '%p ')"
+
+    for REGISTRY_AUTH_FILE in '' ${REGISTRY_AUTH_FILES}
+    do
+        local SKOPEO_ARGS='--dest-decompress'
+        [ -z "${REGISTRY_AUTH_FILE}" ] || SKOPEO_ARGS="${SKOPEO_ARGS} --authfile=${REGISTRY_AUTH_FILE}"
+
+        skopeo copy ${SKOPEO_ARGS} "docker://${IMG_REF}" "dir:${LAYOUT_DIR}" || continue
+
+        local OK='1'
+        break
+    done
+
+    [ "${OK}" = '1' ]
+}
+
+expand() {
+    ROOTFS_DIR="${TMPDIR}/rootfs"
+    mkdir -p "${ROOTFS_DIR}"
+
+    local LAYER_DIFFS="$(skopeo inspect --format '{{ range .Layers }}{{ slice . 7 }} {{ end }}' "dir:${LAYOUT_DIR}")"
+    for LAYER_DIFF in ${LAYER_DIFFS}
+    do
+        local LAYER_PATH="${LAYOUT_DIR}/${LAYER_DIFF}"
+        tar x -f "${LAYER_PATH}" -C "${ROOTFS_DIR}"
+    done
+}
+
+relocate() {
+    local DATA_PATH="${ROOTFS_DIR}/data"
+    mv -f "${DATA_PATH}" "${VOL_DIR}"
+}
+
+#`}}
+
+pull
+expand
+relocate

--- a/pkg/workspace/image/puller_test.go
+++ b/pkg/workspace/image/puller_test.go
@@ -1,0 +1,101 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package image
+
+import (
+	"text/template"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+var _ = Describe("Puller", func() {
+	Context("embed", func() {
+		It("initializes the puller text data", func() {
+			Expect(pullerSHTextData).NotTo(BeEmpty())
+		})
+
+		It("uses sh as the interpreter", func() {
+			Expect(pullerSHTextData).To(HavePrefix("#!/bin/sh\n"))
+		})
+	})
+
+	Context("init", func() {
+		It("instantiates the puller template", func() {
+			Expect(pusherSHTemplate).NotTo(BeNil())
+		})
+	})
+
+	Context("renderPullerSH", func() {
+		It("renders the puller script", func() {
+			var (
+				imgRef = "docker.io/library/scratch:" + rand.String(8)
+				volDir = "/tmp/" + rand.String(8)
+			)
+
+			ret := renderPullerSH(imgRef, volDir)
+			Expect(ret).To(ContainSubstring("\n" + `[ ! -z "${IMG_REF}" ] || IMG_REF='` + imgRef + `'` + "\n"))
+			Expect(ret).To(ContainSubstring("\n" + `[ ! -z "${VOL_DIR}" ] || VOL_DIR='` + volDir + `'` + "\n"))
+		})
+
+		It("normalizes the image reference", func() {
+			var (
+				imgRef = "scratch-" + rand.String(8)
+				volDir = "/tmp/" + rand.String(8)
+			)
+
+			ret := renderPullerSH(imgRef, volDir)
+			Expect(ret).To(ContainSubstring("\n" + `[ ! -z "${IMG_REF}" ] || IMG_REF='docker.io/library/` + imgRef + `:latest'` + "\n"))
+		})
+
+		It("falls back to original image reference when unable to normalize", func() {
+			var (
+				imgRef = "!" + rand.String(8)
+				volDir = "/tmp/" + rand.String(8)
+			)
+
+			ret := renderPullerSH(imgRef, volDir)
+			Expect(ret).To(ContainSubstring("\n" + `[ ! -z "${IMG_REF}" ] || IMG_REF='` + imgRef + `'` + "\n"))
+		})
+
+		It("panics when the template is bad", func() {
+			var (
+				imgRef = "docker.io/library/scratch:" + rand.String(8)
+				volDir = "/tmp/" + rand.String(8)
+			)
+
+			pullerSHTemplate0 := pullerSHTemplate
+			defer func() {
+				pullerSHTemplate = pullerSHTemplate0
+			}()
+
+			pullerSHTemplate = &template.Template{}
+
+			f := func() {
+				ret := renderPullerSH(imgRef, volDir)
+				Expect(ret).To(BeEmpty())
+			}
+			Expect(f).To(PanicWith(MatchError(`template: : "" is an incomplete or empty template`)))
+		})
+	})
+
+	Context("NewPullerContainer", func() {
+		It("returns the expected container", func() {
+			var (
+				imgRef = "docker.io/library/scratch:" + rand.String(8)
+				volDir = "/tmp/" + rand.String(8)
+			)
+
+			pullerSH := renderPullerSH(imgRef, volDir)
+
+			ret := NewPullerContainer(imgRef, volDir)
+			Expect(ret).NotTo(BeNil())
+			Expect(ret.Name).To(Equal("puller"))
+			Expect(ret.Image).To(Equal("quay.io/skopeo/stable:v1.18.0-immutable"))
+			Expect(ret.Command).To(Equal([]string{"/bin/sh", "-c"}))
+			Expect(ret.Args).To(Equal([]string{pullerSH}))
+		})
+	})
+})

--- a/pkg/workspace/image/pusher.go
+++ b/pkg/workspace/image/pusher.go
@@ -1,0 +1,83 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package image
+
+import (
+	"bytes"
+	_ "embed"
+	"encoding/json"
+	"log"
+	"path"
+	"text/template"
+
+	"github.com/distribution/reference"
+	corev1 "k8s.io/api/core/v1"
+)
+
+var (
+	//go:embed pusher.sh
+	pusherSHTextData string
+
+	pusherSHTemplate *template.Template
+)
+
+func init() {
+	t, err := template.New("pusher.sh").Option("missingkey=zero").Parse(pusherSHTextData)
+	if err != nil {
+		panic(err)
+	}
+
+	pusherSHTemplate = t
+}
+
+func renderPusherSH(volDir string, imgRef string, annotationsData map[string]map[string]string, sentinelPath *string) string {
+	normalizedImgRef, err := reference.ParseDockerRef(imgRef)
+	if err != nil {
+		log.Printf("failed to normalize image reference `%s`: %v", imgRef, err)
+	}
+	if normalizedImgRef != nil {
+		imgRef = normalizedImgRef.String()
+	}
+
+	data := map[string]string{
+		"volDir":          volDir,
+		"imgRef":          imgRef,
+		"annotationsData": "{}",
+		"sentinelPath":    path.Join(volDir, "fine_tuning_completed.txt"),
+	}
+
+	if annotationsData != nil {
+		annotationsData, err := json.Marshal(annotationsData)
+		if err != nil {
+			panic(err)
+		}
+
+		data["annotationsData"] = string(annotationsData)
+	}
+
+	if sentinelPath != nil {
+		data["sentinelPath"] = *sentinelPath
+	}
+
+	var buf bytes.Buffer
+	if err := pusherSHTemplate.Execute(&buf, data); err != nil {
+		panic(err)
+	}
+
+	return buf.String()
+}
+
+func NewPusherContainer(inputDirectory string, outputImage string, annotationsData map[string]map[string]string, sentinelPath *string) *corev1.Container {
+	return &corev1.Container{
+		Name:  "pusher",
+		Image: "ghcr.io/oras-project/oras:v1.2.2",
+		Command: []string{
+			"/bin/sh",
+			"-c",
+		},
+		Args: []string{
+			renderPusherSH(inputDirectory, outputImage, annotationsData, sentinelPath),
+		},
+	}
+}

--- a/pkg/workspace/image/pusher.sh
+++ b/pkg/workspace/image/pusher.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+set -ex
+
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
+
+TMPDIR="$(mktemp -d)"
+
+VOL_DIR="${1}"
+[ ! -z "${VOL_DIR}" ] || VOL_DIR='{{ .volDir }}'
+
+IMG_REF="${2}"
+[ ! -z "${IMG_REF}" ] || IMG_REF='{{ .imgRef }}'
+
+[ ! -z '{{ "" }}' ] || ANNOTATIONS_DATA='{{ .annotationsData }}'
+ANNOTATIONS_DATA="${ANNOTATIONS_DATA:-{}}"
+
+[ ! -z '{{ "" }}' ] || SENTINEL_PATH='{{ .sentinelPath }}'
+SENTINEL_PATH="${SENTINEL_PATH:-.}"
+
+#{{`
+
+wait() {
+    until [ -e "${SENTINEL_PATH}" ]
+    do
+        sleep 1
+    done
+}
+
+mklayer() {
+    local DATA_DIR="${TMPDIR}/data"
+    mkdir -p "${DATA_DIR}"
+
+    cp -R "${VOL_DIR}/adapter_config.json" "${VOL_DIR}/adapter_model.safetensors" "${DATA_DIR}"
+
+    local TAR_LAYER_PATH="${TMPDIR}/layer.tar"
+
+    tar c -f "${TAR_LAYER_PATH}" -C "$(dirname "${DATA_DIR}")" "$(basename "${DATA_DIR}")"
+
+    TAR_LAYER_DIFF="$(sha256sum "${TAR_LAYER_PATH}" | cut -d ' ' -f '1')"
+
+    gzip -9 "${TAR_LAYER_PATH}"
+
+    TGZ_LAYER_MIME='application/vnd.oci.image.layer.v1.tar+gzip'
+    TGZ_LAYER_PATH="${TAR_LAYER_PATH}.gz"
+}
+
+mkconfig() {
+    CONFIG_MIME='application/vnd.oci.image.config.v1+json'
+    CONFIG_PATH="${TMPDIR}/config.json"
+
+    printf '{"rootfs":{"diff_ids":["sha256:%s"]}}' "${TAR_LAYER_DIFF}" > "${CONFIG_PATH}"
+}
+
+mkannotations() {
+    ANNOTATIONS_PATH="${TMPDIR}/annotations.json"
+
+    printf '%s' "${ANNOTATIONS_DATA}" > "${ANNOTATIONS_PATH}"
+}
+
+mklayout() {
+    LAYOUT_REF="${TMPDIR}/layout:latest"
+
+    cd "$(dirname "${TGZ_LAYER_PATH}")"
+    oras push --disable-path-validation --annotation-file "${ANNOTATIONS_PATH}" --config "${CONFIG_PATH}:${CONFIG_MIME}" --oci-layout "${LAYOUT_REF}" "$(basename "${TGZ_LAYER_PATH}"):${TGZ_LAYER_MIME}"
+    cd -
+}
+
+push() {
+    oras cp --from-oci-layout "${LAYOUT_REF}" "${IMG_REF}"
+}
+
+resume() {
+    killall -SIGCHLD 'pause' 0</dev/null 1>&0 2>&0 || true
+}
+
+#`}}
+
+wait
+mklayer
+mkconfig
+mkannotations
+mklayout
+push
+resume

--- a/pkg/workspace/image/pusher_test.go
+++ b/pkg/workspace/image/pusher_test.go
@@ -1,0 +1,109 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package image
+
+import (
+	"encoding/json"
+	"text/template"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/rand"
+)
+
+var _ = Describe("Pusher", func() {
+	Context("embed", func() {
+		It("initializes the pusher text data", func() {
+			Expect(pusherSHTextData).NotTo(BeEmpty())
+		})
+
+		It("uses sh as the interpreter", func() {
+			Expect(pusherSHTextData).To(HavePrefix("#!/bin/sh\n"))
+		})
+	})
+
+	Context("init", func() {
+		It("instantiates the pusher template", func() {
+			Expect(pusherSHTemplate).NotTo(BeNil())
+		})
+	})
+
+	Context("renderPusherSH", func() {
+		It("renders the pusher script", func() {
+			var (
+				volDir          = "/tmp/" + rand.String(8)
+				imgRef          = "docker.io/library/scratch:" + rand.String(8)
+				annotationsData = map[string]map[string]string{"$config": {"hello": "world"}, "$manifest": {"foo": "bar"}}
+				sentinelPath    = "/tmp/" + rand.String(8)
+			)
+
+			bytes, err := json.Marshal(annotationsData)
+			Expect(err).NotTo(HaveOccurred())
+
+			ret := renderPusherSH(volDir, imgRef, annotationsData, &sentinelPath)
+			Expect(ret).To(ContainSubstring("\n" + `[ ! -z "${VOL_DIR}" ] || VOL_DIR='` + volDir + `'` + "\n"))
+			Expect(ret).To(ContainSubstring("\n" + `[ ! -z "${IMG_REF}" ] || IMG_REF='` + imgRef + `'` + "\n"))
+			Expect(ret).To(ContainSubstring("\n" + `[ ! -z '' ] || ANNOTATIONS_DATA='` + string(bytes) + `'` + "\n"))
+			Expect(ret).To(ContainSubstring("\n" + `[ ! -z '' ] || SENTINEL_PATH='` + sentinelPath + `'` + "\n"))
+		})
+
+		It("normalizes the image reference", func() {
+			var (
+				volDir = "/tmp/" + rand.String(8)
+				imgRef = "scratch-" + rand.String(8)
+			)
+
+			ret := renderPusherSH(volDir, imgRef, nil, nil)
+			Expect(ret).To(ContainSubstring("\n" + `[ ! -z "${IMG_REF}" ] || IMG_REF='docker.io/library/` + imgRef + `:latest'` + "\n"))
+		})
+
+		It("falls back to original image reference when unable to normalize", func() {
+			var (
+				volDir = "/tmp/" + rand.String(8)
+				imgRef = "^" + rand.String(8)
+			)
+
+			ret := renderPusherSH(volDir, imgRef, nil, nil)
+			Expect(ret).To(ContainSubstring("\n" + `[ ! -z "${IMG_REF}" ] || IMG_REF='` + imgRef + `'` + "\n"))
+		})
+
+		It("panics when the template is bad", func() {
+			var (
+				volDir = "/tmp/" + rand.String(8)
+				imgRef = "docker.io/library/scratch:" + rand.String(8)
+			)
+
+			pusherSHTemplate0 := pusherSHTemplate
+			defer func() {
+				pusherSHTemplate = pusherSHTemplate0
+			}()
+
+			pusherSHTemplate = &template.Template{}
+
+			f := func() {
+				ret := renderPusherSH(volDir, imgRef, nil, nil)
+				Expect(ret).To(BeEmpty())
+			}
+			Expect(f).To(PanicWith(MatchError(`template: : "" is an incomplete or empty template`)))
+		})
+	})
+
+	Context("NewPusherContainer", func() {
+		It("returns the expected container", func() {
+			var (
+				volDir = "/tmp/" + rand.String(8)
+				imgRef = "docker.io/library/scratch:" + rand.String(8)
+			)
+
+			pusherSH := renderPusherSH(volDir, imgRef, nil, nil)
+
+			ret := NewPusherContainer(volDir, imgRef, nil, nil)
+			Expect(ret).NotTo(BeNil())
+			Expect(ret.Name).To(Equal("pusher"))
+			Expect(ret.Image).To(Equal("ghcr.io/oras-project/oras:v1.2.2"))
+			Expect(ret.Command).To(Equal([]string{"/bin/sh", "-c"}))
+			Expect(ret.Args).To(Equal([]string{pusherSH}))
+		})
+	})
+})

--- a/pkg/workspace/image/suite_test.go
+++ b/pkg/workspace/image/suite_test.go
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+package image
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestImage(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Image Suite")
+}

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -94,6 +94,14 @@ var _ = BeforeSuite(func() {
 		},
 	})
 	Expect(err).NotTo(HaveOccurred())
+
+	loadTestEnvVars()
+
+	err = copySecretToNamespace(aiModelsRegistrySecret, namespaceName)
+	Expect(err).NotTo(HaveOccurred())
+
+	err = copySecretToNamespace(e2eACRSecret, namespaceName)
+	Expect(err).NotTo(HaveOccurred())
 })
 
 var _ = AfterSuite(func() {

--- a/test/e2e/inference_with_adapters_test.go
+++ b/test/e2e/inference_with_adapters_test.go
@@ -17,6 +17,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/workspace/image"
 	"github.com/kaito-project/kaito/test/e2e/utils"
 )
 
@@ -33,7 +34,7 @@ var validAdapters1 = []kaitov1beta1.AdapterSpec{
 			Name:  imageName1,
 			Image: fullImageName1,
 			ImagePullSecrets: []string{
-				utils.GetEnv("AI_MODELS_REGISTRY_SECRET"),
+				utils.GetEnv("E2E_ACR_REGISTRY_SECRET"),
 			},
 		},
 		Strength: &DefaultStrength,
@@ -53,17 +54,19 @@ var validAdapters2 = []kaitov1beta1.AdapterSpec{
 	},
 }
 
+var baseInitContainer = image.NewPullerContainer("", "")
+
 var expectedInitContainers1 = []corev1.Container{
 	{
-		Name:  imageName1,
-		Image: fullImageName1,
+		Name:  baseInitContainer.Name + "-" + imageName1,
+		Image: baseInitContainer.Image,
 	},
 }
 
 var expectedInitContainers2 = []corev1.Container{
 	{
-		Name:  imageName2,
-		Image: fullImageName2,
+		Name:  baseInitContainer.Name + "-" + imageName2,
+		Image: baseInitContainer.Image,
 	},
 }
 

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -5,7 +5,6 @@ package e2e
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math/rand"
 	"os"
@@ -113,11 +112,6 @@ func updateCustomWorkspaceWithAdapter(workspaceObj *kaitov1beta1.Workspace, vali
 					Name:      workspaceObj.Name,
 				}, workspaceObj, &client.GetOptions{})
 				Expect(err).NotTo(HaveOccurred())
-
-				workspaceJSON, err := json.Marshal(workspaceObj)
-				Expect(err).NotTo(HaveOccurred())
-
-				GinkgoWriter.Printf("Workspace definition: %s\n", string(workspaceJSON))
 			})
 		})
 	})
@@ -245,11 +239,6 @@ func createAndValidateConfigMap(configMap *v1.ConfigMap) {
 				Name:      configMap.Name,
 			}, configMap, &client.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-
-			configMapJSON, err := json.Marshal(configMap)
-			Expect(err).NotTo(HaveOccurred())
-
-			GinkgoWriter.Printf("ConfigMap definition: %s\n", string(configMapJSON))
 		})
 	})
 }
@@ -285,11 +274,6 @@ func createAndValidateWorkspace(workspaceObj *kaitov1beta1.Workspace) {
 				Name:      workspaceObj.Name,
 			}, workspaceObj, &client.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-
-			workspaceJSON, err := json.Marshal(workspaceObj)
-			Expect(err).NotTo(HaveOccurred())
-
-			GinkgoWriter.Printf("Workspace definition: %s\n", string(workspaceJSON))
 		})
 	})
 }
@@ -324,11 +308,6 @@ func updateAndValidateWorkspace(workspaceObj *kaitov1beta1.Workspace) {
 				Name:      workspaceObj.Name,
 			}, workspaceObj, &client.GetOptions{})
 			Expect(err).NotTo(HaveOccurred())
-
-			workspaceJSON, err := json.Marshal(workspaceObj)
-			Expect(err).NotTo(HaveOccurred())
-
-			GinkgoWriter.Printf("Workspace definition: %s\n", string(workspaceJSON))
 		})
 	})
 }
@@ -345,11 +324,6 @@ func copySecretToNamespace(secretName, targetNamespace string) error {
 	if err != nil {
 		return fmt.Errorf("failed to get secret %s in namespace %s: %v", secretName, originalNamespace, err)
 	}
-
-	secretJSON, err := json.Marshal(originalSecret)
-	Expect(err).NotTo(HaveOccurred())
-
-	GinkgoWriter.Printf("Secret definition: %s\n", string(secretJSON))
 
 	// Create a copy of the secret for the target namespace
 	newSecret := utils.CopySecret(originalSecret, targetNamespace)
@@ -375,11 +349,6 @@ func validateResourceStatus(workspaceObj *kaitov1beta1.Workspace) {
 			if err != nil {
 				return false
 			}
-
-			workspaceJSON, err := json.Marshal(workspaceObj)
-			Expect(err).NotTo(HaveOccurred())
-
-			GinkgoWriter.Printf("Workspace definition: %s\n", string(workspaceJSON))
 
 			_, conditionFound := lo.Find(workspaceObj.Status.Conditions, func(condition metav1.Condition) bool {
 				return condition.Type == string(kaitov1beta1.ConditionTypeResourceStatus) &&
@@ -412,11 +381,6 @@ func validateAssociatedService(workspaceObj *kaitov1beta1.Workspace) {
 				return false
 			}
 
-			serviceJSON, err := json.Marshal(service)
-			Expect(err).NotTo(HaveOccurred())
-
-			GinkgoWriter.Printf("Service definition: %s\n", string(serviceJSON))
-
 			GinkgoWriter.Printf("Found service: %s in namespace %s\n", serviceName, serviceNamespace)
 			return true
 		}, 10*time.Minute, utils.PollInterval).Should(BeTrue(), "Failed to wait for service to be created")
@@ -443,10 +407,6 @@ func validateInferenceResource(workspaceObj *kaitov1beta1.Workspace, expectedRep
 				}, sts)
 				readyReplicas = sts.Status.ReadyReplicas
 
-				statefulSetJSON, err := json.Marshal(sts)
-				Expect(err).NotTo(HaveOccurred())
-
-				GinkgoWriter.Printf("StatefulSet definition: %s\n", string(statefulSetJSON))
 			} else {
 				dep := &appsv1.Deployment{
 					ObjectMeta: metav1.ObjectMeta{
@@ -459,11 +419,6 @@ func validateInferenceResource(workspaceObj *kaitov1beta1.Workspace, expectedRep
 					Name:      workspaceObj.Name,
 				}, dep)
 				readyReplicas = dep.Status.ReadyReplicas
-
-				deploymentJSON, err := json.Marshal(dep)
-				Expect(err).NotTo(HaveOccurred())
-
-				GinkgoWriter.Printf("Deployment definition: %s\n", string(deploymentJSON))
 			}
 
 			if err != nil {
@@ -496,11 +451,6 @@ func validateRevision(workspaceObj *kaitov1beta1.Workspace, revisionStr string) 
 					return false
 				}
 				isWorkloadAnnotationCorrect = dep.Annotations[WorkspaceRevisionAnnotation] == revisionStr
-
-				deploymentJSON, err := json.Marshal(dep)
-				Expect(err).NotTo(HaveOccurred())
-
-				GinkgoWriter.Printf("Deployment definition: %s\n", string(deploymentJSON))
 			} else if workspaceObj.Tuning != nil {
 				job := &batchv1.Job{}
 				err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
@@ -512,11 +462,6 @@ func validateRevision(workspaceObj *kaitov1beta1.Workspace, revisionStr string) 
 					return false
 				}
 				isWorkloadAnnotationCorrect = job.Annotations[WorkspaceRevisionAnnotation] == revisionStr
-
-				jobJSON, err := json.Marshal(job)
-				Expect(err).NotTo(HaveOccurred())
-
-				GinkgoWriter.Printf("Job definition: %s\n", string(jobJSON))
 			}
 			workspaceObjHash := workspaceObj.Annotations[WorkspaceHashAnnotation]
 			revision := &appsv1.ControllerRevision{}
@@ -529,11 +474,6 @@ func validateRevision(workspaceObj *kaitov1beta1.Workspace, revisionStr string) 
 				GinkgoWriter.Printf("Error fetching resource: %v\n", err)
 				return false
 			}
-
-			controllerRevisionJSON, err := json.Marshal(revision)
-			Expect(err).NotTo(HaveOccurred())
-
-			GinkgoWriter.Printf("ControllerRevision definition: %s\n", string(controllerRevisionJSON))
 
 			revisionNum, _ := strconv.ParseInt(revisionStr, 10, 64)
 
@@ -568,11 +508,6 @@ func validateTuningResource(workspaceObj *kaitov1beta1.Workspace) {
 				return false
 			}
 
-			jobJSON, err := json.Marshal(job)
-			Expect(err).NotTo(HaveOccurred())
-
-			GinkgoWriter.Printf("Job definition: %s\n", string(jobJSON))
-
 			jobFailed = job.Status.Failed
 			jobSucceeded = job.Status.Succeeded
 
@@ -602,11 +537,6 @@ func validateTuningJobInputOutput(workspaceObj *kaitov1beta1.Workspace, inputIma
 
 				Expect(err).NotTo(HaveOccurred())
 			}
-
-			jobJSON, err := json.Marshal(job)
-			Expect(err).NotTo(HaveOccurred())
-
-			GinkgoWriter.Printf("Job definition: %s\n", string(jobJSON))
 
 			var pullerContainer *v1.Container
 			for _, container := range job.Spec.Template.Spec.InitContainers {
@@ -653,11 +583,6 @@ func validateACRTuningResultsUploaded(workspaceObj *kaitov1beta1.Workspace, jobN
 			Fail(fmt.Sprintf("Failed to get job %s: %v", jobName, err))
 		}
 
-		jobJSON, err := json.Marshal(job)
-		Expect(err).NotTo(HaveOccurred())
-
-		GinkgoWriter.Printf("Job definition: %s\n", string(jobJSON))
-
 		if job.Status.CompletionTime.IsZero() {
 			time.Sleep(10 * time.Second) // Poll every 10 seconds
 			continue
@@ -685,11 +610,6 @@ func validateWorkspaceReadiness(workspaceObj *kaitov1beta1.Workspace) {
 			if err != nil {
 				return false
 			}
-
-			workspaceJSON, err := json.Marshal(workspaceObj)
-			Expect(err).NotTo(HaveOccurred())
-
-			GinkgoWriter.Printf("Workspace definition: %s\n", string(workspaceJSON))
 
 			_, conditionFound := lo.Find(workspaceObj.Status.Conditions, func(condition metav1.Condition) bool {
 				return condition.Type == string(kaitov1beta1.WorkspaceConditionTypeSucceeded) &&
@@ -815,11 +735,6 @@ func deleteWorkspace(workspaceObj *kaitov1beta1.Workspace) error {
 			if err != nil {
 				return fmt.Errorf("error checking if workspace %s exists: %v", workspaceObj.Name, err)
 			}
-
-			workspaceJSON, err := json.Marshal(workspaceObj)
-			Expect(err).NotTo(HaveOccurred())
-
-			GinkgoWriter.Printf("Workspace definition: %s\n", string(workspaceJSON))
 
 			err = utils.TestingCluster.KubeClient.Delete(ctx, workspaceObj, &client.DeleteOptions{})
 			if err != nil {
@@ -1066,11 +981,6 @@ func validateInferenceConfig(workspaceObj *kaitov1beta1.Workspace) {
 				GinkgoWriter.Printf("Error fetching config: %v\n", err)
 				return false
 			}
-
-			configMapJSON, err := json.Marshal(configMap)
-			Expect(err).NotTo(HaveOccurred())
-
-			GinkgoWriter.Printf("ConfigMap definition: %s\n", string(configMapJSON))
 
 			return len(configMap.Data) > 0
 		}, 10*time.Minute, utils.PollInterval).Should(BeTrue(), "Failed to wait for inference config to be ready")

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -6,7 +6,6 @@ package utils
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log"
@@ -26,7 +25,6 @@ import (
 	pkgscheme "k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"k8s.io/client-go/tools/reference"
 	"k8s.io/client-go/tools/remotecommand"
 
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
@@ -206,39 +204,7 @@ func PrintPodLogsOnFailure(namespace, labelSelector string) {
 	}
 
 	for _, pod := range pods.Items {
-		podJSON, err := json.Marshal(pod)
-		if err != nil {
-			log.Printf("Failed to marshal pod %s/%s: %v", pod.Namespace, pod.Name, err)
-		}
-		if podJSON != nil {
-			log.Printf("Pod Definition for %s/%s: %s\n", pod.Namespace, pod.Name, string(podJSON))
-		}
-
-		ref, err := reference.GetReference(scheme, &pod)
-		if err != nil {
-			log.Printf("Unable to construct reference to %s/%s: %v", pod.Namespace, pod.Name, err)
-		}
-		if ref != nil {
-			ref.Kind = ""
-
-			events, err := coreClient.CoreV1().Events(namespace).Search(scheme, ref)
-			if err != nil {
-				log.Printf("Failed to get events for pod %s/%s: %v", pod.Namespace, pod.Name, err)
-			}
-			if events != nil {
-				for _, event := range events.Items {
-					eventJSON, err := json.Marshal(event)
-					if err != nil {
-						log.Printf("Failed to marshal event for pod %s/%s: %v", pod.Namespace, pod.Name, err)
-					}
-					if eventJSON != nil {
-						log.Printf("Event for pod %s/%s: %s\n", pod.Namespace, pod.Name, string(eventJSON))
-					}
-				}
-			}
-		}
-
-		for _, container := range append(pod.Spec.InitContainers, pod.Spec.Containers...) {
+		for _, container := range pod.Spec.Containers {
 			logs, err := GetPodLogs(coreClient, namespace, pod.Name, container.Name)
 			if err != nil {
 				log.Printf("Failed to get logs from pod %s, container %s: %v", pod.Name, container.Name, err)


### PR DESCRIPTION
**Reason for Change**:
This patch allows us to get rid of DinD, which currently runs in a privileged container. Skopeo will be used to pull images, mimicking the exact pull behavior of [K8s Image Volumes](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/). While ORAS is used to build the image in a way compatible with the implementation of [K8s Image Volumes](https://kubernetes.io/docs/tasks/configure-pod-container/image-volumes/) in `containerd` and `cri-o`.

**Requirements**
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
Fixes #901

**Notes for Reviewers**:
After this patch, images produced with newer versions of Kaito won't run on older versions of Kaito. However, images produced by older versions of Kaito will run on newer versions of Kaito. We probably want to make this clear on the release notes.