### PR TITLE
feat: expose kaito supported models via configmap

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -55,6 +55,10 @@ jobs:
         run: |
           DEVICE=cpu make inference-api-e2e
 
+      - name: Run compare model configs
+        run: |
+          make compare-model-configs    
+
       - name: Upload Codecov report
         uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24 # v5.4.3
         with:

--- a/Makefile
+++ b/Makefile
@@ -531,6 +531,10 @@ release-manifest:
 ## Cleanup
 ## --------------------------------------
 
+.PHONY: compare-model-configs
+compare-model-configs: ## Compare supported_models.yaml with ConfigMap template (ignoring comments)
+	@./hack/compare_model_configs.sh
+
 .PHONY: clean
 clean:
 	@rm -rf $(BIN_DIR)

--- a/charts/kaito/workspace/templates/supported-models-configmap.yaml
+++ b/charts/kaito/workspace/templates/supported-models-configmap.yaml
@@ -1,0 +1,114 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kaito-supported-models
+  namespace: kube-system
+data:
+  SupportedModels: |
+    models:
+      - name: base
+        type: text-generation
+        runtime: tfs
+        tag: 0.0.4
+      - name: llama-3.1-8b-instruct
+        type: text-generation
+        version: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/commit/0e9e39f249a16976918f6564b8830bc894c89659
+        runtime: tfs
+        downloadAtRuntime: true
+        tag: 0.2.0
+      - name: llama-3.3-70b-instruct
+        type: text-generation
+        version: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct/commit/6f6073b423013f6a7d4d9f39144961bfbfbc386b
+        runtime: tfs
+        downloadAtRuntime: true
+        tag: 0.0.1
+      - name: falcon-7b
+        type: text-generation
+        version: https://huggingface.co/tiiuae/falcon-7b/commit/898df1396f35e447d5fe44e0a3ccaaaa69f30d36
+        runtime: tfs
+        tag: 0.2.0
+      - name: falcon-7b-instruct
+        type: text-generation
+        version: https://huggingface.co/tiiuae/falcon-7b-instruct/commit/cf4b3c42ce2fdfe24f753f0f0d179202fea59c99
+        runtime: tfs
+        tag: 0.2.0
+      - name: falcon-40b
+        type: text-generation
+        version: https://huggingface.co/tiiuae/falcon-40b/commit/4a70170c215b36a3cce4b4253f6d0612bb7d4146
+        runtime: tfs
+        tag: 0.2.0
+      - name: falcon-40b-instruct
+        type: text-generation
+        version: https://huggingface.co/tiiuae/falcon-40b-instruct/commit/ecb78d97ac356d098e79f0db222c9ce7c5d9ee5f
+        runtime: tfs
+        tag: 0.2.0
+      - name: mistral-7b
+        type: text-generation
+        version: https://huggingface.co/mistralai/Mistral-7B-v0.3/commit/d8cadc02ac76bd617a919d50b092e59d2d110aff
+        runtime: tfs
+        tag: 0.2.0
+      - name: mistral-7b-instruct
+        type: text-generation
+        version: https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3/commit/e0bc86c23ce5aae1db576c8cca6f06f1f73af2db
+        runtime: tfs
+        tag: 0.2.0
+      - name: phi-2
+        type: text-generation
+        version: https://huggingface.co/microsoft/phi-2/commit/ef382358ec9e382308935a992d908de099b64c23
+        runtime: tfs
+        tag: 0.2.0
+      - name: phi-3-mini-4k-instruct
+        type: text-generation
+        version: https://huggingface.co/microsoft/Phi-3-mini-4k-instruct/commit/0a67737cc96d2554230f90338b163bc6380a2a85
+        runtime: tfs
+        tag: 0.2.0
+      - name: phi-3-mini-128k-instruct
+        type: text-generation
+        version: https://huggingface.co/microsoft/Phi-3-mini-128k-instruct/commit/072cb7562cb8c4adf682a8e186aaafa49469eb5d
+        runtime: tfs
+        tag: 0.2.0
+      - name: phi-3-medium-4k-instruct
+        type: text-generation
+        version: https://huggingface.co/microsoft/Phi-3-medium-4k-instruct/commit/b64223aaea6fbf273c0c8cd0801d5e732dce8897
+        runtime: tfs
+        tag: 0.2.0
+      - name: phi-3-medium-128k-instruct
+        type: text-generation
+        version: https://huggingface.co/microsoft/Phi-3-medium-128k-instruct/commit/fa7d2aa4f5ea69b2e36b20d050cdae79c9bfbb3f
+        runtime: tfs
+        tag: 0.2.0
+      - name: phi-3.5-mini-instruct
+        type: text-generation
+        version: https://huggingface.co/microsoft/Phi-3.5-mini-instruct/commit/3145e03a9fd4cdd7cd953c34d9bbf7ad606122ca
+        runtime: tfs
+        tag: 0.2.0
+      - name: phi-4-mini-instruct
+        type: text-generation
+        version: https://huggingface.co/microsoft/Phi-4-mini-instruct/commit/c0fb9e74abda11b496b7907a9c6c9009a7a0488f
+        runtime: tfs
+        tag: 0.2.0
+      - name: phi-4
+        type: text-generation
+        version: https://huggingface.co/microsoft/phi-4/commit/187ef0342fff0eb3333be9f00389385e95ef0b61
+        runtime: tfs
+        tag: 0.2.0
+      - name: qwen2.5-coder-7b-instruct
+        type: text-generation
+        version: https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct/commit/c03e6d358207e414f1eca0bb1891e29f1db0e242
+        runtime: tfs
+        tag: 0.2.0
+      - name: qwen2.5-coder-32b-instruct
+        type: text-generation
+        version: https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct/commit/381fc969f78efac66bc87ff7ddeadb7e73c218a7
+        runtime: tfs
+        tag: 0.2.0
+      - name: deepseek-r1-distill-qwen-14b
+        type: text-generation
+        version: https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B/commit/1df8507178afcc1bef68cd8c393f61a886323761
+        runtime: tfs
+        tag: 0.2.0
+      - name: deepseek-r1-distill-llama-8b
+        type: text-generation
+        version: https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-8B/commit/6a6f4aa4197940add57724a7707d069478df56b1
+        runtime: tfs
+        tag: 0.2.0

--- a/charts/kaito/workspace/templates/supported-models-configmap.yaml
+++ b/charts/kaito/workspace/templates/supported-models-configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kaito-supported-models
-  namespace: kube-system
+  namespace: {{ .Release.Namespace }}
 data:
   SupportedModels: |
     models:

--- a/hack/compare_model_configs.sh
+++ b/hack/compare_model_configs.sh
@@ -24,7 +24,9 @@
 #   -d, --debug       Keep temporary files for debugging
 #   -h, --help        Show this help message
 
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 
 # Parse command line arguments
 VERBOSE=false

--- a/hack/compare_model_configs.sh
+++ b/hack/compare_model_configs.sh
@@ -1,0 +1,160 @@
+#!/bin/bash
+
+# Copyright KAITO authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Script to compare the content of supported_models.yaml with the SupportedModels 
+# key in the Helm ConfigMap template, ignoring comment lines.
+#
+# Usage: ./compare_model_configs.sh [OPTIONS]
+#
+# Options:
+#   -v, --verbose     Show verbose output including normalized files
+#   -d, --debug       Keep temporary files for debugging
+#   -h, --help        Show this help message
+
+set -e
+
+# Parse command line arguments
+VERBOSE=false
+DEBUG=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        -v|--verbose)
+            VERBOSE=true
+            shift
+            ;;
+        -d|--debug)
+            DEBUG=true
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo
+            echo "Compare the content of supported_models.yaml with the SupportedModels"
+            echo "key in the Helm ConfigMap template, ignoring comment lines."
+            echo
+            echo "Options:"
+            echo "  -v, --verbose     Show verbose output including normalized files"
+            echo "  -d, --debug       Keep temporary files for debugging"
+            echo "  -h, --help        Show this help message"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Use -h or --help for usage information"
+            exit 1
+            ;;
+    esac
+done
+
+MODELS_FILE="presets/workspace/models/supported_models.yaml"
+CONFIGMAP_FILE="charts/kaito/workspace/templates/supported-models-configmap.yaml"
+
+# Check if files exist
+if [[ ! -f "$MODELS_FILE" ]]; then
+    echo "Error: supported_models.yaml not found at $MODELS_FILE"
+    exit 1
+fi
+
+if [[ ! -f "$CONFIGMAP_FILE" ]]; then
+    echo "Error: supported-models-configmap.yaml not found at $CONFIGMAP_FILE"
+    exit 1
+fi
+
+# Function to strip comments and normalize YAML
+normalize_yaml() {
+    local file="$1"
+    # Remove comment lines (lines starting with # after optional whitespace)
+    # Remove inline comments (# and everything after it on a line)
+    # Remove empty lines
+    # Trim leading/trailing whitespace
+    sed -e 's/[[:space:]]*#.*$//' -e '/^[[:space:]]*$/d' "$file" | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//'
+}
+
+# Function to extract SupportedModels value from ConfigMap
+extract_configmap_models() {
+    local file="$1"
+    # Extract the value under SupportedModels key (everything after "SupportedModels: |")
+    # Skip the ConfigMap header and metadata, find the SupportedModels section
+    awk '
+    /SupportedModels: \|/ { 
+        found=1; 
+        next 
+    } 
+    found && /^[[:space:]]*[a-zA-Z]/ && !/^[[:space:]]*models:/ && !/^[[:space:]]*-/ && !/^[[:space:]]*name:/ && !/^[[:space:]]*type:/ && !/^[[:space:]]*version:/ && !/^[[:space:]]*runtime:/ && !/^[[:space:]]*downloadAtRuntime:/ && !/^[[:space:]]*tag:/ && !/^[[:space:]]*resources:/ && !/^[[:space:]]*instanceType:/ && !/^[[:space:]]*labelSelector:/ && !/^[[:space:]]*preferredInstance:/ { 
+        found=0 
+    } 
+    found { 
+        print 
+    }' "$file"
+}
+
+echo "Comparing model configurations..."
+echo "Source file: $MODELS_FILE"
+echo "ConfigMap file: $CONFIGMAP_FILE"
+echo
+
+# Create temporary files for comparison
+TEMP_DIR=$(mktemp -d)
+MODELS_NORMALIZED="$TEMP_DIR/models_normalized.yaml"
+CONFIGMAP_NORMALIZED="$TEMP_DIR/configmap_normalized.yaml"
+
+# Normalize the original models file
+normalize_yaml "$MODELS_FILE" > "$MODELS_NORMALIZED"
+
+# Extract and normalize the ConfigMap models section
+extract_configmap_models "$CONFIGMAP_FILE" | normalize_yaml /dev/stdin > "$CONFIGMAP_NORMALIZED"
+
+# Show verbose output if requested
+if [[ "$VERBOSE" == "true" ]]; then
+    echo "Normalized models file content:"
+    echo "================================"
+    cat "$MODELS_NORMALIZED"
+    echo
+    echo "Normalized ConfigMap content:"
+    echo "============================="
+    cat "$CONFIGMAP_NORMALIZED"
+    echo
+fi
+
+# Compare the normalized files
+if diff -u "$MODELS_NORMALIZED" "$CONFIGMAP_NORMALIZED"; then
+    echo "✅ SUCCESS: Model configurations are identical (ignoring comments)"
+    exit_code=0
+else
+    echo "❌ FAILURE: Model configurations differ"
+    echo
+    echo "Differences found between:"
+    echo "  Left:  $MODELS_FILE (normalized)"
+    echo "  Right: ConfigMap SupportedModels value (normalized)"
+    echo
+    echo "To see the normalized files for debugging:"
+    echo "  Models file (normalized):    $MODELS_NORMALIZED"
+    echo "  ConfigMap section (normalized): $CONFIGMAP_NORMALIZED"
+    exit_code=1
+fi
+
+# Clean up temporary files unless debugging or there were differences
+if [[ $exit_code -eq 0 && "$DEBUG" != "true" ]]; then
+    rm -rf "$TEMP_DIR"
+elif [[ $exit_code -ne 0 || "$DEBUG" == "true" ]]; then
+    echo
+    echo "Temporary files preserved for debugging in: $TEMP_DIR"
+    echo "  Models file (normalized):       $MODELS_NORMALIZED"
+    echo "  ConfigMap section (normalized): $CONFIGMAP_NORMALIZED"
+fi
+
+exit $exit_code


### PR DESCRIPTION
This will help any client to know the list of models that are supported by Kaito, instead of reading from gh repo.