### PR TITLE
fix: add dependencies for vllm runtime

### DIFF
--- a/.github/workflows/e2e-preset-test.yml
+++ b/.github/workflows/e2e-preset-test.yml
@@ -203,8 +203,7 @@ jobs:
                     --node-vm-size ${{ matrix.model.node-vm-size }} \
                     --node-osdisk-size ${{ matrix.model.node-osdisk-size }} \
                     --labels pool=${{ steps.workload.outputs.NODEPOOL_NAME }} \
-                    --node-taints sku=gpu:NoSchedule \
-                    --aks-custom-headers UseGPUDedicatedVHD=true
+                    --node-taints sku=gpu:NoSchedule
             else
                 NODEPOOL_STATE=$(az aks nodepool show \
                                 --name ${{ steps.workload.outputs.NODEPOOL_NAME }} \

--- a/.github/workflows/e2e-preset-tuning-test.yml
+++ b/.github/workflows/e2e-preset-tuning-test.yml
@@ -67,8 +67,7 @@ jobs:
                     --node-vm-size ${{ steps.get_test_meta.outputs.node-vm-size }} \
                     --node-osdisk-size ${{ steps.get_test_meta.outputs.node-osdisk-size }} \
                     --labels pool=${{ steps.get_test_meta.outputs.name }} \
-                    --node-taints sku=gpu:NoSchedule \
-                    --aks-custom-headers UseGPUDedicatedVHD=true
+                    --node-taints sku=gpu:NoSchedule
             else
                 NODEPOOL_STATE=$(az aks nodepool show \
                                 --name ${{ steps.get_test_meta.outputs.name }} \

--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -14,6 +14,10 @@ COPY kaito/presets/workspace/dependencies/requirements.txt /workspace/requiremen
 
 RUN pip install --no-cache-dir -r /workspace/requirements.txt
 
+# Required for torch.compile
+RUN apt-get update -y && apt-get install gcc -y && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
 # 1. Huggingface transformers
 COPY kaito/presets/workspace/inference/${MODEL_TYPE}/inference_api.py \
     kaito/presets/workspace/tuning/${MODEL_TYPE}/cli.py \

--- a/presets/workspace/dependencies/requirements.txt
+++ b/presets/workspace/dependencies/requirements.txt
@@ -1,7 +1,7 @@
 # Dependencies for TFS
 
 # Core Dependencies
-vllm==0.8.1
+vllm==0.8.2
 transformers == 4.49.0
 torch==2.6.0
 accelerate==1.0.0

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -149,7 +149,7 @@ models:
     type: text-generation
     version: https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct/commit/0eb6b1ed2d0c4306bc637d09ecef51e59d3dfe05
     runtime: tfs
-    tag: 0.0.2
+    tag: 0.0.1
     # Tag history:
     # 0.0.1 - New Model!
 

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -149,7 +149,7 @@ models:
     type: text-generation
     version: https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct/commit/0eb6b1ed2d0c4306bc637d09ecef51e59d3dfe05
     runtime: tfs
-    tag: 0.0.1
+    tag: 0.0.2
     # Tag history:
     # 0.0.1 - New Model!
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->

- Updated vllm dependency version to 0.8.2.
- Added GCC installation for torch.compile support.
- Removed deprecated custom headers when creating aks node pool.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:

`--aks-custom-headers UseGPUDedicatedVHD=true` this header was deprecated.

> ERROR: (OperationNotAllowed) AKS no longer supports creating node pools using the GPU image.  If you'd like to create gpu-enabled node pools, please use the supported methods in https://learn.microsoft.com/azure/aks/gpu-cluster?tabs=add-ubuntu-gpu-node-pool. 