### PR TITLE
fix: update helm chart URLs to point to kaito-project instead of Azure

### DIFF
--- a/charts/kaito/index.yaml
+++ b/charts/kaito/index.yaml
@@ -16,7 +16,7 @@ entries:
     - https://github.com/Azure/gpu-provisioner
     type: application
     urls:
-    - https://Azure.github.io/kaito/charts/kaito/gpu-provisioner-0.2.0.tgz
+    - https://kaito-project.github.io/kaito/charts/kaito/gpu-provisioner-0.2.0.tgz
     version: 0.2.0
   - apiVersion: v2
     appVersion: 0.1.0
@@ -33,7 +33,7 @@ entries:
     - https://github.com/Azure/gpu-provisioner
     type: application
     urls:
-    - https://Azure.github.io/kaito/charts/kaito/gpu-provisioner-0.1.0.tgz
+    - https://kaito-project.github.io/kaito/charts/kaito/gpu-provisioner-0.1.0.tgz
     version: 0.1.0
   ragengine:
   - apiVersion: v2
@@ -235,7 +235,7 @@ entries:
     - https://github.com/Azure/kaito
     type: application
     urls:
-    - https://Azure.github.io/kaito/charts/kaito/workspace-0.3.1.tgz
+    - https://kaito-project.github.io/kaito/charts/kaito/workspace-0.3.1.tgz
     version: 0.3.1
   - apiVersion: v2
     appVersion: 0.3.0
@@ -255,7 +255,7 @@ entries:
     - https://github.com/Azure/kaito
     type: application
     urls:
-    - https://Azure.github.io/kaito/charts/kaito/workspace-0.3.0.tgz
+    - https://kaito-project.github.io/kaito/charts/kaito/workspace-0.3.0.tgz
     version: 0.3.0
   - apiVersion: v2
     appVersion: 0.2.2
@@ -275,7 +275,7 @@ entries:
     - https://github.com/Azure/kaito
     type: application
     urls:
-    - https://Azure.github.io/kaito/charts/kaito/workspace-0.2.2.tgz
+    - https://kaito-project.github.io/kaito/charts/kaito/workspace-0.2.2.tgz
     version: 0.2.2
   - apiVersion: v2
     appVersion: 0.2.1
@@ -295,7 +295,7 @@ entries:
     - https://github.com/Azure/kaito
     type: application
     urls:
-    - https://Azure.github.io/kaito/charts/kaito/workspace-0.2.1.tgz
+    - https://kaito-project.github.io/kaito/charts/kaito/workspace-0.2.1.tgz
     version: 0.2.1
   - apiVersion: v2
     appVersion: 0.2.0
@@ -315,6 +315,6 @@ entries:
     - https://github.com/Azure/kaito
     type: application
     urls:
-    - https://Azure.github.io/kaito/charts/kaito/workspace-0.1.0.tgz
+    - https://kaito-project.github.io/kaito/charts/kaito/workspace-0.1.0.tgz
     version: 0.1.0
 generated: "2025-05-14T23:11:53.439864978Z"


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

When onboarding KAITO's helm charts to ArtifactHub, it's complaining that some of them are pointing to an invalid URL:

![image](https://github.com/user-attachments/assets/32fbef2a-12cf-4a85-ad22-7903338316cf)



**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: