### PR TITLE
fix: add nodeclass informer

### DIFF
--- a/cmd/ragengine/main.go
+++ b/cmd/ragengine/main.go
@@ -33,7 +33,6 @@ import (
 	"github.com/kaito-project/kaito/pkg/ragengine/controllers"
 	"github.com/kaito-project/kaito/pkg/ragengine/webhooks"
 	kaitoutils "github.com/kaito-project/kaito/pkg/utils"
-	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 const (
@@ -182,15 +181,4 @@ func withShutdownSignal(ctx context.Context) context.Context {
 		cancel()
 	}()
 	return nctx
-}
-
-func validCloudProvider() bool {
-	cloudProvider := os.Getenv("CLOUD_PROVIDER")
-	switch cloudProvider {
-	case consts.AzureCloudName, consts.AWSCloudName, consts.ArcCloudName:
-		return true
-	default:
-		klog.ErrorS(nil, "invalid cloud provider env", "cloudProvider", cloudProvider)
-		return false
-	}
 }

--- a/cmd/ragengine/main.go
+++ b/cmd/ragengine/main.go
@@ -33,6 +33,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/ragengine/controllers"
 	"github.com/kaito-project/kaito/pkg/ragengine/webhooks"
 	kaitoutils "github.com/kaito-project/kaito/pkg/utils"
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 const (
@@ -119,6 +120,10 @@ func main() {
 		mgr.GetEventRecorderFor("KAITO-RAGEngine-controller"),
 	)
 
+	if !validCloudProvider() {
+		exitWithErrorFunc()
+	}
+
 	if err = ragengineReconciler.SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create controller", "controller", "RAG Eingine")
 		exitWithErrorFunc()
@@ -175,4 +180,15 @@ func withShutdownSignal(ctx context.Context) context.Context {
 		cancel()
 	}()
 	return nctx
+}
+
+func validCloudProvider() bool {
+	cloudProvider := os.Getenv("CLOUD_PROVIDER")
+	switch cloudProvider {
+	case consts.AzureCloudName, consts.AWSCloudName, consts.ArcCloudName:
+		return true
+	default:
+		klog.ErrorS(nil, "invalid cloud provider env", "cloudProvider", cloudProvider)
+		return false
+	}
 }

--- a/cmd/ragengine/main.go
+++ b/cmd/ragengine/main.go
@@ -120,7 +120,9 @@ func main() {
 		mgr.GetEventRecorderFor("KAITO-RAGEngine-controller"),
 	)
 
-	if !validCloudProvider() {
+	cloudProvider := os.Getenv("CLOUD_PROVIDER")
+	if !kaitoutils.ValidCloudProvider(cloudProvider) {
+		klog.ErrorS(nil, "invalid cloud provider env", "cloudProvider", cloudProvider)
 		exitWithErrorFunc()
 	}
 

--- a/cmd/workspace/main.go
+++ b/cmd/workspace/main.go
@@ -122,6 +122,10 @@ func main() {
 		mgr.GetEventRecorderFor("KAITO-Workspace-controller"),
 	)
 
+	if !validCloudProvider() {
+		exitWithErrorFunc()
+	}
+
 	if err = workspaceReconciler.SetupWithManager(mgr); err != nil {
 		klog.ErrorS(err, "unable to create controller", "controller", "Workspace")
 		exitWithErrorFunc()
@@ -190,4 +194,15 @@ func withShutdownSignal(ctx context.Context) context.Context {
 		cancel()
 	}()
 	return nctx
+}
+
+func validCloudProvider() bool {
+	cloudProvider := os.Getenv("CLOUD_PROVIDER")
+	switch cloudProvider {
+	case consts.AzureCloudName, consts.AWSCloudName, consts.ArcCloudName:
+		return true
+	default:
+		klog.ErrorS(nil, "invalid cloud provider env", "cloudProvider", cloudProvider)
+		return false
+	}
 }

--- a/cmd/workspace/main.go
+++ b/cmd/workspace/main.go
@@ -122,7 +122,9 @@ func main() {
 		mgr.GetEventRecorderFor("KAITO-Workspace-controller"),
 	)
 
-	if !validCloudProvider() {
+	cloudProvider := os.Getenv("CLOUD_PROVIDER")
+	if !kaitoutils.ValidCloudProvider(cloudProvider) {
+		klog.ErrorS(nil, "invalid cloud provider env", "cloudProvider", cloudProvider)
 		exitWithErrorFunc()
 	}
 
@@ -194,15 +196,4 @@ func withShutdownSignal(ctx context.Context) context.Context {
 		cancel()
 	}()
 	return nctx
-}
-
-func validCloudProvider() bool {
-	cloudProvider := os.Getenv("CLOUD_PROVIDER")
-	switch cloudProvider {
-	case consts.AzureCloudName, consts.AWSCloudName, consts.ArcCloudName:
-		return true
-	default:
-		klog.ErrorS(nil, "invalid cloud provider env", "cloudProvider", cloudProvider)
-		return false
-	}
 }

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -268,3 +268,12 @@ func SelectNodes(qualified []*v1.Node, preferred []string, previous []string, co
 
 	return qualified[0:count]
 }
+
+func ValidCloudProvider(cloudProvider string) bool {
+	switch cloudProvider {
+	case consts.AzureCloudName, consts.AWSCloudName, consts.ArcCloudName:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -42,6 +42,7 @@ import (
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/nodeclaim"
@@ -50,7 +51,6 @@ import (
 	"github.com/kaito-project/kaito/pkg/workspace/inference"
 	"github.com/kaito-project/kaito/pkg/workspace/manifests"
 	"github.com/kaito-project/kaito/pkg/workspace/tuning"
-	"github.com/kaito-project/kaito/pkg/featuregates"
 )
 
 const (

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -9,11 +9,14 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strconv"
 	"strings"
 	"time"
 
+	azurev1alpha2 "github.com/Azure/karpenter-provider-azure/pkg/apis/v1alpha2"
+	awsv1beta1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1beta1"
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
@@ -28,6 +31,7 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
+	"knative.dev/pkg/apis"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -741,11 +745,7 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1b
 // SetupWithManager sets up the controller with the Manager.
 func (c *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	c.Recorder = mgr.GetEventRecorderFor("Workspace")
-	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{},
-		"spec.nodeName", func(rawObj client.Object) []string {
-			pod := rawObj.(*corev1.Pod)
-			return []string{pod.Spec.NodeName}
-		}); err != nil {
+	if err := c.setupInformers(mgr); err != nil {
 		return err
 	}
 
@@ -761,6 +761,37 @@ func (c *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	go monitorWorkspaces(context.Background(), c.Client)
 
 	return builder.Complete(c)
+}
+
+func (c *WorkspaceReconciler) setupInformers(mgr ctrl.Manager) error {
+	// Index the nodeName field of Pod objects to enable fast lookup.
+	// This will construct informers for all Pods in the cluster as well.
+	if err := mgr.GetFieldIndexer().IndexField(context.Background(), &corev1.Pod{},
+		"spec.nodeName", func(rawObj client.Object) []string {
+			pod := rawObj.(*corev1.Pod)
+			return []string{pod.Spec.NodeName}
+		}); err != nil {
+		return err
+	}
+
+	// Informer for NodeClass
+	provider := os.Getenv("CLOUD_PROVIDER")
+	if provider == "" {
+		return apis.ErrMissingField("CLOUD_PROVIDER environment variable must be set")
+	}
+	if provider == consts.AzureCloudName {
+		_, err := mgr.GetCache().GetInformer(context.Background(), &azurev1alpha2.AKSNodeClass{})
+		if err != nil {
+			return err
+		}
+	} else if provider == consts.AWSCloudName {
+		_, err := mgr.GetCache().GetInformer(context.Background(), &awsv1beta1.EC2NodeClass{})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // watches for nodeClaim with labels indicating workspace name.


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->
add NodeClass informer to avoid calling apiserver
This PR is to replace https://github.com/kaito-project/kaito/pull/1059, which removed CLOUD_PROVIDER env related change according to the suggestion.
**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: