### PR TITLE
chore: Bump golang version to 1.24

### DIFF
--- a/.github/actions/e2e-base-setup/action.yml
+++ b/.github/actions/e2e-base-setup/action.yml
@@ -37,7 +37,7 @@ outputs:
     description: "Whether to run llama 13b"
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
 
 runs:
   using: "composite"
@@ -68,10 +68,10 @@ runs:
       shell: bash
       run: sudo rm -rf ~/go/pkg/mod
 
-    - name: Set up Go 1.23
+    - name: Set up Go 1.24
       uses: actions/setup-go@v5.2.0
       with:
-        go-version: "1.23"
+        go-version: "1.24"
 
     - name: Install Azure CLI latest
       shell: bash

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -9,7 +9,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.24'
 
 jobs:
   create-release:

--- a/.github/workflows/e2e-base-setup.yaml
+++ b/.github/workflows/e2e-base-setup.yaml
@@ -44,7 +44,7 @@ jobs:
       run_llama_13b: ${{ steps.set-outputs.outputs.run_llama_13b }}
 
     env:
-      GO_VERSION: "1.23"
+      GO_VERSION: "1.24"
 
     steps:
       - name: Harden Runner

--- a/.github/workflows/e2e-preset-test.yml
+++ b/.github/workflows/e2e-preset-test.yml
@@ -21,7 +21,7 @@ on:
                 description: "Test on VLLM runtime"
 
 env:
-    GO_VERSION: "1.23"
+    GO_VERSION: "1.24"
     BRANCH_NAME: ${{ github.head_ref || github.ref_name}} 
     FORCE_RUN_ALL: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force-run-all == 'true' }}
     FORCE_RUN_ALL_PHI:  ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force-run-all-phi-models== 'true' }}

--- a/.github/workflows/e2e-preset-tuning-test.yml
+++ b/.github/workflows/e2e-preset-tuning-test.yml
@@ -8,7 +8,7 @@ on:
     workflow_dispatch: {}
 
 env:
-    GO_VERSION: "1.23"
+    GO_VERSION: "1.24"
 
 permissions:
     id-token: write

--- a/.github/workflows/e2e-workflow.yml
+++ b/.github/workflows/e2e-workflow.yml
@@ -36,7 +36,7 @@ jobs:
     
     env:
       TEST_SUITE: ${{ inputs.node_provisioner }}
-      GO_VERSION: "1.23"
+      GO_VERSION: "1.24"
       KARPENTER_NAMESPACE: "karpenter"
       GPU_PROVISIONER_NAMESPACE: "gpu-provisioner"
 

--- a/.github/workflows/kaito-e2e.yml
+++ b/.github/workflows/kaito-e2e.yml
@@ -9,7 +9,7 @@ on:
     paths-ignore: ['docs/**', '**.md', '**.mdx', '**.png', '**.jpg']
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -13,7 +13,7 @@ on:
       - main
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.24'
 
 permissions:
   contents: read

--- a/.github/workflows/preset-image-build-1ES.yml
+++ b/.github/workflows/preset-image-build-1ES.yml
@@ -33,7 +33,7 @@ on:
         description: "Run all Phi models for build"
 
 env:
-    GO_VERSION: "1.23"
+    GO_VERSION: "1.24"
     BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     WEIGHTS_DIR: "/mnt/storage"
 

--- a/.github/workflows/preset-image-build.yml
+++ b/.github/workflows/preset-image-build.yml
@@ -28,7 +28,7 @@ on:
         default: false
         description: "Run all public models for build"
 env:
-    GO_VERSION: "1.23"
+    GO_VERSION: "1.24"
     BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
     WEIGHTS_DIR: "/datadrive"
 

--- a/.github/workflows/publish-rag-controller-gh-image.yml
+++ b/.github/workflows/publish-rag-controller-gh-image.yml
@@ -12,7 +12,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.24'
   IMAGE_NAME: 'kaito-rag-engine'
   REGISTRY: ghcr.io
 

--- a/.github/workflows/publish-rag-service-gh-image.yml
+++ b/.github/workflows/publish-rag-service-gh-image.yml
@@ -12,7 +12,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.24'
   IMAGE_NAME: 'kaito-rag-service'
   REGISTRY: ghcr.io
 

--- a/.github/workflows/publish-workspace-gh-image.yml
+++ b/.github/workflows/publish-workspace-gh-image.yml
@@ -12,7 +12,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.24'
   IMAGE_NAME: 'workspace'
   REGISTRY: ghcr.io
 

--- a/.github/workflows/publish-workspace-mcr-image.yml
+++ b/.github/workflows/publish-workspace-mcr-image.yml
@@ -8,7 +8,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.23'
+  GO_VERSION: '1.24'
   IMAGE_NAME: 'workspace'
 
 jobs:

--- a/.github/workflows/ragengine-e2e-workflow.yml
+++ b/.github/workflows/ragengine-e2e-workflow.yml
@@ -35,7 +35,7 @@ jobs:
     
     env:
       TEST_SUITE: ${{ inputs.node_provisioner }}      
-      GO_VERSION: "1.23"
+      GO_VERSION: "1.24"
       KARPENTER_NAMESPACE: "karpenter"
       GPU_PROVISIONER_NAMESPACE: "gpu-provisioner"
 

--- a/.github/workflows/ragengine-e2e.yml
+++ b/.github/workflows/ragengine-e2e.yml
@@ -12,7 +12,7 @@ on:
       - '.github/**'
 
 env:
-  GO_VERSION: "1.22"
+  GO_VERSION: "1.24"
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/unit-tests-ragengine.yml
+++ b/.github/workflows/unit-tests-ragengine.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: [ "self-hosted", "hostname:kaito-e2e-github-runner" ]
     environment: unit-tests
     steps:
       - name: Harden Runner
@@ -46,3 +46,5 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-tests-ragengine.yml
+++ b/.github/workflows/unit-tests-ragengine.yml
@@ -17,7 +17,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
 
 jobs:
   unit-tests:

--- a/.github/workflows/unit-tests-ragengine.yml
+++ b/.github/workflows/unit-tests-ragengine.yml
@@ -45,5 +45,6 @@ jobs:
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}
           verbose: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-tests-ragengine.yml
+++ b/.github/workflows/unit-tests-ragengine.yml
@@ -46,5 +46,3 @@ jobs:
         with:
           fail_ci_if_error: true
           verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-tests-ragengine.yml
+++ b/.github/workflows/unit-tests-ragengine.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   unit-tests:
-    runs-on: [ "self-hosted", "hostname:kaito-e2e-github-runner" ]
+    runs-on: ubuntu-latest
     environment: unit-tests
     steps:
       - name: Harden Runner
@@ -44,7 +44,5 @@ jobs:
       - name: Upload Coverage to Codecov
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
-          fail_ci_if_error: true
           verbose: true
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -59,6 +59,8 @@ jobs:
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
           ## Comma-separated list of files to upload
+          fail_ci_if_error: true
+          verbose: true
           files: ./coverage.txt
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,7 +17,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: "1.23"
+  GO_VERSION: "1.24"
 
 jobs:
   unit-tests:

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   unit-tests:
-    runs-on: ubuntu-latest
+    runs-on: [ "self-hosted", "hostname:kaito-e2e-github-runner" ]
     environment: unit-tests
     steps:
       - name: Harden Runner
@@ -62,3 +62,5 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           files: ./coverage.txt
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -62,5 +62,3 @@ jobs:
           fail_ci_if_error: true
           verbose: true
           files: ./coverage.txt
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -21,7 +21,7 @@ env:
 
 jobs:
   unit-tests:
-    runs-on: [ "self-hosted", "hostname:kaito-e2e-github-runner" ]
+    runs-on: ubuntu-latest
     environment: unit-tests
     steps:
       - name: Harden Runner
@@ -58,9 +58,6 @@ jobs:
       - name: Upload Codecov report
         uses: codecov/codecov-action@0565863a31f2c772f9f0395002a31e3f06189574 # v5.4.0
         with:
-          ## Comma-separated list of files to upload
-          fail_ci_if_error: true
           verbose: true
           files: ./coverage.txt
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -102,8 +102,9 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 ## --------------------------------------
 .PHONY: unit-test
 unit-test: ## Run unit tests.
-	CGO_ENABLED=1 go test -race -coverprofile=coverage.txt -covermode=atomic -v $(shell go list ./pkg/... ./api/... | \
-	grep -v -e /vendor -e /api/v1alpha1/zz_generated.deepcopy.go -e /api/v1beta1/zz_generated.deepcopy.go -e /pkg/utils/test/...)
+	go test -v $(shell go list ./pkg/... ./api/... | \
+	grep -v -e /vendor -e /api/v1alpha1/zz_generated.deepcopy.go -e /api/v1beta1/zz_generated.deepcopy.go -e /pkg/utils/test/...) \
+	-race -coverprofile=coverage.txt -covermode=atomic
 	go tool cover -func=coverage.txt
 
 .PHONY: rag-service-test

--- a/Makefile
+++ b/Makefile
@@ -102,9 +102,8 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 ## --------------------------------------
 .PHONY: unit-test
 unit-test: ## Run unit tests.
-	go test -v $(shell go list ./pkg/... ./api/... | \
-	grep -v -e /vendor -e /api/v1alpha1/zz_generated.deepcopy.go -e /api/v1beta1/zz_generated.deepcopy.go -e /pkg/utils/test/...) \
-	-race -coverprofile=coverage.txt -covermode=atomic
+	CGO_ENABLED=1 go test -race -coverprofile=coverage.txt -covermode=atomic -v $(shell go list ./pkg/... ./api/... | \
+	grep -v -e /vendor -e /api/v1alpha1/zz_generated.deepcopy.go -e /api/v1beta1/zz_generated.deepcopy.go -e /pkg/utils/test/...)
 	go tool cover -func=coverage.txt
 
 .PHONY: rag-service-test

--- a/Tiltfile
+++ b/Tiltfile
@@ -16,7 +16,7 @@ if 'default_registry' in settings:
 def main(IMG='controller:latest', DISABLE_SECURITY_CONTEXT=True):
 
     DOCKERFILE = '''
-    FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.23
+    FROM --platform=linux/amd64 mcr.microsoft.com/oss/go/microsoft/golang:1.24
     WORKDIR /
     COPY ./tilt_bin/manager /
     CMD ["/manager"]

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+comment:
+  layout: "header, diff, flags, components"  # show component info in the PR comment
+
+component_management:
+  default_rules:  # default rules that will be inherited by all components
+    statuses:
+      - type: project
+        target: auto
+        branches:
+          - "!main"
+  individual_components:
+    - component_id: module_workspace
+      name: workspace
+      paths:
+        - pkg/**
+    - component_id: module_presets
+      name: presets
+      paths:
+        - presets/**
+    - component_id: module_cmd
+      name: main
+      paths:
+        - cmd/**

--- a/docker/ragengine/Dockerfile
+++ b/docker/ragengine/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.23 as builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docker/workspace/Dockerfile
+++ b/docker/workspace/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.23 as builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24 as builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/docs/contributing/readme.md
+++ b/docs/contributing/readme.md
@@ -16,7 +16,7 @@ contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additio
 
 ### Prerequisites
 
-- [Go 1.23](https://go.dev/doc/install) or later
+- [Go 1.24](https://go.dev/doc/install) or later
 - [Tilt](https://tilt.dev/) for rapid, local development
 - [Docker](https://docs.docker.com/get-started/get-docker/) for building container images
 - Kubernetes cluster with Karpenter supported (e.g. AKS, EKS)

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/kaito-project/kaito
 
-go 1.23.0
+go 1.24.0
 
-toolchain go1.23.2
+toolchain go1.24.1
 
 require (
 	github.com/Azure/karpenter-provider-azure v0.7.0


### PR DESCRIPTION
**Reason for Change**:
Bump golang version to 1.24 in all pipelines and for go.mod

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: