### PR TITLE
fix: add node cache to avoid get/list node from apiserver

### DIFF
--- a/pkg/ragengine/controllers/ragengine_controller.go
+++ b/pkg/ragengine/controllers/ragengine_controller.go
@@ -558,6 +558,14 @@ func (c *RAGEngineReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}); err != nil {
 		return err
 	}
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Node{},
+		"metadata.name", func(rawObj client.Object) []string {
+			node := rawObj.(*corev1.Node)
+			return []string{node.Name}
+		}); err != nil {
+		return err
+	}
+
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&kaitov1alpha1.RAGEngine{}).
 		Owns(&appsv1.ControllerRevision{}).

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -753,6 +753,13 @@ func (c *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		}); err != nil {
 		return err
 	}
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Node{},
+		"metadata.name", func(rawObj client.Object) []string {
+			node := rawObj.(*corev1.Node)
+			return []string{node.Name}
+		}); err != nil {
+		return err
+	}
 
 	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&kaitov1beta1.Workspace{}).


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->
fix: add node cache to avoid get/list node from apiserver
**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: