### PR TITLE
feat: add local cache for model files

### DIFF
--- a/charts/kaito/workspace/templates/local-pv-provisioner-ds.yaml
+++ b/charts/kaito/workspace/templates/local-pv-provisioner-ds.yaml
@@ -1,0 +1,130 @@
+# Ref: https://github.com/Azure/kubernetes-volume-drivers/tree/master/local
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: local-disk
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer  # Immediate is not supported
+reclaimPolicy: Delete  # available values: Delete, Retain
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: local-provisioner-config
+  namespace: {{ .Release.Namespace }}
+data:
+  storageClassMap: |
+    local-disk:
+       hostDir: /dev
+       mountDir:  /dev
+       blockCleanerCommand:
+         - "/scripts/quick_reset.sh"
+       volumeMode: Filesystem
+       fsType: ext4
+       namePattern: nvme*
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: local-volume-provisioner-ds
+  namespace: {{ .Release.Namespace }}
+  labels:
+    name: local-volume-provisioner-ds
+spec:
+  selector:
+    matchLabels:
+      name: local-volume-provisioner-ds
+  template:
+    metadata:
+      labels:
+        name: local-volume-provisioner-ds
+    spec:
+      serviceAccountName: local-storage-admin
+      nodeSelector:
+        kubernetes.io/os: linux
+      tolerations:
+        # Allow this pod to be rescheduled while the node is in "critical add-ons only" mode.
+        # This, along with the annotation above marks this pod as a critical add-on.
+        - key: CriticalAddonsOnly
+          operator: Exists
+        - key: nvidia.com/gpu
+          operator: Exists
+          effect: NoSchedule
+        - key: "sku"
+          operator: "Equal"
+          value: "gpu"
+          effect: "NoSchedule"
+      priorityClassName: "system-node-critical"
+      containers:
+        - image: "mcr.microsoft.com/k8s/local-volume-provisioner:v2.8.0"
+          name: provisioner
+          imagePullPolicy: IfNotPresent
+          args:
+            - "--v=2"
+          securityContext:
+            privileged: true
+          env:
+            - name: MY_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: spec.nodeName
+          volumeMounts:
+            - mountPath: /etc/provisioner/config
+              name: provisioner-config
+              readOnly: true
+            - mountPath: /dev/
+              name: local-disk
+              mountPropagation: "HostToContainer"
+      volumes:
+        - name: provisioner-config
+          configMap:
+            name: local-provisioner-config
+        - name: local-disk
+          hostPath:
+            path: /dev/
+
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: local-storage-admin
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-pv-binding
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: local-storage-admin
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: system:persistent-volume-provisioner
+  apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: local-storage-provisioner-node-clusterrole
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups: [""]
+    resources: ["nodes"]
+    verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: local-storage-provisioner-node-binding
+  namespace: {{ .Release.Namespace }}
+subjects:
+  - kind: ServiceAccount
+    name: local-storage-admin
+    namespace: {{ .Release.Namespace }}
+roleRef:
+  kind: ClusterRole
+  name: local-storage-provisioner-node-clusterrole
+  apiGroup: rbac.authorization.k8s.io

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -95,7 +95,7 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 func GenerateStatefulSetManifest(workspaceObj *kaitov1beta1.Workspace, revisionNum string, imageName string,
 	imagePullSecretRefs []corev1.LocalObjectReference, replicas int, commands []string, containerPorts []corev1.ContainerPort,
 	livenessProbe, readinessProbe *corev1.Probe, resourceRequirements corev1.ResourceRequirements,
-	tolerations []corev1.Toleration, volumes []corev1.Volume, volumeMount []corev1.VolumeMount, envVars []corev1.EnvVar) *appsv1.StatefulSet {
+	tolerations []corev1.Toleration, volumes []corev1.Volume, volumeMount []corev1.VolumeMount, envVars []corev1.EnvVar, pvcs []corev1.PersistentVolumeClaim) *appsv1.StatefulSet {
 
 	pullerContainers, pullerEnvVars, pullerVolumes := GeneratePullerContainers(workspaceObj, volumeMount)
 	envVars = append(envVars, pullerEnvVars...)
@@ -137,9 +137,10 @@ func GenerateStatefulSetManifest(workspaceObj *kaitov1beta1.Workspace, revisionN
 			},
 		},
 		Spec: appsv1.StatefulSetSpec{
-			Replicas:            lo.ToPtr(int32(replicas)),
-			PodManagementPolicy: appsv1.ParallelPodManagement,
-			Selector:            labelselector,
+			Replicas:             lo.ToPtr(int32(replicas)),
+			PodManagementPolicy:  appsv1.ParallelPodManagement,
+			Selector:             labelselector,
+			VolumeClaimTemplates: pvcs,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: v1.ObjectMeta{
 					Labels: selector,

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -33,7 +33,8 @@ func TestGenerateStatefulSetManifest(t *testing.T) {
 			nil, //tolerations
 			nil, //volumes
 			nil, //volumeMount
-			nil, //envVars
+			nil, //envVars\
+			nil,
 		)
 
 		assert.Contains(t, obj.GetAnnotations(), v1beta1.WorkspaceRevisionAnnotation)


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in Kaito? Why is it needed? -->

Leverage local PV to utilize GPU SKU-attached
high-performance local disks for model file caching.

Only supports k8s upstream builtin localpv driver for now.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: