### PR TITLE
feat: offload kv cache to cpu RAM on vllm v1

### DIFF
--- a/presets/workspace/dependencies/requirements.txt
+++ b/presets/workspace/dependencies/requirements.txt
@@ -1,7 +1,7 @@
 # Dependencies for TFS
 
 # Core Dependencies
-vllm==0.9.0
+vllm==0.9.1
 transformers == 4.51.3
 torch==2.7.0
 accelerate==1.0.0
@@ -14,6 +14,7 @@ numpy<3.0,>=1.25.0
 sentencepiece==0.2.0
 jinja2>=3.1.0
 starlette==0.47.2
+lmcache==0.3.2
 
 # For accessing Ray dashboard. ray[default] version should be consistent with the one in vllm/vllm-openai:<vllm-version>.
 # Check with `docker run --entrypoint "" vllm/vllm-openai:<vllm-version> pip freeze | grep ray`

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -22,6 +22,9 @@ from typing import Any
 
 import torch
 import uvloop
+import psutil
+import vllm.envs as envs
+from vllm.utils import FlexibleArgumentParser
 import vllm.entrypoints.openai.api_server as api_server
 import yaml
 from vllm.engine.llm_engine import EngineArgs, LLMEngine, VllmConfig
@@ -68,6 +71,12 @@ class KAITOArgumentParser(argparse.ArgumentParser):
             type=int,
             help="Maximum number of steps to find the max available seq len fitting in the GPU memory.",
         )
+        self.add_argument(
+            "--kaito-kv-cache-cpu-memory-utilization",
+            type=float,
+            default=0.5, 
+            help="KV cache CPU memory utilization."
+        )
 
     def _reset_vllm_defaults(self):
         local_rank = int(os.environ.get("LOCAL_RANK", 0))  # Default to 0 if not set
@@ -100,6 +109,8 @@ class KAITOArgumentParser(argparse.ArgumentParser):
             file_config = KaitoConfig.from_yaml(kaito_args.kaito_config_file)
             if kaito_args.kaito_max_probe_steps is None:
                 kaito_args.kaito_max_probe_steps = file_config.max_probe_steps
+            if kaito_args.kaito_kv_cache_cpu_memory_utilization is None:
+                kaito_args.kaito_kv_cache_cpu_memory_utilization = file_config.kv_cache_cpu_memory_utilization
 
             for key, value in file_config.vllm.items():
                 runtime_args.append(f"--{key}")
@@ -124,6 +135,9 @@ class KaitoConfig:
     # Maximum number of steps to find the max available seq len fitting in the GPU memory.
     max_probe_steps: int
 
+    # Optional: CPU memory utilization for the vllm engine in kv cache offload mode. (default: 0.5, set to 0 to disable)
+    kv_cache_cpu_memory_utilization: float
+
     @staticmethod
     def from_yaml(yaml_file: str) -> "KaitoConfig":
         with open(yaml_file) as file:
@@ -131,6 +145,7 @@ class KaitoConfig:
         return KaitoConfig(
             vllm=config_data.get("vllm", {}),
             max_probe_steps=config_data.get("max_probe_steps", 6),
+            kv_cache_cpu_memory_utilization=config_data.get('kv_cache_cpu_memory_utilization', 0.5)
         )
 
     def to_yaml(self) -> str:
@@ -273,6 +288,31 @@ def try_get_max_available_seq_len(args: argparse.Namespace) -> int | None:
         logger.info(f"Using model default max_model_len {max_model_len}")
         return None
 
+def set_kv_cache_offloading_if_appliable(args: argparse.Namespace) -> None:
+    """
+    Set KV cache offloading to CPU RAM if applicable.
+    This is only applicable when VLLM_USE_V1 is enabled and
+    kaito_kv_cache_cpu_memory_utilization is set.
+    """
+    if not envs.is_set("VLLM_USE_V1") and args.kaito_kv_cache_cpu_memory_utilization > 0:
+        logger.info(f"VLLM_USE_V1 is not set, but kaito_kv_cache_cpu_memory_utilization is set as {args.kaito_kv_cache_cpu_memory_utilization}, "
+                       "run create_engine_config to check whether VLLM_USE_V1 should be set.")
+        EngineArgs.from_cli_args(copy.deepcopy(args)).create_engine_config()
+
+    if envs.is_set("VLLM_USE_V1") and envs.VLLM_USE_V1 and args.kaito_kv_cache_cpu_memory_utilization > 0:
+        os.environ["LMCACHE_CHUNK_SIZE"] = "256"
+        os.environ["LMCACHE_LOCAL_CPU"] = "True"
+        available_memory_gb = (psutil.virtual_memory().total - psutil.virtual_memory().used) / (1024 ** 3)
+        logger.info(f"VLLM_USE_V1 is set, Offload KV cache to CPU RAM, size limit: {available_memory_gb} * {args.kaito_kv_cache_cpu_memory_utilization} GB")
+        os.environ["LMCACHE_MAX_LOCAL_CPU_SIZE"] = f"{available_memory_gb * args.kaito_kv_cache_cpu_memory_utilization}"
+
+        if args.kv_transfer_config is None:
+            args.kv_transfer_config = {
+                "kv_connector": "LMCacheConnectorV1",
+                "kv_role": "kv_both",
+            }
+    else:
+        logger.info("VLLM_USE_V1 or kv_cache_cpu_memory_utilization is not set, do not use KV cache offload to CPU RAM.")
 
 if __name__ == "__main__":
     parser = KAITOArgumentParser(description="KAITO wrapper of vLLM serving server")
@@ -286,6 +326,8 @@ if __name__ == "__main__":
     max_available_seq_len = try_get_max_available_seq_len(copy.deepcopy(args))
     if max_available_seq_len is not None:
         args.max_model_len = max_available_seq_len
+
+    set_kv_cache_offloading_if_appliable(args)
 
     # Run the serving server
     logger.info(f"Starting server on port {args.port}")

--- a/presets/workspace/inference/vllm/tests/test_vllm_inference_api.py
+++ b/presets/workspace/inference/vllm/tests/test_vllm_inference_api.py
@@ -71,6 +71,7 @@ def setup_server(request, tmp_path_factory, autouse=True):
     kaito_config = KaitoConfig(
         vllm={"max-model-len": TEST_MODEL_LEN, "served-model-name": TEST_MODEL_NAME},
         max_probe_steps=0,
+        kv_cache_cpu_memory_utilization=0.6,
     )
     with open(config_file, "w") as f:
         f.write(kaito_config.to_yaml())


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
feat: offload kv cache to cpu RAM on vllm v1
this PR adds a new parameter `kaito-kv-cache-cpu-memory-utilization` in `KaitoConfig`, by default, it uses 50% free RAM, and user could disable cpu offloading by set as `0` (default is on with 0.5) 

And we don't want to support cpu offloading on vllm v0 since on v1 is the major version now (A10, A100, H100 are all using vllm v1, only T4 is using v0).

This PR also upgrades vllm to 0.9.1 since vllm 0.9.0 + lmcache is not stable, it crashes a lot, and with vllm 0.9.1 + lmcache, there is no crash after dozens of load tests.

 - vllm v1 example: https://docs.lmcache.ai/getting_started/quickstart/offload_kv_cache.html
https://docs.vllm.ai/en/stable/configuration/engine_args.html#vllmconfig
https://github.com/vllm-project/vllm/blob/main/examples/others/lmcache/cpu_offload_lmcache.py

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Fixes #1296

**Notes for Reviewers**:

### guidellm  benchmark results
- vllm server parameters on `Standard_NC24ads_A100_v4`
```
python3 /workspace/vllm/inference_api.py --tensor-parallel-size=1 --model=meta-llama/Llama-3.1-8B-Instruct --chat-template=/workspace/chat_templates/tool-chat-llama3.1-json.jinja           --tool-call-parser=llama3_json --code-revision=0e9e39f249a16976918f6564b8830bc894c89659 --download-dir=/var/log --gpu-memory-utilization=0.25  --kaito-config-file=/mnt/config/inference_config.yaml --kaito-kv-cache-cpu-memory-utilization=0.5  --max_model_len=20480 --no-enable-prefix-caching  --override-generation-config "temperature=0"   --dtype=float16 --enable-auto-tool-choice --served-model-name=llama-3.1-8b-instruct

INFO 08-14 06:37:07 [gpu_worker.py:227] Available KV cache memory: 3.26 GiB
INFO 08-14 06:37:07 [kv_cache_utils.py:715] GPU KV cache size: 26,688 tokens
```

 - benchmark test command
 ```
export MODEL_NAME=llama-3.1-8b-instruct
python benchmark_serving_multi_turn.py --url http://ip-address  --model $MODEL_NAME --input-file generate_multi_turn.json --num-clients 100 --max-active-conversations 400
```
 
 - with cpu offloading to 110 GB RAM (TTFT is around 1/2 compared to without CPU offloading, that is 1x faster)
```
Parameters:
model=llama-3.1-8b-instruct
num_clients=100
num_conversations=400
active_conversations=400
seed=0
Conversations Generation Parameters:
text_files=pg1184.txt
input_num_turns=UniformDistribution[12, 18]
input_common_prefix_num_tokens=Constant[500]
input_prefix_num_tokens=LognormalDistribution[6, 4]
input_num_tokens=UniformDistribution[120, 160]
output_num_tokens=UniformDistribution[80, 120]
----------------------------------------------------------------------------------------------------
Statistics summary:
runtime_sec = 289.620
requests_per_sec = 7.251
----------------------------------------------------------------------------------------------------
                    count      mean      std      min       25%       50%       75%       90%       99%     99.9%       max
ttft_ms            2100.0  11388.27  3357.74   301.13   9017.39  11547.57  13988.80  15752.72  17089.51  17514.04  17650.14
tpot_ms            2100.0     19.68     1.40    14.89     19.19     19.59     20.05     20.42     22.24     28.09     71.77
latency_ms         2100.0  13340.82  3361.87  1958.98  10890.38  13505.23  15938.99  17762.58  19034.70  19453.70  19573.80
input_num_turns    2100.0      5.29     3.04     1.00      3.00      5.00      7.00      9.00     11.00     11.00     11.00
input_num_tokens   2100.0   1667.46   752.05   515.00   1026.75   1531.00   2262.00   2751.00   3190.01   3257.22   3269.00
output_num_tokens  2100.0    100.30    11.81    27.00     90.00    100.00    110.00    117.00    120.00    120.00    120.00
output_num_chunks  2100.0     99.17    11.77    67.00     89.00     99.00    109.00    116.00    119.00    119.00    119.00
----------------------------------------------------------------------------------------------------
```

 - without cpu offloading
 ```
----------------------------------------------------------------------------------------------------
                    count      mean      std      min       25%       50%       75%       90%       99%     99.9%       max
ttft_ms            2105.0  24414.51  9313.22   608.85  17356.62  24260.36  31035.95  35923.96  48724.60  50546.14  50590.56
tpot_ms            2105.0     43.19     8.97    14.36     36.96     40.42     47.20     55.85     72.53     83.02     85.96
latency_ms         2105.0  28708.70  9693.38  3986.54  21224.82  28536.85  35434.56  41034.25  53633.22  55727.26  56171.64
input_num_turns    2105.0      5.30     3.05     1.00      3.00      5.00      7.00      9.00     11.00     11.00     11.00
input_num_tokens   2105.0   1675.85   758.72   515.00   1028.00   1531.00   2266.00   2756.20   3212.00   3288.82   3303.00
output_num_tokens  2105.0    100.36    11.73    80.00     90.00    100.00    110.00    117.00    120.00    120.00    120.00
output_num_chunks  2105.0     99.36    11.73    79.00     89.00     99.00    109.00    116.00    119.00    119.00    119.00
----------------------------------------------------------------------------------------------------
```