### PR TITLE
docs: update istio environment variable in installation step

### DIFF
--- a/website/docs/gateway-api-inference-extension.md
+++ b/website/docs/gateway-api-inference-extension.md
@@ -65,8 +65,8 @@ helm upgrade -i istio-base oci://$HUB/charts/base --version $TAG -n istio-system
 helm upgrade -i istiod oci://$HUB/charts/istiod \
   --version $TAG \
   -n istio-system \
-  --set meshConfig.defaultConfig.proxyMetadata.SUPPORT_GATEWAY_API_INFERENCE_EXTENSION="true" \
-  --set pilot.env.SUPPORT_GATEWAY_API_INFERENCE_EXTENSION="true" \
+  --set meshConfig.defaultConfig.proxyMetadata.ENABLE_GATEWAY_API_INFERENCE_EXTENSION="true" \
+  --set pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION="true" \
   --set tag=$TAG \
   --set hub=$HUB \
   --wait


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Follow-up for #1434. The correct environment variable to enable during istio installation should be `ENABLE_GATEWAY_API_INFERENCE_EXTENSION`.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: