### PR TITLE
chore: bump local-csi-driver v0.2.3 -> v0.2.4 -> v0.2.5 

### DIFF
--- a/charts/kaito/workspace/templates/local-csi-driver-ds.yaml
+++ b/charts/kaito/workspace/templates/local-csi-driver-ds.yaml
@@ -193,6 +193,7 @@ spec:
         - --trace-sample-rate=1000000
         - --trace-service-id=$(POD_NAME)
         - --v=2
+        - --enable-cleanup=true
         command:
         - /local-csi-driver
         env:
@@ -208,7 +209,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.3"
+        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.4"
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/charts/kaito/workspace/templates/local-csi-driver-ds.yaml
+++ b/charts/kaito/workspace/templates/local-csi-driver-ds.yaml
@@ -209,7 +209,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.4"
+        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.5"
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -240,11 +240,10 @@ spec:
             cpu: 10m
             memory: 60Mi
         securityContext:
-          allowPrivilegeEscalation: true
-          capabilities:
-            add:
-            - SYS_ADMIN
           privileged: true
+          capabilities:
+            drop:
+              - ALL
         terminationMessagePath: /tmp/termination-log
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
@@ -308,6 +307,12 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
         - mountPath: /csi
           name: csi-socket-dir
@@ -336,6 +341,12 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
         - mountPath: /csi
           name: csi-socket-dir
@@ -367,6 +378,12 @@ spec:
           requests:
             cpu: 10m
             memory: 20Mi
+        securityContext:
+          readOnlyRootFilesystem: true
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
         volumeMounts:
         - mountPath: /csi
           name: csi-socket-dir
@@ -379,7 +396,7 @@ spec:
       priorityClassName: system-node-critical
       securityContext:
         seccompProfile:
-          type: Unconfined
+          type: RuntimeDefault
       serviceAccountName: csi-local-node
       terminationGracePeriodSeconds: 60
       tolerations:

--- a/hack/local-csi-driver-charts-sync/local-csi-driver-charts-sync.sh
+++ b/hack/local-csi-driver-charts-sync/local-csi-driver-charts-sync.sh
@@ -12,7 +12,7 @@
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 
 REPO=https://github.com/Azure/local-csi-driver.git
-REVISION="a9a2fd1af2d0fbfe4262f66105dc2569b6394a9c"
+REVISION="38cdc94deda8548076d670ea1beba5d69b349a81"
 
 TEMP_DIR=$(mktemp -d)
 REPO_DIR="$TEMP_DIR/local-csi-driver"
@@ -36,7 +36,7 @@ echo "Checking out revision: $REVISION"
 
 helm template --release-name local-csi-driver \
   --set image.driver.tag="0.0.1-latest" \
-  --set webhook.ephemeral.enabled=false \
+  --set webhook.enforceEphemeral.enabled=false \
   --set webhook.hyperconverged.enabled=false \
   --set observability.metrics.enabled=false \
   "$REPO_DIR/charts/latest/" > "$REPO_DIR/local-csi-driver-charts.yaml"

--- a/hack/local-csi-driver-charts-sync/local-csi-driver-charts-sync.sh
+++ b/hack/local-csi-driver-charts-sync/local-csi-driver-charts-sync.sh
@@ -12,7 +12,7 @@
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 
 REPO=https://github.com/Azure/local-csi-driver.git
-REVISION="38cdc94deda8548076d670ea1beba5d69b349a81"
+REVISION="06932013f5ab544172636a3d907a551914f64b68"
 
 TEMP_DIR=$(mktemp -d)
 REPO_DIR="$TEMP_DIR/local-csi-driver"

--- a/hack/local-csi-driver-charts-sync/local-csi-driver-charts.diff
+++ b/hack/local-csi-driver-charts-sync/local-csi-driver-charts.diff
@@ -1,5 +1,5 @@
 diff --git a/./local-csi-driver-charts.yaml b/./charts/kaito/workspace/templates/local-csi-driver-ds.yaml
-index e7365b6..82e259f 100644
+index 44411b40..9b9877c8 100644
 --- a/./local-csi-driver-charts.yaml
 +++ b/./charts/kaito/workspace/templates/local-csi-driver-ds.yaml
 @@ -4,13 +4,9 @@ apiVersion: v1
@@ -85,11 +85,11 @@ index e7365b6..82e259f 100644
              fieldRef:
                fieldPath: spec.nodeName
 -        image: "localcsidriver.azurecr.io/acstor/local-csi-driver:0.0.1-latest"
-+        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.4"
++        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.5"
          imagePullPolicy: IfNotPresent
          livenessProbe:
            httpGet:
-@@ -287,8 +267,6 @@ spec:
+@@ -286,8 +266,6 @@ spec:
          - --capacity-poll-interval=15s
          - --v=2
          env:

--- a/hack/local-csi-driver-charts-sync/local-csi-driver-charts.diff
+++ b/hack/local-csi-driver-charts-sync/local-csi-driver-charts.diff
@@ -1,5 +1,5 @@
 diff --git a/./local-csi-driver-charts.yaml b/./charts/kaito/workspace/templates/local-csi-driver-ds.yaml
-index 93d0b57..54cb7e4 100644
+index e7365b6..82e259f 100644
 --- a/./local-csi-driver-charts.yaml
 +++ b/./charts/kaito/workspace/templates/local-csi-driver-ds.yaml
 @@ -4,13 +4,9 @@ apiVersion: v1
@@ -80,12 +80,21 @@ index 93d0b57..54cb7e4 100644
        annotations:
          kubectl.kubernetes.io/default-container: driver
      spec:
-@@ -221,7 +201,7 @@ spec:
+@@ -222,7 +202,7 @@ spec:
            valueFrom:
              fieldRef:
                fieldPath: spec.nodeName
 -        image: "localcsidriver.azurecr.io/acstor/local-csi-driver:0.0.1-latest"
-+        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.3"
++        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.4"
          imagePullPolicy: IfNotPresent
          livenessProbe:
            httpGet:
+@@ -287,8 +267,6 @@ spec:
+         - --capacity-poll-interval=15s
+         - --v=2
+         env:
+-        # POD_NAME and POD_NAMESPACE are used for capacity tracking support
+-        # More info: https://github.com/kubernetes-csi/external-provisioner?tab=readme-ov-file#capacity-support
+         - name: NAMESPACE
+           valueFrom:
+             fieldRef:


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Bump local-csi-driver from v0.2.3 to v0.2.5 by cherry-picking #1406 and then #1440.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: