### PR TITLE
ci: add a GitHub Action to check pull request origin

### DIFF
--- a/.github/workflows/check-fork-pr.yml
+++ b/.github/workflows/check-fork-pr.yml
@@ -1,0 +1,31 @@
+name: Check Fork PR
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  check-fork:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
+      - name: Check if PR is from fork
+        run: |
+          echo "PR head repository: ${{ github.event.pull_request.head.repo.full_name }}"
+          echo "Base repository: ${{ github.event.pull_request.base.repo.full_name }}"
+          echo "Is fork: ${{ github.event.pull_request.head.repo.fork }}"
+
+          # Check if the PR is NOT from a fork
+          if [ "${{ github.event.pull_request.head.repo.fork }}" == "false" ]; then
+            echo "❌ Please create your PR from a fork of ${{ github.event.pull_request.base.repo.full_name }}. See https://github.com/kaito-project/kaito/issues/1301 for more information."
+            exit 1
+          else
+            echo "✅ This PR is from a fork. Check passed."
+          fi


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

This PR adds a GitHub Actions workflow to enforce that all pull requests must come from forked repositories rather than direct branches from https://github.com/kaito-project/kaito. This security enhancement prevents contributors from pushing branches directly to the main repository and ensures all contributions follow the standard fork-and-PR workflow. The workflow helps maintain branch hygiene,  better access control and follows open-source best practices.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

Fixes #1301

**Notes for Reviewers**: