### PR TITLE
fix: check nodeclass before controller start

### DIFF
--- a/cmd/ragengine/main.go
+++ b/cmd/ragengine/main.go
@@ -29,10 +29,13 @@ import (
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
+	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/k8sclient"
 	"github.com/kaito-project/kaito/pkg/ragengine/controllers"
 	"github.com/kaito-project/kaito/pkg/ragengine/webhooks"
 	kaitoutils "github.com/kaito-project/kaito/pkg/utils"
+	"github.com/kaito-project/kaito/pkg/utils/consts"
+	"github.com/kaito-project/kaito/pkg/utils/nodeclaim"
 )
 
 const (
@@ -111,6 +114,18 @@ func main() {
 
 	k8sclient.SetGlobalClient(mgr.GetClient())
 	kClient := k8sclient.GetGlobalClient()
+
+	cloudProvider := os.Getenv("CLOUD_PROVIDER")
+	if !kaitoutils.ValidCloudProvider(cloudProvider) {
+		klog.ErrorS(nil, "invalid cloud provider env", "cloudProvider", cloudProvider)
+		exitWithErrorFunc()
+	}
+	if featuregates.FeatureGates[consts.FeatureFlagEnsureNodeClass] {
+		err := nodeclaim.CheckNodeClass(ctx, kClient)
+		if err != nil {
+			exitWithErrorFunc()
+		}
+	}
 
 	ragengineReconciler := controllers.NewRAGEngineReconciler(
 		kClient,

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -314,3 +314,12 @@ func ParseHuggingFaceModelVersion(version string) (repoId string, revision strin
 
 	return "", "", fmt.Errorf(errInvalidModelVersionURL, version)
 }
+
+func ValidCloudProvider(cloudProvider string) bool {
+	switch cloudProvider {
+	case consts.AzureCloudName, consts.AWSCloudName, consts.ArcCloudName:
+		return true
+	default:
+		return false
+	}
+}

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -33,7 +33,6 @@ import (
 
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
-	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 )
@@ -247,13 +246,6 @@ func CreateNodeClaim(ctx context.Context, nodeClaimObj *karpenterv1.NodeClaim, k
 	return retry.OnError(retry.DefaultBackoff, func(err error) bool {
 		return err.Error() != consts.ErrorInstanceTypesUnavailable
 	}, func() error {
-		if featuregates.FeatureGates[consts.FeatureFlagEnsureNodeClass] {
-			err := CheckNodeClass(ctx, kubeClient)
-			if err != nil {
-				return err
-			}
-		}
-
 		err := kubeClient.Create(ctx, nodeClaimObj.DeepCopy(), &client.CreateOptions{})
 		if err != nil {
 			return err


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->
Check `nodeclass` before controller start, rather than check before creating `nodeclaim`

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: