### PR TITLE
feat: add doc_id to /query result nodes

### DIFF
--- a/presets/ragengine/main.py
+++ b/presets/ragengine/main.py
@@ -213,7 +213,7 @@ async def index_documents(request: IndexRequest):
     ```json
     {
       "response": "...",
-      "source_nodes": [{"node_id": "node1", "text": "RAG explanation...", "score": 0.95, "metadata": {}}],
+      "source_nodes": [{"doc_id": "doc1", "node_id": "node1", "text": "RAG explanation...", "score": 0.95, "metadata": {}}],
       "metadata": {}
     }
     ```

--- a/presets/ragengine/models.py
+++ b/presets/ragengine/models.py
@@ -69,6 +69,7 @@ class QueryRequest(BaseModel):
 
 # Define models for NodeWithScore, and QueryResponse
 class NodeWithScore(BaseModel):
+    doc_id: str
     node_id: str
     text: str
     score: float

--- a/presets/ragengine/tests/api/test_main.py
+++ b/presets/ragengine/tests/api/test_main.py
@@ -261,6 +261,7 @@ async def test_reranker_and_query_with_index(mock_get, async_client):
     # Perform indexing
     response = await async_client.post("/index", json=index_request_payload)
     assert response.status_code == 200
+    index_response = response.json()
 
     # Query request payload with reranking
     top_n = 2  # The number of relevant docs returned in reranker response
@@ -283,16 +284,17 @@ async def test_reranker_and_query_with_index(mock_get, async_client):
     # Validate each source node in the query response
     expected_source_nodes = [
         {"text": "Have you ever visited Paris? It is a beautiful city where you can eat delicious food and see the Eiffel Tower. I really enjoyed all the cities in France, but its capital with the Eiffel Tower is my favorite city.",
-         "score": 10.0, "metadata": {}},
+         "score": 10.0, "metadata": {}, "doc_id": index_response[3]["doc_id"]},
         {"text": "I really enjoyed my trip to Paris, France. The city is beautiful and the "
                  "food is delicious. I would love to visit again. Such a great capital city.",
-         "score": 10.0, "metadata": {}},
+         "score": 10.0, "metadata": {}, "doc_id": index_response[4]["doc_id"]},
     ]
     for i, expected_node in enumerate(expected_source_nodes):
         actual_node = query_response["source_nodes"][i]
         assert actual_node["text"] == expected_node["text"]
         assert actual_node["score"] == expected_node["score"]
         assert actual_node["metadata"] == expected_node["metadata"]
+        assert actual_node["doc_id"] == expected_node["doc_id"]
 
     # Ensure HTTPX requests were made
     assert respx.calls.call_count == 2  # One for rerank, one for query completion

--- a/presets/ragengine/tests/vector_store/test_base_store.py
+++ b/presets/ragengine/tests/vector_store/test_base_store.py
@@ -85,7 +85,7 @@ class BaseVectorStoreTest(ABC):
             Document(text="First document", metadata={"type": "text"}),
             Document(text="Second document", metadata={"type": "text"})
         ]
-        await vector_store_manager.index_documents("test_index", documents)
+        index_doc_resp = await vector_store_manager.index_documents("test_index", documents)
 
         params = {"temperature": 0.7}
         query_result = await vector_store_manager.query("test_index", "First", top_k=1,
@@ -95,6 +95,7 @@ class BaseVectorStoreTest(ABC):
         assert query_result["response"] == "{'result': 'This is the completion from the API'}"
         assert query_result["source_nodes"][0]["text"] == "First document"
         assert query_result["source_nodes"][0]["score"] == pytest.approx(self.expected_query_score, rel=1e-6)
+        assert query_result["source_nodes"][0]["doc_id"] == index_doc_resp[0]
         assert respx.calls.call_count == 1  # Ensure only one LLM inference request was made
 
     @pytest.mark.asyncio

--- a/presets/ragengine/vector_store/base.py
+++ b/presets/ragengine/vector_store/base.py
@@ -178,12 +178,13 @@ class BaseVectorStore(ABC):
             "response": query_result.response,
             "source_nodes": [
                 {
-                    "node_id": node.node_id,
-                    "text": node.text,
-                    "score": node.score,
-                    "metadata": node.metadata
+                    "doc_id": source_node.node.ref_doc_id,
+                    "node_id": source_node.node_id,
+                    "text": source_node.text,
+                    "score": source_node.score,
+                    "metadata": source_node.metadata
                 }
-                for node in query_result.source_nodes
+                for source_node in query_result.source_nodes
             ],
             "metadata": query_result.metadata,
         }


### PR DESCRIPTION
**Reason for Change**:
The doc_id field is used to reference documents throughout the RAGEngine routes so it is best to have the doc_id field present on /query results.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: