### PR TITLE
chore: remove torchrun and distributed inference references

### DIFF
--- a/pkg/utils/test/testModel.go
+++ b/pkg/utils/test/testModel.go
@@ -27,10 +27,9 @@ func (*baseTestModel) GetInferenceParameters() *model.PresetParam {
 				ModelRunParams: emptyParams,
 			},
 			Transformers: model.HuggingfaceTransformersParam{
-				BaseCommand:        "accelerate launch",
-				InferenceMainFile:  "/workspace/tfs/inference_api.py",
-				TorchRunParams:     emptyParams,
-				TorchRunRdzvParams: emptyParams,
+				BaseCommand:       "accelerate launch",
+				InferenceMainFile: "/workspace/tfs/inference_api.py",
+				AccelerateParams:  emptyParams,
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,

--- a/pkg/workspace/inference/preset-inference-types.go
+++ b/pkg/workspace/inference/preset-inference-types.go
@@ -7,46 +7,13 @@ import (
 )
 
 const (
-	DefaultNnodes       = "1"
-	DefaultNprocPerNode = "1"
-	DefaultNodeRank     = "0"
-	DefaultMasterAddr   = "localhost"
-	DefaultMasterPort   = "29500"
-)
-
-// Torch Rendezvous Params
-const (
-	DefaultMaxRestarts  = "3"
-	DefaultRdzvId       = "rdzv_id"
-	DefaultRdzvBackend  = "c10d"            // Pytorch Native Distributed data store
-	DefaultRdzvEndpoint = "localhost:29500" // e.g. llama-2-13b-chat-0.llama-headless.default.svc.cluster.local:29500
-)
-
-const (
-	DefaultConfigFile   = "config.yaml"
 	DefaultNumProcesses = "1"
 	DefaultNumMachines  = "1"
 	DefaultMachineRank  = "0"
 	DefaultGPUIds       = "all"
 )
 
-// TODO: remove the above local variables starting with lower cases.
 var (
-	DefaultTorchRunParams = map[string]string{
-		"nnodes":         DefaultNnodes,
-		"nproc_per_node": DefaultNprocPerNode,
-		"node_rank":      DefaultNodeRank,
-		"master_addr":    DefaultMasterAddr,
-		"master_port":    DefaultMasterPort,
-	}
-
-	DefaultTorchRunRdzvParams = map[string]string{
-		"max_restarts":  DefaultMaxRestarts,
-		"rdzv_id":       DefaultRdzvId,
-		"rdzv_backend":  DefaultRdzvBackend,
-		"rdzv_endpoint": DefaultRdzvEndpoint,
-	}
-
 	DefaultAccelerateParams = map[string]string{
 		"num_processes": DefaultNumProcesses,
 		"num_machines":  DefaultNumMachines,

--- a/pkg/workspace/inference/preset-inferences_test.go
+++ b/pkg/workspace/inference/preset-inferences_test.go
@@ -47,7 +47,7 @@ func TestCreatePresetInference(t *testing.T) {
 			},
 			workload:      "Deployment",
 			expectedImage: "test-registry/kaito-test-model:base-test-model",
-			// No BaseCommand, TorchRunParams, TorchRunRdzvParams, or ModelRunParams
+			// No BaseCommand, AccelerateParams, or ModelRunParams
 			// So expected cmd consists of shell command and inference file
 			expectedCmd: "/bin/sh -c python3 /workspace/vllm/inference_api.py --tensor-parallel-size=2 --served-model-name=mymodel --gpu-memory-utilization=0.90 --kaito-config-file=/mnt/config/inference_config.yaml",
 			hasAdapters: false,
@@ -67,7 +67,7 @@ func TestCreatePresetInference(t *testing.T) {
 			},
 			workload:      "Deployment",
 			expectedImage: "test-registry/kaito-test-model:test-no-tensor-parallel-model",
-			// No BaseCommand, TorchRunParams, TorchRunRdzvParams, or ModelRunParams
+			// No BaseCommand, AccelerateParams, or ModelRunParams
 			// So expected cmd consists of shell command and inference file
 			expectedCmd: "/bin/sh -c python3 /workspace/vllm/inference_api.py --kaito-config-file=/mnt/config/inference_config.yaml --gpu-memory-utilization=0.90",
 			hasAdapters: false,
@@ -87,7 +87,7 @@ func TestCreatePresetInference(t *testing.T) {
 			},
 			workload:      "Deployment",
 			expectedImage: "test-registry/kaito-test-model:test-no-lora-support-model",
-			// No BaseCommand, TorchRunParams, TorchRunRdzvParams, or ModelRunParams
+			// No BaseCommand, AccelerateParams, or ModelRunParams
 			// So expected cmd consists of shell command and inference file
 			expectedCmd: "/bin/sh -c python3 /workspace/vllm/inference_api.py --kaito-config-file=/mnt/config/inference_config.yaml --gpu-memory-utilization=0.90",
 			hasAdapters: false,
@@ -129,29 +129,10 @@ func TestCreatePresetInference(t *testing.T) {
 			},
 			workload:      "Deployment",
 			expectedImage: "test-registry/kaito-test-model:base-test-model",
-			// No BaseCommand, TorchRunParams, TorchRunRdzvParams, or ModelRunParams
+			// No BaseCommand, AccelerateParams, or ModelRunParams
 			// So expected cmd consists of shell command and inference file
 			expectedCmd: "/bin/sh -c accelerate launch /workspace/tfs/inference_api.py",
 			hasAdapters: false,
-			expectedEnvVars: []corev1.EnvVar{{
-				Name:  "PYTORCH_CUDA_ALLOC_CONF",
-				Value: "expandable_segments:True",
-			}},
-		},
-
-		"test-distributed-model/transformers": {
-			workspace: test.MockWorkspaceDistributedModel,
-			nodeCount: 1,
-			modelName: "test-distributed-model",
-			callMocks: func(c *test.MockClient) {
-				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
-				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Service{}), mock.Anything).Return(nil)
-				c.On("Create", mock.IsType(context.TODO()), mock.IsType(&appsv1.StatefulSet{}), mock.Anything).Return(nil)
-			},
-			workload:      "StatefulSet",
-			expectedImage: "test-registry/kaito-test-distributed-model:base-test-model",
-			expectedCmd:   "/bin/sh -c accelerate launch --nnodes=1 --nproc_per_node=0 --max_restarts=3 --rdzv_id=job --rdzv_backend=c10d --rdzv_endpoint=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local:29500 /workspace/tfs/inference_api.py",
-			hasAdapters:   false,
 			expectedEnvVars: []corev1.EnvVar{{
 				Name:  "PYTORCH_CUDA_ALLOC_CONF",
 				Value: "expandable_segments:True",

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -35,16 +35,9 @@ func GenerateHeadlessServiceManifest(workspaceObj *kaitov1beta1.Workspace) *core
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Selector:  selector,
-			ClusterIP: "None",
-			Ports: []corev1.ServicePort{
-				{
-					Name:       "torchrun",
-					Protocol:   corev1.ProtocolTCP,
-					Port:       29500,
-					TargetPort: intstr.FromInt32(29500),
-				},
-			},
+			Selector:                 selector,
+			ClusterIP:                "None",
+			Ports:                    []corev1.ServicePort{},
 			PublishNotReadyAddresses: true,
 		},
 	}
@@ -77,13 +70,6 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 					Protocol:   corev1.ProtocolTCP,
 					Port:       80,
 					TargetPort: intstr.FromInt32(5000),
-				},
-				// Torch NCCL Port
-				{
-					Name:       "torch",
-					Protocol:   corev1.ProtocolTCP,
-					Port:       29500,
-					TargetPort: intstr.FromInt32(29500),
 				},
 			},
 			Selector: selector,

--- a/pkg/workspace/tuning/preset-tuning.go
+++ b/pkg/workspace/tuning/preset-tuning.go
@@ -366,13 +366,13 @@ func prepareModelRunParameters(ctx context.Context, tuningObj *model.PresetParam
 func prepareTuningParameters(ctx context.Context, wObj *kaitov1beta1.Workspace, modelCommand string,
 	tuningObj *model.PresetParam, skuNumGPUs int) ([]string, corev1.ResourceRequirements) {
 	hfParam := tuningObj.Transformers // Only support Huggingface for now
-	if hfParam.TorchRunParams == nil {
-		hfParam.TorchRunParams = make(map[string]string)
+	if hfParam.AccelerateParams == nil {
+		hfParam.AccelerateParams = make(map[string]string)
 	}
 	// Set # of processes to GPU Count
 	numProcesses := getInstanceGPUCount(wObj.Resource.InstanceType)
-	hfParam.TorchRunParams["num_processes"] = fmt.Sprintf("%d", numProcesses)
-	torchCommand := utils.BuildCmdStr(hfParam.BaseCommand, hfParam.TorchRunParams, hfParam.TorchRunRdzvParams)
+	hfParam.AccelerateParams["num_processes"] = fmt.Sprintf("%d", numProcesses)
+	torchCommand := utils.BuildCmdStr(hfParam.BaseCommand, hfParam.AccelerateParams)
 	commands := utils.ShellCmd(torchCommand + " " + modelCommand)
 
 	resourceRequirements := corev1.ResourceRequirements{

--- a/pkg/workspace/tuning/preset-tuning_test.go
+++ b/pkg/workspace/tuning/preset-tuning_test.go
@@ -285,9 +285,8 @@ func TestPrepareTuningParameters(t *testing.T) {
 			tuningObj: &model.PresetParam{
 				RuntimeParam: model.RuntimeParam{
 					Transformers: model.HuggingfaceTransformersParam{
-						BaseCommand:        "python train.py",
-						TorchRunParams:     map[string]string{},
-						TorchRunRdzvParams: map[string]string{},
+						BaseCommand:      "python train.py",
+						AccelerateParams: map[string]string{},
 					},
 				},
 				GPUCountRequirement: "2",

--- a/presets/workspace/models/deepseek/model.go
+++ b/presets/workspace/models/deepseek/model.go
@@ -63,7 +63,7 @@ func (*llama8b) GetInferenceParameters() *model.PresetParam {
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetDeepseekInference,
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    deepseekLlama8bRunParams,
 			},
@@ -100,7 +100,7 @@ func (*qwen14b) GetInferenceParameters() *model.PresetParam {
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetDeepseekInference,
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    deepseekQwen14bRunParams,
 			},

--- a/presets/workspace/models/falcon/model.go
+++ b/presets/workspace/models/falcon/model.go
@@ -66,7 +66,7 @@ func (*falcon7b) GetInferenceParameters() *model.PresetParam {
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetFalconInference,
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    falconRunParams,
 			},
@@ -94,9 +94,9 @@ func (*falcon7b) GetTuningParameters() *model.PresetParam {
 		PerGPUMemoryRequirement:   "16Gi",
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
-				BaseCommand:    baseCommandPresetFalconTuning,
-				TorchRunParams: tuning.DefaultAccelerateParams,
-				//ModelRunPrams:             falconRunTuningParams, // TODO
+				BaseCommand:      baseCommandPresetFalconTuning,
+				AccelerateParams: tuning.DefaultAccelerateParams,
+				// ModelRunPrams:    falconRunTuningParams, // TODO
 			},
 		},
 		ReadinessTimeout:              time.Duration(30) * time.Minute,
@@ -125,7 +125,7 @@ func (*falcon7bInst) GetInferenceParameters() *model.PresetParam {
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetFalconInference,
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    falconRunParams,
 			},
@@ -169,7 +169,7 @@ func (*falcon40b) GetInferenceParameters() *model.PresetParam {
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetFalconInference,
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    falconRunParams,
 			},
@@ -191,9 +191,9 @@ func (*falcon40b) GetTuningParameters() *model.PresetParam {
 		PerGPUMemoryRequirement:   "16Gi",
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
-				BaseCommand:    baseCommandPresetFalconTuning,
-				TorchRunParams: tuning.DefaultAccelerateParams,
-				//ModelRunPrams:             falconRunTuningParams, // TODO
+				BaseCommand:      baseCommandPresetFalconTuning,
+				AccelerateParams: tuning.DefaultAccelerateParams,
+				// ModelRunPrams:    falconRunTuningParams, // TODO
 			},
 		},
 		ReadinessTimeout: time.Duration(30) * time.Minute,
@@ -220,7 +220,7 @@ func (*falcon40bInst) GetInferenceParameters() *model.PresetParam {
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetFalconInference,
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    falconRunParams,
 			},

--- a/presets/workspace/models/llama3/model.go
+++ b/presets/workspace/models/llama3/model.go
@@ -52,7 +52,7 @@ func (*llama3_1_8BInstruct) GetInferenceParameters() *model.PresetParam {
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetLlamaInference,
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    llamaRunParams,
 			},

--- a/presets/workspace/models/mistral/model.go
+++ b/presets/workspace/models/mistral/model.go
@@ -54,7 +54,7 @@ func (*mistral7b) GetInferenceParameters() *model.PresetParam {
 		PerGPUMemoryRequirement:   "0Gi", // We run Mistral using native vertical model parallel, no per GPU memory requirement.
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				ModelRunParams:    mistralRunParams,
 				BaseCommand:       baseCommandPresetMistralInference,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
@@ -78,8 +78,8 @@ func (*mistral7b) GetTuningParameters() *model.PresetParam {
 		PerGPUMemoryRequirement:   "16Gi",
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
-				//TorchRunParams:            tuning.DefaultAccelerateParams,
-				//ModelRunParams:            mistralRunParams,
+				// AccelerateParams: tuning.DefaultAccelerateParams,
+				// ModelRunParams:   mistralRunParams,
 				BaseCommand: baseCommandPresetMistralTuning,
 			},
 		},
@@ -107,7 +107,7 @@ func (*mistral7bInst) GetInferenceParameters() *model.PresetParam {
 		PerGPUMemoryRequirement:   "0Gi", // We run mistral using native vertical model parallel, no per GPU memory requirement.
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				ModelRunParams:    mistralRunParams,
 				BaseCommand:       baseCommandPresetMistralInference,
 				InferenceMainFile: inference.DefaultTransformersMainFile,

--- a/presets/workspace/models/phi2/model.go
+++ b/presets/workspace/models/phi2/model.go
@@ -47,7 +47,7 @@ func (*phi2) GetInferenceParameters() *model.PresetParam {
 		PerGPUMemoryRequirement:   "0Gi", // We run Phi using native vertical model parallel, no per GPU memory requirement.
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				ModelRunParams:    phiRunParams,
 				BaseCommand:       baseCommandPresetPhiInference,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
@@ -70,8 +70,8 @@ func (*phi2) GetTuningParameters() *model.PresetParam {
 		PerGPUMemoryRequirement:   "16Gi",
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
-				// TorchRunParams:            inference.DefaultAccelerateParams,
-				// ModelRunParams:            phiRunParams,
+				// AccelerateParams: inference.DefaultAccelerateParams,
+				// ModelRunParams:   phiRunParams,
 				BaseCommand: baseCommandPresetPhiTuning,
 			},
 		},

--- a/presets/workspace/models/phi3/model.go
+++ b/presets/workspace/models/phi3/model.go
@@ -69,7 +69,7 @@ func (*phi3Mini4KInst) GetInferenceParameters() *model.PresetParam {
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetPhiInference,
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    phiRunParams,
 			},
@@ -89,7 +89,7 @@ func (*phi3Mini4KInst) GetTuningParameters() *model.PresetParam {
 		GPUCountRequirement:       "1",
 		TotalGPUMemoryRequirement: "72Gi",
 		PerGPUMemoryRequirement:   "72Gi",
-		// TorchRunParams:            inference.DefaultAccelerateParams,
+		// AccelerateParams:          inference.DefaultAccelerateParams,
 		// ModelRunParams:            phiRunParams,
 		ReadinessTimeout: time.Duration(30) * time.Minute,
 		RuntimeParam: model.RuntimeParam{
@@ -118,7 +118,7 @@ func (*phi3Mini128KInst) GetInferenceParameters() *model.PresetParam {
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetPhiInference,
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    phiRunParams,
 			},
@@ -165,7 +165,7 @@ func (*phi3_5MiniInst) GetInferenceParameters() *model.PresetParam {
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetPhiInference,
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    phiRunParams,
 			},
@@ -185,7 +185,7 @@ func (*phi3_5MiniInst) GetTuningParameters() *model.PresetParam {
 		GPUCountRequirement:       "1",
 		TotalGPUMemoryRequirement: "72Gi",
 		PerGPUMemoryRequirement:   "72Gi",
-		// TorchRunParams:            inference.DefaultAccelerateParams,
+		// AccelerateParams:          inference.DefaultAccelerateParams,
 		// ModelRunParams:            phiRunParams,
 		ReadinessTimeout: time.Duration(30) * time.Minute,
 		RuntimeParam: model.RuntimeParam{
@@ -214,7 +214,7 @@ func (*Phi3Medium4kInstruct) GetInferenceParameters() *model.PresetParam {
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetPhiInference,
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    phiRunParams,
 			},
@@ -234,7 +234,7 @@ func (*Phi3Medium4kInstruct) GetTuningParameters() *model.PresetParam {
 		GPUCountRequirement:       "1",
 		TotalGPUMemoryRequirement: "80Gi",
 		PerGPUMemoryRequirement:   "80Gi",
-		// TorchRunParams:            inference.DefaultAccelerateParams,
+		// AccelerateParams:          inference.DefaultAccelerateParams,
 		// ModelRunParams:            phiRunParams,
 		ReadinessTimeout: time.Duration(30) * time.Minute,
 		RuntimeParam: model.RuntimeParam{
@@ -263,7 +263,7 @@ func (*Phi3Medium128kInstruct) GetInferenceParameters() *model.PresetParam {
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetPhiInference,
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    phiRunParams,
 			},

--- a/presets/workspace/models/phi4/model.go
+++ b/presets/workspace/models/phi4/model.go
@@ -54,7 +54,7 @@ func (*phi4Model) GetInferenceParameters() *model.PresetParam {
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetPhiInference,
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    phiRunParams,
 			},
@@ -103,7 +103,7 @@ func (*phi4MiniInstruct) GetInferenceParameters() *model.PresetParam {
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
 				BaseCommand:       baseCommandPresetPhiInference,
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
 				ModelRunParams:    phiRunParams,
 			},

--- a/presets/workspace/models/qwen/model.go
+++ b/presets/workspace/models/qwen/model.go
@@ -52,7 +52,7 @@ func (*qwen2_5Coder7BInstruct) GetInferenceParameters() *model.PresetParam {
 		PerGPUMemoryRequirement:   "0Gi", // We run qwen using native vertical model parallel, no per GPU memory requirement.
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				ModelRunParams:    qwenRunParams,
 				BaseCommand:       baseCommandPresetQwenInference,
 				InferenceMainFile: inference.DefaultTransformersMainFile,
@@ -76,8 +76,8 @@ func (*qwen2_5Coder7BInstruct) GetTuningParameters() *model.PresetParam {
 		PerGPUMemoryRequirement:   "24Gi",
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
-				//TorchRunParams:            tuning.DefaultAccelerateParams,
-				//ModelRunParams:            qwenRunParams,
+				// AccelerateParams: tuning.DefaultAccelerateParams,
+				// ModelRunParams:   qwenRunParams,
 				BaseCommand: baseCommandPresetQwenTuning,
 			},
 		},
@@ -105,7 +105,7 @@ func (*qwen2_5Coder32BInstruct) GetInferenceParameters() *model.PresetParam {
 		PerGPUMemoryRequirement:   "0Gi",  // We run qwen using native vertical model parallel, no per GPU memory requirement.
 		RuntimeParam: model.RuntimeParam{
 			Transformers: model.HuggingfaceTransformersParam{
-				TorchRunParams:    inference.DefaultAccelerateParams,
+				AccelerateParams:  inference.DefaultAccelerateParams,
 				ModelRunParams:    qwenRunParams,
 				BaseCommand:       baseCommandPresetQwenInference,
 				InferenceMainFile: inference.DefaultTransformersMainFile,


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->

With https://github.com/kaito-project/kaito/blob/main/docs/proposals/20250325-distributed-inference.md, we are planning to discontinue support for distributed inference with torchrun and Transformers. Instead, users can only run multi-node distributed inference with vLLM going forward.

With Llama 2 removed in #1091, there is currently no preset model that relies on torchrun distributed inference, so now is a good time to clean up before implementing the proposal above.

**Changelog**

- **Makefile**:
  - Removed `RUN_LLAMA_13B` variable and references, as Llama 2 13B/70B are deprecated.
  - Fixed formatting issues in `aws-karpenter-helm` and `aws-patch-install-helm` targets.
- **pkg/model/interface.go**:
  - Replaced `TorchRunParams` and `TorchRunRdzvParams` with `AccelerateParams` in `HuggingfaceTransformersParam`.
  - Updated `buildHuggingfaceInferenceCommand` to use `AccelerateParams`.
  - Improved comments for clarity.
- **pkg/utils/test/testModel.go**:
  - Updated `baseTestModel` to use `AccelerateParams` instead of `TorchRunParams` and `TorchRunRdzvParams`.
- **pkg/workspace/inference/preset-inference-types.go**:
  - Removed `TorchRunParams`, `TorchRunRdzvParams`, and related constants.
  - Added `DefaultAccelerateParams` for `accelerate launch` configuration.
- **pkg/workspace/inference/preset-inferences.go**:
  - Removed `updateTorchParamsForDistributedInference`, as `accelerate launch` handles distributed setup natively.
  - Simplified `CreatePresetInference` by removing torch-specific logic.
- **pkg/workspace/inference/preset-inferences_test.go**:
  - Updated test cases to reflect `accelerate launch` commands and removed `TorchRunParams`/`TorchRunRdzvParams`.
  - Removed `test-distributed-model/transformers` test, as distributed logic is now handled by `accelerate`.
- **pkg/workspace/manifests/manifests.go**:
  - Removed torch-specific ports (29500) from `GenerateHeadlessServiceManifest` and `GenerateServiceManifest`.
- **pkg/workspace/tuning/preset-tuning.go**:
  - Updated `prepareTuningParameters` to use `AccelerateParams` for `accelerate launch`.
- **pkg/workspace/tuning/preset-tuning_test.go**:
  - Updated tests to use `AccelerateParams` instead of `TorchRunParams`/`TorchRunRdzvParams`.
- **presets/workspace/models/**:
  - Updated model files (`deepseek`, `falcon`, `llama3`, `mistral`, `phi2`, `phi3`, `phi4`, `qwen`) to use `AccelerateParams` instead of `TorchRunParams`.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

Ref #912

**Notes for Reviewers**: