### PR TITLE
chore: add license header check for Python files

### DIFF
--- a/.github/workflows/kind-cluster/determine_models.py
+++ b/.github/workflows/kind-cluster/determine_models.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
 import json
 import os
 import shutil

--- a/.github/workflows/kind-cluster/main.py
+++ b/.github/workflows/kind-cluster/main.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
 import os
 import random
 import shutil

--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -1,7 +1,7 @@
 name: License Header
 
 concurrency:
-  group:  ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 on:
@@ -14,9 +14,21 @@ permissions:
 
 jobs:
   check:
+    name: License Header (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: Go
+            extension: '*.go'
+            boilerplate_file: 'hack/boilerplate.go.txt'
+            ignore_pattern: '*/*.deepcopy.go'
+          - language: Python
+            extension: '*.py'
+            boilerplate_file: 'hack/boilerplate.python.txt'
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
@@ -30,19 +42,29 @@ jobs:
           submodules: true
           fetch-depth: 0
 
-      - name: Check Go file headers
+      - name: Check ${{ matrix.language }} file headers
         run: |
-          boilerplate_file="hack/boilerplate.go.txt"
+          boilerplate_file="${{ matrix.boilerplate_file }}"
+          extension="${{ matrix.extension }}"
+          ignore_pattern="${{ matrix.ignore_pattern }}"
+
           boilerplate_content=$(cat "$boilerplate_file")
           boilerplate_lines=$(awk 'END{print NR}' "$boilerplate_file")
 
-          # Find all .go files
-          mapfile -t go_files < <(find . -type f -name '*.go' -not -name '*.deepcopy.go')
+          boilerplate_content=$(cat "$boilerplate_file")
+          boilerplate_lines=$(grep -c '^' "$boilerplate_file")
+
+          find_cmd="find . -type f -name '$extension'"
+          if [ -n "$ignore_pattern" ]; then
+            find_cmd="$find_cmd -not -path '$ignore_pattern'"
+          fi
+
+          # Find all relevant files
+          mapfile -t files < <(eval $find_cmd)
 
           exit_code=0
-          failed_files=""
 
-          for file in "${go_files[@]}"; do
+          for file in "${files[@]}"; do
             # Get the header of the current file
             header=$(head -n "$boilerplate_lines" "$file")
 
@@ -56,6 +78,6 @@ jobs:
           if [ $exit_code -ne 0 ]; then
             echo "Please add the content of '$boilerplate_file' to the beginning of the listed files."
           else
-            echo "Boilerplate check passed for all Go files."
+            echo "Boilerplate check passed for all ${{ matrix.language }} files."
           fi
           exit $exit_code

--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -14,7 +14,6 @@ permissions:
 
 jobs:
   check:
-    name: License Header (${{ matrix.language }})
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/demo/inferenceUI/chainlit_openai.py
+++ b/demo/inferenceUI/chainlit_openai.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
 import os
 from urllib.parse import urljoin
 

--- a/demo/inferenceUI/chainlit_transformers.py
+++ b/demo/inferenceUI/chainlit_transformers.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
 import os
 from urllib.parse import urljoin
 

--- a/docker/presets/models/tfs-onnx/convert_to_onnx.py
+++ b/docker/presets/models/tfs-onnx/convert_to_onnx.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
 import sys
 import subprocess
 from optimum.onnxruntime import AutoOptimizationConfig, ORTModelForCausalLM, ORTOptimizer
@@ -6,7 +8,7 @@ import glob
 def download_and_convert(repo_name):
     """
     Download and convert a model to ONNX format.
-    
+
     Parameters:
     repo_name (str): The repository name to download the model from.
     model_name (str): The name to save the ONNX model as.
@@ -39,7 +41,7 @@ def download_and_convert(repo_name):
         return model
     except Exception as e:
         print(f"Failed to convert model to ONNX with caching: {e}")
-    
+
     try:
         model = ORTModelForCausalLM.from_pretrained(repo_name, use_cache=False, export=True, provider="CUDAExecutionProvider")
         model.save_pretrained(f"{repo_name}")
@@ -56,7 +58,7 @@ def onnx_optimize_model(model, repo_name):
         optimizer.optimize(save_dir=repo_name, optimization_config=optimization_config)
     except NotImplementedError as e:
         print("ONNX Optimization not supported for this model yet:", e)
-    except Exception as e: 
+    except Exception as e:
         print("Optimizing model failed", e)
 
 if __name__ == "__main__":

--- a/presets/ragengine/__init__.py
+++ b/presets/ragengine/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.

--- a/presets/ragengine/embedding/__init__.py
+++ b/presets/ragengine/embedding/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.

--- a/presets/ragengine/inference/__init__.py
+++ b/presets/ragengine/inference/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.

--- a/presets/ragengine/tests/__init__.py
+++ b/presets/ragengine/tests/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.

--- a/presets/ragengine/tests/api/__init__.py
+++ b/presets/ragengine/tests/api/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.

--- a/presets/ragengine/tests/vector_store/__init__.py
+++ b/presets/ragengine/tests/vector_store/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.

--- a/presets/ragengine/vector_store/__init__.py
+++ b/presets/ragengine/vector_store/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.

--- a/presets/ragengine/vector_store_manager/__init__.py
+++ b/presets/ragengine/vector_store_manager/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.

--- a/presets/workspace/inference/text-generation/tests/test_inference_api.py
+++ b/presets/workspace/inference/text-generation/tests/test_inference_api.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
 import importlib
 import sys
 from pathlib import Path

--- a/presets/workspace/inference/text-generation/tests/test_model_config.py
+++ b/presets/workspace/inference/text-generation/tests/test_model_config.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
 import importlib
 import sys
 from pathlib import Path
@@ -29,7 +31,7 @@ def configured_model_config(request):
 
     # Create and configure the ModelConfig instance
     model_config = ModelConfig(
-        pipeline=request.param['pipeline'], 
+        pipeline=request.param['pipeline'],
         pretrained_model_name_or_path=request.param['model_path'],
     )
 

--- a/presets/workspace/inference/vllm/tests/test_vllm_inference_api.py
+++ b/presets/workspace/inference/vllm/tests/test_vllm_inference_api.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
 import sys
 import os
 import subprocess

--- a/presets/workspace/test/scripts/generate_manifests.py
+++ b/presets/workspace/test/scripts/generate_manifests.py
@@ -1,3 +1,5 @@
+# Copyright (c) Microsoft Corporation.
+# Licensed under the MIT license.
 #!/usr/bin/env python3
 import json
 import yaml


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->

Enhances the `license-header.yml` workflow to check license headers for both Go and Python files, ensuring consistent licensing across the Kaito codebase.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: