### PR TITLE
chore: Run nvidia-device-plugin only on gpu node.

### DIFF
--- a/charts/kaito/workspace/templates/nvidia-device-plugin-ds.yaml
+++ b/charts/kaito/workspace/templates/nvidia-device-plugin-ds.yaml
@@ -20,18 +20,7 @@ spec:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
-            - matchExpressions:
-              {{- if eq .Values.cloudProviderName "azure" }}
-              - key: kubernetes.azure.com/cluster
-                operator: Exists
-              - key: type
-                operator: NotIn
-                values:
-                - virtual-kubelet
-              {{- else if eq .Values.cloudProviderName "aws" }}
-              - key: "k8s.io/cloud-provider-aws"
-                operator: Exists
-              {{- end }}
+{{ toYaml .Values.nvDevicePluginNodeSelectorTerm | indent 12 }}
       tolerations:
         # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
         # This, along with the annotation above marks this pod as a critical add-on.

--- a/charts/kaito/workspace/values-aws.yaml
+++ b/charts/kaito/workspace/values-aws.yaml
@@ -36,9 +36,5 @@ clusterName: "kaito"
 nvDevicePluginNodeSelectorTerm:
 # gpu node selection term works for azure gpu node
   - matchExpressions:
-    - key: kubernetes.azure.com/cluster
+    - key: "k8s.io/cloud-provider-aws"
       operator: Exists
-    - key: type
-      operator: NotIn
-      values:
-      - virtual-kubelet


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->
Run nvidia-device-plugin only on gpu node.
**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: