### PR TITLE
fix: remove new line in hf-token secret

### DIFF
--- a/pkg/ragengine/manifests/manifests.go
+++ b/pkg/ragengine/manifests/manifests.go
@@ -14,6 +14,8 @@
 package manifests
 
 import (
+	"strings"
+
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -127,7 +129,7 @@ func RAGSetEnv(ragEngineObj *kaitov1alpha1.RAGEngine) []corev1.EnvVar {
 			envs = append(envs, modelIDEnv)
 		}
 		if ragEngineObj.Spec.Embedding.Local.ModelAccessSecret != "" {
-			accessSecret := ragEngineObj.Spec.Embedding.Local.ModelAccessSecret
+			accessSecret := strings.TrimRight(ragEngineObj.Spec.Embedding.Local.ModelAccessSecret, "\n")
 			accessSecretEnv := corev1.EnvVar{
 				Name:  "ACCESS_SECRET",
 				Value: accessSecret,

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
@@ -407,7 +408,7 @@ func SetModelDownloadInfo(ctx *generator.WorkspaceGeneratorContext, spec *corev1
 			ValueFrom: &corev1.EnvVarSource{
 				SecretKeyRef: &corev1.SecretKeySelector{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: ctx.Workspace.Inference.Preset.PresetOptions.ModelAccessSecret,
+						Name: strings.TrimRight(ctx.Workspace.Inference.Preset.PresetOptions.ModelAccessSecret, "\n"),
 					},
 					Key: "HF_TOKEN",
 				},


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
fix: remove new line in hf-token secret

this is a common mistake if user base64 encode a huggingface token by using `echo hf-token | base64` which append a new line automatically, the right command is `echo -n hf-token | base64`, this PR removes the new line in RAG and preset for huggingface token wihch could avoid such mistake

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: