### PR TITLE
docs: updage RAG Docs to remove rerank options

### DIFF
--- a/website/docs/rag.md
+++ b/website/docs/rag.md
@@ -63,7 +63,7 @@ metadata:
   name: ragengine-start
 spec:
   compute:
-    instanceType: "Standard_NC6s_v3"
+    instanceType: "Standard_NV6"
     labelSelector:
       matchLabels:
         apps: ragengine-example
@@ -368,7 +368,7 @@ Use this endpoint to permanently remove an index and all its data when it is no 
 
 ### Query Index
 
-To query a specific index for relevant documents and optionally rerank results with an LLM, use the `/query` API route. This endpoint accepts a POST request with the index name, query string, and optional parameters for result count, LLM generation, and reranking.
+To query a specific index for relevant documents, use the `/query` API route. This endpoint accepts a POST request with the index name, query string, and optional parameters for result count, and LLM generation.
 
 **Request Example:**
 
@@ -381,9 +381,6 @@ POST /query
   "llm_params": {
     "temperature": 0.7,
     "max_tokens": 2048
-  },
-  "rerank_params": {
-    "top_n": 3
   }
 }
 ```
@@ -392,7 +389,6 @@ POST /query
 - `query`: The query string.
 - `top_k`: (optional) Number of top documents to retrieve (default: 5).
 - `llm_params`: (optional) Parameters for LLM-based generation (e.g., temperature, max_tokens).
-- `rerank_params`: (optional, experimental) Parameters for reranking results with an LLM.
 
 **Response Example:**
 
@@ -423,9 +419,6 @@ POST /query
 - `response`: The generated answer or summary from the LLM (if enabled).
 - `source_nodes`: List of source nodes with their text, score, and metadata.
 - `metadata`: Additional metadata about the query or response.
-
-**Experimental Warning:**  
-The `rerank_params` option is experimental and may cause the query to fail if the LLM reranker produces an invalid response. If reranking fails, the request will return an error.
 
 Use this endpoint to retrieve relevant information from your indexed documents and optionally generate answers using an LLM.
 

--- a/website/docs/rag.md
+++ b/website/docs/rag.md
@@ -63,7 +63,7 @@ metadata:
   name: ragengine-start
 spec:
   compute:
-    instanceType: "Standard_NV6"
+    instanceType: "Standard_NC4as_T4_v3"
     labelSelector:
       matchLabels:
         apps: ragengine-example


### PR DESCRIPTION
**Reason for Change**:
remove rerank options from RAG /query API as upstream llama-index is broken

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
Resolves #1241 

**Notes for Reviewers**: