### PR TITLE
fix: cannot read kv-cache-cpu-memory-utilization from ConfigMap

### DIFF
--- a/charts/kaito/workspace/templates/inference-params.yaml
+++ b/charts/kaito/workspace/templates/inference-params.yaml
@@ -8,6 +8,9 @@ data:
     # Maximum number of steps to find the max available seq len fitting in the GPU memory.
     max_probe_steps: 6
 
+    # Optional: CPU memory utilization for the vllm engine in kv cache offload mode. (default: 0.5, set to 0 to disable)
+    kv_cache_cpu_memory_utilization: 0.5
+
     vllm:
       cpu-offload-gb: 0
       swap-space: 4

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -73,7 +73,6 @@ class KAITOArgumentParser(argparse.ArgumentParser):
         self.add_argument(
             "--kaito-kv-cache-cpu-memory-utilization",
             type=float,
-            default=0.5,
             help="KV cache CPU memory utilization.",
         )
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
fix: cannot read  kv-cache-cpu-memory-utilization from ConfigMap

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: