### PR TITLE
refactor: remove fields from PresetParam in favor of embedded Metadata

### DIFF
--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -80,8 +80,8 @@ type Metadata struct {
 
 // PresetParam defines the preset inference parameters for a model.
 type PresetParam struct {
-	Tag             string // The model image tag
-	ModelFamilyName string // The name of the model family.
+	Metadata
+
 	ImageAccessMode string // Defines where the Image is Public or Private.
 
 	DiskStorageRequirement        string         // Disk storage requirements for the model.

--- a/pkg/workspace/tuning/preset-tuning_test.go
+++ b/pkg/workspace/tuning/preset-tuning_test.go
@@ -71,7 +71,9 @@ func TestGetTuningImageInfo(t *testing.T) {
 				},
 			},
 			presetObj: &model.PresetParam{
-				Tag: "latest",
+				Metadata: model.Metadata{
+					Tag: "latest",
+				},
 			},
 			expected: "testregistry/kaito-testpreset:latest",
 		},
@@ -87,7 +89,9 @@ func TestGetTuningImageInfo(t *testing.T) {
 				},
 			},
 			presetObj: &model.PresetParam{
-				Tag: "latest",
+				Metadata: model.Metadata{
+					Tag: "latest",
+				},
 			},
 			expected: "/kaito-testpreset:latest",
 		},

--- a/presets/workspace/models/deepseek/model.go
+++ b/presets/workspace/models/deepseek/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/pkg/workspace/inference"
+	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
 
 func init() {
@@ -22,15 +23,12 @@ func init() {
 	})
 }
 
-var (
+const (
 	PresetDeepSeekR1DistillLlama8BModel = "deepseek-r1-distill-llama-8b"
 	PresetDeepSeekR1DistillQwen14BModel = "deepseek-r1-distill-qwen-14b"
+)
 
-	PresetDeepSeekTagMap = map[string]string{
-		"DeepSeekDistillLlama8B": "0.1.0",
-		"DeepSeekDistillQwen14B": "0.1.0",
-	}
-
+var (
 	baseCommandPresetDeepseekInference = "accelerate launch"
 	deepseekLlama8bRunParams           = map[string]string{
 		"torch_dtype": "bfloat16",
@@ -58,7 +56,7 @@ type llama8b struct{}
 
 func (*llama8b) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "DeepSeek",
+		Metadata:                  metadata.MustGet(PresetDeepSeekR1DistillLlama8BModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -78,7 +76,6 @@ func (*llama8b) GetInferenceParameters() *model.PresetParam {
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetDeepSeekTagMap["DeepSeekDistillLlama8B"],
 	}
 }
 func (*llama8b) GetTuningParameters() *model.PresetParam {
@@ -97,7 +94,7 @@ type qwen14b struct{}
 
 func (*qwen14b) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "DeepSeek",
+		Metadata:                  metadata.MustGet(PresetDeepSeekR1DistillQwen14BModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -117,7 +114,6 @@ func (*qwen14b) GetInferenceParameters() *model.PresetParam {
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetDeepSeekTagMap["DeepSeekDistillQwen14B"],
 	}
 }
 func (*qwen14b) GetTuningParameters() *model.PresetParam {

--- a/presets/workspace/models/falcon/model.go
+++ b/presets/workspace/models/falcon/model.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/pkg/workspace/inference"
 	"github.com/kaito-project/kaito/pkg/workspace/tuning"
+	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
 
 func init() {
@@ -31,19 +32,14 @@ func init() {
 	})
 }
 
-var (
+const (
 	PresetFalcon7BModel          = "falcon-7b"
 	PresetFalcon40BModel         = "falcon-40b"
 	PresetFalcon7BInstructModel  = PresetFalcon7BModel + "-instruct"
 	PresetFalcon40BInstructModel = PresetFalcon40BModel + "-instruct"
+)
 
-	PresetFalconTagMap = map[string]string{
-		"Falcon7B":          "0.1.0",
-		"Falcon7BInstruct":  "0.1.0",
-		"Falcon40B":         "0.1.0",
-		"Falcon40BInstruct": "0.1.0",
-	}
-
+var (
 	baseCommandPresetFalconInference = "accelerate launch"
 	baseCommandPresetFalconTuning    = "cd /workspace/tfs/ && python3 metrics_server.py & accelerate launch"
 	falconRunParams                  = map[string]string{
@@ -63,7 +59,7 @@ type falcon7b struct{}
 
 func (*falcon7b) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Falcon",
+		Metadata:                  metadata.MustGet(PresetFalcon7BModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -89,12 +85,11 @@ func (*falcon7b) GetInferenceParameters() *model.PresetParam {
 			DisableTensorParallelism: true,
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetFalconTagMap["Falcon7B"],
 	}
 }
 func (*falcon7b) GetTuningParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Falcon",
+		Metadata:                  metadata.MustGet(PresetFalcon7BModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -108,7 +103,6 @@ func (*falcon7b) GetTuningParameters() *model.PresetParam {
 			},
 		},
 		ReadinessTimeout:              time.Duration(30) * time.Minute,
-		Tag:                           PresetFalconTagMap["Falcon7B"],
 		TuningPerGPUMemoryRequirement: map[string]int{"qlora": 16},
 	}
 }
@@ -126,7 +120,7 @@ type falcon7bInst struct{}
 
 func (*falcon7bInst) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Falcon",
+		Metadata:                  metadata.MustGet(PresetFalcon7BInstructModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -141,7 +135,7 @@ func (*falcon7bInst) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "falcon-7b-instruct",
+				ModelName:      PresetFalcon7BInstructModel,
 				ModelRunParams: falconRunParamsVLLM,
 				DisallowLoRA:   true,
 			},
@@ -152,7 +146,6 @@ func (*falcon7bInst) GetInferenceParameters() *model.PresetParam {
 			DisableTensorParallelism: true,
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetFalconTagMap["Falcon7BInstruct"],
 	}
 
 }
@@ -172,7 +165,7 @@ type falcon40b struct{}
 
 func (*falcon40b) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Falcon",
+		Metadata:                  metadata.MustGet(PresetFalcon40BModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "400",
 		GPUCountRequirement:       "2",
@@ -187,17 +180,16 @@ func (*falcon40b) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "falcon-40b",
+				ModelName:      PresetFalcon40BModel,
 				ModelRunParams: falconRunParamsVLLM,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetFalconTagMap["Falcon40B"],
 	}
 }
 func (*falcon40b) GetTuningParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Falcon",
+		Metadata:                  metadata.MustGet(PresetFalcon40BModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "2",
@@ -211,7 +203,6 @@ func (*falcon40b) GetTuningParameters() *model.PresetParam {
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetFalconTagMap["Falcon40B"],
 	}
 }
 func (*falcon40b) SupportDistributedInference() bool {
@@ -227,7 +218,7 @@ type falcon40bInst struct{}
 
 func (*falcon40bInst) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Falcon",
+		Metadata:                  metadata.MustGet(PresetFalcon40BInstructModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "400",
 		GPUCountRequirement:       "2",
@@ -242,12 +233,11 @@ func (*falcon40bInst) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "falcon-40b-instruct",
+				ModelName:      PresetFalcon40BInstructModel,
 				ModelRunParams: falconRunParamsVLLM,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetFalconTagMap["Falcon40BInstruct"],
 	}
 }
 func (*falcon40bInst) GetTuningParameters() *model.PresetParam {

--- a/presets/workspace/models/llama2/model.go
+++ b/presets/workspace/models/llama2/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/pkg/workspace/inference"
+	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
 
 func init() {
@@ -26,6 +27,12 @@ func init() {
 	})
 }
 
+const (
+	Llama7B  = "llama-2-7b"
+	Llama13B = "llama-2-13b"
+	Llama70B = "llama-2-70b"
+)
+
 var (
 	baseCommandPresetLlama = "cd /workspace/llama/llama-2 && torchrun"
 	llamaRunParams         = map[string]string{
@@ -40,7 +47,7 @@ type llama2Text7b struct{}
 
 func (*llama2Text7b) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "LLaMa2",
+		Metadata:                  metadata.MustGet(Llama7B),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePrivate),
 		DiskStorageRequirement:    "34Gi",
 		GPUCountRequirement:       "1",
@@ -76,7 +83,7 @@ type llama2Text13b struct{}
 
 func (*llama2Text13b) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "LLaMa2",
+		Metadata:                  metadata.MustGet(Llama13B),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePrivate),
 		DiskStorageRequirement:    "46Gi",
 		GPUCountRequirement:       "2",
@@ -112,7 +119,7 @@ type llama2Text70b struct{}
 
 func (*llama2Text70b) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "LLaMa2",
+		Metadata:                  metadata.MustGet(Llama70B),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePrivate),
 		DiskStorageRequirement:    "158Gi",
 		GPUCountRequirement:       "8",

--- a/presets/workspace/models/llama2chat/model.go
+++ b/presets/workspace/models/llama2chat/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/pkg/workspace/inference"
+	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
 
 func init() {
@@ -26,6 +27,12 @@ func init() {
 	})
 }
 
+const (
+	Llama7BChat  = "llama-2-7b-chat"
+	Llama13BChat = "llama-2-13b-chat"
+	Llama70BChat = "llama-2-70b-chat"
+)
+
 var (
 	baseCommandPresetLlama = "cd /workspace/llama/llama-2 && torchrun"
 	llamaRunParams         = map[string]string{
@@ -40,7 +47,7 @@ type llama2Chat7b struct{}
 
 func (*llama2Chat7b) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "LLaMa2",
+		Metadata:                  metadata.MustGet(Llama7BChat),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePrivate),
 		DiskStorageRequirement:    "34Gi",
 		GPUCountRequirement:       "1",
@@ -76,7 +83,7 @@ type llama2Chat13b struct{}
 
 func (*llama2Chat13b) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "LLaMa2",
+		Metadata:                  metadata.MustGet(Llama13BChat),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePrivate),
 		DiskStorageRequirement:    "46Gi",
 		GPUCountRequirement:       "2",
@@ -113,7 +120,7 @@ type llama2Chat70b struct{}
 
 func (*llama2Chat70b) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "LLaMa2",
+		Metadata:                  metadata.MustGet(Llama70BChat),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePrivate),
 		DiskStorageRequirement:    "158Gi",
 		GPUCountRequirement:       "8",

--- a/presets/workspace/models/mistral/model.go
+++ b/presets/workspace/models/mistral/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/pkg/workspace/inference"
+	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
 
 func init() {
@@ -22,15 +23,12 @@ func init() {
 	})
 }
 
-var (
+const (
 	PresetMistral7BModel         = "mistral-7b"
 	PresetMistral7BInstructModel = PresetMistral7BModel + "-instruct"
+)
 
-	PresetMistralTagMap = map[string]string{
-		"Mistral7B":         "0.1.0",
-		"Mistral7BInstruct": "0.1.0",
-	}
-
+var (
 	baseCommandPresetMistralInference = "accelerate launch"
 	baseCommandPresetMistralTuning    = "cd /workspace/tfs/ && python3 metrics_server.py & accelerate launch"
 	mistralRunParams                  = map[string]string{
@@ -50,7 +48,7 @@ type mistral7b struct{}
 
 func (*mistral7b) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Mistral",
+		Metadata:                  metadata.MustGet(PresetMistral7BModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "100Gi",
 		GPUCountRequirement:       "1",
@@ -65,18 +63,17 @@ func (*mistral7b) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "mistral-7b",
+				ModelName:      PresetMistral7BModel,
 				ModelRunParams: mistralRunParamsVLLM,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetMistralTagMap["Mistral7B"],
 	}
 
 }
 func (*mistral7b) GetTuningParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Mistral",
+		Metadata:                  metadata.MustGet(PresetMistral7BModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "100Gi",
 		GPUCountRequirement:       "1",
@@ -90,7 +87,6 @@ func (*mistral7b) GetTuningParameters() *model.PresetParam {
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetMistralTagMap["Mistral7B"],
 	}
 }
 
@@ -107,7 +103,7 @@ type mistral7bInst struct{}
 
 func (*mistral7bInst) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Mistral",
+		Metadata:                  metadata.MustGet(PresetMistral7BInstructModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "100Gi",
 		GPUCountRequirement:       "1",
@@ -122,12 +118,11 @@ func (*mistral7bInst) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "mistral-7b-instruct",
+				ModelName:      PresetMistral7BInstructModel,
 				ModelRunParams: mistralRunParamsVLLM,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetMistralTagMap["Mistral7BInstruct"],
 	}
 
 }

--- a/presets/workspace/models/phi2/model.go
+++ b/presets/workspace/models/phi2/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/pkg/workspace/inference"
+	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
 
 func init() {
@@ -18,13 +19,11 @@ func init() {
 	})
 }
 
-var (
+const (
 	PresetPhi2Model = "phi-2"
+)
 
-	PresetPhiTagMap = map[string]string{
-		"Phi2": "0.1.0",
-	}
-
+var (
 	baseCommandPresetPhiInference = "accelerate launch"
 	baseCommandPresetPhiTuning    = "cd /workspace/tfs/ && python3 metrics_server.py & accelerate launch"
 	phiRunParams                  = map[string]string{
@@ -42,7 +41,7 @@ type phi2 struct{}
 
 func (*phi2) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi",
+		Metadata:                  metadata.MustGet(PresetPhi2Model),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -57,17 +56,16 @@ func (*phi2) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "phi-2",
+				ModelName:      PresetPhi2Model,
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetPhiTagMap["Phi2"],
 	}
 }
 func (*phi2) GetTuningParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi",
+		Metadata:                  metadata.MustGet(PresetPhi2Model),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -81,7 +79,6 @@ func (*phi2) GetTuningParameters() *model.PresetParam {
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetPhiTagMap["Phi2"],
 	}
 }
 func (*phi2) SupportDistributedInference() bool {

--- a/presets/workspace/models/phi3/model.go
+++ b/presets/workspace/models/phi3/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/pkg/workspace/inference"
+	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
 
 func init() {
@@ -34,21 +35,15 @@ func init() {
 	})
 }
 
-var (
+const (
 	PresetPhi3Mini4kModel     = "phi-3-mini-4k-instruct"
 	PresetPhi3Mini128kModel   = "phi-3-mini-128k-instruct"
 	PresetPhi3Medium4kModel   = "phi-3-medium-4k-instruct"
 	PresetPhi3Medium128kModel = "phi-3-medium-128k-instruct"
 	PresetPhi3_5MiniInstruct  = "phi-3.5-mini-instruct"
+)
 
-	PresetPhiTagMap = map[string]string{
-		"Phi3Mini4kInstruct":     "0.1.0",
-		"Phi3Mini128kInstruct":   "0.1.0",
-		"Phi3Medium4kInstruct":   "0.1.0",
-		"Phi3Medium128kInstruct": "0.1.0",
-		"Phi3_5MiniInstruct":     "0.1.0",
-	}
-
+var (
 	baseCommandPresetPhiInference = "accelerate launch"
 	baseCommandPresetPhiTuning    = "cd /workspace/tfs/ && python3 metrics_server.py & accelerate launch"
 	phiRunParams                  = map[string]string{
@@ -67,7 +62,7 @@ type phi3Mini4KInst struct{}
 
 func (*phi3Mini4KInst) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi3",
+		Metadata:                  metadata.MustGet(PresetPhi3Mini4kModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -82,17 +77,16 @@ func (*phi3Mini4KInst) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "phi-3-mini-4k-instruct",
+				ModelName:      PresetPhi3Mini4kModel,
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetPhiTagMap["Phi3Mini4kInstruct"],
 	}
 }
 func (*phi3Mini4KInst) GetTuningParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi3",
+		Metadata:                  metadata.MustGet(PresetPhi3Mini4kModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -106,7 +100,6 @@ func (*phi3Mini4KInst) GetTuningParameters() *model.PresetParam {
 				BaseCommand: baseCommandPresetPhiTuning,
 			},
 		},
-		Tag: PresetPhiTagMap["Phi3Mini4kInstruct"],
 	}
 }
 func (*phi3Mini4KInst) SupportDistributedInference() bool { return false }
@@ -120,7 +113,7 @@ type phi3Mini128KInst struct{}
 
 func (*phi3Mini128KInst) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi3",
+		Metadata:                  metadata.MustGet(PresetPhi3Mini128kModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -135,17 +128,16 @@ func (*phi3Mini128KInst) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "phi-3-mini-128k-instruct",
+				ModelName:      PresetPhi3Mini128kModel,
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetPhiTagMap["Phi3Mini128kInstruct"],
 	}
 }
 func (*phi3Mini128KInst) GetTuningParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi3",
+		Metadata:                  metadata.MustGet(PresetPhi3Mini128kModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -157,7 +149,6 @@ func (*phi3Mini128KInst) GetTuningParameters() *model.PresetParam {
 				BaseCommand: baseCommandPresetPhiTuning,
 			},
 		},
-		Tag: PresetPhiTagMap["Phi3Mini128kInstruct"],
 	}
 }
 func (*phi3Mini128KInst) SupportDistributedInference() bool { return false }
@@ -171,7 +162,7 @@ type phi3_5MiniInst struct{}
 
 func (*phi3_5MiniInst) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi3_5",
+		Metadata:                  metadata.MustGet(PresetPhi3_5MiniInstruct),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -186,17 +177,16 @@ func (*phi3_5MiniInst) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "phi-3.5-mini-instruct",
+				ModelName:      PresetPhi3_5MiniInstruct,
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetPhiTagMap["Phi3_5MiniInstruct"],
 	}
 }
 func (*phi3_5MiniInst) GetTuningParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi3_5",
+		Metadata:                  metadata.MustGet(PresetPhi3_5MiniInstruct),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -210,7 +200,6 @@ func (*phi3_5MiniInst) GetTuningParameters() *model.PresetParam {
 				BaseCommand: baseCommandPresetPhiTuning,
 			},
 		},
-		Tag: PresetPhiTagMap["Phi3_5MiniInstruct"],
 	}
 }
 func (*phi3_5MiniInst) SupportDistributedInference() bool { return false }
@@ -224,7 +213,7 @@ type Phi3Medium4kInstruct struct{}
 
 func (*Phi3Medium4kInstruct) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi3",
+		Metadata:                  metadata.MustGet(PresetPhi3Medium4kModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -239,17 +228,16 @@ func (*Phi3Medium4kInstruct) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "phi-3-medium-4k-instruct",
+				ModelName:      PresetPhi3Medium4kModel,
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetPhiTagMap["Phi3Medium4kInstruct"],
 	}
 }
 func (*Phi3Medium4kInstruct) GetTuningParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi3",
+		Metadata:                  metadata.MustGet(PresetPhi3Medium4kModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -263,7 +251,6 @@ func (*Phi3Medium4kInstruct) GetTuningParameters() *model.PresetParam {
 				BaseCommand: baseCommandPresetPhiTuning,
 			},
 		},
-		Tag: PresetPhiTagMap["Phi3Medium4kInstruct"],
 	}
 }
 func (*Phi3Medium4kInstruct) SupportDistributedInference() bool { return false }
@@ -277,7 +264,7 @@ type Phi3Medium128kInstruct struct{}
 
 func (*Phi3Medium128kInstruct) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi3",
+		Metadata:                  metadata.MustGet(PresetPhi3Medium128kModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -292,17 +279,16 @@ func (*Phi3Medium128kInstruct) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "phi-3-medium-128k-instruct",
+				ModelName:      PresetPhi3Medium128kModel,
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetPhiTagMap["Phi3Medium128kInstruct"],
 	}
 }
 func (*Phi3Medium128kInstruct) GetTuningParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi3",
+		Metadata:                  metadata.MustGet(PresetPhi3Medium128kModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -314,7 +300,6 @@ func (*Phi3Medium128kInstruct) GetTuningParameters() *model.PresetParam {
 				BaseCommand: baseCommandPresetPhiTuning,
 			},
 		},
-		Tag: PresetPhiTagMap["Phi3Medium128kInstruct"],
 	}
 }
 func (*Phi3Medium128kInstruct) SupportDistributedInference() bool { return false }

--- a/presets/workspace/models/phi4/model.go
+++ b/presets/workspace/models/phi4/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/pkg/workspace/inference"
+	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
 
 func init() {
@@ -22,15 +23,12 @@ func init() {
 	})
 }
 
-var (
+const (
 	PresetPhi4Model             = "phi-4"
 	PresetPhi4MiniInstructModel = "phi-4-mini-instruct"
+)
 
-	PresetPhiTagMap = map[string]string{
-		"Phi4":             "0.1.0",
-		"Phi4MiniInstruct": "0.1.0",
-	}
-
+var (
 	baseCommandPresetPhiInference = "accelerate launch"
 	baseCommandPresetPhiTuning    = "cd /workspace/tfs/ && python3 metrics_server.py & accelerate launch"
 	phiRunParams                  = map[string]string{
@@ -49,7 +47,7 @@ type phi4Model struct{}
 
 func (*phi4Model) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi4",
+		Metadata:                  metadata.MustGet(PresetPhi4Model),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "100Gi",
 		GPUCountRequirement:       "1",
@@ -64,18 +62,17 @@ func (*phi4Model) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "phi-4",
+				ModelName:      PresetPhi4Model,
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetPhiTagMap["Phi4"],
 	}
 }
 
 func (*phi4Model) GetTuningParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi4",
+		Metadata:                  metadata.MustGet(PresetPhi4Model),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "100Gi",
 		GPUCountRequirement:       "1",
@@ -87,7 +84,6 @@ func (*phi4Model) GetTuningParameters() *model.PresetParam {
 				BaseCommand: baseCommandPresetPhiTuning,
 			},
 		},
-		Tag: PresetPhiTagMap["Phi4"],
 	}
 }
 
@@ -102,7 +98,7 @@ type phi4MiniInstruct struct{}
 
 func (*phi4MiniInstruct) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi4",
+		Metadata:                  metadata.MustGet(PresetPhi4MiniInstructModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -117,18 +113,17 @@ func (*phi4MiniInstruct) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "phi-4-mini-instruct",
+				ModelName:      PresetPhi4MiniInstructModel,
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetPhiTagMap["Phi4MiniInstruct"],
 	}
 }
 
 func (*phi4MiniInstruct) GetTuningParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Phi4",
+		Metadata:                  metadata.MustGet(PresetPhi4MiniInstructModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "50Gi",
 		GPUCountRequirement:       "1",
@@ -140,7 +135,6 @@ func (*phi4MiniInstruct) GetTuningParameters() *model.PresetParam {
 				BaseCommand: baseCommandPresetPhiTuning,
 			},
 		},
-		Tag: PresetPhiTagMap["Phi4MiniInstruct"],
 	}
 }
 

--- a/presets/workspace/models/qwen/model.go
+++ b/presets/workspace/models/qwen/model.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/pkg/workspace/inference"
+	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
 
 func init() {
@@ -22,15 +23,12 @@ func init() {
 	})
 }
 
-var (
+const (
 	PresetQwen2_5Coder7BInstructModel  = "qwen2.5-coder-7b-instruct"
 	PresetQwen2_5Coder32BInstructModel = "qwen2.5-coder-32b-instruct"
+)
 
-	PresetTagMap = map[string]string{
-		"Qwen2.5-Coder-7B-Instruct":  "0.1.0",
-		"Qwen2.5-Coder-32B-Instruct": "0.1.0",
-	}
-
+var (
 	baseCommandPresetQwenInference = "accelerate launch"
 	baseCommandPresetQwenTuning    = "cd /workspace/tfs/ && python3 metrics_server.py & accelerate launch"
 	qwenRunParams                  = map[string]string{
@@ -48,7 +46,7 @@ type qwen2_5Coder7BInstruct struct{}
 
 func (*qwen2_5Coder7BInstruct) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Qwen",
+		Metadata:                  metadata.MustGet(PresetQwen2_5Coder7BInstructModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "100Gi",
 		GPUCountRequirement:       "1",
@@ -68,13 +66,12 @@ func (*qwen2_5Coder7BInstruct) GetInferenceParameters() *model.PresetParam {
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetTagMap["Qwen2.5-Coder-7B-Instruct"],
 	}
 }
 
 func (*qwen2_5Coder7BInstruct) GetTuningParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "qwen",
+		Metadata:                  metadata.MustGet(PresetQwen2_5Coder7BInstructModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "100Gi",
 		GPUCountRequirement:       "1",
@@ -88,7 +85,6 @@ func (*qwen2_5Coder7BInstruct) GetTuningParameters() *model.PresetParam {
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetTagMap["Qwen2.5-Coder-7B-Instruct"],
 	}
 }
 
@@ -105,7 +101,7 @@ type qwen2_5Coder32BInstruct struct{}
 
 func (*qwen2_5Coder32BInstruct) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "Qwen",
+		Metadata:                  metadata.MustGet(PresetQwen2_5Coder32BInstructModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "120Gi",
 		GPUCountRequirement:       "1",
@@ -125,13 +121,12 @@ func (*qwen2_5Coder32BInstruct) GetInferenceParameters() *model.PresetParam {
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetTagMap["Qwen2.5-Coder-32B-Instruct"],
 	}
 }
 
 func (*qwen2_5Coder32BInstruct) GetTuningParameters() *model.PresetParam {
 	return &model.PresetParam{
-		ModelFamilyName:           "qwen",
+		Metadata:                  metadata.MustGet(PresetQwen2_5Coder32BInstructModel),
 		ImageAccessMode:           string(kaitov1beta1.ModelImageAccessModePublic),
 		DiskStorageRequirement:    "120Gi",
 		GPUCountRequirement:       "1",
@@ -143,7 +138,6 @@ func (*qwen2_5Coder32BInstruct) GetTuningParameters() *model.PresetParam {
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
-		Tag:              PresetTagMap["Qwen2.5-Coder-32B-Instruct"],
 	}
 }
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->

Fully integrates supported_models.yaml as the source of truth for model metadata, replacing hardcoded ModelFamilyName and tag maps in model presets.

**Changes:**
- Updated `PresetParam` in `pkg/model/interface.go` to embed `Metadata` struct, removing `ModelFamilyName` and `Tag`.
- Modified model files (e.g., `deepseek`, `falcon`, `llama2`, `mistral`, etc.) to use `metadata.MustGet` for metadata retrieval.
- Added constants for model names and removed tag maps in model files.
- Enhanced `presets/workspace/models/metadata.go` with `MustGet` function and mutex for thread-safe metadata access.
- Updated `api/v1alpha1` and `api/v1beta1` validation logic to use `params` variable for inference parameters.
- Adjusted `preset-tuning_test.go` to reflect `Metadata` embedding in `PresetParam`.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: