### PR TITLE
docs: fix ConfigMap creation sequence in example docs

### DIFF
--- a/examples/inference/kaito_workspace_custom_config.yaml
+++ b/examples/inference/kaito_workspace_custom_config.yaml
@@ -1,17 +1,3 @@
-apiVersion: kaito.sh/v1beta1
-kind: Workspace
-metadata:
-  name: workspace-deepseek-r1-distill-qwen-14b
-resource:
-  instanceType: "Standard_NC24ads_A100_v4"
-  labelSelector:
-    matchLabels:
-      apps: deepseek-r1-distill-qwen-14b
-inference:
-  preset:
-    name: "deepseek-r1-distill-qwen-14b"
-  config: "ds-inference-params"
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -32,3 +18,17 @@ data:
       num-scheduler-steps: 1
       enable-chunked-prefill: true
       # see https://docs.vllm.ai/en/latest/serving/engine_args.html for more options.
+---
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  name: workspace-deepseek-r1-distill-qwen-14b
+resource:
+  instanceType: "Standard_NC24ads_A100_v4"
+  labelSelector:
+    matchLabels:
+      apps: deepseek-r1-distill-qwen-14b
+inference:
+  preset:
+    name: "deepseek-r1-distill-qwen-14b"
+  config: "ds-inference-params"

--- a/examples/inference/kaito_workspace_llama-3.3_70b_instruct.yaml
+++ b/examples/inference/kaito_workspace_llama-3.3_70b_instruct.yaml
@@ -1,19 +1,3 @@
-apiVersion: kaito.sh/v1beta1
-kind: Workspace
-metadata:
-  name: workspace-llama-3-3-70b-instruct
-resource:
-  count: 2
-  instanceType: "Standard_NC48ads_A100_v4"
-  labelSelector:
-    matchLabels:
-      apps: llama-3-3-70b-instruct
-inference:
-  preset:
-    name: llama-3.3-70b-instruct
-    presetOptions:
-      modelAccessSecret: hf-token
-  config: "llama-inference-params"
 ---
 apiVersion: v1
 kind: Secret
@@ -34,3 +18,20 @@ data:
       gpu-memory-utilization: 0.95
       swap-space: 4
       max-model-len: 16384
+---
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  name: workspace-llama-3-3-70b-instruct
+resource:
+  count: 2
+  instanceType: "Standard_NC48ads_A100_v4"
+  labelSelector:
+    matchLabels:
+      apps: llama-3-3-70b-instruct
+inference:
+  preset:
+    name: llama-3.3-70b-instruct
+    presetOptions:
+      modelAccessSecret: hf-token
+  config: "llama-inference-params"

--- a/website/docs/inference.md
+++ b/website/docs/inference.md
@@ -80,21 +80,6 @@ Multi-node distributed inference is currently supported only with the vLLM runti
 Users can customize vLLM runtime parameters by creating a ConfigMap containing an `inference_config.yaml` file and referencing it in the workspace spec. For example:
 
 ```yaml
-apiVersion: kaito.sh/v1beta1
-kind: Workspace
-metadata:
-  namespace: myns
-  name: workspace-example
-resource:
-  instanceType: "Standard_NC24ads_A100_v4"
-  labelSelector:
-    matchLabels:
-      apps: example
-inference:
-  preset:
-    name: "example-model"
-  config: "my-inference-params"  # Reference to ConfigMap name
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -109,6 +94,21 @@ data:
       max-model-len: 131072         # Maximum sequence length
       swap-space: 4                 # CPU swap space in GB
       cpu-offload-gb: 0             # Amount of GPU memory to offload to CPU
+---
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  namespace: myns
+  name: workspace-example
+resource:
+  instanceType: "Standard_NC24ads_A100_v4"
+  labelSelector:
+    matchLabels:
+      apps: example
+inference:
+  preset:
+    name: "example-model"
+  config: "my-inference-params"  # Reference to ConfigMap name
 ```
 
 Key vLLM parameters include:

--- a/website/docs/multi-node-inference.md
+++ b/website/docs/multi-node-inference.md
@@ -88,6 +88,16 @@ Pre-provisioned nodes must have the same matching labels as specified in the `re
 You can customize vLLM runtime parameters for distributed inference using a ConfigMap:
 
 ```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: distributed-inference-config
+data:
+  inference_config.yaml: |
+    vllm:
+      gpu-memory-utilization: 0.95
+      max-model-len: 131072
+---
 apiVersion: kaito.sh/v1beta1
 kind: Workspace
 metadata:
@@ -102,16 +112,6 @@ inference:
   preset:
     name: "llama-3.3-70b-instruct"
   config: "distributed-inference-config"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: distributed-inference-config
-data:
-  inference_config.yaml: |
-    vllm:
-      gpu-memory-utilization: 0.95
-      max-model-len: 131072
 ```
 
 Key parameters for multi-node inference:

--- a/website/versioned_docs/version-v0.5.0/inference.md
+++ b/website/versioned_docs/version-v0.5.0/inference.md
@@ -80,21 +80,6 @@ Multi-node distributed inference is currently supported only with the vLLM runti
 Users can customize vLLM runtime parameters by creating a ConfigMap containing an `inference_config.yaml` file and referencing it in the workspace spec. For example:
 
 ```yaml
-apiVersion: kaito.sh/v1beta1
-kind: Workspace
-metadata:
-  namespace: myns
-  name: workspace-example
-resource:
-  instanceType: "Standard_NC24ads_A100_v4"
-  labelSelector:
-    matchLabels:
-      apps: example
-inference:
-  preset:
-    name: "example-model"
-  config: "my-inference-params"  # Reference to ConfigMap name
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -109,6 +94,21 @@ data:
       max-model-len: 131072         # Maximum sequence length
       swap-space: 4                 # CPU swap space in GB
       cpu-offload-gb: 0             # Amount of GPU memory to offload to CPU
+---
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  namespace: myns
+  name: workspace-example
+resource:
+  instanceType: "Standard_NC24ads_A100_v4"
+  labelSelector:
+    matchLabels:
+      apps: example
+inference:
+  preset:
+    name: "example-model"
+  config: "my-inference-params"  # Reference to ConfigMap name
 ```
 
 Key vLLM parameters include:

--- a/website/versioned_docs/version-v0.5.0/multi-node-inference.md
+++ b/website/versioned_docs/version-v0.5.0/multi-node-inference.md
@@ -87,6 +87,16 @@ Pre-provisioned nodes must have the same matching labels as specified in the `re
 You can customize vLLM runtime parameters for distributed inference using a ConfigMap:
 
 ```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: distributed-inference-config
+data:
+  inference_config.yaml: |
+    vllm:
+      gpu-memory-utilization: 0.95
+      max-model-len: 131072
+---
 apiVersion: kaito.sh/v1beta1
 kind: Workspace
 metadata:
@@ -101,16 +111,6 @@ inference:
   preset:
     name: "llama-3.3-70b-instruct"
   config: "distributed-inference-config"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: distributed-inference-config
-data:
-  inference_config.yaml: |
-    vllm:
-      gpu-memory-utilization: 0.95
-      max-model-len: 131072
 ```
 
 Key parameters for multi-node inference:

--- a/website/versioned_docs/version-v0.5.1/inference.md
+++ b/website/versioned_docs/version-v0.5.1/inference.md
@@ -80,21 +80,6 @@ Multi-node distributed inference is currently supported only with the vLLM runti
 Users can customize vLLM runtime parameters by creating a ConfigMap containing an `inference_config.yaml` file and referencing it in the workspace spec. For example:
 
 ```yaml
-apiVersion: kaito.sh/v1beta1
-kind: Workspace
-metadata:
-  namespace: myns
-  name: workspace-example
-resource:
-  instanceType: "Standard_NC24ads_A100_v4"
-  labelSelector:
-    matchLabels:
-      apps: example
-inference:
-  preset:
-    name: "example-model"
-  config: "my-inference-params"  # Reference to ConfigMap name
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -109,6 +94,21 @@ data:
       max-model-len: 131072         # Maximum sequence length
       swap-space: 4                 # CPU swap space in GB
       cpu-offload-gb: 0             # Amount of GPU memory to offload to CPU
+---
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  namespace: myns
+  name: workspace-example
+resource:
+  instanceType: "Standard_NC24ads_A100_v4"
+  labelSelector:
+    matchLabels:
+      apps: example
+inference:
+  preset:
+    name: "example-model"
+  config: "my-inference-params"  # Reference to ConfigMap name
 ```
 
 Key vLLM parameters include:

--- a/website/versioned_docs/version-v0.5.1/multi-node-inference.md
+++ b/website/versioned_docs/version-v0.5.1/multi-node-inference.md
@@ -87,6 +87,16 @@ Pre-provisioned nodes must have the same matching labels as specified in the `re
 You can customize vLLM runtime parameters for distributed inference using a ConfigMap:
 
 ```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: distributed-inference-config
+data:
+  inference_config.yaml: |
+    vllm:
+      gpu-memory-utilization: 0.95
+      max-model-len: 131072
+---
 apiVersion: kaito.sh/v1beta1
 kind: Workspace
 metadata:
@@ -101,16 +111,6 @@ inference:
   preset:
     name: "llama-3.3-70b-instruct"
   config: "distributed-inference-config"
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: distributed-inference-config
-data:
-  inference_config.yaml: |
-    vllm:
-      gpu-memory-utilization: 0.95
-      max-model-len: 131072
 ```
 
 Key parameters for multi-node inference:


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
doc: fix ConfigMap creation sequence in example docs

ConfigMap should be created before worksapce, otherwise in the first run of `kubectl apply -f ...` command, it would report ConfigMap not found error, then you need to run `kubectl apply -f ...` command twice to workaround this issue.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: