### PR TITLE
fix doc error kaito.sh/enablelb should be True instead of true

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ kind: Workspace
 metadata:
   name: my-workspace
   annotations:
-    kaito.sh/bypass-resource-checks: "true"
+    kaito.sh/bypass-resource-checks: "True"
   # ... rest of the workspace spec
 ```
 > Caution: Using this annotation may lead to degraded performance or out-of-memory errors if GPU resources are insufficient for your model. Warnings will be logged accordingly.
@@ -17,12 +17,12 @@ metadata:
 
 ### Exposing Service via LoadBalancer (Testing Only)
 
-For **testing** purposes, you may annotate your workspace resource with `kaito.sh/enablelb: "true"` to automatically create a `LoadBalancer` type service with a public IP for the inference service:
+For **testing** purposes, you may annotate your workspace resource with `kaito.sh/enablelb: "True"` to automatically create a `LoadBalancer` type service with a public IP for the inference service:
 
 ```yaml
 metadata:
   annotations:
-    kaito.sh/enablelb: "true"
+    kaito.sh/enablelb: "True"
 ```
 > Important: This approach is **NOT** recommended for production environments. For production scenarios, use an [Ingress Controller](https://learn.microsoft.com/en-us/azure/aks/ingress-basic?tabs=azure-cli) to safely expose the service.
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
doc bug fix. according to [code](https://github.com/kaito-project/kaito/blob/4309784a8468fa7bfe261be9067001d7b09027f9/pkg/workspace/controllers/workspace_controller.go#L589), it is just a val == "True". true is not working
**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: