### PR TITLE
feat: adding RAGEngine CRD shortName and ServiceReady status column

### DIFF
--- a/api/v1alpha1/ragengine_types.go
+++ b/api/v1alpha1/ragengine_types.go
@@ -99,10 +99,11 @@ type RAGEngineStatus struct {
 // RAGEngine is the Schema for the ragengine API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
-// +kubebuilder:resource:path=ragengines,scope=Namespaced,categories=ragengine
+// +kubebuilder:resource:path=ragengines,scope=Namespaced,categories=ragengine,shortName=rag
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Instance",type="string",JSONPath=".spec.compute.instanceType",description=""
 // +kubebuilder:printcolumn:name="ResourceReady",type="string",JSONPath=".status.conditions[?(@.type==\"ResourceReady\")].status",description=""
+// +kubebuilder:printcolumn:name="ServiceReady",type="string",JSONPath=".status.conditions[?(@.type==\"ServiceReady\")].status",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 type RAGEngine struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/charts/kaito/ragengine/crds/kaito.sh_ragengines.yaml
+++ b/charts/kaito/ragengine/crds/kaito.sh_ragengines.yaml
@@ -13,6 +13,8 @@ spec:
     kind: RAGEngine
     listKind: RAGEngineList
     plural: ragengines
+    shortNames:
+    - rag
     singular: ragengine
   scope: Namespaced
   versions:
@@ -22,6 +24,9 @@ spec:
       type: string
     - jsonPath: .status.conditions[?(@.type=="ResourceReady")].status
       name: ResourceReady
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ServiceReady")].status
+      name: ServiceReady
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age

--- a/config/crd/bases/kaito.sh_ragengines.yaml
+++ b/config/crd/bases/kaito.sh_ragengines.yaml
@@ -13,6 +13,8 @@ spec:
     kind: RAGEngine
     listKind: RAGEngineList
     plural: ragengines
+    shortNames:
+    - rag
     singular: ragengine
   scope: Namespaced
   versions:
@@ -22,6 +24,9 @@ spec:
       type: string
     - jsonPath: .status.conditions[?(@.type=="ResourceReady")].status
       name: ResourceReady
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ServiceReady")].status
+      name: ServiceReady
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age


### PR DESCRIPTION
**Reason for Change**:
Adding `rag` as a shortName for RAGEngine CR, and adding a ServiceReady column on the CR to display RAG service readiness.
