### PR TITLE
chore: bump local-csi-driver to v0.2.3

### DIFF
--- a/charts/kaito/workspace/templates/local-csi-driver-ds.yaml
+++ b/charts/kaito/workspace/templates/local-csi-driver-ds.yaml
@@ -208,7 +208,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.0"
+        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.3"
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -272,7 +272,7 @@ spec:
         - --feature-gates=Topology=true
         - --strict-topology=true
         - --enable-capacity
-        - --capacity-ownerref-level=1
+        - --capacity-ownerref-level=0
         - --capacity-poll-interval=15s
         - --v=2
         env:
@@ -344,7 +344,7 @@ spec:
         - --csi-address=/csi/csi.sock
         - --kubelet-registration-path=/var/lib/kubelet/plugins/localdisk.csi.acstor.io/csi.sock
         - --http-endpoint=:8092
-        - --v=2
+        - --v=1
         env:
         image: "mcr.microsoft.com/oss/v2/kubernetes-csi/csi-node-driver-registrar:v2.13.0"
         imagePullPolicy: IfNotPresent

--- a/hack/local-csi-driver-charts-sync/local-csi-driver-charts-sync.sh
+++ b/hack/local-csi-driver-charts-sync/local-csi-driver-charts-sync.sh
@@ -12,7 +12,7 @@
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 
 REPO=https://github.com/Azure/local-csi-driver.git
-REVISION="cf32dac2eb8006f25438127d446bc48797de9204"
+REVISION="a9a2fd1af2d0fbfe4262f66105dc2569b6394a9c"
 
 TEMP_DIR=$(mktemp -d)
 REPO_DIR="$TEMP_DIR/local-csi-driver"
@@ -35,6 +35,7 @@ echo "Checking out revision: $REVISION"
 (cd "$REPO_DIR" && git switch -c "$REVISION") || { echo "Failed to checkout revision $REVISION"; exit 1; }
 
 helm template --release-name local-csi-driver \
+  --set image.driver.tag="0.0.1-latest" \
   --set webhook.ephemeral.enabled=false \
   --set webhook.hyperconverged.enabled=false \
   --set observability.metrics.enabled=false \

--- a/hack/local-csi-driver-charts-sync/local-csi-driver-charts.diff
+++ b/hack/local-csi-driver-charts-sync/local-csi-driver-charts.diff
@@ -1,5 +1,5 @@
 diff --git a/./local-csi-driver-charts.yaml b/./charts/kaito/workspace/templates/local-csi-driver-ds.yaml
-index ede249f..60cde8b 100644
+index 93d0b57..54cb7e4 100644
 --- a/./local-csi-driver-charts.yaml
 +++ b/./charts/kaito/workspace/templates/local-csi-driver-ds.yaml
 @@ -4,13 +4,9 @@ apiVersion: v1
@@ -42,7 +42,7 @@ index ede249f..60cde8b 100644
  roleRef:
    apiGroup: rbac.authorization.k8s.io
    kind: ClusterRole
-@@ -141,31 +131,24 @@ roleRef:
+@@ -141,34 +131,24 @@ roleRef:
  subjects:
  - kind: ServiceAccount
    name: csi-local-node
@@ -57,6 +57,7 @@ index ede249f..60cde8b 100644
 +  namespace: {{ .Release.Namespace }}
    labels:
 -    app: csi-local
+-    app.kubernetes.io/component: csi-local-node
 -    helm.sh/chart: local-csi-driver-0.0.1-latest
 -    app.kubernetes.io/name: local-csi-driver
 -    app.kubernetes.io/instance: local-csi-driver
@@ -66,23 +67,25 @@ index ede249f..60cde8b 100644
    selector:
      matchLabels:
        app: csi-local-node
+-      app.kubernetes.io/component: csi-local-node
 -      app.kubernetes.io/name: local-csi-driver
 -      app.kubernetes.io/instance: local-csi-driver
    template:
      metadata:
        labels:
          app: csi-local-node
+-        app.kubernetes.io/component: csi-local-node
 -        app.kubernetes.io/name: local-csi-driver
 -        app.kubernetes.io/instance: local-csi-driver
        annotations:
          kubectl.kubernetes.io/default-container: driver
      spec:
-@@ -218,7 +201,7 @@ spec:
+@@ -221,7 +201,7 @@ spec:
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
 -        image: "localcsidriver.azurecr.io/acstor/local-csi-driver:0.0.1-latest"
-+        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.0"
++        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.3"
          imagePullPolicy: IfNotPresent
          livenessProbe:
            httpGet:


### PR DESCRIPTION
**Reason for Change**:

Updates local-csi-driver to v0.2.3.

Note: if upgrading there is a manual step needed for capacity-based pod scheduling to continue working:

```console
kubectl -n kube-system delete CSIStorageCapacity -l csi.storage.k8s.io/drivername=localdisk.csi.acstor.io
```
This shouldn't be needed for Kaito since it handles pod scheduling to select specific GPU nodes and doesn't rely on capacity-based scheduling.

Release notes: 
- https://github.com/Azure/local-csi-driver/releases/tag/v0.2.3
- https://github.com/Azure/local-csi-driver/releases/tag/v0.2.2
- https://github.com/Azure/local-csi-driver/releases/tag/v0.2.1

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: