### PR TITLE
docs: verify docs site with Algolia

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -60,6 +60,7 @@ jobs:
       env:
         ALGOLIA_APP_ID: ${{ secrets.ALGOLIA_APP_ID }}
         ALGOLIA_API_KEY: ${{ secrets.ALGOLIA_API_KEY }}
+        ALGOLIA_SITE_VERIFICATION: ${{ secrets.ALGOLIA_SITE_VERIFICATION }}
 
     - name: Deploy to GitHub Pages
       uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e # v4.0.0

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -12,6 +12,18 @@ const config = {
     tagline: 'Kubernetes AI Toolchain Operator',
     favicon: 'img/favicon.ico',
 
+    headTags: [
+        {
+            tagName: "meta",
+            attributes: {
+                // Allow Algolia crawler to index the site
+                // See https://www.algolia.com/doc/tools/crawler/getting-started/create-crawler/#verify-your-domain.
+                name: "algolia-site-verification",
+                content: process.env.ALGOLIA_SITE_VERIFICATION || "DUMMY_SITE_VERIFICATION",
+            }
+        },
+    ],
+
     // Set the production url of your site here
     url: 'https://kaito-project.github.io',
     // Set the /<baseUrl>/ pathname under which your site is served


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Currently, the search function in the docs site is not working because Algolia wasn't able to verify the ownership of the site domain.

<img width="1369" height="484" alt="image" src="https://github.com/user-attachments/assets/877a237f-068f-4025-ae98-545498d5972d" />

Per https://www.algolia.com/doc/tools/crawler/getting-started/create-crawler/#verify-your-domain, we can verify the domain by adding a `<meta>` HTML tag with specific content. I've added the site verification payload as a repository secret:

<img width="805" height="256" alt="image" src="https://github.com/user-attachments/assets/3f1be440-0603-422e-b838-d32291a7747c" />


**Testing**

<img width="373" height="173" alt="image" src="https://github.com/user-attachments/assets/9e44705b-cf4a-42b0-b3ca-f3c4d0f4e28f" />


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

Follow-up for #1197

**Notes for Reviewers**: