### PR TITLE
Revert "fix: add missing pynvml package dependency"

### DIFF
--- a/presets/workspace/dependencies/requirements.txt
+++ b/presets/workspace/dependencies/requirements.txt
@@ -15,7 +15,6 @@ sentencepiece==0.2.0
 jinja2>=3.1.0
 starlette==0.47.2
 lmcache==0.3.3
-pynvml==12.0.0
 
 # For accessing Ray dashboard. ray[default] version should be consistent with the one in vllm/vllm-openai:<vllm-version>.
 # Check with `docker run --entrypoint "" vllm/vllm-openai:<vllm-version> pip freeze | grep ray`


### PR DESCRIPTION
Reverts kaito-project/kaito#1424

[`nvidia-ml-py`](https://pypi.org/project/nvidia-ml-py/) is already added in https://github.com/kaito-project/kaito/pull/1405. https://pypi.org/project/pynvml/ is NOT the correct package to import `pynvml`.

<img width="1138" height="573" alt="image" src="https://github.com/user-attachments/assets/e77fe46f-9872-45eb-867a-797fa01b31a2" />