### PR TITLE
fix: pin the pytest-asyncio package

### DIFF
--- a/presets/ragengine/requirements-test.txt
+++ b/presets/ragengine/requirements-test.txt
@@ -3,5 +3,5 @@
 
 # Test dependencies
 pytest
-pytest-asyncio
+pytest-asyncio==0.26.0
 respx


### PR DESCRIPTION
**Reason for Change**:
pytest-asyncio had a 1.0.0 release that broke out UT's. We will pin it for now to unblock ut pipelines.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
broken ut's

**Notes for Reviewers**: