### PR TITLE
chore: Revert the model used in the rag e2e test back to Phi-3

### DIFF
--- a/test/rage2e/rag_test.go
+++ b/test/rage2e/rag_test.go
@@ -37,7 +37,7 @@ import (
 )
 
 const (
-	PresetPhi4MiniInstructModel = "phi-4-mini-instruct"
+	PresetPhi3Mini128kModel = "phi-3-mini-128k-instruct"
 )
 
 func loadTestEnvVars() {
@@ -271,7 +271,7 @@ func createPhi3WorkspaceWithPresetPublicModeAndVLLM(numOfReplica int) *kaitov1be
 		workspaceObj = utils.GenerateInferenceWorkspaceManifestWithVLLM(uniqueID, namespaceName, "", numOfReplica, "Standard_NV36ads_A10_v5",
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "rag-e2e-test-phi-4-mini-instruct-vllm"},
-			}, nil, PresetPhi4MiniInstructModel, nil, nil, nil, "")
+			}, nil, PresetPhi3Mini128kModel, nil, nil, nil, "")
 
 		createAndValidateWorkspace(workspaceObj)
 	})


### PR DESCRIPTION
**Reason for Change**:
Revert the model used in the rag e2e test back to Phi-3 to avoid the query test failure

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: