### PR TITLE
feat: strip managed fields for controller informer

### DIFF
--- a/cmd/ragengine/main.go
+++ b/cmd/ragengine/main.go
@@ -21,6 +21,7 @@ import (
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/webhook"
 	ctrl "sigs.k8s.io/controller-runtime"
+	runtimecache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -103,6 +104,9 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
+		Cache: runtimecache.Options{
+			DefaultTransform: runtimecache.TransformStripManagedFields(),
+		},
 	})
 	if err != nil {
 		klog.ErrorS(err, "unable to start manager")

--- a/cmd/workspace/main.go
+++ b/cmd/workspace/main.go
@@ -21,6 +21,7 @@ import (
 	"knative.dev/pkg/injection/sharedmain"
 	"knative.dev/pkg/webhook"
 	ctrl "sigs.k8s.io/controller-runtime"
+	runtimecache "sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
@@ -104,6 +105,9 @@ func main() {
 		// if you are doing or is intended to do any operation such as perform cleanups
 		// after the manager stops then its usage might be unsafe.
 		// LeaderElectionReleaseOnCancel: true,
+		Cache: runtimecache.Options{
+			DefaultTransform: runtimecache.TransformStripManagedFields(),
+		},
 	})
 	if err != nil {
 		klog.ErrorS(err, "unable to start manager")


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->
Managed fields are often very large, taking up around 30% memory space of cache resources.
but we don't need them in the controllers, so strip managed fields in order to reduce cache memory.

**Requirements**

- [x] added unit tests and e2e tests (if applicable)


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: