### PR TITLE
feat: add custom workspace examples for gpt-oss

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,12 @@
 [![codecov](https://codecov.io/gh/kaito-project/kaito/graph/badge.svg?token=XAQLLPB2AR)](https://codecov.io/gh/kaito-project/kaito)
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkaito-project%2Fkaito.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkaito-project%2Fkaito?ref=badge_shield)
 
-| ![notification](website/static/img/bell.svg) What is NEW!                                                                                                                                                                                                |
-| ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| ![notification](website/static/img/bell.svg) What is NEW! |
+| --------------------------------------------------------- |
+| Added custom workspace examples for HuggingFace models [openai/gpt-oss-20b](https://github.com/kaito-project/kaito/tree/main/examples/inference/kaito_workspace_gpt_oss_20b_custom.yaml) and [openai/gpt-oss-120b](https://github.com/kaito-project/kaito/tree/main/examples/inference/kaito_workspace_gpt_oss_120b_custom.yaml). These use a pre-release [`vllm/vllm-openai:gptoss`](https://hub.docker.com/layers/vllm/vllm-openai/gptoss/images/sha256-23c3feefba723be97ff9e9bd769aed7d165839a79bc042eb8f3a13dd2a469e1c) image and are **not recommended for production**. We are actively working on adding official KAITO presets for these models. |
 | Retrieval Augmented Generation (RAG) support is live! - KAITO RagEngine uses LlamaIndex and FAISS, learn about from [here](https://kaito-project.github.io/kaito/docs/rag)! |
-| Latest Release: Aug 7th, 2025. KAITO v0.6.0                                                                                                                                                                                                  |
-| First Release: Nov 15th, 2023. KAITO v0.1.0.                                                                                                                                                                                                   |
+| Latest Release: Aug 7th, 2025. KAITO v0.6.0 |
+| First Release: Nov 15th, 2023. KAITO v0.1.0. |
 
 KAITO is an operator that automates the AI/ML model inference or tuning workload in a Kubernetes cluster.
 The target models are popular open-sourced large models such as [phi-4](https://huggingface.co/microsoft/phi-4) and [llama](https://huggingface.co/meta-llama).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 | ![notification](website/static/img/bell.svg) What is NEW! |
 | --------------------------------------------------------- |
-| Added custom workspace examples for HuggingFace models [openai/gpt-oss-20b](https://github.com/kaito-project/kaito/tree/main/examples/inference/kaito_workspace_gpt_oss_20b_custom.yaml) and [openai/gpt-oss-120b](https://github.com/kaito-project/kaito/tree/main/examples/inference/kaito_workspace_gpt_oss_120b_custom.yaml). These use a pre-release [`vllm/vllm-openai:gptoss`](https://hub.docker.com/layers/vllm/vllm-openai/gptoss/images/sha256-23c3feefba723be97ff9e9bd769aed7d165839a79bc042eb8f3a13dd2a469e1c) image and are **not recommended for production**. We are actively working on adding official KAITO presets for these models. |
+| Added custom workspace examples for HuggingFace models [openai/gpt-oss-20b](https://github.com/kaito-project/kaito/tree/main/examples/inference/kaito_workspace_gpt_oss_20b.yaml) and [openai/gpt-oss-120b](https://github.com/kaito-project/kaito/tree/main/examples/inference/kaito_workspace_gpt_oss_120b.yaml). These use a pre-release [`vllm/vllm-openai:gptoss`](https://hub.docker.com/layers/vllm/vllm-openai/gptoss/images/sha256-23c3feefba723be97ff9e9bd769aed7d165839a79bc042eb8f3a13dd2a469e1c) image and are **not recommended for production**. We are actively working on adding official KAITO presets for these models. |
 | Retrieval Augmented Generation (RAG) support is live! - KAITO RagEngine uses LlamaIndex and FAISS, learn about from [here](https://kaito-project.github.io/kaito/docs/rag)! |
 | Latest Release: Aug 7th, 2025. KAITO v0.6.0 |
 | First Release: Nov 15th, 2023. KAITO v0.1.0. |

--- a/examples/inference/kaito_workspace_gpt_oss_120b.yaml
+++ b/examples/inference/kaito_workspace_gpt_oss_120b.yaml
@@ -1,0 +1,51 @@
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  name: workspace-gpt-oss-120b
+resource:
+  instanceType: Standard_NC40ads_H100_v5
+  labelSelector:
+    matchLabels:
+      app: gpt-oss-120b
+inference:
+  template:
+    metadata:
+      labels:
+        app: gpt-oss-120b
+    spec:
+      containers:
+        - name: vllm-openai
+          image: vllm/vllm-openai:gptoss
+          imagePullPolicy: IfNotPresent
+          args:
+            - --model
+            - openai/gpt-oss-120b
+            - --swap-space
+            - "4"
+            - --gpu-memory-utilization
+            - "0.85"
+            - --port
+            - "5000"
+          # https://github.com/vllm-project/vllm/issues/22290#issuecomment-3157328173
+          env:
+            - name: VLLM_ATTENTION_BACKEND
+              value: TRITON_ATTN_VLLM_V1
+          ports:
+            - containerPort: 5000
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+            requests:
+              nvidia.com/gpu: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 5000
+            initialDelaySeconds: 60
+            periodSeconds: 15
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 5000
+            initialDelaySeconds: 900
+            periodSeconds: 30

--- a/examples/inference/kaito_workspace_gpt_oss_20b.yaml
+++ b/examples/inference/kaito_workspace_gpt_oss_20b.yaml
@@ -1,0 +1,51 @@
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  name: workspace-gpt-oss-20b
+resource:
+  instanceType: Standard_NV36ads_A10_v5
+  labelSelector:
+    matchLabels:
+      node.kubernetes.io/instance-type: Standard_NV36ads_A10_v5
+inference:
+  template:
+    metadata:
+      labels:
+        app: gpt-oss-20b
+    spec:
+      containers:
+        - name: vllm-openai
+          image: vllm/vllm-openai:gptoss
+          imagePullPolicy: IfNotPresent
+          args:
+            - --model
+            - openai/gpt-oss-20b
+            - --swap-space
+            - "4"
+            - --gpu-memory-utilization
+            - "0.85"
+            - --port
+            - "5000"
+          # https://github.com/vllm-project/vllm/issues/22290#issuecomment-3157328173
+          env:
+            - name: VLLM_ATTENTION_BACKEND
+              value: TRITON_ATTN_VLLM_V1
+          ports:
+            - containerPort: 5000
+          resources:
+            limits:
+              nvidia.com/gpu: 1
+            requests:
+              nvidia.com/gpu: 1
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: 5000
+            initialDelaySeconds: 30
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: 5000
+            initialDelaySeconds: 600
+            periodSeconds: 20

--- a/website/versioned_docs/version-v0.6.x/intro.md
+++ b/website/versioned_docs/version-v0.6.x/intro.md
@@ -5,7 +5,7 @@ slug: /
 
 :::info What's NEW!
 
-Added custom workspace examples for HuggingFace models [openai/gpt-oss-20b](https://github.com/kaito-project/kaito/tree/main/examples/inference/kaito_workspace_gpt_oss_20b_custom.yaml) and [openai/gpt-oss-120b](https://github.com/kaito-project/kaito/tree/main/examples/inference/kaito_workspace_gpt_oss_120b_custom.yaml). These use a pre-release [`vllm/vllm-openai:gptoss`](https://hub.docker.com/layers/vllm/vllm-openai/gptoss/images/sha256-23c3feefba723be97ff9e9bd769aed7d165839a79bc042eb8f3a13dd2a469e1c) image and are **not recommended for production**. We are actively working on adding official KAITO presets for these models.
+Added custom workspace examples for HuggingFace models [openai/gpt-oss-20b](https://github.com/kaito-project/kaito/tree/main/examples/inference/kaito_workspace_gpt_oss_20b.yaml) and [openai/gpt-oss-120b](https://github.com/kaito-project/kaito/tree/main/examples/inference/kaito_workspace_gpt_oss_120b.yaml). These use a pre-release [`vllm/vllm-openai:gptoss`](https://hub.docker.com/layers/vllm/vllm-openai/gptoss/images/sha256-23c3feefba723be97ff9e9bd769aed7d165839a79bc042eb8f3a13dd2a469e1c) image and are **not recommended for production**. We are actively working on adding official KAITO presets for these models.
 
 
 Retrieval Augmented Generation (RAG) support is live! - KAITO RagEngine uses LlamaIndex and FAISS, learn about from [here](https://kaito-project.github.io/kaito/docs/rag)!

--- a/website/versioned_docs/version-v0.6.x/intro.md
+++ b/website/versioned_docs/version-v0.6.x/intro.md
@@ -5,8 +5,12 @@ slug: /
 
 :::info What's NEW!
 
+Added custom workspace examples for HuggingFace models [openai/gpt-oss-20b](https://github.com/kaito-project/kaito/tree/main/examples/inference/kaito_workspace_gpt_oss_20b_custom.yaml) and [openai/gpt-oss-120b](https://github.com/kaito-project/kaito/tree/main/examples/inference/kaito_workspace_gpt_oss_120b_custom.yaml). These use a pre-release [`vllm/vllm-openai:gptoss`](https://hub.docker.com/layers/vllm/vllm-openai/gptoss/images/sha256-23c3feefba723be97ff9e9bd769aed7d165839a79bc042eb8f3a13dd2a469e1c) image and are **not recommended for production**. We are actively working on adding official KAITO presets for these models.
+
+
 Retrieval Augmented Generation (RAG) support is live! - KAITO RagEngine uses LlamaIndex and FAISS, learn about from [here](https://kaito-project.github.io/kaito/docs/rag)!
-**Latest Release:** July 18th, 2025. KAITO v0.5.1.
+
+**Latest Release:** Aug 7th, 2025. KAITO v0.6.0.
 
 **First Release:** Nov 15th, 2023. KAITO v0.1.0.
 :::


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

feat: add custom workspace examples for gpt-oss

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

```
❯ k get workspace
NAME                    INSTANCE                  RESOURCEREADY   INFERENCEREADY   JOBSTARTED   WORKSPACESUCCEEDED   AGE
workspace-gpt-oss-20b   Standard_NV36ads_A10_v5   True            True                          True                 3h1m

❯ k get po
NAME                                    READY   STATUS    RESTARTS   AGE
workspace-gpt-oss-20b-7d67867cc-f8v7t   1/1     Running   0          178m
```

<img width="1682" height="1059" alt="image" src="https://github.com/user-attachments/assets/a40a2cc1-6e06-4e1f-bfdd-2fc02e43c57c" />


**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

Ref #1354

**Notes for Reviewers**: