### PR TITLE
docs: adding docs for RAGEngine routes

### DIFF
--- a/docs/RAG/README.md
+++ b/docs/RAG/README.md
@@ -171,7 +171,7 @@ GET /indexes/test_index/documents?metadata_filter={"author":"John Doe"}
 
 ### Updating Documents
 
-To update existing documents in a specific index, use the `/indexes/{index_name}/documents` API route. This endpoint accepts a POST request with the index name in the URL and a list of documents to update in the request body. The documents provided
+To update existing documents in a specific index, use the `/indexes/{index_name}/documents` API route. This endpoint accepts a POST request with the index name in the URL and a list of documents to update in the request body.
 
 **Request Example:**
 
@@ -301,7 +301,7 @@ Use this endpoint to restore previously persisted indexes into memory for queryi
 
 ### Delete Index
 
-To delete an entire index and all of its documents, use the `/indexes/{index_name}` API route. This endpoint accepts a DELETE request with the index name in the URL. Deleting an index is irreversible and will remove all associated documents from both memory and disk (if persisted).
+To delete an entire index and all of its documents, use the `/indexes/{index_name}` API route. This endpoint accepts a DELETE request with the index name in the URL. Deleting an index is irreversible and will remove all associated documents from memory.
 
 **Request Example:**
 
@@ -369,8 +369,5 @@ POST /query
 - `response`: The generated answer or summary from the LLM (if enabled).
 - `source_nodes`: List of source documents/nodes with their text, score, and metadata.
 - `metadata`: Additional metadata about the query or response.
-
-**Experimental Warning:**  
-The `rerank_params` option is experimental and may cause the query to fail if the LLM reranker produces an invalid response. If reranking fails, the request will return an error.
 
 Use this endpoint to retrieve relevant information from your indexed documents and optionally generate answers using an LLM.

--- a/docs/RAG/README.md
+++ b/docs/RAG/README.md
@@ -54,6 +54,7 @@ kubectl apply -f examples/RAG/kaito_ragengine_phi_3.yaml
 ```
 
 ## Usage
+
 ### Creating an Index With Documents
 
 To add documents to an index or create a new index, use the `/index` API route. This endpoint accepts a POST request with the index name and a list of documents to be indexed.
@@ -297,3 +298,79 @@ POST /load/example_index?path=./custom_path/example_index
 ```
 
 Use this endpoint to restore previously persisted indexes into memory for querying and updates.
+
+### Delete Index
+
+To delete an entire index and all of its documents, use the `/indexes/{index_name}` API route. This endpoint accepts a DELETE request with the index name in the URL. Deleting an index is irreversible and will remove all associated documents from both memory and disk (if persisted).
+
+**Request Example:**
+
+```
+DELETE /indexes/example_index
+```
+
+- `index_name`: The name of the index to delete.
+
+**Response Example:**
+
+```json
+{
+  "message": "Successfully deleted index example_index."
+}
+```
+
+Use this endpoint to permanently remove an index and all its data when it is no longer needed.
+
+### Query Index
+
+To query a specific index for relevant documents and optionally rerank results with an LLM, use the `/query` API route. This endpoint accepts a POST request with the index name, query string, and optional parameters for result count, LLM generation, and reranking.
+
+**Request Example:**
+
+```json
+POST /query
+{
+  "index_name": "example_index",
+  "query": "What is RAG?",
+  "top_k": 5,
+  "llm_params": {
+    "temperature": 0.7,
+    "max_tokens": 2048
+  },
+  "rerank_params": {
+    "top_n": 3
+  }
+}
+```
+
+- `index_name`: The name of the index to query.
+- `query`: The query string.
+- `top_k`: (optional) Number of top documents to retrieve (default: 5).
+- `llm_params`: (optional) Parameters for LLM-based generation (e.g., temperature, max_tokens).
+- `rerank_params`: (optional, experimental) Parameters for reranking results with an LLM.
+
+**Response Example:**
+
+```json
+{
+  "response": "RAG stands for Retrieval-Augmented Generation...",
+  "source_nodes": [
+    {
+      "node_id": "node1",
+      "text": "RAG explanation...",
+      "score": 0.95,
+      "metadata": {}
+    }
+  ],
+  "metadata": {}
+}
+```
+
+- `response`: The generated answer or summary from the LLM (if enabled).
+- `source_nodes`: List of source documents/nodes with their text, score, and metadata.
+- `metadata`: Additional metadata about the query or response.
+
+**Experimental Warning:**  
+The `rerank_params` option is experimental and may cause the query to fail if the LLM reranker produces an invalid response. If reranking fails, the request will return an error.
+
+Use this endpoint to retrieve relevant information from your indexed documents and optionally generate answers using an LLM.

--- a/docs/RAG/README.md
+++ b/docs/RAG/README.md
@@ -6,8 +6,6 @@ This document presents how to use the Kaito `ragengine` Custom Resource Definiti
 
 Please check the installation guidance [here](./RAGEngine-installation.md) for deployment using Azure CLI.
 
-## Usage
-
 ### Prerequisite
 Before creating a RAGEngine, ensure you have an accessible model inference endpoint. This endpoint can be:
 
@@ -49,7 +47,59 @@ spec:
     url: "<inference-url>/v1/completions" 
 ```
 
-### Splitting Documents with CodeSplitter
+### Apply the Manifest
+After you create your YAML configuration, run:
+```sh
+kubectl apply -f examples/RAG/kaito_ragengine_phi_3.yaml
+```
+
+## Usage
+### Creating an Index With Documents
+
+To add documents to an index or create a new index, use the `/index` API route. This endpoint accepts a POST request with the index name and a list of documents to be indexed.
+
+**Request Example:**
+
+```json
+POST /index
+{
+  "index_name": "example_index",
+  "documents": [
+    {
+      "text": "Sample document text.",
+      "metadata": {
+        "author": "John Doe",
+        "category": "example"
+      }
+    }
+  ]
+}
+```
+
+- `index_name`: The name of the index to create or update.
+- `documents`: A list of documents, each with a `text` field and optional `metadata`.
+
+**Response Example:**
+
+```json
+[
+  {
+    "doc_id": "123456",
+    "text": "Sample document text.",
+    "hash_value": null,
+    "metadata": {
+      "author": "John Doe",
+      "category": "example"
+    },
+    "is_truncated": false
+  }
+]
+```
+
+Each returned document includes its unique `doc_id`, the original text, metadata, and a flag indicating if the text was truncated. The `doc_id` will be important for document update/delete calls. 
+
+
+#### Splitting Documents with CodeSplitter
 
 By default, RAGEngine splits documents into sentences. However, you can instruct the engine to split documents using the `CodeSplitter` (for code-aware chunking) by providing metadata in your API request.
 
@@ -71,9 +121,179 @@ To use the `CodeSplitter`, set the `split_type` to `"code"` and specify the prog
 
 This instructs the RAGEngine to use code-aware splitting for the provided document. If `split_type` is not set or set to any other value, sentence splitting will be used by default.
 
-### Apply the Manifest
-After you create your YAML configuration, run:
-```sh
-kubectl apply -f examples/RAG/kaito_ragengine_phi_3.yaml
+### List Documents
+
+To retrieve a paginated list of documents from a specific index, use the `/indexes/{index_name}/documents` API route. This endpoint accepts a GET request with optional query parameters for pagination, text truncation, and metadata filtering.
+
+**Request Example:**
+
+```
+GET /indexes/test_index/documents?limit=5&offset=0&max_text_length=500
 ```
 
+- `limit`: (optional) Maximum number of documents to return (default: 10, max: 100).
+- `offset`: (optional) Starting point for the document list (default: 0).
+- `max_text_length`: (optional) Maximum text length to return per document (default: 1000).
+- `metadata_filter`: (optional) A JSON string representing key-value pairs to filter documents by their metadata.
+
+**Response Example:**
+
+```json
+{
+  "documents": [
+    {
+      "doc_id": "123456",
+      "text": "Sample document text.",
+      "metadata": {"author": "John Doe"},
+      "is_truncated": true
+    },
+    {
+      "doc_id": "123457",
+      "text": "Another document text.",
+      "metadata": {"author": "Jane Doe"},
+      "is_truncated": false
+    }
+  ],
+  "count": 2
+}
+```
+
+Each document in the response includes its unique `doc_id`, the (possibly truncated) text, metadata, and a flag indicating if the text was truncated.
+
+**Note:**  
+If you want to filter documents by metadata, provide the `metadata_filter` parameter as a JSON string. For example:
+
+```
+GET /indexes/test_index/documents?metadata_filter={"author":"John Doe"}
+```
+
+
+### Updating Documents
+
+To update existing documents in a specific index, use the `/indexes/{index_name}/documents` API route. This endpoint accepts a POST request with the index name in the URL and a list of documents to update in the request body. The documents provided
+
+**Request Example:**
+
+```json
+POST /indexes/test_index/documents
+{
+  "documents": [
+    {
+      "doc_id": "sampleid",
+      "text": "Updated document text.",
+      "metadata": {
+        "author": "John Doe",
+        "category": "example"
+      }
+    }
+  ]
+}
+```
+
+- `doc_id`: The unique identifier of the document to update.
+- `text`: The new or updated text for the document.
+- `metadata`: (Optional) Updated metadata for the document.
+
+**Response Example:**
+
+```json
+{
+  "updated_documents": [
+    {
+      "doc_id": "sampleid",
+      "text": "Updated document text.",
+      "metadata": {
+        "author": "John Doe",
+        "category": "example"
+      }
+    }
+  ],
+  "unchanged_documents": [],
+  "not_found_documents": []
+}
+```
+
+- `updated_documents`: Documents that were successfully updated.
+- `unchanged_documents`: Documents that were provided but did not require changes.
+- `not_found_documents`: Documents with IDs that were not found in the index.
+
+Use this endpoint to keep your indexed documents up to date with the latest content or metadata.
+
+### Delete Documents
+
+
+To delete one or more documents from a specific index, use the `/indexes/{index_name}/documents/delete` API route. This endpoint accepts a POST request with the index name in the URL and a list of document IDs to delete in the request body.
+
+**Request Example:**
+
+```json
+POST /indexes/test_index/documents/delete
+{
+  "doc_ids": ["doc_id_1", "doc_id_2", "doc_id_3"]
+}
+```
+
+- `doc_ids`: A list of document IDs to delete from the specified index.
+
+**Response Example:**
+
+```json
+{
+  "deleted_doc_ids": ["doc_id_1", "doc_id_2"],
+  "not_found_doc_ids": ["doc_id_3"]
+}
+```
+
+- `deleted_doc_ids`: Document IDs that were successfully deleted.
+- `not_found_doc_ids`: Document IDs that were not found in the index.
+
+Use this endpoint to remove documents that are no longer needed from your index.
+
+### Persist Index
+
+To save (persist) the data of an index to disk, use the `/persist/{index_name}` API route. This endpoint accepts a POST request with the index name in the URL and an optional `path` query parameter specifying where to save the index data.
+
+**Request Example:**
+
+```
+POST /persist/example_index?path=./custom_path
+```
+
+- `index_name`: The name of the index to persist.
+- `path`: (optional) The directory path where the index will be saved. If not provided, the default directory is used.
+
+**Response Example:**
+
+```json
+{
+  "message": "Successfully persisted index example_index to ./custom_path/example_index."
+}
+```
+
+Use this endpoint to ensure your indexed data is safely stored on disk.
+
+---
+
+### Load Index
+
+To load an existing index from disk, use the `/load/{index_name}` API route. This endpoint accepts a POST request with the index name in the URL, an optional `path` query parameter specifying where to load the index from, and an optional `overwrite` flag.
+
+**Request Example:**
+
+```
+POST /load/example_index?path=./custom_path/example_index
+```
+
+- `index_name`: The name of the index to load.
+- `path`: (optional) The path to load the index from. If not provided, the default directory is used.
+- `overwrite`: (optional, default: false) If true, will overwrite the existing index if it already exists in memory.
+
+**Response Example:**
+
+```json
+{
+  "message": "Successfully loaded index example_index from ./custom_path/example_index."
+}
+```
+
+Use this endpoint to restore previously persisted indexes into memory for querying and updates.

--- a/docs/RAG/example_rag_client.py
+++ b/docs/RAG/example_rag_client.py
@@ -1,0 +1,122 @@
+import requests
+import json
+
+class KAITORagClient:
+    """
+    A bare bones client for interacting with the RAGEngine API.
+    This client provides methods to index documents, query the engine,
+    update documents, delete documents, list documents, and manage indexes.
+    """
+
+    def __init__(self, base_url):
+        self.base_url = base_url
+        self.headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json"
+        }
+
+    def index_documents(self, index_name, documents):
+        """
+        Index documents in the RAGEngine.
+        documents: list of dicts, each with 'text' and optional 'metadata'
+        """
+        url = f"{self.base_url}/index"
+        payload = {
+            "index_name": index_name,
+            "documents": documents
+        }
+        resp = requests.post(url, json=payload, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def query(self, index_name, query, llm_temperature, llm_max_tokens, top_k=5):
+        """
+        Query the RAGEngine.
+        query: str, the query text
+        top_k: int, number of results to return
+        metadata: optional dict, additional metadata for the query
+        """
+        url = f"{self.base_url}/query"
+        payload = {
+            "index_name": index_name,
+            "query": query,
+            "top_k": top_k,
+            "llm_params": {
+                "temperature": llm_temperature,
+                "max_tokens": llm_max_tokens
+            }
+        }
+        resp = requests.post(url, json=payload, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_documents(self, index_name, documents):
+        """
+        Update a document in the RAGEngine.
+        documents: list of dicts, each with 'id', 'text', and optional 'metadata'
+        """
+        url = f"{self.base_url}/indexes/{index_name}/documents"
+        payload = {"documents": documents}
+        resp = requests.post(url, json=payload, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def delete_documents(self, index_name, document_ids):
+        """
+        Delete a document from the RAGEngine by its ID.
+        """
+        url = f"{self.base_url}/indexes/{index_name}/documents/delete"
+        payload = {"doc_ids": document_ids}
+        resp = requests.post(url, json=payload, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def list_documents(self, index_name, metadata_filter, limit=10, offset=0):
+        """
+        List documents in the RAGEngine.
+        """
+        url = f"{self.base_url}/indexes/{index_name}/documents"
+        params = {"limit": limit, "offset": offset }
+        if metadata_filter:
+            params["metadata_filter"] = json.dumps(metadata_filter)
+        resp = requests.get(url, headers=self.headers, params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def list_indexes(self):
+        """
+        List all indexes in the RAGEngine.
+        """
+        url = f"{self.base_url}/indexes"
+        resp = requests.get(url, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def persist_index(self, index_name, path="/tmp"):
+        """
+        Persist an index in the RAGEngine.
+        """
+        url = f"{self.base_url}/persist/{index_name}"
+        params = {"path": path}
+        resp = requests.post(url, params=params, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def load_index(self, index_name, path="/tmp", overwrite=True):
+        """
+        Load an index in the RAGEngine.
+        """
+        url = f"{self.base_url}/load/{index_name}"
+        params = {"path": path, "overwrite": overwrite}
+        resp = requests.post(url, params=params, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def list_indexes(self, index_name):
+        """
+        List all indexes in the RAGEngine.
+        """
+        url = f"{self.base_url}/indexes/{index_name}"
+        resp = requests.delete(url, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()


### PR DESCRIPTION
**Reason for Change**:
Adding docs for all RAGEngine routes and bare bones example python client.