### PR TITLE
chore: polish local-csi-driver charts

### DIFF
--- a/charts/kaito/ragengine/templates/deployment.yaml
+++ b/charts/kaito/ragengine/templates/deployment.yaml
@@ -33,6 +33,8 @@ spec:
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           env:
+            - name: CONFIG_LOGGING_NAME
+              value: "kaito-logging-config"
             - name: WEBHOOK_SERVICE
               value: {{ include "kaito.fullname" . }}
             - name: WEBHOOK_PORT

--- a/charts/kaito/ragengine/templates/knative-logging-configmap.yaml
+++ b/charts/kaito/ragengine/templates/knative-logging-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-logging
+  name: kaito-logging-config
   namespace: {{ .Release.Namespace }}
 data:
   loglevel.controller: {{ .Values.logging.level | quote }}

--- a/charts/kaito/workspace/templates/deployment.yaml
+++ b/charts/kaito/workspace/templates/deployment.yaml
@@ -35,6 +35,8 @@ spec:
           args:
             - --feature-gates={{ include "utils.joinKeyValuePairs" .Values.featureGates }}
           env:
+            - name: CONFIG_LOGGING_NAME
+              value: "kaito-logging-config"
             - name: WEBHOOK_SERVICE
               value: {{ include "kaito.fullname" . }}-svc
             - name: WEBHOOK_PORT

--- a/charts/kaito/workspace/templates/knative-logging-configmap.yaml
+++ b/charts/kaito/workspace/templates/knative-logging-configmap.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: config-logging
+  name: kaito-logging-config
   namespace: {{ .Release.Namespace }}
 data:
   loglevel.controller: {{ .Values.logging.level | quote }}

--- a/charts/kaito/workspace/templates/local-csi-driver-ds.yaml
+++ b/charts/kaito/workspace/templates/local-csi-driver-ds.yaml
@@ -249,9 +249,6 @@ spec:
         volumeMounts:
         - mountPath: /dev
           name: device
-        - mountPath: /etc/kubernetes/
-          name: k8s-cfg
-          readOnly: true
         - mountPath: /csi
           name: csi-socket-dir
         - mountPath: /var/lib/kubelet/
@@ -391,10 +388,6 @@ spec:
           path: /dev
           type: Directory
         name: device
-      - hostPath:
-          path: /etc/kubernetes/
-          type: DirectoryOrCreate
-        name: k8s-cfg
       - hostPath:
           path: /var/lib/kubelet/plugins/localdisk.csi.acstor.io/
           type: DirectoryOrCreate

--- a/charts/kaito/workspace/templates/local-csi-storageclass.yaml
+++ b/charts/kaito/workspace/templates/local-csi-storageclass.yaml
@@ -1,16 +1,12 @@
 # notes: This CSI driver is compatible with various environments, including Azure and AWS,
 # ensuring broad interoperability without vendor lock-in.
-{{- if not (lookup "storage.k8s.io/v1" "StorageClass" "" "kaito-local-nvme-disk") }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: kaito-local-nvme-disk
   labels:
     {{- include "kaito.labels" . | nindent 4 }}
-parameters:
-  {}
 provisioner: localdisk.csi.acstor.io
 reclaimPolicy: Delete
 volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
-{{- end }}

--- a/hack/local-csi-driver-charts-sync/local-csi-driver-charts-sync.sh
+++ b/hack/local-csi-driver-charts-sync/local-csi-driver-charts-sync.sh
@@ -32,7 +32,7 @@ echo "Created temporary directory: $TEMP_DIR"
 echo "Cloning $REPO repository..."
 git clone "$REPO" "$REPO_DIR"
 echo "Checking out revision: $REVISION"
-(cd "$REPO_DIR" && git switch -c "$REVISION") || { echo "Failed to checkout revision $REVISION"; exit 1; }
+(cd "$REPO_DIR" && git checkout "$REVISION") || { echo "Failed to checkout revision $REVISION"; exit 1; }
 
 helm template --release-name local-csi-driver \
   --set image.driver.tag="0.0.1-latest" \

--- a/hack/local-csi-driver-charts-sync/local-csi-driver-charts.diff
+++ b/hack/local-csi-driver-charts-sync/local-csi-driver-charts.diff
@@ -1,5 +1,5 @@
 diff --git a/./local-csi-driver-charts.yaml b/./charts/kaito/workspace/templates/local-csi-driver-ds.yaml
-index 93d0b57..54cb7e4 100644
+index 93d0b571..cd8173e2 100644
 --- a/./local-csi-driver-charts.yaml
 +++ b/./charts/kaito/workspace/templates/local-csi-driver-ds.yaml
 @@ -4,13 +4,9 @@ apiVersion: v1
@@ -89,3 +89,24 @@ index 93d0b57..54cb7e4 100644
          imagePullPolicy: IfNotPresent
          livenessProbe:
            httpGet:
+@@ -262,9 +242,6 @@ spec:
+         volumeMounts:
+         - mountPath: /dev
+           name: device
+-        - mountPath: /etc/kubernetes/
+-          name: k8s-cfg
+-          readOnly: true
+         - mountPath: /csi
+           name: csi-socket-dir
+         - mountPath: /var/lib/kubelet/
+@@ -404,10 +381,6 @@ spec:
+           path: /dev
+           type: Directory
+         name: device
+-      - hostPath:
+-          path: /etc/kubernetes/
+-          type: DirectoryOrCreate
+-        name: k8s-cfg
+       - hostPath:
+           path: /var/lib/kubelet/plugins/localdisk.csi.acstor.io/
+           type: DirectoryOrCreate


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

- remove /etc/kubernetes/ hostpath mount
- rename logging configmap to avoid confliction

**Notes for Reviewers**:

both helm upgrade and rollback are tested.