### PR TITLE
release: update helm chart workflows to accept tag input from workflow_dispatch

### DIFF
--- a/.github/workflows/publish-ragengine-helm-chart.yaml
+++ b/.github/workflows/publish-ragengine-helm-chart.yaml
@@ -1,6 +1,11 @@
 name: Publish ragengine helm chart
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v0.6.1)'
+        required: true
   repository_dispatch:
     types: [ publish-ragengine-helm-chart ]
 
@@ -28,7 +33,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-          ref: ${{ github.event.client_payload.tag }}
+          ref: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
 
       - name: Package ragengine helm chart
         run: |
@@ -42,5 +47,3 @@ jobs:
           charts_dir: packaged-rag
           target_dir: charts/kaito
           linting: off
-
- 

--- a/.github/workflows/publish-workspace-helm-chart.yaml
+++ b/.github/workflows/publish-workspace-helm-chart.yaml
@@ -1,6 +1,11 @@
 name: Publish workspace helm chart
 
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v0.6.1)'
+        required: true
   repository_dispatch:
     types: [ publish-workspace-helm-chart ]
 
@@ -28,7 +33,7 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-          ref: ${{ github.event.client_payload.tag }}
+          ref: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
 
       - name: Package workspace helm chart
         run: |


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

The current release pipeline can only publish helm charts right after building the controller images. For the upcoming patch release v0.6.1, since it's a helm-chart-only change and there is no change to the controller images, there is no need to trigger the entire release pipeline. Instead, this PR adds the option to only trigger the publish helm charts pipeline only.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: