### PR TITLE
test: Exclude gpu-provisioner check in case of running e2e on managed mode

### DIFF
--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -24,6 +24,7 @@ var (
 	ctx                 = context.Background()
 	namespaceName       = fmt.Sprint(utils.E2eNamespace, rand.Intn(100))
 	nodeProvisionerName = os.Getenv("TEST_SUITE")
+	deploymentMode      = os.Getenv("DEPLOYMENT_MODE")
 )
 
 var _ = BeforeSuite(func() {
@@ -53,7 +54,8 @@ var _ = BeforeSuite(func() {
 			Should(Succeed(), "Failed to wait for	karpenter deployment")
 	}
 
-	if nodeProvisionerName == "gpuprovisioner" {
+	if deploymentMode != "managed" &&
+		nodeProvisionerName == "gpuprovisioner" {
 		gpuName := os.Getenv("GPU_PROVISIONER_NAME")
 		gpuNamespace := os.Getenv("GPU_PROVISIONER_NAMESPACE")
 		//check gpu-provisioner deployment is up and running

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"math/rand"
 	"os"
@@ -20,11 +21,12 @@ import (
 	"github.com/kaito-project/kaito/test/e2e/utils"
 )
 
+var skipGPUProvisionerCheck = flag.Bool("skip-gpu-provisioner-check", false, "Skip checking for GPU provisioner pod in e2e tests")
+
 var (
 	ctx                 = context.Background()
 	namespaceName       = fmt.Sprint(utils.E2eNamespace, rand.Intn(100))
 	nodeProvisionerName = os.Getenv("TEST_SUITE")
-	deploymentMode      = os.Getenv("DEPLOYMENT_MODE")
 )
 
 var _ = BeforeSuite(func() {
@@ -54,7 +56,8 @@ var _ = BeforeSuite(func() {
 			Should(Succeed(), "Failed to wait for	karpenter deployment")
 	}
 
-	if deploymentMode != "managed" &&
+	// Only check GPU provisioner if the flag is not set
+	if !*skipGPUProvisionerCheck &&
 		nodeProvisionerName == "gpuprovisioner" {
 		gpuName := os.Getenv("GPU_PROVISIONER_NAME")
 		gpuNamespace := os.Getenv("GPU_PROVISIONER_NAMESPACE")

--- a/test/e2e/inference_with_adapters_test.go
+++ b/test/e2e/inference_with_adapters_test.go
@@ -214,7 +214,7 @@ var _ = Describe("Workspace Preset", func() {
 		if CurrentSpecReport().Failed() {
 			utils.PrintPodLogsOnFailure(namespaceName, "")     // The Preset Pod
 			utils.PrintPodLogsOnFailure("kaito-workspace", "") // The Kaito Workspace Pod
-			if deploymentMode != "managed" {
+			if !*skipGPUProvisionerCheck {
 				utils.PrintPodLogsOnFailure("gpu-provisioner", "") // The gpu-provisioner Pod
 			}
 			Fail("Fail threshold reached")

--- a/test/e2e/inference_with_adapters_test.go
+++ b/test/e2e/inference_with_adapters_test.go
@@ -214,7 +214,9 @@ var _ = Describe("Workspace Preset", func() {
 		if CurrentSpecReport().Failed() {
 			utils.PrintPodLogsOnFailure(namespaceName, "")     // The Preset Pod
 			utils.PrintPodLogsOnFailure("kaito-workspace", "") // The Kaito Workspace Pod
-			utils.PrintPodLogsOnFailure("gpu-provisioner", "") // The gpu-provisioner Pod
+			if deploymentMode != "managed" {
+				utils.PrintPodLogsOnFailure("gpu-provisioner", "") // The gpu-provisioner Pod
+			}
 			Fail("Fail threshold reached")
 		}
 	})

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -802,7 +802,7 @@ var _ = Describe("Workspace Preset", func() {
 		if CurrentSpecReport().Failed() {
 			utils.PrintPodLogsOnFailure(namespaceName, "")     // The Preset Pod
 			utils.PrintPodLogsOnFailure("kaito-workspace", "") // The Kaito Workspace Pod
-			if deploymentMode != "managed" {
+			if !*skipGPUProvisionerCheck {
 				utils.PrintPodLogsOnFailure("gpu-provisioner", "") // The gpu-provisioner Pod
 			}
 			Fail("Fail threshold reached")

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -59,7 +59,7 @@ func loadTestEnvVars() {
 	// Currently required for uploading fine-tuning results
 	e2eACRSecret = utils.GetEnv("E2E_ACR_REGISTRY_SECRET")
 	supportedModelsYamlPath = utils.GetEnv("SUPPORTED_MODELS_YAML_PATH")
-	azureClusterName = utils.GetEnv("AZURE_CLUSTER_NAME")
+	azureClusterName = strings.ToLower(utils.GetEnv("AZURE_CLUSTER_NAME"))
 	hfToken = utils.GetEnv("HF_TOKEN")
 }
 
@@ -802,7 +802,9 @@ var _ = Describe("Workspace Preset", func() {
 		if CurrentSpecReport().Failed() {
 			utils.PrintPodLogsOnFailure(namespaceName, "")     // The Preset Pod
 			utils.PrintPodLogsOnFailure("kaito-workspace", "") // The Kaito Workspace Pod
-			utils.PrintPodLogsOnFailure("gpu-provisioner", "") // The gpu-provisioner Pod
+			if deploymentMode != "managed" {
+				utils.PrintPodLogsOnFailure("gpu-provisioner", "") // The gpu-provisioner Pod
+			}
 			Fail("Fail threshold reached")
 		}
 	})

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -25,7 +25,9 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		if CurrentSpecReport().Failed() {
 			utils.PrintPodLogsOnFailure(namespaceName, "")     // The Preset Pod
 			utils.PrintPodLogsOnFailure("kaito-workspace", "") // The Kaito Workspace Pod
-			utils.PrintPodLogsOnFailure("gpu-provisioner", "") // The gpu-provisioner Pod
+			if deploymentMode != "managed" {
+				utils.PrintPodLogsOnFailure("gpu-provisioner", "") // The gpu-provisioner Pod
+			}
 			Fail("Fail threshold reached")
 		}
 	})

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		if CurrentSpecReport().Failed() {
 			utils.PrintPodLogsOnFailure(namespaceName, "")     // The Preset Pod
 			utils.PrintPodLogsOnFailure("kaito-workspace", "") // The Kaito Workspace Pod
-			if deploymentMode != "managed" {
+			if !*skipGPUProvisionerCheck {
 				utils.PrintPodLogsOnFailure("gpu-provisioner", "") // The gpu-provisioner Pod
 			}
 			Fail("Fail threshold reached")

--- a/test/rage2e/e2e_test.go
+++ b/test/rage2e/e2e_test.go
@@ -5,6 +5,7 @@ package e2e
 
 import (
 	"context"
+	"flag"
 	"fmt"
 	"math/rand"
 	"os"
@@ -19,6 +20,8 @@ import (
 
 	"github.com/kaito-project/kaito/test/e2e/utils"
 )
+
+var skipGPUProvisionerCheck = flag.Bool("skip-gpu-provisioner-check", false, "Skip checking for GPU provisioner pod in e2e tests")
 
 var (
 	ctx                 = context.Background()
@@ -53,7 +56,8 @@ var _ = BeforeSuite(func() {
 			Should(Succeed(), "Failed to wait for	karpenter deployment")
 	}
 
-	if nodeProvisionerName == "gpuprovisioner" {
+	if !*skipGPUProvisionerCheck &&
+		nodeProvisionerName == "gpuprovisioner" {
 		gpuName := os.Getenv("GPU_PROVISIONER_NAME")
 		gpuNamespace := os.Getenv("GPU_PROVISIONER_NAMESPACE")
 		//check gpu-provisioner deployment is up and running

--- a/test/rage2e/rag_test.go
+++ b/test/rage2e/rag_test.go
@@ -71,7 +71,9 @@ var _ = Describe("RAGEngine", func() {
 			utils.PrintPodLogsOnFailure(namespaceName, "")     // The Preset Pod
 			utils.PrintPodLogsOnFailure("kaito-workspace", "") // The Kaito Workspace Pod
 			utils.PrintPodLogsOnFailure("kaito-ragengine", "") // The Kaito ragengine Pod
-			utils.PrintPodLogsOnFailure("gpu-provisioner", "") // The gpu-provisioner Pod
+			if !*skipGPUProvisionerCheck {
+				utils.PrintPodLogsOnFailure("gpu-provisioner", "") // The gpu-provisioner Pod
+			}
 			Fail("Fail threshold reached")
 		}
 	})


### PR DESCRIPTION
**Reason for Change**:
E2E tests needs to pass the gpu-provisioner pod/deployment checks when running on managed mode. To add flexibility  to the e2e framework, a new go test flag `skip-gpu-provisioner-check` is introduced. default value is false which will check for gpu-provisioner. 

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: