### PR TITLE
docs: add hideable sidebar option to Docusaurus config

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -97,6 +97,11 @@ const config = {
                     },
                 ],
             },
+            docs: {
+                sidebar: {
+                    hideable: true,
+                },
+            },
             footer: {
                 style: 'dark',
                 links: [


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

this PR adds a hideable option to the Docusaurus sidebar configuration allowing users to easily toggle sidebar visibility. It improves website navigation and user experience by providing more flexibility

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

No related GitHub issue; this is a minor UX enhancement with no breaking changes to existing website structure