### PR TITLE
chore: Rename model name to keep aligned with huggingface model card

### DIFF
--- a/presets/workspace/models/deepseek/model.go
+++ b/presets/workspace/models/deepseek/model.go
@@ -69,7 +69,7 @@ func (*llama8b) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetDeepSeekR1DistillLlama8BModel,
+				ModelName:      "deepseek-ai/DeepSeek-R1-Distill-Llama-8B",
 				ModelRunParams: deepseekLlama8bRunParamsVLLM,
 			},
 		},
@@ -106,7 +106,7 @@ func (*qwen14b) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetDeepSeekR1DistillQwen14BModel,
+				ModelName:      "deepseek-ai/DeepSeek-R1-Distill-Qwen-14B",
 				ModelRunParams: deepseekQwen14bRunParamsVLLM,
 			},
 		},

--- a/presets/workspace/models/falcon/model.go
+++ b/presets/workspace/models/falcon/model.go
@@ -72,7 +72,7 @@ func (*falcon7b) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      "falcon-7b",
+				ModelName:      "tiiuae/falcon-7b",
 				ModelRunParams: falconRunParamsVLLM,
 				DisallowLoRA:   true,
 			},
@@ -131,7 +131,7 @@ func (*falcon7bInst) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetFalcon7BInstructModel,
+				ModelName:      "tiiuae/falcon-7b-instruct",
 				ModelRunParams: falconRunParamsVLLM,
 				DisallowLoRA:   true,
 			},
@@ -175,7 +175,7 @@ func (*falcon40b) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetFalcon40BModel,
+				ModelName:      "tiiuae/falcon-40b",
 				ModelRunParams: falconRunParamsVLLM,
 			},
 		},
@@ -226,7 +226,7 @@ func (*falcon40bInst) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetFalcon40BInstructModel,
+				ModelName:      "tiiuae/falcon-40b-instruct",
 				ModelRunParams: falconRunParamsVLLM,
 			},
 		},

--- a/presets/workspace/models/llama3/model.go
+++ b/presets/workspace/models/llama3/model.go
@@ -59,7 +59,7 @@ func (*llama3_1_8BInstruct) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetLlama3_1_8BInstructModel,
+				ModelName:      "meta-llama/Llama-3.1-8B-Instruct",
 				ModelRunParams: llamaRunParamsVLLM,
 			},
 		},

--- a/presets/workspace/models/mistral/model.go
+++ b/presets/workspace/models/mistral/model.go
@@ -61,7 +61,7 @@ func (*mistral7b) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetMistral7BModel,
+				ModelName:      "mistralai/Mistral-7B-v0.3",
 				ModelRunParams: mistralRunParamsVLLM,
 			},
 		},
@@ -114,7 +114,7 @@ func (*mistral7bInst) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetMistral7BInstructModel,
+				ModelName:      "mistralai/Mistral-7B-Instruct-v0.3",
 				ModelRunParams: mistralRunParamsVLLM,
 			},
 		},

--- a/presets/workspace/models/phi2/model.go
+++ b/presets/workspace/models/phi2/model.go
@@ -54,7 +54,7 @@ func (*phi2) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetPhi2Model,
+				ModelName:      "microsoft/phi-2",
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},

--- a/presets/workspace/models/phi3/model.go
+++ b/presets/workspace/models/phi3/model.go
@@ -75,7 +75,7 @@ func (*phi3Mini4KInst) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetPhi3Mini4kModel,
+				ModelName:      "microsoft/Phi-3-mini-4k-instruct",
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},
@@ -124,7 +124,7 @@ func (*phi3Mini128KInst) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetPhi3Mini128kModel,
+				ModelName:      "microsoft/Phi-3-mini-128k-instruct",
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},
@@ -171,7 +171,7 @@ func (*phi3_5MiniInst) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetPhi3_5MiniInstruct,
+				ModelName:      "microsoft/Phi-3.5-mini-instruct",
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},
@@ -220,7 +220,7 @@ func (*Phi3Medium4kInstruct) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetPhi3Medium4kModel,
+				ModelName:      "microsoft/Phi-3-medium-4k-instruct",
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},
@@ -269,7 +269,7 @@ func (*Phi3Medium128kInstruct) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetPhi3Medium128kModel,
+				ModelName:      "microsoft/Phi-3-medium-128k-instruct",
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},

--- a/presets/workspace/models/phi4/model.go
+++ b/presets/workspace/models/phi4/model.go
@@ -60,7 +60,7 @@ func (*phi4Model) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetPhi4Model,
+				ModelName:      "microsoft/phi-4",
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},
@@ -109,7 +109,7 @@ func (*phi4MiniInstruct) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetPhi4MiniInstructModel,
+				ModelName:      "microsoft/Phi-4-mini-instruct",
 				ModelRunParams: phiRunParamsVLLM,
 			},
 		},

--- a/presets/workspace/models/qwen/model.go
+++ b/presets/workspace/models/qwen/model.go
@@ -59,7 +59,7 @@ func (*qwen2_5Coder7BInstruct) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetQwen2_5Coder7BInstructModel,
+				ModelName:      "Qwen/Qwen2.5-Coder-7B-Instruct",
 				ModelRunParams: qwenRunParamsVLLM,
 			},
 		},
@@ -112,7 +112,7 @@ func (*qwen2_5Coder32BInstruct) GetInferenceParameters() *model.PresetParam {
 			},
 			VLLM: model.VLLMParam{
 				BaseCommand:    inference.DefaultVLLMCommand,
-				ModelName:      PresetQwen2_5Coder32BInstructModel,
+				ModelName:      "Qwen/Qwen2.5-Coder-32B-Instruct",
 				ModelRunParams: qwenRunParamsVLLM,
 			},
 		},


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->
chore: Rename model name to keep aligned with huggingface model card

It's easier for benchmark suites to fetch model config from huggingface . https://github.com/vllm-project/vllm/issues/16574
**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: