### PR TITLE
feat: Add Annotation Bypass GPU Mem check

### DIFF
--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -39,6 +39,9 @@ const (
 
 	// AnnotationWorkspaceRuntime is the annotation for runtime selection.
 	AnnotationWorkspaceRuntime = KAITOPrefix + "runtime"
+
+	// AnnotationBypassResourceChecks allows bypassing resource requirement checks like GPU memory.
+	AnnotationBypassResourceChecks = KAITOPrefix + "bypass-resource-checks"
 )
 
 // GetWorkspaceRuntimeName returns the runtime name of the workspace.

--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-package v1alpha1
+package v1beta1
 
 import (
 	"context"
@@ -55,8 +55,16 @@ func (w *Workspace) Validate(ctx context.Context) (errs *apis.FieldError) {
 		klog.InfoS("Validate creation", "workspace", fmt.Sprintf("%s/%s", w.Namespace, w.Name))
 		errs = errs.Also(w.validateCreate().ViaField("spec"))
 		if w.Inference != nil {
+			// Check if the bypass resource checks annotation is set
+			bypassResourceChecks := false
+			if w.GetAnnotations() != nil {
+				if _, exists := w.GetAnnotations()[AnnotationBypassResourceChecks]; exists {
+					bypassResourceChecks = true
+				}
+			}
+
 			// TODO: Add Adapter Spec Validation - Including DataSource Validation for Adapter
-			errs = errs.Also(w.Resource.validateCreateWithInference(w.Inference).ViaField("resource"),
+			errs = errs.Also(w.Resource.validateCreateWithInference(w.Inference, bypassResourceChecks).ViaField("resource"),
 				w.Inference.validateCreate(ctx, w.Namespace).ViaField("inference"))
 		}
 		if w.Tuning != nil {
@@ -290,7 +298,7 @@ func (r *ResourceSpec) validateCreateWithTuning(tuning *TuningSpec) (errs *apis.
 	return errs
 }
 
-func (r *ResourceSpec) validateCreateWithInference(inference *InferenceSpec) (errs *apis.FieldError) {
+func (r *ResourceSpec) validateCreateWithInference(inference *InferenceSpec, bypassResourceChecks bool) (errs *apis.FieldError) {
 	var presetName string
 	if inference.Preset != nil {
 		presetName = strings.ToLower(string(inference.Preset.Name))
@@ -325,42 +333,57 @@ func (r *ResourceSpec) validateCreateWithInference(inference *InferenceSpec) (er
 
 			// Separate the checks for specific error messages
 			if machineTotalNumGPUs.Cmp(modelGPUCount) < 0 {
-				errs = errs.Also(apis.ErrInvalidValue(
-					fmt.Sprintf(
-						"Insufficient number of GPUs: Instance type %s provides %s, but preset %s requires at least %d",
-						instanceType,
-						machineTotalNumGPUs.String(),
-						presetName,
-						modelGPUCount.Value(),
-					),
-					"instanceType",
-				))
+				if bypassResourceChecks {
+					klog.Warningf("Bypassing resource check: Insufficient number of GPUs detected but continuing due to bypass flag. Instance type %s provides %s, but preset %s requires at least %d",
+						instanceType, machineTotalNumGPUs.String(), presetName, modelGPUCount.Value())
+				} else {
+					errs = errs.Also(apis.ErrInvalidValue(
+						fmt.Sprintf(
+							"Insufficient number of GPUs: Instance type %s provides %s, but preset %s requires at least %d",
+							instanceType,
+							machineTotalNumGPUs.String(),
+							presetName,
+							modelGPUCount.Value(),
+						),
+						"instanceType",
+					))
+				}
 			}
 
 			if machinePerGPUMemory.Cmp(modelPerGPUMemory) < 0 {
-				errs = errs.Also(apis.ErrInvalidValue(
-					fmt.Sprintf(
-						"Insufficient per GPU memory: Instance type %s provides %s per GPU, but preset %s requires at least %s per GPU",
-						instanceType,
-						machinePerGPUMemory.String(),
-						presetName,
-						modelPerGPUMemory.String(),
-					),
-					"instanceType",
-				))
+				if bypassResourceChecks {
+					klog.Warningf("Bypassing resource check: Insufficient per GPU memory but continuing due to bypass flag. Instance type %s provides %s per GPU, but preset %s requires at least %s per GPU",
+						instanceType, machinePerGPUMemory.String(), presetName, modelPerGPUMemory.String())
+				} else {
+					errs = errs.Also(apis.ErrInvalidValue(
+						fmt.Sprintf(
+							"Insufficient per GPU memory: Instance type %s provides %s per GPU, but preset %s requires at least %s per GPU",
+							instanceType,
+							machinePerGPUMemory.String(),
+							presetName,
+							modelPerGPUMemory.String(),
+						),
+						"instanceType",
+					))
+				}
 			}
 
 			if machineTotalGPUMem.Cmp(modelTotalGPUMemory) < 0 {
-				errs = errs.Also(apis.ErrInvalidValue(
-					fmt.Sprintf(
-						"Insufficient total GPU memory: Instance type %s has a total of %s, but preset %s requires at least %s",
-						instanceType,
-						machineTotalGPUMem.String(),
-						presetName,
-						modelTotalGPUMemory.String(),
-					),
-					"instanceType",
-				))
+				if bypassResourceChecks {
+					klog.Warningf("Bypassing resource check: Insufficient total GPU memory detected but continuing due to bypass flag. Instance type %s has a total of %s, but preset %s requires at least %s",
+						instanceType, machineTotalGPUMem.String(), presetName, modelTotalGPUMemory.String())
+				} else {
+					errs = errs.Also(apis.ErrInvalidValue(
+						fmt.Sprintf(
+							"Insufficient total GPU memory: Instance type %s has a total of %s, but preset %s requires at least %s",
+							instanceType,
+							machineTotalGPUMem.String(),
+							presetName,
+							modelTotalGPUMemory.String(),
+						),
+						"instanceType",
+					))
+				}
 			}
 		}
 	} else {

--- a/api/v1alpha1/workspace_validation.go
+++ b/api/v1alpha1/workspace_validation.go
@@ -1,7 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT license.
 
-package v1beta1
+package v1alpha1
 
 import (
 	"context"

--- a/api/v1alpha1/workspace_validation_test.go
+++ b/api/v1alpha1/workspace_validation_test.go
@@ -420,7 +420,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 				totalGPUMemoryRequirement = tc.modelTotalGPUMemory
 				perGPUMemoryRequirement = tc.modelPerGPUMemory
 
-				errs := tc.resourceSpec.validateCreateWithInference(&spec)
+				errs := tc.resourceSpec.validateCreateWithInference(&spec, false)
 				hasErrs := errs != nil
 				if hasErrs != tc.expectErrs {
 					t.Errorf("validateCreate() errors = %v, expectErrs %v", errs, tc.expectErrs)

--- a/api/v1beta1/labels.go
+++ b/api/v1beta1/labels.go
@@ -30,6 +30,9 @@ const (
 
 	// AnnotationWorkspaceRuntime is the annotation for runtime selection.
 	AnnotationWorkspaceRuntime = KAITOPrefix + "runtime"
+
+	// AnnotationBypassResourceChecks allows bypassing resource requirement checks like GPU memory.
+	AnnotationBypassResourceChecks = KAITOPrefix + "bypass-resource-checks"
 )
 
 // GetWorkspaceRuntimeName returns the runtime name of the workspace.

--- a/api/v1beta1/workspace_validation.go
+++ b/api/v1beta1/workspace_validation.go
@@ -60,7 +60,6 @@ func (w *Workspace) Validate(ctx context.Context) (errs *apis.FieldError) {
 			if w.GetAnnotations() != nil {
 				if _, exists := w.GetAnnotations()[AnnotationBypassResourceChecks]; exists {
 					bypassResourceChecks = true
-					klog.Warningf("Bypassing resource requirement checks due to annotation %s", AnnotationBypassResourceChecks)
 				}
 			}
 
@@ -335,7 +334,7 @@ func (r *ResourceSpec) validateCreateWithInference(inference *InferenceSpec, byp
 			// Separate the checks for specific error messages
 			if machineTotalNumGPUs.Cmp(modelGPUCount) < 0 {
 				if bypassResourceChecks {
-					klog.Warningf("Insufficient number of GPUs (bypassed): Instance type %s provides %s, but preset %s requires at least %d",
+					klog.Warningf("Bypassing resource check: Insufficient number of GPUs detected but continuing due to bypass flag. Instance type %s provides %s, but preset %s requires at least %d",
 						instanceType, machineTotalNumGPUs.String(), presetName, modelGPUCount.Value())
 				} else {
 					errs = errs.Also(apis.ErrInvalidValue(
@@ -353,7 +352,7 @@ func (r *ResourceSpec) validateCreateWithInference(inference *InferenceSpec, byp
 
 			if machinePerGPUMemory.Cmp(modelPerGPUMemory) < 0 {
 				if bypassResourceChecks {
-					klog.Warningf("Insufficient per GPU memory (bypassed): Instance type %s provides %s per GPU, but preset %s requires at least %s per GPU",
+					klog.Warningf("Bypassing resource check: Insufficient per GPU memory: Instance type %s provides %s per GPU, but preset %s requires at least %s per GPU",
 						instanceType, machinePerGPUMemory.String(), presetName, modelPerGPUMemory.String())
 				} else {
 					errs = errs.Also(apis.ErrInvalidValue(
@@ -371,7 +370,7 @@ func (r *ResourceSpec) validateCreateWithInference(inference *InferenceSpec, byp
 
 			if machineTotalGPUMem.Cmp(modelTotalGPUMemory) < 0 {
 				if bypassResourceChecks {
-					klog.Warningf("Insufficient total GPU memory (bypassed): Instance type %s has a total of %s, but preset %s requires at least %s",
+					klog.Warningf("Bypassing resource check: Insufficient total GPU memory detected but continuing due to bypass flag. Instance type %s has a total of %s, but preset %s requires at least %s",
 						instanceType, machineTotalGPUMem.String(), presetName, modelTotalGPUMemory.String())
 				} else {
 					errs = errs.Also(apis.ErrInvalidValue(

--- a/api/v1beta1/workspace_validation.go
+++ b/api/v1beta1/workspace_validation.go
@@ -55,8 +55,17 @@ func (w *Workspace) Validate(ctx context.Context) (errs *apis.FieldError) {
 		klog.InfoS("Validate creation", "workspace", fmt.Sprintf("%s/%s", w.Namespace, w.Name))
 		errs = errs.Also(w.validateCreate().ViaField("spec"))
 		if w.Inference != nil {
+			// Check if the bypass resource checks annotation is set
+			bypassResourceChecks := false
+			if w.GetAnnotations() != nil {
+				if _, exists := w.GetAnnotations()[AnnotationBypassResourceChecks]; exists {
+					bypassResourceChecks = true
+					klog.Warningf("Bypassing resource requirement checks due to annotation %s", AnnotationBypassResourceChecks)
+				}
+			}
+
 			// TODO: Add Adapter Spec Validation - Including DataSource Validation for Adapter
-			errs = errs.Also(w.Resource.validateCreateWithInference(w.Inference).ViaField("resource"),
+			errs = errs.Also(w.Resource.validateCreateWithInference(w.Inference, bypassResourceChecks).ViaField("resource"),
 				w.Inference.validateCreate(ctx, w.Namespace).ViaField("inference"))
 		}
 		if w.Tuning != nil {
@@ -290,7 +299,7 @@ func (r *ResourceSpec) validateCreateWithTuning(tuning *TuningSpec) (errs *apis.
 	return errs
 }
 
-func (r *ResourceSpec) validateCreateWithInference(inference *InferenceSpec) (errs *apis.FieldError) {
+func (r *ResourceSpec) validateCreateWithInference(inference *InferenceSpec, bypassResourceChecks bool) (errs *apis.FieldError) {
 	var presetName string
 	if inference.Preset != nil {
 		presetName = strings.ToLower(string(inference.Preset.Name))
@@ -325,42 +334,57 @@ func (r *ResourceSpec) validateCreateWithInference(inference *InferenceSpec) (er
 
 			// Separate the checks for specific error messages
 			if machineTotalNumGPUs.Cmp(modelGPUCount) < 0 {
-				errs = errs.Also(apis.ErrInvalidValue(
-					fmt.Sprintf(
-						"Insufficient number of GPUs: Instance type %s provides %s, but preset %s requires at least %d",
-						instanceType,
-						machineTotalNumGPUs.String(),
-						presetName,
-						modelGPUCount.Value(),
-					),
-					"instanceType",
-				))
+				if bypassResourceChecks {
+					klog.Warningf("Insufficient number of GPUs (bypassed): Instance type %s provides %s, but preset %s requires at least %d",
+						instanceType, machineTotalNumGPUs.String(), presetName, modelGPUCount.Value())
+				} else {
+					errs = errs.Also(apis.ErrInvalidValue(
+						fmt.Sprintf(
+							"Insufficient number of GPUs: Instance type %s provides %s, but preset %s requires at least %d",
+							instanceType,
+							machineTotalNumGPUs.String(),
+							presetName,
+							modelGPUCount.Value(),
+						),
+						"instanceType",
+					))
+				}
 			}
 
 			if machinePerGPUMemory.Cmp(modelPerGPUMemory) < 0 {
-				errs = errs.Also(apis.ErrInvalidValue(
-					fmt.Sprintf(
-						"Insufficient per GPU memory: Instance type %s provides %s per GPU, but preset %s requires at least %s per GPU",
-						instanceType,
-						machinePerGPUMemory.String(),
-						presetName,
-						modelPerGPUMemory.String(),
-					),
-					"instanceType",
-				))
+				if bypassResourceChecks {
+					klog.Warningf("Insufficient per GPU memory (bypassed): Instance type %s provides %s per GPU, but preset %s requires at least %s per GPU",
+						instanceType, machinePerGPUMemory.String(), presetName, modelPerGPUMemory.String())
+				} else {
+					errs = errs.Also(apis.ErrInvalidValue(
+						fmt.Sprintf(
+							"Insufficient per GPU memory: Instance type %s provides %s per GPU, but preset %s requires at least %s per GPU",
+							instanceType,
+							machinePerGPUMemory.String(),
+							presetName,
+							modelPerGPUMemory.String(),
+						),
+						"instanceType",
+					))
+				}
 			}
 
 			if machineTotalGPUMem.Cmp(modelTotalGPUMemory) < 0 {
-				errs = errs.Also(apis.ErrInvalidValue(
-					fmt.Sprintf(
-						"Insufficient total GPU memory: Instance type %s has a total of %s, but preset %s requires at least %s",
-						instanceType,
-						machineTotalGPUMem.String(),
-						presetName,
-						modelTotalGPUMemory.String(),
-					),
-					"instanceType",
-				))
+				if bypassResourceChecks {
+					klog.Warningf("Insufficient total GPU memory (bypassed): Instance type %s has a total of %s, but preset %s requires at least %s",
+						instanceType, machineTotalGPUMem.String(), presetName, modelTotalGPUMemory.String())
+				} else {
+					errs = errs.Also(apis.ErrInvalidValue(
+						fmt.Sprintf(
+							"Insufficient total GPU memory: Instance type %s has a total of %s, but preset %s requires at least %s",
+							instanceType,
+							machineTotalGPUMem.String(),
+							presetName,
+							modelTotalGPUMemory.String(),
+						),
+						"instanceType",
+					))
+				}
 			}
 		}
 	} else {

--- a/api/v1beta1/workspace_validation.go
+++ b/api/v1beta1/workspace_validation.go
@@ -352,7 +352,7 @@ func (r *ResourceSpec) validateCreateWithInference(inference *InferenceSpec, byp
 
 			if machinePerGPUMemory.Cmp(modelPerGPUMemory) < 0 {
 				if bypassResourceChecks {
-					klog.Warningf("Bypassing resource check: Insufficient per GPU memory: Instance type %s provides %s per GPU, but preset %s requires at least %s per GPU",
+					klog.Warningf("Bypassing resource check: Insufficient per GPU memory but continuing due to bypass flag. Instance type %s provides %s per GPU, but preset %s requires at least %s per GPU",
 						instanceType, machinePerGPUMemory.String(), presetName, modelPerGPUMemory.String())
 				} else {
 					errs = errs.Also(apis.ErrInvalidValue(

--- a/api/v1beta1/workspace_validation_test.go
+++ b/api/v1beta1/workspace_validation_test.go
@@ -420,7 +420,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 				totalGPUMemoryRequirement = tc.modelTotalGPUMemory
 				perGPUMemoryRequirement = tc.modelPerGPUMemory
 
-				errs := tc.resourceSpec.validateCreateWithInference(&spec)
+				errs := tc.resourceSpec.validateCreateWithInference(&spec, false)
 				hasErrs := errs != nil
 				if hasErrs != tc.expectErrs {
 					t.Errorf("validateCreate() errors = %v, expectErrs %v", errs, tc.expectErrs)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,2 +1,28 @@
 # Notes:
-For **testing** purposes, users can add the `kaito.sh/enablelb: "True"` annotation to the workspace custom resource. As a result, a `loadbalancer` type service will be created for the inference service with a public IP being assigned. However, this is **NOT** recommended for production use. An [ingress controller](https://learn.microsoft.com/en-us/azure/aks/ingress-basic?tabs=azure-cli) is recommended to expose the service to public.
+
+### GPU Resource Requirement Bypass
+To bypass GPU memory requirement checks, annotate your workspace resource as follows:
+```yaml
+apiVersion: kaito.sh/v1alpha1
+kind: Workspace
+metadata:
+  name: my-workspace
+  annotations:
+    kaito.sh/bypass-resource-checks: "true"
+  # ... rest of the workspace spec
+```
+> Caution: Using this annotation may lead to degraded performance or out-of-memory errors if GPU resources are insufficient for your model. Warnings will be logged accordingly.
+
+---
+
+### Exposing Service via LoadBalancer (Testing Only)
+
+For **testing** purposes, you may annotate your workspace resource with `kaito.sh/enablelb: "true"` to automatically create a `LoadBalancer` type service with a public IP for the inference service:
+
+```yaml
+metadata:
+  annotations:
+    kaito.sh/enablelb: "true"
+```
+> Important: This approach is **NOT** recommended for production environments. For production scenarios, use an [Ingress Controller](https://learn.microsoft.com/en-us/azure/aks/ingress-basic?tabs=azure-cli) to safely expose the service.
+


### PR DESCRIPTION
**Reason for Change**:
Add a workspace annotation to bypass validation checks for the minimum GPU memory required by their workspace.