### PR TITLE
feat: add update/delete document api's and handling for faiss

### DIFF
--- a/presets/ragengine/models.py
+++ b/presets/ragengine/models.py
@@ -25,6 +25,13 @@ class IndexRequest(BaseModel):
     index_name: str
     documents: List[Document]
 
+class UpdateDocumentRequest(BaseModel):
+    doc_id: str
+    text: str
+    hash_value: Optional[str] = None
+    metadata: Optional[dict] = Field(default_factory=dict)
+    is_truncated: bool = False
+
 class QueryRequest(BaseModel):
     index_name: str
     query: str

--- a/presets/ragengine/tests/api/test_main.py
+++ b/presets/ragengine/tests/api/test_main.py
@@ -107,6 +107,86 @@ async def test_query_index_success(mock_get, async_client):
 @pytest.mark.asyncio
 @respx.mock
 @patch("requests.get")  # Mock the requests.get call for fetching model metadata
+async def test_document_update_success(mock_get, async_client):
+    #Mock the response for the default model fetch
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "data": [{"id": "mock-model", "max_model_len": 2048}]
+    }
+
+    # Mock HTTPX response for Custom Inference API
+    mock_response = {"result": "This is the completion from the API"}
+    respx.post("http://localhost:5000/v1/completions").mock(return_value=httpx.Response(200, json=mock_response))
+
+    # Index Request
+    request_data = {
+        "index_name": "test_update_index",
+        "documents": [
+            {"text": "This is a test document"},
+            {"text": "Another test document"}
+        ]
+    }
+
+    response = await async_client.post("/index", json=request_data)
+    assert response.status_code == 200
+    doc1, doc2 = response.json()
+    update_doc = doc1 if doc1["text"] == "Another test document" else doc2
+    assert update_doc["doc_id"] != ""
+
+    update_doc_id = update_doc["doc_id"]
+    update_doc["text"] = "This is an updated test document"
+    response = await async_client.post(f"/indexes/test_update_index/documents/{update_doc_id}", json=update_doc)
+    assert response.status_code == 200
+    assert response.json()["doc_id"] == update_doc_id
+    assert response.json()["text"] == "This is an updated test document"
+
+    # Query Request
+    request_data = {
+        "index_name": "test_update_index",
+        "query": "updates test query",
+        "top_k": 1,
+        "llm_params": {"temperature": 0.7}
+    }
+
+    response = await async_client.post("/query", json=request_data)
+    assert response.status_code == 200
+    assert response.json()["response"] == "{'result': 'This is the completion from the API'}"
+    assert len(response.json()["source_nodes"]) == 1
+    assert response.json()["source_nodes"][0]["text"] == "This is an updated test document"
+    assert response.json()["source_nodes"][0]["score"] == pytest.approx(0.48061275482177734, rel=1e-6)
+    assert response.json()["source_nodes"][0]["metadata"] == {}
+
+    assert respx.calls.call_count == 1
+
+@pytest.mark.asyncio
+async def test_document_delete_success(async_client):
+    # Index Request
+    request_data = {
+        "index_name": "test_delete_index",
+        "documents": [
+            {"text": "This is a test document"},
+            {"text": "Another test document"}
+        ]
+    }
+
+    response = await async_client.post("/index", json=request_data)
+    assert response.status_code == 200
+    doc1, doc2 = response.json()
+    update_doc = doc1 if doc1["text"] == "Another test document" else doc2
+    assert update_doc["doc_id"] != ""
+
+    response = await async_client.delete(f"/indexes/test_delete_index/documents/{update_doc["doc_id"]}")
+    assert response.status_code == 200
+
+    response = await async_client.get(f"/indexes/test_delete_index/documents")
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+    assert len(response.json()["documents"]) == 1
+    assert response.json()["documents"][0]["text"] == "This is a test document"
+
+@pytest.mark.asyncio
+@respx.mock
+@patch("requests.get")  # Mock the requests.get call for fetching model metadata
 async def test_reranker_and_query_with_index(mock_get, async_client):
     """
     Test reranker and query functionality with indexed documents.

--- a/presets/ragengine/tests/vector_store/test_base_store.py
+++ b/presets/ragengine/tests/vector_store/test_base_store.py
@@ -109,6 +109,61 @@ class BaseVectorStoreTest(ABC):
                                                     BaseVectorStore.generate_doc_id("Fourth document"))
 
     @pytest.mark.asyncio
+    @respx.mock
+    @patch("requests.get")
+    async def test_update_document(self, mock_get, vector_store_manager):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {
+            "data": [{"id": "mock-model", "max_model_len": 2048}]
+        }
+
+        mock_response = {"result": "This is the completion from the API"}
+        respx.post(LLM_INFERENCE_URL).mock(return_value=httpx.Response(200, json=mock_response))
+
+        documents = [Document(text="Fifth document", metadata={"type": "text"})]
+        ids = await vector_store_manager.index_documents("test_index", documents)
+
+        await vector_store_manager.update_document(
+            "test_index", ids[0], Document(text="Updated Fifth document", metadata={"type": "text"})
+        )
+
+        assert await vector_store_manager.document_exists("test_index", Document(text="Updated Fifth document", metadata={"type": "text"}),
+                                                    ids[0])
+
+        # Check if the document was updated
+        result = await vector_store_manager.query("test_index", "Updated Fifth document", top_k=1,
+                                              llm_params={}, rerank_params={})
+        assert result["source_nodes"][0]["text"] == "Updated Fifth document"
+    
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("requests.get")
+    async def test_delete_document(self, mock_get, vector_store_manager):
+        mock_get.return_value.status_code = 200
+        mock_get.return_value.json.return_value = {
+            "data": [{"id": "mock-model", "max_model_len": 2048}]
+        }
+
+        mock_response = {"result": "This is the completion from the API"}
+        respx.post(LLM_INFERENCE_URL).mock(return_value=httpx.Response(200, json=mock_response))
+
+        documents = [
+            Document(text=f"Document {i}", metadata={"type": "text"})
+            for i in range(10)
+        ]
+        ids = await vector_store_manager.index_documents("test_index", documents)
+
+        for idx, doc_id in enumerate(ids):
+            await vector_store_manager.delete_document("test_index", doc_id)
+            assert not await vector_store_manager.document_exists("test_index", Document(text=f"Document {idx}", metadata={"type": "text"}), doc_id)
+            # Check if the document was deleted
+            result = await vector_store_manager.query("test_index", "document", top_k=1,
+                                                llm_params={}, rerank_params={})
+            
+            assert len(result["source_nodes"]) == 1 if (idx < len(ids) - 1) else len(result["source_nodes"]) == 0
+
+
+    @pytest.mark.asyncio
     async def test_add_document_on_existing_index(self, vector_store_manager):
         # Create index with single doc
         await vector_store_manager.index_documents("test_add_index", [Document(text=f"Initial Doc", metadata={"type": "text"})])

--- a/presets/ragengine/vector_store/faiss_map_store.py
+++ b/presets/ragengine/vector_store/faiss_map_store.py
@@ -1,0 +1,60 @@
+import numpy as np
+from typing import Any, List, cast
+
+from llama_index.core.schema import BaseNode
+from llama_index.core.bridge.pydantic import PrivateAttr
+from llama_index.vector_stores.faiss import FaissVectorStore
+
+class FaissVectorMapStore(FaissVectorStore):
+    ref_doc_id_map: dict = {}
+
+    def __init__(
+        self,
+        faiss_index: Any,
+    ) -> None:
+        """Initialize params."""
+        import_err_msg = """
+            `faiss` package not found. For instructions on
+            how to install `faiss` please visit
+            https://github.com/facebookresearch/faiss/wiki/Installing-Faiss
+        """
+        try:
+            import faiss
+        except ImportError:
+            raise ImportError(import_err_msg)
+        super().__init__(faiss_index=faiss_index)
+
+    def add(
+        self,
+        nodes: List[BaseNode],
+        **add_kwargs: Any,
+    ) -> List[str]:
+        """Add nodes to index.
+
+        NOTE: in the Faiss vector store, we do not store text in Faiss.
+
+        Args:
+            nodes: List[BaseNode]: list of nodes with embeddings
+
+        """
+        new_ids = []
+        for node in nodes:
+            text_embedding = node.get_embedding()
+            text_embedding_np = np.array(text_embedding, dtype="float32")[np.newaxis, :]
+            new_id = str(self._faiss_index.ntotal)
+            self.ref_doc_id_map[node.ref_doc_id] = self._faiss_index.ntotal
+            self._faiss_index.add_with_ids(text_embedding_np, self._faiss_index.ntotal)
+            new_ids.append(new_id)
+        return new_ids
+
+    def delete(self, ref_doc_id: str, **delete_kwargs: Any) -> None:
+        """
+        Delete nodes using with ref_doc_id.
+
+        Args:
+            ref_doc_id (str): The doc_id of the document to delete.
+
+        """
+        if ref_doc_id in self.ref_doc_id_map:
+            self._faiss_index.remove_ids(np.array([int(self.ref_doc_id_map[ref_doc_id])], dtype=np.int64))
+            del self.ref_doc_id_map[ref_doc_id]

--- a/presets/ragengine/vector_store/faiss_map_store.py
+++ b/presets/ragengine/vector_store/faiss_map_store.py
@@ -56,5 +56,6 @@ class FaissVectorMapStore(FaissVectorStore):
 
         """
         if ref_doc_id in self.ref_doc_id_map:
+            # https://github.com/facebookresearch/faiss/wiki/Special-operations-on-indexes#removing-elements-from-an-index
             self._faiss_index.remove_ids(np.array([int(self.ref_doc_id_map[ref_doc_id])], dtype=np.int64))
             del self.ref_doc_id_map[ref_doc_id]

--- a/presets/ragengine/vector_store/faiss_store.py
+++ b/presets/ragengine/vector_store/faiss_store.py
@@ -4,18 +4,72 @@
 from typing import List
 
 import faiss
+import asyncio
+import numpy as np
 from llama_index.vector_stores.faiss import FaissVectorStore
 from ragengine.models import Document
 from ragengine.embedding.base import BaseEmbeddingModel
 from .base import BaseVectorStore
+from .faiss_map_store import FaissVectorMapStore
 
 
 class FaissVectorStoreHandler(BaseVectorStore):
     def __init__(self, embed_model: BaseEmbeddingModel):
         super().__init__(embed_model, use_rwlock=True)
         self.dimension = self.embed_model.get_embedding_dimension()
+        self.fiass_index_reference = {}
 
     async def _create_new_index(self, index_name: str, documents: List[Document]) -> List[str]:
         faiss_index = faiss.IndexFlatL2(self.dimension)
-        vector_store = FaissVectorStore(faiss_index=faiss_index)
+        id_index = faiss.IndexIDMap(faiss_index)
+        self.fiass_index_reference[index_name] = id_index
+        vector_store = FaissVectorMapStore(faiss_index=id_index)
         return await self._create_index_common(index_name, documents, vector_store)
+
+    async def delete_document(self, index_name: str, doc_id: str):
+        if index_name not in self.fiass_index_reference:
+            raise ValueError(f"No such index: '{index_name}' exists.")
+        retrieved_doc = await self.index_map[index_name].docstore.aget_ref_doc_info(doc_id)
+        if not retrieved_doc:
+            return
+        faiss_doc_id = self._get_faiss_doc_id(index_name, retrieved_doc.node_ids[0])
+        if faiss_doc_id is not None:
+            if self.use_rwlock:
+                async with self.rwlock.writer_lock:
+                    tasks = [
+                        asyncio.to_thread(self.fiass_index_reference[index_name].remove_ids, np.array([np.int64(faiss_doc_id)], dtype=np.int64)),
+                        asyncio.to_thread(self.index_map[index_name].index_struct.delete, faiss_doc_id),
+                        self.index_map[index_name]._adelete_from_docstore(doc_id),
+                    ]
+                    await asyncio.gather(*tasks)
+                    self.index_map[index_name]._storage_context.index_store.add_index_struct(self.index_map[index_name]._index_struct)
+                    self.index_store.add_index_struct(self.index_map[index_name]._index_struct)
+            else:
+                tasks = [
+                    asyncio.to_thread(self.fiass_index_reference[index_name].remove_ids, np.array([np.int64(faiss_doc_id)], dtype=np.int64)),
+                    asyncio.to_thread(self.index_map[index_name].index_struct.delete, faiss_doc_id),
+                    self.index_map[index_name]._adelete_from_docstore(doc_id),
+                ]
+                await asyncio.gather(*tasks)
+                self.index_map[index_name]._storage_context.index_store.add_index_struct(self.index_map[index_name]._index_struct)
+                self.index_store.add_index_struct(self.index_map[index_name]._index_struct)
+    
+    async def update_document(self, index_name: str, doc_id: str, document: Document):
+        if index_name not in self.index_map:
+            raise ValueError(f"No such index: '{index_name}' exists.")
+        if self.use_rwlock:
+            async with self.rwlock.writer_lock:
+                await self.delete_document(index_name, doc_id)
+                await self.add_document_to_index(index_name, document, doc_id)
+        else:
+            await self.delete_document(index_name, doc_id)
+            await self.add_document_to_index(index_name, document, doc_id)
+
+    def _get_faiss_doc_id(self, index_name: str, doc_id: str) -> str:
+        if index_name not in self.index_map:
+            raise ValueError(f"No such index: '{index_name}' exists.")
+
+        for k, v in self.index_map[index_name].index_struct.nodes_dict.items():
+            if v == doc_id:
+                return k
+        return None

--- a/presets/ragengine/vector_store/faiss_store.py
+++ b/presets/ragengine/vector_store/faiss_store.py
@@ -17,44 +17,62 @@ class FaissVectorStoreHandler(BaseVectorStore):
     def __init__(self, embed_model: BaseEmbeddingModel):
         super().__init__(embed_model, use_rwlock=True)
         self.dimension = self.embed_model.get_embedding_dimension()
-        self.fiass_index_reference = {}
 
     async def _create_new_index(self, index_name: str, documents: List[Document]) -> List[str]:
         faiss_index = faiss.IndexFlatL2(self.dimension)
+        # we cant use the IndexFlatL2 directly as its delete functionality changes document ids.
+        # we can wrap it in the IDMap to keep the same functionality but also be able to index by ids and support delete with llama_index
+        # https://github.com/facebookresearch/faiss/wiki/Faiss-indexes#supported-operations
         id_index = faiss.IndexIDMap(faiss_index)
-        self.fiass_index_reference[index_name] = id_index
         vector_store = FaissVectorMapStore(faiss_index=id_index)
         return await self._create_index_common(index_name, documents, vector_store)
 
+    # this function should be removes and the BaseVectorStore should be used instead,
+    # but there is a bug in llama_index that prevents this from working
     async def delete_document(self, index_name: str, doc_id: str):
-        if index_name not in self.fiass_index_reference:
+        """
+        Delete a document from the index.
+        Args:
+            index_name (str): The name of the index to delete from.
+            doc_id (str): The document ID to delete.
+        """
+        if index_name not in self.index_map:
             raise ValueError(f"No such index: '{index_name}' exists.")
         retrieved_doc = await self.index_map[index_name].docstore.aget_ref_doc_info(doc_id)
         if not retrieved_doc:
             return
-        faiss_doc_id = self._get_faiss_doc_id(index_name, retrieved_doc.node_ids[0])
+        faiss_doc_id = self.index_map[index_name].storage_context.vector_store.ref_doc_id_map.get(doc_id)
         if faiss_doc_id is not None:
             if self.use_rwlock:
                 async with self.rwlock.writer_lock:
                     tasks = [
-                        asyncio.to_thread(self.fiass_index_reference[index_name].remove_ids, np.array([np.int64(faiss_doc_id)], dtype=np.int64)),
-                        asyncio.to_thread(self.index_map[index_name].index_struct.delete, faiss_doc_id),
+                        # delete references which can be done in parallel
+                        asyncio.to_thread(self.index_map[index_name].storage_context.vector_store.delete, doc_id),
+                        asyncio.to_thread(self.index_map[index_name].index_struct.delete, str(faiss_doc_id)),
                         self.index_map[index_name]._adelete_from_docstore(doc_id),
                     ]
                     await asyncio.gather(*tasks)
-                    self.index_map[index_name]._storage_context.index_store.add_index_struct(self.index_map[index_name]._index_struct)
+                    # update index_structs at different levels
+                    self.index_map[index_name].storage_context.index_store.add_index_struct(self.index_map[index_name]._index_struct)
                     self.index_store.add_index_struct(self.index_map[index_name]._index_struct)
             else:
                 tasks = [
-                    asyncio.to_thread(self.fiass_index_reference[index_name].remove_ids, np.array([np.int64(faiss_doc_id)], dtype=np.int64)),
-                    asyncio.to_thread(self.index_map[index_name].index_struct.delete, faiss_doc_id),
+                    asyncio.to_thread(self.index_map[index_name].storage_context.vector_store.delete, doc_id),
+                    asyncio.to_thread(self.index_map[index_name].index_struct.delete, str(faiss_doc_id)),
                     self.index_map[index_name]._adelete_from_docstore(doc_id),
                 ]
                 await asyncio.gather(*tasks)
-                self.index_map[index_name]._storage_context.index_store.add_index_struct(self.index_map[index_name]._index_struct)
+                self.index_map[index_name].storage_context.index_store.add_index_struct(self.index_map[index_name]._index_struct)
                 self.index_store.add_index_struct(self.index_map[index_name]._index_struct)
     
     async def update_document(self, index_name: str, doc_id: str, document: Document):
+        """
+        Update a document in the index.
+        Args:
+            index_name (str): The name of the index to update.
+            doc_id (str): The document ID to update.
+            document (Document): The new document to add.
+        """
         if index_name not in self.index_map:
             raise ValueError(f"No such index: '{index_name}' exists.")
         if self.use_rwlock:
@@ -64,12 +82,3 @@ class FaissVectorStoreHandler(BaseVectorStore):
         else:
             await self.delete_document(index_name, doc_id)
             await self.add_document_to_index(index_name, document, doc_id)
-
-    def _get_faiss_doc_id(self, index_name: str, doc_id: str) -> str:
-        if index_name not in self.index_map:
-            raise ValueError(f"No such index: '{index_name}' exists.")
-
-        for k, v in self.index_map[index_name].index_struct.nodes_dict.items():
-            if v == doc_id:
-                return k
-        return None

--- a/presets/ragengine/vector_store_manager/manager.py
+++ b/presets/ragengine/vector_store_manager/manager.py
@@ -42,6 +42,18 @@ class VectorStoreManager:
             max_text_length
         )
 
+    async def update_document(self,
+            index_name: str,
+            doc_id: str,
+            new_doc: Document
+    ) -> None:
+        """Update a document in the index."""
+        return await self.vector_store.update_document(index_name, doc_id, new_doc)
+
+    async def delete_document(self, index_name: str, doc_id: str) -> None:
+        """Delete a document from the index."""
+        return await self.vector_store.delete_document(index_name, doc_id)
+
     async def persist(self, index_name: str, path: str) -> None:
         """Persist existing index."""
         return await self.vector_store.persist(index_name, path)


### PR DESCRIPTION
**Reason for Change**:
This adds update/delete document api's and handling for FAISS. This required a wrapper around the LlamaIndex FaissVectorStore and wrapping our initially used FlatL2 faiss index with a IDMap index to support delete operations.  Base functionality is still the same with the wrapped index, we just now have support for document mapping to id's in the IDMap index.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: