### PR TITLE
ci: Expand trivy scanning to other images

### DIFF
--- a/.github/workflows/preset-image-build.yml
+++ b/.github/workflows/preset-image-build.yml
@@ -75,6 +75,40 @@ jobs:
             echo "is_empty=false" >> $GITHUB_OUTPUT
           fi
 
+  scan-baseos-image:
+    name: Scan preset base os image
+    runs-on: ubuntu-latest
+    env:
+      IMAGE_REF: "test/preset-tfs:latest"
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build image from Dockerfile
+        env:
+          OUTPUT_TYPE: type=docker
+          IMAGE_REF: ${{ env.IMAGE_REF }}
+        run: |
+          docker buildx build \
+            --platform linux/amd64 \
+            --output="${OUTPUT_TYPE}" \
+            -t "${IMAGE_REF}" \
+            --build-arg VERSION="v0.0.1" \
+            --build-arg MODEL_TYPE="text-generation" \
+            --target dependencies \
+            -f docker/presets/models/tfs/Dockerfile ../
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37 # v0.31.0
+        with:
+          image-ref: "${{ env.IMAGE_REF }}"
+          format: "table"
+          exit-code: "1"
+          ignore-unfixed: true
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN"
+          scanners: "vuln"
+
   build-models:
     needs: determine-models
     if: needs.determine-models.outputs.is_matrix_empty == 'false'

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -2,39 +2,39 @@ name: Trivy vulnerability scanner
 on:
   push:
     branches:
-      - master
+      - main
   pull_request:
 jobs:
-  build:
-    name: Build
+  build-and-scan:
+    name: Scan ${{ matrix.image }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: docker-build-workspace
+            image: test/workspace:latest
+            registry: test
+
     steps:
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v5
-        with:
-          go-version: 1.24.2
-        id: go
 
       - name: Checkout code
-        uses: actions/checkout@v4
-      
-      - name: Build workspace image from Dockerfile
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Build image from Dockerfile
         run: |
-          export REGISTRY=test
+          export REGISTRY=${{ matrix.registry }}
           export VERSION=latest
-          export DOCKER_CLI_EXPERIMENTAL=enabled
           export OUTPUT_TYPE="type=docker"
           export ARCH="amd64"
-          make docker-build-workspace
-      
+          make ${{ matrix.target }}
+
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        env:
-          TRIVY_DB_REPOSITORY: "public.ecr.aws/aquasecurity/trivy-db:2"
+        uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37 # v0.31.0
         with:
-          image-ref: 'test/workspace:latest'
-          format: 'table'
-          exit-code: '1'
+          image-ref: "test/workspace:latest"
+          format: "table"
+          exit-code: "1"
           ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN'
+          vuln-type: "os,library"
+          severity: "CRITICAL,HIGH,MEDIUM,LOW,UNKNOWN"

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -15,6 +15,12 @@ jobs:
           - target: docker-build-workspace
             image: test/workspace:latest
             registry: test
+          - target: docker-build-ragengine
+            image: test/ragengine:latest
+            registry: test
+          - target: docker-build-ragservice
+            image: test/kaito-rag-service:v0.0.1
+            registry: test
 
     steps:
 
@@ -24,15 +30,15 @@ jobs:
       - name: Build image from Dockerfile
         run: |
           export REGISTRY=${{ matrix.registry }}
-          export VERSION=latest
+          export IMG_TAG=latest
           export OUTPUT_TYPE="type=docker"
           export ARCH="amd64"
-          make ${{ matrix.target }}
+          make ${{ matrix.target }} BUILD_FLAGS="--target dependencies"
 
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@76071ef0d7ec797419534a183b498b4d6366cf37 # v0.31.0
         with:
-          image-ref: "test/workspace:latest"
+          image-ref: ${{ matrix.image }}
           format: "table"
           exit-code: "1"
           ignore-unfixed: true

--- a/Makefile
+++ b/Makefile
@@ -58,6 +58,8 @@ AWS_KARPENTER_VERSION ?=1.0.8
 # Scripts
 GO_INSTALL := ./hack/go-install.sh
 
+BUILD_FLAGS ?=
+
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
 GOBIN=$(shell go env GOPATH)/bin
@@ -257,6 +259,7 @@ docker-build-workspace: docker-buildx
 		--output=$(OUTPUT_TYPE) \
 		--platform="linux/$(ARCH)" \
 		--pull \
+		$(BUILD_FLAGS) \
 		--tag $(REGISTRY)/$(IMG_NAME):$(IMG_TAG) .
 
 .PHONY: docker-build-ragengine
@@ -266,6 +269,7 @@ docker-build-ragengine: docker-buildx
 		--output=$(OUTPUT_TYPE) \
 		--platform="linux/$(ARCH)" \
 		--pull \
+		$(BUILD_FLAGS) \
 		--tag $(REGISTRY)/$(RAGENGINE_IMAGE_NAME):$(IMG_TAG) .
 
 .PHONY: docker-build-rag-service
@@ -275,6 +279,7 @@ docker-build-ragservice: docker-buildx
         --output=$(OUTPUT_TYPE) \
         --file ./docker/ragengine/service/Dockerfile \
         --pull \
+		$(BUILD_FLAGS) \
         --tag $(REGISTRY)/$(RAGENGINE_SERVICE_IMG_NAME):$(RAGENGINE_SERVICE_IMG_TAG) .
 
 .PHONY: docker-build-adapter
@@ -285,6 +290,7 @@ docker-build-adapter: docker-buildx
 		--output=$(OUTPUT_TYPE) \
 		--platform="linux/$(ARCH)" \
 		--pull \
+		$(BUILD_FLAGS) \
 		--tag $(REGISTRY)/e2e-adapter:0.0.1 .
 	docker buildx build \
 		--build-arg ADAPTER_PATH=docker/adapters/adapter2 \
@@ -292,6 +298,7 @@ docker-build-adapter: docker-buildx
 		--output=$(OUTPUT_TYPE) \
 		--platform="linux/$(ARCH)" \
 		--pull \
+		$(BUILD_FLAGS) \
 		--tag $(REGISTRY)/e2e-adapter2:0.0.1 .
 	docker buildx build \
 		--build-arg ADAPTER_PATH=docker/adapters/adapter-phi-3-mini-pycoder \
@@ -299,6 +306,7 @@ docker-build-adapter: docker-buildx
 		--output=$(OUTPUT_TYPE) \
 		--platform="linux/$(ARCH)" \
 		--pull \
+		$(BUILD_FLAGS) \
 		--tag $(REGISTRY)/adapter-phi-3-mini-pycoder:0.0.1 .
 
 .PHONY: docker-build-dataset
@@ -309,6 +317,7 @@ docker-build-dataset: docker-buildx
 		--output=$(OUTPUT_TYPE) \
 		--platform="linux/$(ARCH)" \
 		--pull \
+		$(BUILD_FLAGS) \
 		--tag $(REGISTRY)/e2e-dataset:0.0.1 .
 	docker buildx build \
 		--build-arg ADAPTER_PATH=docker/datasets/dataset2 \
@@ -324,6 +333,7 @@ docker-build-llm-reference-preset: docker-buildx
 		-t ghcr.io/kaito-repo/kaito/llm-reference-preset:$(VERSION) \
 		-t ghcr.io/kaito-repo/kaito/llm-reference-preset:latest \
 		-f docs/custom-model-integration/Dockerfile.reference \
+		$(BUILD_FLAGS) \
 		--build-arg MODEL_TYPE=text-generation \
 		--build-arg VERSION=$(VERSION) .
 

--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim AS base
+FROM python:3.12-slim AS dependencies
 
 ARG MODEL_TYPE
 ARG VERSION
@@ -16,6 +16,8 @@ RUN pip install --no-cache-dir -q -r /workspace/requirements.txt
 # Required for torch.compile
 RUN apt-get update -y && apt-get install --no-install-recommends curl gcc libc-dev perl -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
+
+FROM dependencies AS base
 
 # 1. Huggingface transformers
 COPY presets/workspace/inference/${MODEL_TYPE}/inference_api.py \

--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -9,15 +9,15 @@ ENV RAY_USAGE_STATS_ENABLED="1"
 # Set the working directory
 WORKDIR /workspace
 
-COPY presets/workspace/dependencies/requirements.txt /workspace/requirements.txt
-
-RUN pip install --no-cache-dir -q -r /workspace/requirements.txt
-
 # Required for torch.compile
 RUN apt-get update -y && apt-get install --no-install-recommends curl gcc libc-dev perl -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 FROM dependencies AS base
+
+COPY presets/workspace/dependencies/requirements.txt /workspace/requirements.txt
+
+RUN pip install --no-cache-dir -q -r /workspace/requirements.txt
 
 # 1. Huggingface transformers
 COPY presets/workspace/inference/${MODEL_TYPE}/inference_api.py \

--- a/docker/ragengine/Dockerfile
+++ b/docker/ragengine/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24 as builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24 AS dependencies
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -14,6 +14,8 @@ RUN \
     --mount=type=cache,target=${GOCACHE} \
     --mount=type=cache,target=/go/pkg/mod \
     go mod download
+
+FROM dependencies AS builder
 
 # Copy the go source
 COPY cmd/ cmd/

--- a/docker/ragengine/service/Dockerfile
+++ b/docker/ragengine/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12-slim
+FROM python:3.12-slim AS dependencies
 
 # Install system dependencies for building Python packages
 RUN apt-get update && apt-get upgrade -y \
@@ -10,6 +10,8 @@ RUN apt-get update && apt-get upgrade -y \
     perl \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
+
+FROM dependencies AS base
 
 WORKDIR /app
 

--- a/docker/workspace/Dockerfile
+++ b/docker/workspace/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24 as builder
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24 as dependencies
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -14,6 +14,8 @@ RUN \
     --mount=type=cache,target=${GOCACHE} \
     --mount=type=cache,target=/go/pkg/mod \
     go mod download
+
+FROM dependencies as builder
 
 # Copy the go source
 COPY cmd/ cmd/


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->

Refactored preset image dockerfile to group os dependencies in one target fo easy scanning
Converted trivy pipeline into matrix strategy

**Issue Fixed**:
N/A

**Notes for Reviewers**:
I am not sure if all of these require scanning, happy to cut down to a subset. Some images I've left out because they are quite large, e.g. the `llm-reference-preset` and `ragservice` images