### PR TITLE
chore: use run id, number, and attempt to create unique azure resource names

### DIFF
--- a/.github/actions/e2e-base-setup/action.yml
+++ b/.github/actions/e2e-base-setup/action.yml
@@ -50,14 +50,11 @@ runs:
     - name: Set e2e Resource and Cluster Name
       shell: bash
       run: |
-        rand=$(git rev-parse --short ${{ inputs.git_sha }})
-        if [ -z "$rand" ]; then
-          rand=$RANDOM
-        fi
+        ID="ri${{ github.run_id }}rn${{ github.run_number }}ra${{ github.run_attempt }}"
 
-        echo "VERSION=${rand}" >> $GITHUB_ENV
-        echo "CLUSTER_NAME=${{ inputs.node_provisioner }}${rand}" >> $GITHUB_ENV
-        echo "REGISTRY=${{ inputs.node_provisioner }}${rand}.azurecr.io" >> $GITHUB_ENV
+        echo "VERSION=${ID}" >> $GITHUB_ENV
+        echo "CLUSTER_NAME=kaito${ID}" >> $GITHUB_ENV
+        echo "REGISTRY=kaito${ID}.azurecr.io" >> $GITHUB_ENV
         echo "RUN_LLAMA_13B=false" >> $GITHUB_ENV
 
     - name: Set Registry

--- a/.github/workflows/e2e-base-setup.yaml
+++ b/.github/workflows/e2e-base-setup.yaml
@@ -61,15 +61,11 @@ jobs:
 
       - name: Set e2e Resource and Cluster Name
         run: |
-          rand=$(git rev-parse --short ${{ inputs.git_sha }})
-          
-          if [ "$rand" = "" ]; then
-             rand=$RANDOM
-          fi
+          ID="ri${{ github.run_id }}rn${{ github.run_number }}ra${{ github.run_attempt }}"
 
-          echo "VERSION=${rand}" >> $GITHUB_ENV
-          echo "CLUSTER_NAME=${{ inputs.node_provisioner }}${rand}" >> $GITHUB_ENV
-          echo "REGISTRY=${{ inputs.node_provisioner }}${rand}.azurecr.io" >> $GITHUB_ENV
+          echo "VERSION=${ID}" >> $GITHUB_ENV
+          echo "CLUSTER_NAME=kaito${ID}" >> $GITHUB_ENV
+          echo "REGISTRY=kaito${ID}.azurecr.io" >> $GITHUB_ENV
           echo "RUN_LLAMA_13B=false" >> $GITHUB_ENV
 
       - name: Set Registry


### PR DESCRIPTION
**Reason for Change**:
E2E Pipelines were failing to run because of name collisions in Azure.

**Requirements**
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
Fixes #953

**Notes for Reviewers**:
See https://github.com/kaito-project/kaito/actions/runs/14071339635/job/39405996019?pr=950#step:5:650 and https://github.com/kaito-project/kaito/actions/runs/14071339635/job/39406506397?pr=950#step:5:274.