### PR TITLE
docs: fix bits of spellings and revise code of conduct for clarity

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,9 +1,17 @@
 # KAITO Code of Conduct
 
-This project has adopted the [Cloud Native Compute Foundation Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md).
+The KAITO project follows the [Cloud Native Computing Foundation (CNCF) Code of Conduct](https://github.com/cncf/foundation/blob/main/code-of-conduct.md) to ensure a respectful, inclusive, and collaborative community.
 
-Resources:
+## Resources
 
-- [Jurisdiction Policy](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md)
-- For detailed instructions on how to submit a report, including how to submit a report anonymously, please see the [Incident Resolution Procedures](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md).
-- For incidents occurring in the Kubernetes community, please contact the [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) via <conduct@kubernetes.io>.
+- **Jurisdiction Policy**
+
+  Read the [CNCF Code of Conduct Committee Jurisdiction Policy](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-committee-jurisdiction-policy.md)
+
+- **Incident Reporting**
+
+  For detailed instructions on how to report an incident, including anonymous submissions, please refer to the [Incident Resolution Procedures](https://github.com/cncf/foundation/blob/main/code-of-conduct/coc-incident-resolution-procedures.md)
+
+- **Kubernetes Community Incidents**
+
+  If the incident occurs within the Kubernetes community, please contact the [Kubernetes Code of Conduct Committee](https://git.k8s.io/community/committee-code-of-conduct) at **[conduct@kubernetes.io](mailto:conduct@kubernetes.io)**


### PR DESCRIPTION
Updated the KAITO Code of Conduct to clarify resources and reporting procedures