### PR TITLE
ci: update generate-identities.sh to take 3 position args only

### DIFF
--- a/.github/actions/e2e-base-setup/action.yaml
+++ b/.github/actions/e2e-base-setup/action.yaml
@@ -138,7 +138,6 @@ runs:
     - name: Create Identities and Permissions for ${{ inputs.node_provisioner }}
       shell: bash
       run: |
-        AZURE_SUBSCRIPTION_ID=$E2E_SUBSCRIPTION_ID \
         make generate-identities
       env:
         AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}
@@ -149,7 +148,6 @@ runs:
       if: ${{ inputs.node_provisioner == 'gpuprovisioner' }}
       shell: bash
       run: |
-        AZURE_SUBSCRIPTION_ID=$E2E_SUBSCRIPTION_ID \
         make gpu-provisioner-helm
       env:
         AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}

--- a/Makefile
+++ b/Makefile
@@ -428,7 +428,7 @@ aws-patch-install-helm: ## Install Kaito workspace Helm chart and set AWS env va
 
 generate-identities: ## Create identities for the provisioner component.
 	./hack/deploy/generate-identities.sh \
-	$(AZURE_CLUSTER_NAME) $(AZURE_RESOURCE_GROUP) $(TEST_SUITE) $(AZURE_SUBSCRIPTION_ID)
+	$(AZURE_CLUSTER_NAME) $(AZURE_RESOURCE_GROUP) $(TEST_SUITE)
 
 ## --------------------------------------
 ## GPU Provisioner Installation

--- a/hack/deploy/generate-identities.sh
+++ b/hack/deploy/generate-identities.sh
@@ -7,8 +7,8 @@ set -euo pipefail
 # and the name of the component for which the identities and role assignments are being created.
 # # Path: hack/deploy/deploy.sh
 
-if [ "$#" -ne 4 ]; then
-    echo "Usage: $0 <cluster-name> <resource-group> <component-name> <subscription-id>"
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 <cluster-name> <resource-group> <component-name>"
     exit 1
 fi
 
@@ -18,7 +18,6 @@ AZURE_CLUSTER_NAME=$1
 AZURE_RESOURCE_GROUP=$2
 COMPONENT_NAME=$3
 
-AZURE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
 AKS_JSON=$(az aks show --name "${AZURE_CLUSTER_NAME}" --resource-group "${AZURE_RESOURCE_GROUP}")
 IDENTITY_NAME=${COMPONENT_NAME}Identity
 FED_NAME=${COMPONENT_NAME}-fed


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Fixes e2e CI failure in https://github.com/kaito-project/kaito/actions/runs/16755370055/job/47437848976?pr=1345, which is likely caused by the lost of `E2E_SUBSCRIPTION_ID` variable somewhere that I can't identify. I realized AZURE_SBUSCRIPTION_ID environment variable is not used anymore so let's remove it from `make generate-identities` and `make gpu-provisioner-helm`.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: