### PR TITLE
fix: add nodeSelector on Linux to avoid crash on Windows node

### DIFF
--- a/charts/kaito/workspace/templates/nvidia-device-plugin-ds.yaml
+++ b/charts/kaito/workspace/templates/nvidia-device-plugin-ds.yaml
@@ -16,6 +16,8 @@ spec:
       labels:
         name: nvidia-device-plugin-ds
     spec:
+      nodeSelector:
+        kubernetes.io/os: linux
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:

--- a/charts/kaito/workspace/values.yaml
+++ b/charts/kaito/workspace/values.yaml
@@ -32,7 +32,8 @@ resources:
   requests:
     cpu: 10m
     memory: 64Mi
-nodeSelector: {}
+nodeSelector:
+  kubernetes.io/os: linux
 tolerations: []
 affinity: {}
 # Values can be "azure" or "aws" or "arc"


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
fix: add nodeSelector on Linux to avoid crash on Windows node

```
kaito-workspace     kaito-workspace-6db9666b47-xjz7m                      0/1     ImagePullBackOff    0               12d     10.244.4.201   akswgen2000000                      <none>           <none>
kaito-workspace     nvidia-device-plugin-daemonset-nx8d7                  0/1     ImagePullBackOff    0               27d     10.244.4.237   akswgen2000000                      <none>           <none>
```

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: