### PR TITLE
fix: add presets/ragengine to rag e2e test workflow

### DIFF
--- a/.github/workflows/ragengine-e2e.yaml
+++ b/.github/workflows/ragengine-e2e.yaml
@@ -10,6 +10,7 @@ on:
       - 'test/**'
       - 'pkg/ragengine/**'
       - '.github/**'
+      - 'presets/ragengine/**'
 
 env:
   GO_VERSION: "1.24"


### PR DESCRIPTION
**Reason for Change**:
add presets/ragengine to rag e2e test workflow so pr's for ragengine ask for the e2e workflow run

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: