### PR TITLE
feat: update rag engine image url to be build from env

### DIFF
--- a/charts/kaito/ragengine/templates/deployment.yaml
+++ b/charts/kaito/ragengine/templates/deployment.yaml
@@ -44,11 +44,11 @@ spec:
             - name: CLOUD_PROVIDER
               value: {{ .Values.cloudProviderName }}
             - name: PRESET_RAG_REGISTRY_NAME
-              value: {{ .Values.presetRagRegistryName }}
+              value: {{ .Values.presetRagRegistryName | default "aimodelsregistrytest.azurecr.io" }}
             - name: PRESET_RAG_IMAGE_NAME
-              value: {{ .Values.presetRagImageName }}
+              value: {{ .Values.presetRagImageName | default "kaito-rag-service" }}
             - name: PRESET_RAG_IMAGE_TAG
-              value: {{ .Values.presetRagImageTag }}
+              value: {{ .Values.presetRagImageTag | default "0.3.2" }}
           ports:
             - name: http-metrics
               containerPort: 8080

--- a/charts/kaito/ragengine/templates/deployment.yaml
+++ b/charts/kaito/ragengine/templates/deployment.yaml
@@ -43,6 +43,12 @@ spec:
                   fieldPath: metadata.namespace
             - name: CLOUD_PROVIDER
               value: {{ .Values.cloudProviderName }}
+            - name: PRESET_RAG_REGISTRY_NAME
+              value: {{ .Values.presetRagRegistryName }}
+            - name: PRESET_RAG_IMAGE_NAME
+              value: {{ .Values.presetRagImageName }}
+            - name: PRESET_RAG_IMAGE_TAG
+              value: {{ .Values.presetRagImageTag }}
           ports:
             - name: http-metrics
               containerPort: 8080

--- a/charts/kaito/ragengine/values.yaml
+++ b/charts/kaito/ragengine/values.yaml
@@ -29,3 +29,6 @@ tolerations: []
 affinity: {}
 # Values can be "azure" or "aws"
 cloudProviderName: "azure"
+presetRagRegistryName: "aimodelsregistrytest.azurecr.io"
+presetRagImageName: "kaito-rag-service"
+presetRagImageTag: "0.3.2"

--- a/pkg/ragengine/controllers/preset-rag.go
+++ b/pkg/ragengine/controllers/preset-rag.go
@@ -67,6 +67,39 @@ var (
 	}
 )
 
+type ImageConfig struct {
+	RegistryName string
+	ImageName    string
+	ImageTag     string
+}
+
+func (ic ImageConfig) GetImage() string {
+	return fmt.Sprintf("%s/%s:%s", ic.RegistryName, ic.ImageName, ic.ImageTag)
+}
+
+func getImageConfig() ImageConfig {
+	registryName := os.Getenv("PRESET_RAG_REGISTRY_NAME")
+	if registryName == "" {
+		registryName = "aimodelsregistrytest.azurecr.io"
+	}
+
+	imageName := os.Getenv("PRESET_RAG_IMAGE_NAME")
+	if imageName == "" {
+		imageName = "kaito-rag-service"
+	}
+
+	imageTag := os.Getenv("PRESET_RAG_IMAGE_TAG")
+	if imageTag == "" {
+		imageTag = "0.3.2"
+	}
+
+	return ImageConfig{
+		RegistryName: registryName,
+		ImageName:    imageName,
+		ImageTag:     imageTag,
+	}
+}
+
 func CreatePresetRAG(ctx context.Context, ragEngineObj *v1alpha1.RAGEngine, revisionNum string, kubeClient client.Client) (client.Object, error) {
 	var volumes []corev1.Volume
 	var volumeMounts []corev1.VolumeMount
@@ -102,22 +135,7 @@ func CreatePresetRAG(ctx context.Context, ragEngineObj *v1alpha1.RAGEngine, revi
 	}
 	commands := utils.ShellCmd("python3 main.py")
 
-	registryName := os.Getenv("PRESET_RAG_REGISTRY_NAME")
-	if registryName == "" {
-		registryName = "aimodelsregistrytest.azurecr.io"
-	}
-
-	imageName := os.Getenv("PRESET_RAG_IMAGE_NAME")
-	if imageName == "" {
-		imageName = "kaito-rag-service"
-	}
-
-	imageVersion := os.Getenv("PRESET_RAG_IMAGE_TAG")
-	if imageVersion == "" {
-		imageVersion = "0.3.2"
-	}
-
-	image := fmt.Sprintf("%s/%s:%s", registryName, imageName, imageVersion)
+	image := getImageConfig().GetImage()
 
 	imagePullSecretRefs := []corev1.LocalObjectReference{}
 

--- a/pkg/ragengine/controllers/preset-rag.go
+++ b/pkg/ragengine/controllers/preset-rag.go
@@ -78,26 +78,19 @@ func (ic ImageConfig) GetImage() string {
 }
 
 func getImageConfig() ImageConfig {
-	registryName := os.Getenv("PRESET_RAG_REGISTRY_NAME")
-	if registryName == "" {
-		registryName = "aimodelsregistrytest.azurecr.io"
-	}
-
-	imageName := os.Getenv("PRESET_RAG_IMAGE_NAME")
-	if imageName == "" {
-		imageName = "kaito-rag-service"
-	}
-
-	imageTag := os.Getenv("PRESET_RAG_IMAGE_TAG")
-	if imageTag == "" {
-		imageTag = "0.3.2"
-	}
-
 	return ImageConfig{
-		RegistryName: registryName,
-		ImageName:    imageName,
-		ImageTag:     imageTag,
+		RegistryName: getEnv("PRESET_RAG_REGISTRY_NAME", "aimodelsregistrytest.azurecr.io"),
+		ImageName:    getEnv("PRESET_RAG_IMAGE_NAME", "kaito-rag-service"),
+		ImageTag:     getEnv("PRESET_RAG_IMAGE_TAG", "0.3.2"),
 	}
+}
+
+func getEnv(key, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	return value
 }
 
 func CreatePresetRAG(ctx context.Context, ragEngineObj *v1alpha1.RAGEngine, revisionNum string, kubeClient client.Client) (client.Object, error) {

--- a/pkg/ragengine/controllers/preset-rag.go
+++ b/pkg/ragengine/controllers/preset-rag.go
@@ -4,6 +4,8 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"os"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -100,7 +102,22 @@ func CreatePresetRAG(ctx context.Context, ragEngineObj *v1alpha1.RAGEngine, revi
 	}
 	commands := utils.ShellCmd("python3 main.py")
 
-	image := "aimodelsregistrytest.azurecr.io/kaito-rag-service:0.3.2" //TODO: Change to the mcr image when release
+	registryName := os.Getenv("PRESET_RAG_REGISTRY_NAME")
+	if registryName == "" {
+		registryName = "aimodelsregistrytest.azurecr.io"
+	}
+
+	imageName := os.Getenv("PRESET_RAG_IMAGE_NAME")
+	if imageName == "" {
+		imageName = "kaito-rag-service"
+	}
+
+	imageVersion := os.Getenv("PRESET_RAG_IMAGE_TAG")
+	if imageVersion == "" {
+		imageVersion = "0.3.2"
+	}
+
+	image := fmt.Sprintf("%s/%s:%s", registryName, imageName, imageVersion)
 
 	imagePullSecretRefs := []corev1.LocalObjectReference{}
 


### PR DESCRIPTION
**Reason for Change**:
This makes it so the RAGEngine image can be built from env variables. This will allow for E2E tests to pull the correct image as well as easier image bumps in the future.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: