### PR TITLE
chore: bump local-csi-driver to v0.2.4

### DIFF
--- a/charts/kaito/workspace/templates/local-csi-driver-ds.yaml
+++ b/charts/kaito/workspace/templates/local-csi-driver-ds.yaml
@@ -193,6 +193,7 @@ spec:
         - --trace-sample-rate=1000000
         - --trace-service-id=$(POD_NAME)
         - --v=2
+        - --enable-cleanup=true
         command:
         - /local-csi-driver
         env:
@@ -208,7 +209,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.3"
+        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.4"
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/hack/local-csi-driver-charts-sync/local-csi-driver-charts-sync.sh
+++ b/hack/local-csi-driver-charts-sync/local-csi-driver-charts-sync.sh
@@ -12,7 +12,7 @@
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 
 REPO=https://github.com/Azure/local-csi-driver.git
-REVISION="a9a2fd1af2d0fbfe4262f66105dc2569b6394a9c"
+REVISION="38cdc94deda8548076d670ea1beba5d69b349a81"
 
 TEMP_DIR=$(mktemp -d)
 REPO_DIR="$TEMP_DIR/local-csi-driver"
@@ -36,7 +36,7 @@ echo "Checking out revision: $REVISION"
 
 helm template --release-name local-csi-driver \
   --set image.driver.tag="0.0.1-latest" \
-  --set webhook.ephemeral.enabled=false \
+  --set webhook.enforceEphemeral.enabled=false \
   --set webhook.hyperconverged.enabled=false \
   --set observability.metrics.enabled=false \
   "$REPO_DIR/charts/latest/" > "$REPO_DIR/local-csi-driver-charts.yaml"

--- a/hack/local-csi-driver-charts-sync/local-csi-driver-charts.diff
+++ b/hack/local-csi-driver-charts-sync/local-csi-driver-charts.diff
@@ -1,5 +1,5 @@
 diff --git a/./local-csi-driver-charts.yaml b/./charts/kaito/workspace/templates/local-csi-driver-ds.yaml
-index 93d0b571..cd8173e2 100644
+index e7365b6..82e259f 100644
 --- a/./local-csi-driver-charts.yaml
 +++ b/./charts/kaito/workspace/templates/local-csi-driver-ds.yaml
 @@ -4,13 +4,9 @@ apiVersion: v1
@@ -80,33 +80,21 @@ index 93d0b571..cd8173e2 100644
        annotations:
          kubectl.kubernetes.io/default-container: driver
      spec:
-@@ -221,7 +201,7 @@ spec:
+@@ -222,7 +202,7 @@ spec:
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
 -        image: "localcsidriver.azurecr.io/acstor/local-csi-driver:0.0.1-latest"
-+        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.3"
++        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.4"
          imagePullPolicy: IfNotPresent
          livenessProbe:
            httpGet:
-@@ -262,9 +242,6 @@ spec:
-         volumeMounts:
-         - mountPath: /dev
-           name: device
--        - mountPath: /etc/kubernetes/
--          name: k8s-cfg
--          readOnly: true
-         - mountPath: /csi
-           name: csi-socket-dir
-         - mountPath: /var/lib/kubelet/
-@@ -404,10 +381,6 @@ spec:
-           path: /dev
-           type: Directory
-         name: device
--      - hostPath:
--          path: /etc/kubernetes/
--          type: DirectoryOrCreate
--        name: k8s-cfg
-       - hostPath:
-           path: /var/lib/kubelet/plugins/localdisk.csi.acstor.io/
-           type: DirectoryOrCreate
+@@ -287,8 +267,6 @@ spec:
+         - --capacity-poll-interval=15s
+         - --v=2
+         env:
+-        # POD_NAME and POD_NAMESPACE are used for capacity tracking support
+-        # More info: https://github.com/kubernetes-csi/external-provisioner?tab=readme-ov-file#capacity-support
+         - name: NAMESPACE
+           valueFrom:
+             fieldRef:


### PR DESCRIPTION
**Reason for Change**:
Updates local-csi-driver to v0.2.4

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:

Release notes: https://github.com/Azure/local-csi-driver/releases/tag/v0.2.4

The `--enable-cleanup=true` flag was added in https://github.com/Azure/local-csi-driver/pull/146. It deletes the VG + PV if there are no LV when the pod is deleted, which helps clean up the node so it can be re-used.

The ephemeral webhook flag name was changed in https://github.com/Azure/local-csi-driver/pull/136.

Waiting for the image to publish in MCR, then ready for review.