### PR TITLE
fix: only add finalizer when the object is not in deletion state

### DIFF
--- a/pkg/ragengine/controllers/ragengine_controller.go
+++ b/pkg/ragengine/controllers/ragengine_controller.go
@@ -76,12 +76,12 @@ func (c *RAGEngineReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 
 	klog.InfoS("Reconciling", "RAG Engine", req.NamespacedName)
 
-	if err := c.ensureFinalizer(ctx, ragEngineObj); err != nil {
-		return reconcile.Result{}, err
-	}
-
-	// Handle deleting ragengine, garbage collect all the resources.
-	if !ragEngineObj.DeletionTimestamp.IsZero() {
+	if ragEngineObj.DeletionTimestamp.IsZero() {
+		if err := c.ensureFinalizer(ctx, ragEngineObj); err != nil {
+			return reconcile.Result{}, err
+		}
+	} else {
+		// Handle deleting ragengine, garbage collect all the resources.
 		return c.deleteRAGEngine(ctx, ragEngineObj)
 	}
 

--- a/pkg/ragengine/controllers/ragengine_gc_finalizer.go
+++ b/pkg/ragengine/controllers/ragengine_gc_finalizer.go
@@ -42,9 +42,8 @@ func (c *RAGEngineReconciler) garbageCollectRAGEngine(ctx context.Context, ragEn
 				"ragengine", klog.KObj(ragEngineObj))
 			return ctrl.Result{}, updateErr
 		}
+		klog.InfoS("successfully removed the ragengine finalizers", "ragengine", klog.KObj(ragEngineObj))
 	}
 
-	klog.InfoS("successfully removed the ragengine finalizers",
-		"ragengine", klog.KObj(ragEngineObj))
 	return ctrl.Result{}, nil
 }

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -80,11 +80,12 @@ func (c *WorkspaceReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 
 	klog.InfoS("Reconciling", "workspace", req.NamespacedName)
 
-	if err := c.ensureFinalizer(ctx, workspaceObj); err != nil {
-		return reconcile.Result{}, err
-	}
-	// Handle deleting workspace, garbage collect all the resources.
-	if !workspaceObj.DeletionTimestamp.IsZero() {
+	if workspaceObj.DeletionTimestamp.IsZero() {
+		if err := c.ensureFinalizer(ctx, workspaceObj); err != nil {
+			return reconcile.Result{}, err
+		}
+	} else {
+		// Handle deleting workspace, garbage collect all the resources.
 		return c.deleteWorkspace(ctx, workspaceObj)
 	}
 

--- a/pkg/workspace/controllers/workspace_gc_finalizer.go
+++ b/pkg/workspace/controllers/workspace_gc_finalizer.go
@@ -43,9 +43,8 @@ func (c *WorkspaceReconciler) garbageCollectWorkspace(ctx context.Context, wObj 
 				"workspace", klog.KObj(wObj))
 			return ctrl.Result{}, updateErr
 		}
+		klog.InfoS("successfully removed the workspace finalizers", "workspace", klog.KObj(wObj))
 	}
 
-	klog.InfoS("successfully removed the workspace finalizers",
-		"workspace", klog.KObj(wObj))
 	return ctrl.Result{}, nil
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->
Only add finalizer when the object is not in deletion state.
Otherwise the finalizer will be added/remove again and again until it is finally completely deleted. 
**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: