### PR TITLE
fix: Pin disable chunked prefill on V100 Arch

### DIFF
--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -62,7 +62,7 @@ class KAITOArgumentParser(argparse.ArgumentParser):
         }
 
         # Chunked Prefill not supported on V100 Architectures - Set to False
-        gpu_name = torch.cuda.get_device_name(0)
+        gpu_name = torch.cuda.get_device_name(0).upper()
         if "V100" in gpu_name:
             engine_default_args["enable_chunked_prefill"] = False
 

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -60,6 +60,12 @@ class KAITOArgumentParser(argparse.ArgumentParser):
             "disable_log_stats": False,
             "uvicorn_log_level": "error"
         }
+
+        # Chunked Prefill not supported on V100 Architectures - Set to False
+        gpu_name = torch.cuda.get_device_name(0)
+        if "V100" in gpu_name:
+            engine_default_args["enable_chunked_prefill"] = False
+
         self.vllm_parser.set_defaults(**engine_default_args)
 
     def parse_args(self, *args, **kwargs):


### PR DESCRIPTION
**Reason for Change**:
Through testing we find chunked prefill unsupported on V100 arch. Detect this and set to false.