### PR TITLE
fix: avoid extra node creation on informercache delay

### DIFF
--- a/pkg/utils/controller.go
+++ b/pkg/utils/controller.go
@@ -1,0 +1,229 @@
+/*
+Copyright 2014 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// notes: This file contains code copied from https://github.com/kubernetes/kubernetes/blob/01c55353873dcb80b1280c0d470ca29f07b48466/pkg/controller/controller_utils.go#L61-L319
+// import it from k8s once it is available in the go module.
+
+package utils
+
+import (
+	"fmt"
+	"sync/atomic"
+	"time"
+
+	"k8s.io/client-go/tools/cache"
+	"k8s.io/klog/v2"
+	"k8s.io/utils/clock"
+)
+
+const (
+	// If a watch drops a delete event for a pod, it'll take this long
+	// before a dormant controller waiting for those packets is woken up anyway. It is
+	// specifically targeted at the case where some problem prevents an update
+	// of expectations, without it the controller could stay asleep forever. This should
+	// be set based on the expected latency of watch events.
+	//
+	// Currently a controller can service (create *and* observe the watch events for said
+	// creation) about 10 pods a second, so it takes about 1 min to service
+	// 500 pods. Just creation is limited to 20qps, and watching happens with ~10-30s
+	// latency/pod at the scale of 3000 pods over 100 nodes.
+	ExpectationsTimeout = 5 * time.Minute
+)
+
+// Expectations are a way for controllers to tell the controller manager what they expect. eg:
+//	ControllerExpectations: {
+//		controller1: expects  2 adds in 2 minutes
+//		controller2: expects  2 dels in 2 minutes
+//		controller3: expects -1 adds in 2 minutes => controller3's expectations have already been met
+//	}
+//
+// Implementation:
+//	ControlleeExpectation = pair of atomic counters to track controllee's creation/deletion
+//	ControllerExpectationsStore = TTLStore + a ControlleeExpectation per controller
+//
+// * Once set expectations can only be lowered
+// * A controller isn't synced till its expectations are either fulfilled, or expire
+// * Controllers that don't set expectations will get woken up for every matching controllee
+
+// ExpKeyFunc to parse out the key from a ControlleeExpectation
+var ExpKeyFunc = func(obj interface{}) (string, error) {
+	if e, ok := obj.(*ControlleeExpectations); ok {
+		return e.key, nil
+	}
+	return "", fmt.Errorf("could not find key for obj %#v", obj)
+}
+
+// ControllerExpectationsInterface is an interface that allows users to set and wait on expectations.
+// Only abstracted out for testing.
+// Warning: if using KeyFunc it is not safe to use a single ControllerExpectationsInterface with different
+// types of controllers, because the keys might conflict across types.
+type ControllerExpectationsInterface interface {
+	GetExpectations(controllerKey string) (*ControlleeExpectations, bool, error)
+	SatisfiedExpectations(logger klog.Logger, controllerKey string) bool
+	DeleteExpectations(logger klog.Logger, controllerKey string)
+	SetExpectations(logger klog.Logger, controllerKey string, add, del int) error
+	ExpectCreations(logger klog.Logger, controllerKey string, adds int) error
+	ExpectDeletions(logger klog.Logger, controllerKey string, dels int) error
+	CreationObserved(logger klog.Logger, controllerKey string)
+	DeletionObserved(logger klog.Logger, controllerKey string)
+	RaiseExpectations(logger klog.Logger, controllerKey string, add, del int)
+	LowerExpectations(logger klog.Logger, controllerKey string, add, del int)
+	GetExpectationStartTime(controllerKey string) *time.Time
+}
+
+// ControllerExpectations is a cache mapping controllers to what they expect to see before being woken up for a sync.
+type ControllerExpectations struct {
+	cache.Store
+}
+
+// GetExpectations returns the ControlleeExpectations of the given controller.
+func (r *ControllerExpectations) GetExpectations(controllerKey string) (*ControlleeExpectations, bool, error) {
+	exp, exists, err := r.GetByKey(controllerKey)
+	if err == nil && exists {
+		return exp.(*ControlleeExpectations), true, nil
+	}
+	return nil, false, err
+}
+
+// DeleteExpectations deletes the expectations of the given controller from the TTLStore.
+func (r *ControllerExpectations) DeleteExpectations(logger klog.Logger, controllerKey string) {
+	if exp, exists, err := r.GetByKey(controllerKey); err == nil && exists {
+		if err := r.Delete(exp); err != nil {
+
+			logger.V(2).Info("Error deleting expectations", "controller", controllerKey, "err", err)
+		}
+	}
+}
+
+// SatisfiedExpectations returns true if the required adds/dels for the given controller have been observed.
+// Add/del counts are established by the controller at sync time, and updated as controllees are observed by the controller
+// manager.
+func (r *ControllerExpectations) SatisfiedExpectations(logger klog.Logger, controllerKey string) bool {
+	if exp, exists, err := r.GetExpectations(controllerKey); exists {
+		if exp.Fulfilled() {
+			logger.V(4).Info("Controller expectations fulfilled", "expectations", exp)
+			return true
+		} else if exp.isExpired() {
+			logger.V(4).Info("Controller expectations expired", "expectations", exp)
+			return true
+		} else {
+			logger.V(4).Info("Controller still waiting on expectations", "expectations", exp)
+			return false
+		}
+	} else if err != nil {
+		logger.V(2).Info("Error encountered while checking expectations, forcing sync", "err", err)
+	} else {
+		// When a new controller is created, it doesn't have expectations.
+		// When it doesn't see expected watch events for > TTL, the expectations expire.
+		//	- In this case it wakes up, creates/deletes controllees, and sets expectations again.
+		// When it has satisfied expectations and no controllees need to be created/destroyed > TTL, the expectations expire.
+		//	- In this case it continues without setting expectations till it needs to create/delete controllees.
+		logger.V(4).Info("Controller either never recorded expectations, or the ttl expired", "controller", controllerKey)
+	}
+	// Trigger a sync if we either encountered and error (which shouldn't happen since we're
+	// getting from local store) or this controller hasn't established expectations.
+	return true
+}
+
+// GetExpectationStartTime returns the time when the expectations for the given controller were set.
+func (r *ControllerExpectations) GetExpectationStartTime(controllerKey string) *time.Time {
+	if exp, exists, _ := r.GetExpectations(controllerKey); exists {
+		return &exp.timestamp
+	}
+	return nil
+}
+
+// TODO: Extend ExpirationCache to support explicit expiration.
+// TODO: Make this possible to disable in tests.
+// TODO: Support injection of clock.
+func (exp *ControlleeExpectations) isExpired() bool {
+	return clock.RealClock{}.Since(exp.timestamp) > ExpectationsTimeout
+}
+
+// SetExpectations registers new expectations for the given controller. Forgets existing expectations.
+func (r *ControllerExpectations) SetExpectations(logger klog.Logger, controllerKey string, add, del int) error {
+	exp := &ControlleeExpectations{add: int64(add), del: int64(del), key: controllerKey, timestamp: clock.RealClock{}.Now()}
+	logger.V(4).Info("Setting expectations", "expectations", exp)
+	return r.Add(exp)
+}
+
+func (r *ControllerExpectations) ExpectCreations(logger klog.Logger, controllerKey string, adds int) error {
+	return r.SetExpectations(logger, controllerKey, adds, 0)
+}
+
+func (r *ControllerExpectations) ExpectDeletions(logger klog.Logger, controllerKey string, dels int) error {
+	return r.SetExpectations(logger, controllerKey, 0, dels)
+}
+
+// Decrements the expectation counts of the given controller.
+func (r *ControllerExpectations) LowerExpectations(logger klog.Logger, controllerKey string, add, del int) {
+	if exp, exists, err := r.GetExpectations(controllerKey); err == nil && exists {
+		exp.Add(int64(-add), int64(-del))
+		// The expectations might've been modified since the update on the previous line.
+		logger.V(4).Info("Lowered expectations", "expectations", exp)
+	}
+}
+
+// Increments the expectation counts of the given controller.
+func (r *ControllerExpectations) RaiseExpectations(logger klog.Logger, controllerKey string, add, del int) {
+	if exp, exists, err := r.GetExpectations(controllerKey); err == nil && exists {
+		exp.Add(int64(add), int64(del))
+		// The expectations might've been modified since the update on the previous line.
+		logger.V(4).Info("Raised expectations", "expectations", exp)
+	}
+}
+
+// CreationObserved atomically decrements the `add` expectation count of the given controller.
+func (r *ControllerExpectations) CreationObserved(logger klog.Logger, controllerKey string) {
+	r.LowerExpectations(logger, controllerKey, 1, 0)
+}
+
+// DeletionObserved atomically decrements the `del` expectation count of the given controller.
+func (r *ControllerExpectations) DeletionObserved(logger klog.Logger, controllerKey string) {
+	r.LowerExpectations(logger, controllerKey, 0, 1)
+}
+
+// ControlleeExpectations track controllee creates/deletes.
+type ControlleeExpectations struct {
+	// Important: Since these two int64 fields are using sync/atomic, they have to be at the top of the struct due to a bug on 32-bit platforms
+	// See: https://golang.org/pkg/sync/atomic/ for more information
+	add       int64
+	del       int64
+	key       string
+	timestamp time.Time
+}
+
+// Add increments the add and del counters.
+func (e *ControlleeExpectations) Add(add, del int64) {
+	atomic.AddInt64(&e.add, add)
+	atomic.AddInt64(&e.del, del)
+}
+
+// Fulfilled returns true if this expectation has been fulfilled.
+func (e *ControlleeExpectations) Fulfilled() bool {
+	// TODO: think about why this line being atomic doesn't matter
+	return atomic.LoadInt64(&e.add) <= 0 && atomic.LoadInt64(&e.del) <= 0
+}
+
+// GetExpectations returns the add and del expectations of the controllee.
+func (e *ControlleeExpectations) GetExpectations() (int64, int64) {
+	return atomic.LoadInt64(&e.add), atomic.LoadInt64(&e.del)
+}
+
+// NewControllerExpectations returns a store for ControllerExpectations.
+func NewControllerExpectations() *ControllerExpectations {
+	return &ControllerExpectations{cache.NewStore(ExpKeyFunc)}
+}

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -18,6 +18,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"sort"
 	"strconv"
@@ -42,7 +43,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
@@ -68,24 +68,31 @@ type WorkspaceReconciler struct {
 	Log      logr.Logger
 	Scheme   *runtime.Scheme
 	Recorder record.EventRecorder
+
+	klogger      klog.Logger
+	expectations *utils.ControllerExpectations
 }
 
 func NewWorkspaceReconciler(client client.Client, scheme *runtime.Scheme, log logr.Logger, Recorder record.EventRecorder) *WorkspaceReconciler {
 	return &WorkspaceReconciler{
-		Client:   client,
-		Scheme:   scheme,
-		Log:      log,
-		Recorder: Recorder,
+		Client:       client,
+		Scheme:       scheme,
+		Log:          log,
+		klogger:      klog.NewKlogr().WithName("WorkspaceController"),
+		Recorder:     Recorder,
+		expectations: utils.NewControllerExpectations(),
 	}
 }
 
 func (c *WorkspaceReconciler) Reconcile(ctx context.Context, req reconcile.Request) (reconcile.Result, error) {
 	workspaceObj := &kaitov1beta1.Workspace{}
 	if err := c.Client.Get(ctx, req.NamespacedName, workspaceObj); err != nil {
-		if !apierrors.IsNotFound(err) {
-			klog.ErrorS(err, "failed to get workspace", "workspace", req.Name)
+		if apierrors.IsNotFound(err) {
+			c.expectations.DeleteExpectations(c.klogger, req.String())
+			return reconcile.Result{}, nil
 		}
-		return reconcile.Result{}, client.IgnoreNotFound(err)
+		klog.ErrorS(err, "failed to get workspace", "workspace", req.Name)
+		return reconcile.Result{}, err
 	}
 
 	klog.InfoS("Reconciling", "workspace", req.NamespacedName)
@@ -124,9 +131,23 @@ func (c *WorkspaceReconciler) ensureFinalizer(ctx context.Context, workspaceObj 
 }
 
 func (c *WorkspaceReconciler) addOrUpdateWorkspace(ctx context.Context, wObj *kaitov1beta1.Workspace) (reconcile.Result, error) {
+	reqKey := client.ObjectKeyFromObject(wObj).String()
+	// nodeclaim don't meet expectation if no enough node events are observed within the timeout period.
+	if !c.expectations.SatisfiedExpectations(c.klogger, reqKey) {
+		startTime := c.expectations.GetExpectationStartTime(reqKey)
+		requeueTime := time.Second * 5
+		if startTime != nil {
+			requeueTime = startTime.Add(utils.ExpectationsTimeout).Sub(clock.RealClock{}.Now())
+		}
+		return reconcile.Result{RequeueAfter: requeueTime}, nil
+	}
+
 	// Read ResourceSpec
 	err := c.applyWorkspaceResource(ctx, wObj)
 	if err != nil {
+		if errors.Is(err, reconcile.TerminalError(nil)) {
+			return reconcile.Result{}, nil
+		}
 		if updateErr := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1beta1.WorkspaceConditionTypeSucceeded, metav1.ConditionFalse,
 			"workspaceFailed", err.Error()); updateErr != nil {
 			klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
@@ -341,11 +362,12 @@ func (c *WorkspaceReconciler) applyWorkspaceResource(ctx context.Context, wObj *
 			return err
 		}
 
-		newNodes, err := c.createNewNodes(ctx, wObj, newNodesCount)
+		err := c.createNewNodes(ctx, wObj, newNodesCount)
 		if err != nil {
 			return fmt.Errorf("failed to create new nodes: %w", err)
 		}
-		selectedNodes = append(selectedNodes, newNodes...)
+		// will be triggered again by the NodeClaim event
+		return reconcile.TerminalError(errors.New("waiting for new nodes to be created"))
 	}
 
 	// Ensure all gpu plugins are running successfully.
@@ -458,20 +480,33 @@ func (c *WorkspaceReconciler) createAllNodeClaims(ctx context.Context, wObj *kai
 
 	nodeClaims := make([]*karpenterv1.NodeClaim, 0, count)
 
-	for i := 0; i < count; i++ {
+	for range count {
 		var newNodeClaim *karpenterv1.NodeClaim
 
+		// Set expectations before creating the NodeClaim incase event handler
+		// observes the NodeClaim creation event before the controller does.
+		c.expectations.ExpectCreations(c.klogger, client.ObjectKeyFromObject(wObj).String(), 1)
+		newNodeCreated := false
 		err := retry.OnError(retry.DefaultRetry, func(err error) bool {
 			return apierrors.IsAlreadyExists(err)
 		}, func() error {
 			newNodeClaim = nodeclaim.GenerateNodeClaimManifest(nodeOSDiskSize, wObj)
-			return nodeclaim.CreateNodeClaim(ctx, newNodeClaim, c.Client)
+			err0 := nodeclaim.CreateNodeClaim(ctx, newNodeClaim, c.Client)
+			if err0 == nil {
+				newNodeCreated = true
+			}
+			return err0
 		})
+		if !newNodeCreated {
+			// Decrement the expected number of creates because the informer won't observe this nodeclaim
+			c.expectations.CreationObserved(c.klogger, client.ObjectKeyFromObject(wObj).String())
+		}
 
 		if err != nil {
 			klog.ErrorS(err, "failed to create nodeClaim", "nodeClaim", newNodeClaim.Name)
 			return nil, fmt.Errorf("failed to create nodeClaim %s: %w", newNodeClaim.Name, err)
 		}
+		klog.InfoS("NodeClaim created successfully", "nodeClaim", newNodeClaim.Name, "workspace", klog.KObj(wObj))
 
 		nodeClaims = append(nodeClaims, newNodeClaim)
 	}
@@ -479,55 +514,24 @@ func (c *WorkspaceReconciler) createAllNodeClaims(ctx context.Context, wObj *kai
 	return nodeClaims, nil
 }
 
-func (c *WorkspaceReconciler) createNewNodes(ctx context.Context, wObj *kaitov1beta1.Workspace, newNodesCount int) ([]*corev1.Node, error) {
+func (c *WorkspaceReconciler) createNewNodes(ctx context.Context, wObj *kaitov1beta1.Workspace, newNodesCount int) error {
 	// Create all node claims at once
 	nodeOSDiskSize := c.determineNodeOSDiskSize(wObj)
-	newNodeClaims, err := c.createAllNodeClaims(ctx, wObj, newNodesCount, nodeOSDiskSize)
+	_, err := c.createAllNodeClaims(ctx, wObj, newNodesCount, nodeOSDiskSize)
 	if err != nil {
 		if updateErr := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1beta1.ConditionTypeResourceStatus, metav1.ConditionFalse,
 			"workspaceResourceStatusFailed", err.Error()); updateErr != nil {
 			klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
-			return nil, updateErr
+			return updateErr
 		}
-		return nil, err
+		return err
 	}
-
-	// Wait for all node claims to be ready
-	if err := nodeclaim.WaitForPendingNodeClaims(ctx, wObj, c.Client); err != nil {
-		return nil, err
+	if updateErr := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1beta1.ConditionTypeResourceStatus, metav1.ConditionFalse,
+		"workspaceResourceCreated", "nodeclaims created"); updateErr != nil {
+		klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
+		return updateErr
 	}
-
-	// Get node object details
-	newNodes, err := c.getNewNodes(ctx, newNodeClaims)
-	if err != nil {
-		if updateErr := c.updateStatusConditionIfNotMatch(ctx, wObj, kaitov1beta1.ConditionTypeResourceStatus, metav1.ConditionFalse,
-			"workspaceResourceStatusFailed", err.Error()); updateErr != nil {
-			klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
-			return nil, updateErr
-		}
-		return nil, err
-	}
-
-	return newNodes, nil
-}
-
-// getNewNodes returns the new nodes created from the given node claims.
-func (c *WorkspaceReconciler) getNewNodes(ctx context.Context, nodeClaims []*karpenterv1.NodeClaim) ([]*corev1.Node, error) {
-	nodes := make([]*corev1.Node, 0, len(nodeClaims))
-
-	for i, nodeClaim := range nodeClaims {
-		klog.InfoS("Checking NodeClaim status", "nodeClaim", nodeClaim.Name, "index", i+1, "total", len(nodeClaims))
-
-		// Get the node object from the nodeClaim status nodeName
-		node, err := resources.GetNode(ctx, nodeClaim.Status.NodeName, c.Client)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get node for nodeClaim %s: %w", nodeClaim.Name, err)
-		}
-
-		nodes = append(nodes, node)
-	}
-
-	return nodes, nil
+	return nil
 }
 
 // ensureNodePlugins ensures node plugins are installed.
@@ -809,34 +813,17 @@ func (c *WorkspaceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&batchv1.Job{}).
-		Watches(&karpenterv1.NodeClaim{}, c.watchNodeClaims(), builder.WithPredicates(nodeclaim.NodeClaimPredicate)).
+		Watches(&karpenterv1.NodeClaim{},
+			&nodeClaimEventHandler{
+				logger:         c.klogger,
+				expectations:   c.expectations,
+				enqueueHandler: enqueueWorkspaceForNodeClaim,
+			},
+			builder.WithPredicates(nodeclaim.NodeClaimPredicate),
+		).
 		WithOptions(controller.Options{MaxConcurrentReconciles: 5})
 
 	go monitorWorkspaces(context.Background(), c.Client)
 
 	return builder.Complete(c)
-}
-
-// watches for nodeClaim with labels indicating workspace name.
-func (c *WorkspaceReconciler) watchNodeClaims() handler.EventHandler {
-	return handler.EnqueueRequestsFromMapFunc(
-		func(ctx context.Context, o client.Object) []reconcile.Request {
-			nodeClaimObj := o.(*karpenterv1.NodeClaim)
-			name, ok := nodeClaimObj.Labels[kaitov1beta1.LabelWorkspaceName]
-			if !ok {
-				return nil
-			}
-			namespace, ok := nodeClaimObj.Labels[kaitov1beta1.LabelWorkspaceNamespace]
-			if !ok {
-				return nil
-			}
-			return []reconcile.Request{
-				{
-					NamespacedName: client.ObjectKey{
-						Name:      name,
-						Namespace: namespace,
-					},
-				},
-			}
-		})
 }

--- a/pkg/workspace/controllers/workspace_event_handler.go
+++ b/pkg/workspace/controllers/workspace_event_handler.go
@@ -1,0 +1,86 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/utils"
+)
+
+type nodeClaimEventHandler struct {
+	enqueueHandler handler.TypedEventHandler[client.Object, reconcile.Request]
+	expectations   *utils.ControllerExpectations
+	logger         klog.Logger
+}
+
+var _ handler.TypedEventHandler[client.Object, reconcile.Request] = (*nodeClaimEventHandler)(nil)
+
+func getControllerKeyForNodeClaim(nc *karpenterv1.NodeClaim) *client.ObjectKey {
+	name, ok := nc.Labels[kaitov1beta1.LabelWorkspaceName]
+	if !ok {
+		return nil
+	}
+	namespace, ok := nc.Labels[kaitov1beta1.LabelWorkspaceNamespace]
+	if !ok {
+		return nil
+	}
+	return &client.ObjectKey{Namespace: namespace, Name: name}
+}
+
+func (n *nodeClaimEventHandler) Create(ctx context.Context, evt event.TypedCreateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	nc := evt.Object.(*karpenterv1.NodeClaim)
+	if nc.DeletionTimestamp != nil {
+		n.Delete(ctx, event.TypedDeleteEvent[client.Object]{Object: nc}, q)
+		return
+	}
+	if key := getControllerKeyForNodeClaim(nc); key != nil {
+		n.expectations.CreationObserved(n.logger, key.String())
+		n.enqueueHandler.Create(ctx, evt, q)
+	}
+}
+
+func (n *nodeClaimEventHandler) Delete(ctx context.Context, evt event.TypedDeleteEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	n.enqueueHandler.Delete(ctx, evt, q)
+}
+
+func (n *nodeClaimEventHandler) Generic(ctx context.Context, evt event.TypedGenericEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+}
+
+func (n *nodeClaimEventHandler) Update(ctx context.Context, evt event.TypedUpdateEvent[client.Object], q workqueue.TypedRateLimitingInterface[reconcile.Request]) {
+	n.enqueueHandler.Update(ctx, evt, q)
+}
+
+var enqueueWorkspaceForNodeClaim = handler.EnqueueRequestsFromMapFunc(
+	func(ctx context.Context, o client.Object) []reconcile.Request {
+		nodeClaimObj := o.(*karpenterv1.NodeClaim)
+		key := getControllerKeyForNodeClaim(nodeClaimObj)
+		if key == nil {
+			return nil
+		}
+		return []reconcile.Request{
+			{
+				NamespacedName: *key,
+			},
+		}
+	})


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

in scenarios where the informercache experiences significant delay,
the controller may mistakenly create redundant nodes due to stale state.

this change leverages the expectations mechanism. The controller now
only reconciles when expectations are fully satisfied, ensuring observed
state is sufficiently up-to-date.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

Fixes #1300 

**Notes for Reviewers**:

reference: https://github.com/kubernetes/kubernetes/blob/master/pkg/controller/replicaset/replica_set.go