### PR TITLE
fix: should not check preset model in sync loop

### DIFF
--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -92,13 +92,6 @@ func (c *WorkspaceReconciler) Reconcile(ctx context.Context, req reconcile.Reque
 		return reconcile.Result{}, err
 	}
 
-	if workspaceObj.Inference != nil && workspaceObj.Inference.Preset != nil {
-		if !plugin.KaitoModelRegister.Has(string(workspaceObj.Inference.Preset.Name)) {
-			return reconcile.Result{}, fmt.Errorf("the preset model name %s is not registered for workspace %s/%s",
-				string(workspaceObj.Inference.Preset.Name), workspaceObj.Namespace, workspaceObj.Name)
-		}
-	}
-
 	result, err := c.addOrUpdateWorkspace(ctx, workspaceObj)
 	if err != nil {
 		return result, err


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->
Should not check preset model in sync loop, this can lead to enqueue and reconcile endlessly.
Since there is already [the same check in validation webhook](https://github.com/kaito-project/kaito/blob/main/api/v1beta1/workspace_validation.go#L433-L436), so just delete the code should be fine.
Anyway, it's inappropriate to check the preset model in the sync loop.
**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: