### PR TITLE
ci: update release branch prefix to 'release-'

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
       release_branch:
-        description: 'Release branch (e.g., official/v0.2.2)'
+        description: 'Release branch (e.g., release-0.6)'
         required: true
         type: string
 
@@ -40,7 +40,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-          ref: ${{ github.event.inputs.release_branch }}
+          ref: ${{ github.event.inputs.release_version }}
 
       - name: Validate inputs
         run: |
@@ -49,8 +49,8 @@ jobs:
             echo "Error: Release version must follow format vX.Y.Z"
             exit 1
           fi
-          if [[ ! "${{ github.event.inputs.release_branch }}" =~ ^official/ ]]; then
-            echo "Error: Release branch must start with 'official/'"
+          if [[ ! "${{ github.event.inputs.release_branch }}" =~ ^release- ]]; then
+            echo "Error: Release branch must start with 'release-'"
             exit 1
           fi
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Transition release branch prefix from `official/v0.X.Y` to `release-0.X`

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: