### PR TITLE
fix: helm: StorageClass upgrades & rollbacks idempotent

### DIFF
--- a/charts/kaito/workspace/templates/local-csi-storageclass.yaml
+++ b/charts/kaito/workspace/templates/local-csi-storageclass.yaml
@@ -1,5 +1,6 @@
 # notes: This CSI driver is compatible with various environments, including Azure and AWS,
 # ensuring broad interoperability without vendor lock-in.
+{{- if not (lookup "storage.k8s.io/v1" "StorageClass" "" "kaito-local-nvme-disk") }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
@@ -12,3 +13,4 @@ provisioner: localdisk.csi.acstor.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
+{{- end }}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

'Error: cannot patch kaito-local-nvme-disk with kind StorageClass: StorageClass.storage.k8s.io kaito-local-nvme-disk is invalid: parameters: Forbidden: updates to parameters are forbidden.'


**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: