### PR TITLE
[WIP] feat: enable prefix caching in RAG generation

### DIFF
--- a/api/v1alpha1/ragengine_types.go
+++ b/api/v1alpha1/ragengine_types.go
@@ -52,6 +52,9 @@ type InferenceServiceSpec struct {
 	// AccessSecret is the name of the secret that contains the service access token.
 	// +optional
 	AccessSecret string `json:"accessSecret,omitempty"`
+	// PrefixCaching specifies whether to enable prefix caching flag for the inference service if it is vLLM.
+	// +optional
+	PrefixCaching bool `json:"prefixCaching,omitempty"`
 }
 
 type RAGEngineSpec struct {

--- a/charts/kaito/ragengine/crds/kaito.sh_ragengines.yaml
+++ b/charts/kaito/ragengine/crds/kaito.sh_ragengines.yaml
@@ -180,6 +180,10 @@ spec:
                     description: URL points to a running inference service endpoint
                       which accepts http(s) payload.
                     type: string
+                  prefixCaching:
+                    description: PrefixCaching specifies whether to enable prefix caching
+                      flag for the inference service if it is vLLM.
+                    type: boolean
                 required:
                 - url
                 type: object

--- a/config/crd/bases/kaito.sh_ragengines.yaml
+++ b/config/crd/bases/kaito.sh_ragengines.yaml
@@ -180,6 +180,10 @@ spec:
                     description: URL points to a running inference service endpoint
                       which accepts http(s) payload.
                     type: string
+                  prefixCaching:
+                    description: PrefixCaching specifies whether to enable prefix caching
+                      flag for the inference service if it is vLLM.
+                    type: boolean
                 required:
                 - url
                 type: object

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -156,6 +156,9 @@ type VLLMParam struct {
 	// Indicates if vllm supports LoRA (Low-Rank Adaptation) for this model.
 	// doc: https://docs.vllm.ai/en/latest/models/supported_models.html#text-generation-task-generate
 	DisallowLoRA bool
+	// Indicates if vllm supports automatic prefix caching for this model.
+	// doc: https://docs.vllm.ai/en/latest/features/automatic_prefix_caching.html
+	EnablePrefxCaching bool
 }
 
 func (p *PresetParam) DeepCopy() *PresetParam {
@@ -258,6 +261,9 @@ func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
 	}
 	if !p.VLLM.DisallowLoRA && rc.AdaptersEnabled {
 		p.VLLM.ModelRunParams["enable-lora"] = ""
+	}
+	if p.VLLM.EnablePrefxCaching {
+		p.VLLM.ModelRunParams["enable-prefix-caching"] = ""
 	}
 	if p.DownloadAtRuntime {
 		repoId, revision, _ := utils.ParseHuggingFaceModelVersion(p.Version)

--- a/pkg/ragengine/manifests/manifests.go
+++ b/pkg/ragengine/manifests/manifests.go
@@ -160,6 +160,21 @@ func RAGSetEnv(ragEngineObj *kaitov1alpha1.RAGEngine) []corev1.EnvVar {
 		}
 		envs = append(envs, accessSecretEnv)
 	}
+
+	enablePrefixCaching := ragEngineObj.Spec.InferenceService.PrefixCaching
+	if enablePrefixCaching {
+		prefixCachingEnv := corev1.EnvVar{
+			Name:  "LLM_ENABLE_PREFIX_CACHING",
+			Value: "true",
+		}
+		envs = append(envs, prefixCachingEnv)
+	} else {
+		prefixCachingEnv := corev1.EnvVar{
+			Name:  "LLM_ENABLE_PREFIX_CACHING",
+			Value: "false",
+		}
+		envs = append(envs, prefixCachingEnv)
+	}
 	return envs
 }
 

--- a/presets/ragengine/config.py
+++ b/presets/ragengine/config.py
@@ -40,6 +40,7 @@ LLM_RERANKER_TOP_N = int(os.getenv("LLM_RERANKER_TOP_N", 3))  # Default top 3 re
 # LLM (Large Language Model) configuration
 LLM_INFERENCE_URL = os.getenv("LLM_INFERENCE_URL", "http://localhost:5000/v1/completions")
 LLM_ACCESS_SECRET = os.getenv("LLM_ACCESS_SECRET", "default-access-secret")
+LLM_ENABLE_PREFIX_CACHING = os.getenv("LLM_ENABLE_PREFIX_CACHING", "false")
 # LLM_RESPONSE_FIELD = os.getenv("LLM_RESPONSE_FIELD", "result")  # Uncomment if needed in the future
 
 """

--- a/presets/ragengine/inference/inference.py
+++ b/presets/ragengine/inference/inference.py
@@ -12,7 +12,7 @@ from llama_index.core.llms.callbacks import llm_completion_callback
 import requests
 from requests.exceptions import HTTPError
 from urllib.parse import urlparse, urljoin
-from ragengine.config import LLM_INFERENCE_URL, LLM_ACCESS_SECRET #, LLM_RESPONSE_FIELD
+from ragengine.config import LLM_INFERENCE_URL, LLM_ACCESS_SECRET, LLM_ENABLE_PREFIX_CACHING #, LLM_RESPONSE_FIELD
 from fastapi import HTTPException
 import concurrent.futures
 
@@ -97,12 +97,16 @@ class Inference(CustomLLM):
 
     async def _async_huggingface_remote_complete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
         data = {"prompt": prompt, **kwargs}
+        if LLM_ENABLE_PREFIX_CACHING.lower() == "true":
+            data["enable_prefix_caching"] = True
         return await self._async_post_request(data, headers={"Authorization": f"Bearer {LLM_ACCESS_SECRET}", "Content-Type": "application/json"})
     async def _async_custom_api_complete(self, prompt: str, **kwargs: Any) -> CompletionResponse:
         model_name, model_max_len = self._get_default_model_info()
         if kwargs.get("model"):
             model_name = kwargs.pop("model")
         data = {"prompt": prompt, **kwargs}
+        if LLM_ENABLE_PREFIX_CACHING.lower() == "true":
+            data["enable_prefix_caching"] = True
         if model_name:
             data["model"] = model_name # Include the model only if it is not None
         if model_max_len and data.get("max_tokens"):


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->

Set `enable-prefix-caching` to true in model.py as default so if cx use model trained by kaito, it use this feature by default
In presets, set `enable_prefix_caching` to true if cx set parameter `prefixCaching` as true, add this parameter to huggingface or custom model when cx use vLLM
WIP for more test

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Fixes #920 

**Notes for Reviewers**: