### PR TITLE
chore: add more packages in python dependency install

### DIFF
--- a/presets/workspace/dependencies/README.md
+++ b/presets/workspace/dependencies/README.md
@@ -1,3 +1,12 @@
 # Requirement
 
-Pip dependencies for both KAITO inference and tuning.
+Pip dependencies for both Kaito inference and tuning.
+ - make sure you have installed following python packages before proceeding:
+```console
+pip install -U pip setuptools wheel
+```
+
+ - if you have problem installing `pyarrow` package, you could install an old version instead, e.g.
+```console
+pip install pyarrow==15.0.1
+```

--- a/presets/workspace/dependencies/README.md
+++ b/presets/workspace/dependencies/README.md
@@ -1,11 +1,6 @@
 # Requirement
 
 Pip dependencies for both Kaito inference and tuning.
- - make sure you have installed following python packages before proceeding:
-```console
-pip install -U pip setuptools wheel
-```
-
  - if you have problem installing `pyarrow` package, you could install an old version instead, e.g.
 ```console
 pip install pyarrow==15.0.1

--- a/presets/workspace/dependencies/requirements.txt
+++ b/presets/workspace/dependencies/requirements.txt
@@ -20,6 +20,8 @@ starlette==0.47.2
 ray[default]==2.43.0
 
 # Utility libraries
+setuptools>=77.0.3,<80.9.0
+wheel==0.45.1
 datasets==2.19.1
 peft==0.11.1
 bitsandbytes==0.45.3


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
chore: add more packages in python dependency install

<details>
<summary>
related error messages I have hit during `pip install -r ./presets/workspace/dependencies/requirements.txt`
</summary>

```
  Ã— Getting requirements to build wheel did not run successfully.
  â”‚ exit code: 1
  â•°â”€> [20 lines of output]
      Traceback (most recent call last):
        File "/usr/local/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 389, in <module>
          main()
        File "/usr/local/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 373, in main
          json_out["return_val"] = hook(**hook_input["kwargs"])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/usr/local/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 143, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-ubkg0pqw/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 331, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-ubkg0pqw/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 301, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-ubkg0pqw/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 512, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-ubkg0pqw/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 317, in run_setup
          exec(code, locals())
        File "<string>", line 24, in <module>
      ModuleNotFoundError: No module named 'torch'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error
```
 - `pip install pyarrow` failure
```
 -- Found Cython version: 3.1.2
  CMake Error at CMakeLists.txt:289 (find_package):
    By not providing "FindArrow.cmake" in CMAKE_MODULE_PATH this project has
    asked CMake to find a package configuration file provided by "Arrow", but
    CMake did not find one.

    Could not find a package configuration file provided by "Arrow" with any of
    the following names:

      ArrowConfig.cmake
      arrow-config.cmake

    Add the installation prefix of "Arrow" to CMAKE_PREFIX_PATH or set
    "Arrow_DIR" to a directory containing one of the above files.  If "Arrow"
    provides a separate development package or SDK, be sure it has been
    installed.


  -- Configuring incomplete, errors occurred!
  See also "/tmp/pip-install-o8cmp946/pyarrow_f6b9e6c5c6344c1d9282f0327da3bdbd/build/temp.linux-x86_64-cpython-312/CMakeFiles/CMakeOutput.log".
  error: command '/usr/bin/cmake' failed with exit code 1
  [end of output]
```

</details>

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: