### PR TITLE
fix: update GPUMemGB for Standard_ND96amsr_A100_v4

### DIFF
--- a/pkg/sku/azure_sku_handler.go
+++ b/pkg/sku/azure_sku_handler.go
@@ -17,7 +17,7 @@ func NewAzureSKUHandler() CloudSKUHandler {
 		{SKU: "Standard_NC48ads_A100_v4", GPUCount: 2, GPUMemGB: 160, GPUModel: "NVIDIA A100"},
 		{SKU: "Standard_NC96ads_A100_v4", GPUCount: 4, GPUMemGB: 320, GPUModel: "NVIDIA A100"},
 		{SKU: "Standard_ND96asr_A100_v4", GPUCount: 8, GPUMemGB: 320, GPUModel: "NVIDIA A100"},
-		{SKU: "Standard_ND96amsr_A100_v4", GPUCount: 8, GPUMemGB: 80, GPUModel: "NVIDIA A100"},
+		{SKU: "Standard_ND96amsr_A100_v4", GPUCount: 8, GPUMemGB: 640, GPUModel: "NVIDIA A100"},
 		// https://learn.microsoft.com/en-us/azure/virtual-machines/sizes/gpu-accelerated/ncadsh100v5-series
 		{SKU: "Standard_NC40ads_H100_v5", GPUCount: 1, GPUMemGB: 94, GPUModel: "NVIDIA H100"},
 		{SKU: "Standard_NC80adis_H100_v5", GPUCount: 2, GPUMemGB: 188, GPUModel: "NVIDIA H100"},


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->

`Standard_ND96amsr_A100_v4` has 8 A100 GPUs with 80GB each, totaling 640GB of GPU memory, not 80GB.

![image](https://github.com/user-attachments/assets/4158697d-e22f-400c-b23a-36dd6e12113d)


**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: