### PR TITLE
Add Azure Linux examples and E2Es

### DIFF
--- a/examples/inference/azure-linux-kaito-workspaces.yaml
+++ b/examples/inference/azure-linux-kaito-workspaces.yaml
@@ -1,0 +1,61 @@
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  name: phi-2-azure-linux-workspace
+spec:
+  resource:
+    instanceType: "Standard_NC12s_v3"
+    count: 1
+    labelSelector:
+      matchLabels:
+        # This label tells GPU provisioner to use Azure Linux
+        kaito.sh/node-image-family: "AzureLinux"
+        workload: "phi-2-inference"
+        environment: "production"
+  inference:
+    preset:
+      name: "phi-2"
+      # Optional: specify image pull secrets if using private registry
+      # imagePullSecrets:
+      #   - name: "my-registry-secret"
+
+---
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  name: falcon-7b-azure-linux-workspace
+  annotations:
+    # Alternative: using annotation for Azure Linux
+    kaito.sh/node-image-family: "AzureLinux"
+    description: "Falcon 7B model on Azure Linux nodes"
+spec:
+  resource:
+    instanceType: "Standard_NC24s_v3"
+    count: 1
+    labelSelector:
+      matchLabels:
+        workload: "falcon-7b-inference"
+        team: "ml-engineering"
+  inference:
+    preset:
+      name: "falcon-7b"
+
+---
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  name: llama-3-1-8b-azure-linux-workspace
+spec:
+  resource:
+    instanceType: "Standard_NC24ads_A100_v4"
+    count: 2  # Multi-node deployment
+    labelSelector:
+      matchLabels:
+        kaito.sh/node-image-family: "AzureLinux"  # Case-insensitive
+        workload: "llama-inference"
+        scale: "multi-node"
+  inference:
+    preset:
+      name: "llama-3.1-8b-instruct"
+      # Model access secret for gated models
+      modelAccessSecret: "hf-token-secret"


### PR DESCRIPTION
This pull request introduces support for provisioning Azure Linux nodes in inference workspaces, along with associated validation and fallback mechanisms. The changes span workspace configurations, end-to-end tests, and utility functions to ensure seamless integration and testing of this feature.

### Azure Linux Node Support in Workspace Configurations:
* Added configurations for inference workspaces (`phi-2`, `falcon-7b`, and `llama-3.1-8b`) to use Azure Linux nodes with label-based or annotation-based specifications. Multi-node deployment and gated model access are supported (`examples/inference/azure-linux-kaito-workspaces.yaml`).

### End-to-End Test Enhancements:
* Introduced test cases to validate Azure Linux node provisioning, annotation-based support, and fallback to Ubuntu nodes when an invalid image family is specified (`test/e2e/preset_test.go`).
* Added helper functions for creating workspaces with Azure Linux configurations and invalid image families (`test/e2e/preset_test.go`).

### Utility Functions for Validation:
* Added utility functions for validating Azure Linux nodes, retrieving nodes by labels, and verifying workspace integration with Azure Linux (`test/e2e/utils/utils.go`).

### Dependency Updates:
* Imported `sigs.k8s.io/controller-runtime/pkg/client` to enable advanced Kubernetes client operations (`test/e2e/utils/utils.go`).
Fixes: https://github.com/Azure/gpu-provisioner/issues/158