### PR TITLE
feat: Update Workflows for RAG Release

### DIFF
--- a/.github/workflows/publish-rag-controller-gh-image.yml
+++ b/.github/workflows/publish-rag-controller-gh-image.yml
@@ -13,7 +13,7 @@ permissions:
 
 env:
   GO_VERSION: '1.24'
-  IMAGE_NAME: 'kaito-rag-engine'
+  IMAGE_NAME: 'ragengine'
   REGISTRY: ghcr.io
 
 jobs:
@@ -97,11 +97,12 @@ jobs:
 
       - name: Build image
         run: |
-          make docker-build-ragengine
+          OUTPUT_TYPE=type=registry make docker-build-ragengine
         env:
-          REGISTRY: ${{ env.REGISTRY }}
-          RAGENGINE_IMG_NAME: ${{ env.IMAGE_NAME }}
-          RAGENGINE_IMG_TAG: ${{ needs.check-tag.outputs.tag }}
+          VERSION: ${{ needs.check-tag.outputs.tag }}
+          REGISTRY: ${{ steps.get-registry.outputs.registry_repository }}
+          RAGENGINE_IMAGE_NAME: ragengine
+          IMG_TAG: ${{ env.IMG_TAG }}
 
       - name: Scan ${{ steps.get-registry.outputs.registry_repository }}/${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }}
         uses: aquasecurity/trivy-action@master
@@ -126,3 +127,14 @@ jobs:
       registry: ${{ needs.build-scan-publish-gh-images.outputs.registry_repository }}
       k8s_version: ${{ vars.AKS_K8S_VERSION }}
       tag: ${{ needs.check-tag.outputs.tag }}
+
+  publish-mcr-image:
+    runs-on: ubuntu-latest
+    needs: [ check-tag, run-e2e-gh-image ]
+    steps:
+      - name: 'Dispatch ragengine MCR publishing'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: publish-rag-controller-mcr-image
+          client-payload: '{"tag": "${{ needs.check-tag.outputs.tag }}"}'

--- a/.github/workflows/publish-rag-controller-mcr-image.yml
+++ b/.github/workflows/publish-rag-controller-mcr-image.yml
@@ -1,7 +1,7 @@
-name: Publish KAITO MCR image
+name: Publish RAGEngine MCR image
 on:
   repository_dispatch:
-    types: [ publish-mcr-image ]
+    types: [ publish-rag-controller-mcr-image ]
 
 permissions:
   contents: write
@@ -9,7 +9,7 @@ permissions:
 
 env:
   GO_VERSION: '1.24'
-  IMAGE_NAME: 'workspace'
+  IMAGE_NAME: 'ragengine'
 
 jobs:
   build-publish-mcr-image:
@@ -38,23 +38,23 @@ jobs:
           az login --identity
           az acr login -n ${{ secrets.KAITO_MCR_REGISTRY }}
 
-      - name: 'Build and Publish to MCR'
+      - name: 'Build and Publish RAGEngine to MCR'
         id: Publish
         run: |
-          OUTPUT_TYPE=type=registry make docker-build-workspace
+          OUTPUT_TYPE=type=registry make docker-build-ragengine
         env:
           VERSION: ${{ github.event.client_payload.tag }}
           REGISTRY: ${{ secrets.KAITO_MCR_REGISTRY }}/public/aks/kaito
-          IMG_NAME: workspace
+          RAGENGINE_IMAGE_NAME: ragengine
           IMG_TAG: ${{ env.IMG_TAG }}
 
-  publish-helm-chart:
+  dispatch-rag-service-mcr:
     runs-on: ubuntu-latest
     needs: [ build-publish-mcr-image ]
     steps:
-      - name: 'Dispatch release tag for workspace helm chart'
+      - name: 'Dispatch RAG service MCR publishing'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: publish-workspace-helm-chart
-          client-payload: '{"tag": "${{ github.event.client_payload.tag }}"}'
+          event-type: publish-rag-service-mcr-image
+          client-payload: '{"tag": "${{ github.event.client_payload.tag }}"}' 

--- a/.github/workflows/publish-rag-service-gh-image.yml
+++ b/.github/workflows/publish-rag-service-gh-image.yml
@@ -97,10 +97,11 @@ jobs:
 
       - name: Build image
         run: |
-          make docker-build-rag-service
+          OUTPUT_TYPE=type=registry make docker-build-ragservice
         env:
-          REGISTRY: ${{ env.REGISTRY }}
-          RAGENGINE_SERVICE_IMG_NAME: ${{ env.IMAGE_NAME }}
+          VERSION: ${{ needs.check-tag.outputs.tag }}
+          REGISTRY: ${{ steps.get-registry.outputs.registry_repository }}
+          RAGENGINE_SERVICE_IMG_NAME: kaito-rag-service
           RAGENGINE_SERVICE_IMG_TAG: ${{ needs.check-tag.outputs.tag }}
 
       - name: Scan ${{ steps.get-registry.outputs.registry_repository }}/${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }}
@@ -116,3 +117,14 @@ jobs:
         env:
           TRIVY_USERNAME: ${{ github.actor }}
           TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-mcr-image:
+    runs-on: ubuntu-latest
+    needs: [ check-tag, build-scan-publish-gh-images ]
+    steps:
+      - name: 'Dispatch rag service MCR publishing'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: publish-rag-service-mcr-image
+          client-payload: '{"tag": "${{ needs.check-tag.outputs.tag }}"}'

--- a/.github/workflows/publish-rag-service-mcr-image.yml
+++ b/.github/workflows/publish-rag-service-mcr-image.yml
@@ -1,15 +1,14 @@
-name: Publish KAITO MCR image
+name: Publish RAG Service MCR image
 on:
   repository_dispatch:
-    types: [ publish-mcr-image ]
+    types: [ publish-rag-service-mcr-image ]
 
 permissions:
   contents: write
   packages: write
 
 env:
-  GO_VERSION: '1.24'
-  IMAGE_NAME: 'workspace'
+  IMAGE_NAME: 'kaito-rag-service'
 
 jobs:
   build-publish-mcr-image:
@@ -17,11 +16,6 @@ jobs:
       labels: [ "self-hosted", "1ES.Pool=1es-aks-kaito-agent-pool-ubuntu" ]
     environment: publish-mcr
     steps:
-      - name: Set up Go ${{ env.GO_VERSION }}
-        uses: actions/setup-go@v5.4.0
-        with:
-          go-version: ${{ env.GO_VERSION  }}
-
       - name: Set Image tag
         run: |
           ver=${{ github.event.client_payload.tag }}
@@ -38,23 +32,23 @@ jobs:
           az login --identity
           az acr login -n ${{ secrets.KAITO_MCR_REGISTRY }}
 
-      - name: 'Build and Publish to MCR'
+      - name: 'Build and Publish RAG Service to MCR'
         id: Publish
         run: |
-          OUTPUT_TYPE=type=registry make docker-build-workspace
+          OUTPUT_TYPE=type=registry make docker-build-ragservice
         env:
           VERSION: ${{ github.event.client_payload.tag }}
           REGISTRY: ${{ secrets.KAITO_MCR_REGISTRY }}/public/aks/kaito
-          IMG_NAME: workspace
-          IMG_TAG: ${{ env.IMG_TAG }}
+          RAGENGINE_SERVICE_IMG_NAME: kaito-rag-service
+          RAGENGINE_SERVICE_IMG_TAG: ${{ github.event.client_payload.tag }}
 
   publish-helm-chart:
     runs-on: ubuntu-latest
     needs: [ build-publish-mcr-image ]
     steps:
-      - name: 'Dispatch release tag for workspace helm chart'
+      - name: 'Dispatch release tag for ragengine helm chart'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          event-type: publish-workspace-helm-chart
-          client-payload: '{"tag": "${{ github.event.client_payload.tag }}"}'
+          event-type: publish-ragengine-helm-chart
+          client-payload: '{"tag": "${{ github.event.client_payload.tag }}"}' 

--- a/.github/workflows/publish-ragengine-helm-chart.yml
+++ b/.github/workflows/publish-ragengine-helm-chart.yml
@@ -1,0 +1,50 @@
+name: Publish ragengine helm chart
+
+on:
+  repository_dispatch:
+    types: [ publish-ragengine-helm-chart ]
+
+permissions:
+  id-token: write # This is required for requesting the JWT
+  packages: write
+  contents: write
+  actions: read
+  deployments: read
+  pull-requests: read
+
+jobs:
+  publish-ragengine-helm:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          submodules: true
+          fetch-depth: 0
+          ref: ${{ github.event.client_payload.tag }}
+
+      - name: Publish ragengine helm chart
+        uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          charts_dir: charts/kaito/ragengine
+          target_dir: charts/kaito
+          linting: off
+
+  create-ragengine-release:
+    runs-on: ubuntu-latest
+    needs: [ publish-ragengine-helm ]
+    steps:
+      - name: 'Dispatch release tag to create a ragengine release'
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: create-release
+          client-payload: '{"tag": "${{ github.event.client_payload.tag }}"}' 

--- a/.github/workflows/publish-workspace-gh-image.yml
+++ b/.github/workflows/publish-workspace-gh-image.yml
@@ -101,6 +101,8 @@ jobs:
         env:
           VERSION: ${{ needs.check-tag.outputs.tag }}
           REGISTRY: ${{ steps.get-registry.outputs.registry_repository }}
+          IMG_NAME: workspace
+          IMG_TAG: ${{ env.IMG_TAG }}
 
       - name: Scan ${{ steps.get-registry.outputs.registry_repository }}/${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }}
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/publish-workspace-helm-chart.yml
+++ b/.github/workflows/publish-workspace-helm-chart.yml
@@ -1,9 +1,8 @@
-name: Publish helm chart
+name: Publish workspace helm chart
 
 on:
   repository_dispatch:
-    types: [ publish-helm-chart ]
-  workflow_dispatch:
+    types: [ publish-workspace-helm-chart ]
 
 permissions:
   id-token: write # This is required for requesting the JWT
@@ -14,7 +13,7 @@ permissions:
   pull-requests: read
 
 jobs:
-  publish-helm:
+  publish-workspace-helm:
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -31,22 +30,21 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.client_payload.tag }}
 
-      - name: Publish Workspace Helm chart
+      - name: Publish workspace helm chart
         uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          charts_dir: charts/kaito
+          charts_dir: charts/kaito/workspace
           target_dir: charts/kaito
           linting: off
 
-  create-release:
+  create-workspace-release:
     runs-on: ubuntu-latest
-    needs: [ publish-helm ]
+    needs: [ publish-workspace-helm ]
     steps:
-      - name: 'Dispatch release tag to create a release'
+      - name: 'Dispatch release tag to create a workspace release'
         uses: peter-evans/repository-dispatch@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: create-release
-          client-payload: '{"tag": "${{ github.event.client_payload.tag }}"}'
-
+          client-payload: '{"tag": "${{ github.event.client_payload.tag }}"}' 


### PR DESCRIPTION
**Reason for Change**:
Create separate workflows for releasing workspace and ragengine controllers and ragengine service. 

RagEngine Controller Release Flow
```
publish-rag-controller-gh-image.yml 
  ↓ (E2E tests)
  ↓ (dispatch: publish-rag-controller-mcr-image)
publish-rag-controller-mcr-image.yml
  ↓ (dispatch: publish-ragengine-helm-chart)
publish-ragengine-helm-chart.yml
  ↓ (dispatch: create-release)
create-release.yml
```

RagEngine Service Release Flow
```
publish-rag-service-gh-image.yml 
  ↓ (E2E tests)
  ↓ (dispatch: publish-rag-service-mcr-image)
publish-rag-service-mcr-image.yml
  ↓ (dispatch: publish-ragengine-helm-chart)
publish-ragengine-helm-chart.yml
  ↓ (dispatch: create-release)
create-release.yml
```

Workspace Release Flow
```
publish-workspace-gh-image.yml 
  ↓ (E2E tests)
  ↓ (dispatch: publish-mcr-image)
publish-workspace-mcr-image.yml
  ↓ (dispatch: publish-workspace-helm-chart)
publish-workspace-helm-chart.yml
  ↓ (dispatch: create-release)
create-release.yml
```