### PR TITLE
fix: document id's on list document responses are the same as document id's on create document responses

### DIFF
--- a/presets/ragengine/tests/api/test_main.py
+++ b/presets/ragengine/tests/api/test_main.py
@@ -297,14 +297,12 @@ async def test_list_documents_in_index_success(async_client):
 
     response = await async_client.post("/index", json=request_data)
     assert response.status_code == 200
-    print(response.json())
     doc1, doc2 = response.json()
 
     # Retrieve documents for the specific index
     response = await async_client.get(f"/indexes/{index_name}/documents")
     assert response.status_code == 200
     response_json = response.json()
-    print(response_json)
 
     # Ensure documents exist correctly in the specific index
     assert response_json["count"] == 2

--- a/presets/ragengine/tests/api/test_main.py
+++ b/presets/ragengine/tests/api/test_main.py
@@ -297,6 +297,7 @@ async def test_list_documents_in_index_success(async_client):
 
     response = await async_client.post("/index", json=request_data)
     assert response.status_code == 200
+    doc1, doc2 = response.json()
 
     # Retrieve documents for the specific index
     response = await async_client.get(f"/indexes/{index_name}/documents")
@@ -306,6 +307,8 @@ async def test_list_documents_in_index_success(async_client):
     # Ensure documents exist correctly in the specific index
     assert response_json["count"] == 2
     assert len(response_json["documents"]) == 2
+    assert response_json["documents"][0]["doc_id"] == doc1["doc_id"]
+    assert response_json["documents"][1]["doc_id"] == doc2["doc_id"]
     assert ({item["text"] for item in response_json["documents"]}
             == {item["text"] for item in request_data["documents"]})
 

--- a/presets/ragengine/tests/api/test_main.py
+++ b/presets/ragengine/tests/api/test_main.py
@@ -297,18 +297,21 @@ async def test_list_documents_in_index_success(async_client):
 
     response = await async_client.post("/index", json=request_data)
     assert response.status_code == 200
+    print(response.json())
     doc1, doc2 = response.json()
 
     # Retrieve documents for the specific index
     response = await async_client.get(f"/indexes/{index_name}/documents")
     assert response.status_code == 200
     response_json = response.json()
+    print(response_json)
 
     # Ensure documents exist correctly in the specific index
     assert response_json["count"] == 2
     assert len(response_json["documents"]) == 2
-    assert response_json["documents"][0]["doc_id"] == doc1["doc_id"]
-    assert response_json["documents"][1]["doc_id"] == doc2["doc_id"]
+    assert all(((item['doc_id'] == doc1['doc_id'] and item['text'] == doc1['text']) or
+               (item['doc_id'] == doc2['doc_id'] and item['text'] == doc2['text'])) for item in response_json["documents"])
+    
     assert ({item["text"] for item in response_json["documents"]}
             == {item["text"] for item in request_data["documents"]})
 

--- a/presets/ragengine/tests/vector_store/test_base_store.py
+++ b/presets/ragengine/tests/vector_store/test_base_store.py
@@ -124,11 +124,8 @@ class BaseVectorStoreTest(ABC):
         all_docs = await vector_store_manager.list_documents_in_index("test_add_index", limit=10, offset=1)
         print(all_docs)
 
-        for idx, doc_id in enumerate(ids):
-            # list_documents_in_index returns documents with doc_id's that are not the same as the id's returned from index_documents
-            response_doc = [doc for doc in all_docs if doc['doc_id'] == vector_store_manager.index_map['test_add_index'].docstore.get_ref_doc_info(doc_id).node_ids[0]][0] or None
-            assert response_doc is not None
-            assert documents[idx].text == response_doc['text']
+        # Validate id's from index_documents match the expected ids
+        assert all(doc['doc_id'] == ids[idx] for idx, doc in enumerate(all_docs))
 
     @pytest.mark.asyncio
     async def test_persist_index(self, vector_store_manager):

--- a/presets/ragengine/vector_store/base.py
+++ b/presets/ragengine/vector_store/base.py
@@ -214,17 +214,17 @@ class BaseVectorStore(ABC):
         """
         try:
             if isinstance(doc_store, SimpleDocumentStore):
-                text, hash_value = doc_stub.text, doc_stub.hash
+                text, hash_value, ref_doc_id = doc_stub.text, doc_stub.hash, doc_stub.ref_doc_id
             else:
                 doc_info = await doc_store.aget_document(doc_id)
-                text, hash_value = doc_info.text, doc_info.hash
+                text, hash_value, ref_doc_id = doc_info.text, doc_info.hash, doc_stub.ref_doc_id
 
             # Truncate if needed
             is_truncated = bool(max_text_length and len(text) > max_text_length)
             truncated_text = text[:max_text_length] if is_truncated else text
 
             return {
-                "doc_id": doc_id,
+                "doc_id": ref_doc_id,
                 "text": truncated_text,
                 "hash_value": hash_value,
                 "metadata": getattr(doc_stub, "metadata", {}),

--- a/presets/ragengine/vector_store/base.py
+++ b/presets/ragengine/vector_store/base.py
@@ -86,13 +86,13 @@ class BaseVectorStore(ABC):
         """Common logic for creating a new index with documents."""
         storage_context = StorageContext.from_defaults(vector_store=vector_store)
         llama_docs = []
-        indexed_doc_ids = set()
+        indexed_doc_ids = [None] * len(documents)
 
-        for doc in documents:
+        for idx, doc in enumerate(documents):
             doc_id = self.generate_doc_id(doc.text)
             llama_doc = LlamaDocument(id_=doc_id, text=doc.text, metadata=doc.metadata)
             llama_docs.append(llama_doc)
-            indexed_doc_ids.add(doc_id)
+            indexed_doc_ids[idx] = doc_id
 
         if llama_docs:
             if self.use_rwlock:
@@ -118,7 +118,7 @@ class BaseVectorStore(ABC):
                 index.set_index_id(index_name)
                 self.index_map[index_name] = index
                 self.index_store.add_index_struct(index.index_struct)
-        return list(indexed_doc_ids)
+        return indexed_doc_ids
 
     async def query(self,
               index_name: str,


### PR DESCRIPTION
**Reason for Change**:
LlamaIndex has some internal node id referencing it uses within its document stores that differ from the [document ID's we create documents with](https://github.com/kaito-project/kaito/blob/10af1f42eddbacb9e335b06bebbb4088cad7b629/presets/ragengine/vector_store/base.py#L44C1-L45C1).

This change updates the response ID's from the internal LlamaIndex nodeIds to the document ID's we create for the documents. I chose the `ref_doc_id` because it is what is stored within the vector store on document additions, so when users look into the vector store(cosmos/postgres/etc.) they will see the same doc id as is returned from the ragengine service.

I also found that the id list build on document create calls with new indexes was also returning a random ordered list by calling list() on a set. Changed this fill out lists by document indexes in the input list.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: