### PR TITLE
docs: update slack community links to cncf workspace

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,14 +149,13 @@ Linux Foundation ID group through the [Linux Foundation Support website](https:/
 
 ## Get Involved!
 
-- Join our [KAITO Community Slack](https://join.slack.com/t/kaito-z6a6575/shared_invite/zt-37gh89vw7-odHfqmPRc5oRnDG99SBJNA) to discuss features in development and proposals.
+- Visit [#kaito channel in CNCF Slack](https://cloud-native.slack.com/archives/C09B4EWCZ5M) to discuss features in development and proposals.
 - We host a weekly community meeting for contributors on Tuesdays at 4:00pm PST. Please join here: [meeting link](https://zoom-lfx.platform.linuxfoundation.org/meeting/99948431028?password=05912bb9-53fb-4b22-a634-ab5f8261e94c).
 - Reference the weekly meeting notes in our [KAITO community calls doc](https://docs.google.com/document/d/1OEC-WUQ2wn0TDQPsU09shMoXn5cW3dSrdu-M43Q79dA/edit?usp=sharing)!
 
 ## License
 
 See [Apache License 2.0](LICENSE).
-
 
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fkaito-project%2Fkaito.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fkaito-project%2Fkaito?ref=badge_large)
 

--- a/website/docs/intro.md
+++ b/website/docs/intro.md
@@ -63,5 +63,5 @@ The details of the service APIs can be found in this [document](./rag.md).
 ## Community
 
 - **GitHub**: [kaito-project/kaito](https://github.com/kaito-project/kaito)
-- **Slack**: [Join our community](https://join.slack.com/t/kaito-z6a6575/shared_invite/zt-37gh89vw7-odHfqmPRc5oRnDG99SBJNA)
+- **Slack**: [Join #kaito channel in CNCF Slack](https://cloud-native.slack.com/archives/C09B4EWCZ5M)
 - **Email**: [kaito-dev@microsoft.com](mailto:kaito-dev@microsoft.com)

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -127,7 +127,7 @@ const config = {
                             },
                             {
                                 label: 'Slack',
-                                href: 'https://join.slack.com/t/kaito-z6a6575/shared_invite/zt-37gh89vw7-odHfqmPRc5oRnDG99SBJNA',
+                                href: 'https://cloud-native.slack.com/archives/C09B4EWCZ5M',
                             },
                         ],
                     },


### PR DESCRIPTION
**Reason for Change:**
Update community Slack links to point to CNCF workspace where KAITO discussions now take place. this improves discoverability of the kaito community and aligns with our cncf participation
