### PR TITLE
fix: update arc GPUMem to 32 and add more examples for arc

### DIFF
--- a/examples/inference/arc-examples/kaito_workspace_deepseek_r1_distill_llama_8b_with_customized_config.yaml
+++ b/examples/inference/arc-examples/kaito_workspace_deepseek_r1_distill_llama_8b_with_customized_config.yaml
@@ -1,0 +1,30 @@
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  name: workspace-deepseek-r1-distill-llama-8b
+resource:
+  instanceType: <your-vm-sku>
+  preferredNodes:
+    - <your-arc-node-name>
+  labelSelector:
+    matchLabels:
+      apps: llm-inference
+inference:
+  preset:
+    name: "deepseek-r1-distill-llama-8b"
+  config: "ds-inference-params"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ds-inference-params
+data:
+  inference_config.yaml: |
+    # Maximum number of steps to find the max available seq len fitting in the GPU memory.
+    max_probe_steps: 6
+
+    vllm:
+      cpu-offload-gb: 0
+      swap-space: 4
+      max-model-len: 4096
+      # see https://docs.vllm.ai/en/latest/serving/engine_args.html for more options.

--- a/examples/inference/arc-examples/kaito_workspace_phi_4_mini.yaml
+++ b/examples/inference/arc-examples/kaito_workspace_phi_4_mini.yaml
@@ -1,0 +1,14 @@
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  name: workspace-phi-4-mini
+resource:
+  instanceType: <your-vm-sku>
+  preferredNodes:
+    - <your-arc-node-name>
+  labelSelector:
+    matchLabels:
+      apps: llm-inference
+inference:
+  preset:
+    name: phi-4-mini-instruct 

--- a/examples/inference/arc-examples/kaito_workspace_qwen_2.5_coder_7b-instruct.yaml
+++ b/examples/inference/arc-examples/kaito_workspace_qwen_2.5_coder_7b-instruct.yaml
@@ -1,0 +1,14 @@
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  name: workspace-qwen-2-5-coder-7b-instruct
+resource:
+  instanceType: <your-vm-sku>
+  preferredNodes:
+    - <your-arc-node-name>
+  labelSelector:
+    matchLabels:
+      apps: llm-inference
+inference:
+  preset:
+    name: qwen2.5-coder-7b-instruct

--- a/pkg/sku/arc_sku_handker.go
+++ b/pkg/sku/arc_sku_handker.go
@@ -10,12 +10,12 @@ func NewArcSKUHandler() CloudSKUHandler {
 		{SKU: "Standard_NK12", GPUCount: 2, GPUMemGB: 16, GPUModel: "NVIDIA T4"},
 		{SKU: "Standard_NC4_A2", GPUCount: 1, GPUMemGB: 16, GPUModel: "NVIDIA A2"},
 		{SKU: "Standard_NC8_A2", GPUCount: 1, GPUMemGB: 16, GPUModel: "NVIDIA A2"},
-		{SKU: "Standard_NC16_A2", GPUCount: 2, GPUMemGB: 48, GPUModel: "NVIDIA A2"},
-		{SKU: "Standard_NC32_A2", GPUCount: 2, GPUMemGB: 48, GPUModel: "NVIDIA A2"},
+		{SKU: "Standard_NC16_A2", GPUCount: 2, GPUMemGB: 32, GPUModel: "NVIDIA A2"},
+		{SKU: "Standard_NC32_A2", GPUCount: 2, GPUMemGB: 32, GPUModel: "NVIDIA A2"},
 		{SKU: "Standard_NC4_A16", GPUCount: 1, GPUMemGB: 16, GPUModel: "NVIDIA A16"},
 		{SKU: "Standard_NC8_A16", GPUCount: 1, GPUMemGB: 16, GPUModel: "NVIDIA A16"},
-		{SKU: "Standard_NC16_A16", GPUCount: 2, GPUMemGB: 48, GPUModel: "NVIDIA A16"},
-		{SKU: "Standard_NC32_A16", GPUCount: 2, GPUMemGB: 48, GPUModel: "NVIDIA A16"},
+		{SKU: "Standard_NC16_A16", GPUCount: 2, GPUMemGB: 32, GPUModel: "NVIDIA A16"},
+		{SKU: "Standard_NC32_A16", GPUCount: 2, GPUMemGB: 32, GPUModel: "NVIDIA A16"},
 	}
 	return NewGeneralSKUHandler(supportedSKUs)
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->
The GPU memory size of SKU NC16 should be 32 not 48
**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: