### PR TITLE
feat: add node manager for ensuring device plugin and accelerator label

### DIFF
--- a/pkg/utils/workspace/workspace_test.go
+++ b/pkg/utils/workspace/workspace_test.go
@@ -320,7 +320,10 @@ func TestUpdateWorkspaceStatus(t *testing.T) {
 
 		ctx := context.Background()
 		key := &client.ObjectKey{Name: "test-workspace", Namespace: "default"}
-		err := UpdateWorkspaceStatus(ctx, mockClient, key, condition)
+		err := UpdateWorkspaceStatus(ctx, mockClient, key, func(status *kaitov1beta1.WorkspaceStatus) error {
+			meta.SetStatusCondition(&status.Conditions, *condition)
+			return nil
+		})
 
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
@@ -345,7 +348,10 @@ func TestUpdateWorkspaceStatus(t *testing.T) {
 
 		ctx := context.Background()
 		key := &client.ObjectKey{Name: "test-workspace", Namespace: "default"}
-		err := UpdateWorkspaceStatus(ctx, mockClient, key, condition)
+		err := UpdateWorkspaceStatus(ctx, mockClient, key, func(status *kaitov1beta1.WorkspaceStatus) error {
+			meta.SetStatusCondition(&status.Conditions, *condition)
+			return nil
+		})
 
 		assert.NoError(t, err) // Should not return error for NotFound
 		mockClient.AssertExpectations(t)
@@ -368,7 +374,10 @@ func TestUpdateWorkspaceStatus(t *testing.T) {
 
 		ctx := context.Background()
 		key := &client.ObjectKey{Name: "test-workspace", Namespace: "default"}
-		err := UpdateWorkspaceStatus(ctx, mockClient, key, condition)
+		err := UpdateWorkspaceStatus(ctx, mockClient, key, func(status *kaitov1beta1.WorkspaceStatus) error {
+			meta.SetStatusCondition(&status.Conditions, *condition)
+			return nil
+		})
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "network error")
@@ -447,7 +456,10 @@ func TestUpdateWorkspaceStatus(t *testing.T) {
 
 		ctx := context.Background()
 		key := &client.ObjectKey{Name: "test-workspace", Namespace: "default"}
-		err := UpdateWorkspaceStatus(ctx, mockClient, key, condition)
+		err := UpdateWorkspaceStatus(ctx, mockClient, key, func(status *kaitov1beta1.WorkspaceStatus) error {
+			meta.SetStatusCondition(&status.Conditions, *condition)
+			return nil
+		})
 
 		assert.NoError(t, err)
 		mockClient.AssertExpectations(t)
@@ -488,7 +500,10 @@ func TestUpdateWorkspaceStatus(t *testing.T) {
 
 		ctx := context.Background()
 		key := &client.ObjectKey{Name: "test-workspace", Namespace: "default"}
-		err := UpdateWorkspaceStatus(ctx, mockClient, key, condition)
+		err := UpdateWorkspaceStatus(ctx, mockClient, key, func(status *kaitov1beta1.WorkspaceStatus) error {
+			meta.SetStatusCondition(&status.Conditions, *condition)
+			return nil
+		})
 
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "permanent error")

--- a/pkg/workspace/resource/node.go
+++ b/pkg/workspace/resource/node.go
@@ -1,0 +1,175 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sort"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/utils"
+	"github.com/kaito-project/kaito/pkg/utils/nodeclaim"
+	"github.com/kaito-project/kaito/pkg/utils/resources"
+	"github.com/kaito-project/kaito/pkg/utils/workspace"
+)
+
+type NodeManager struct {
+	client.Client
+}
+
+func NewNodeManager(c client.Client) *NodeManager {
+	return &NodeManager{
+		Client: c,
+	}
+}
+
+func (c *NodeManager) EnsureNodeResource(ctx context.Context, wObj *kaitov1beta1.Workspace, existingNodeClaims []*karpenterv1.NodeClaim, workerNodes []string) (bool, error) {
+	// ensure Nvidia device plugins are ready for the workspace when instance type is known.
+	knownGPUConfig, _ := utils.GetGPUConfigBySKU(wObj.Resource.InstanceType)
+	if knownGPUConfig != nil {
+		readyNodeClaims := make([]*karpenterv1.NodeClaim, 0, len(existingNodeClaims))
+		for i := range existingNodeClaims {
+			if nodeclaim.IsNodeClaimReadyNotDeleting(existingNodeClaims[i]) {
+				readyNodeClaims = append(readyNodeClaims, existingNodeClaims[i])
+			}
+		}
+
+		if isReady, err := c.ensureNodePlugin(ctx, wObj, readyNodeClaims); err != nil {
+			if updateErr := workspace.UpdateStatusConditionIfNotMatch(ctx, c.Client, wObj, kaitov1beta1.ConditionTypeResourceStatus, metav1.ConditionFalse,
+				"workspaceResourceStatusFailed", err.Error()); updateErr != nil {
+				klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
+				return isReady, updateErr
+			}
+			return isReady, err
+		} else if !isReady {
+			return isReady, nil
+		}
+	}
+
+	// Add the ready nodes names to the WorkspaceStatus.WorkerNodes.
+	sort.Strings(workerNodes)
+	if !reflect.DeepEqual(wObj.Status.WorkerNodes, workerNodes) {
+		if err := workspace.UpdateWorkspaceStatus(ctx, c.Client, &client.ObjectKey{Name: wObj.Name, Namespace: wObj.Namespace}, func(status *kaitov1beta1.WorkspaceStatus) error {
+			status.WorkerNodes = workerNodes
+			return nil
+		}); err != nil {
+			if updateErr := workspace.UpdateStatusConditionIfNotMatch(ctx, c.Client, wObj, kaitov1beta1.ConditionTypeResourceStatus, metav1.ConditionFalse,
+				"workspaceResourceStatusFailed", err.Error()); updateErr != nil {
+				klog.ErrorS(updateErr, "failed to update workspace status", "workspace", klog.KObj(wObj))
+				return false, updateErr
+			}
+			return false, err
+		}
+	}
+
+	if err := workspace.UpdateStatusConditionIfNotMatch(ctx, c.Client, wObj, kaitov1beta1.ConditionTypeResourceStatus, metav1.ConditionTrue,
+		"workspaceResourceStatusSuccess", "workspace resource is ready"); err != nil {
+		klog.ErrorS(err, "failed to update workspace status", "workspace", klog.KObj(wObj))
+		return false, err
+	}
+
+	return true, nil
+}
+
+// ensureNodePlugin ensures that NVIDIA device plugins are ready on all nodes for the workspace
+func (c *NodeManager) ensureNodePlugin(ctx context.Context, wObj *kaitov1beta1.Workspace, readyNodeClaims []*karpenterv1.NodeClaim) (bool, error) {
+	nodes, err := c.getReadyNodesFromNodeClaims(ctx, wObj, readyNodeClaims)
+	if err != nil {
+		if updateErr := workspace.UpdateStatusConditionIfNotMatch(ctx, c.Client, wObj, kaitov1beta1.ConditionTypeResourceStatus, metav1.ConditionFalse,
+			"NodeListError", fmt.Sprintf("Failed to get nodes for workspace: %v", err)); updateErr != nil {
+			klog.ErrorS(updateErr, "failed to update resource status condition", "workspace", klog.KObj(wObj))
+			return false, updateErr
+		}
+		return false, fmt.Errorf("failed to get nodes for workspace: %w", err)
+	}
+
+	// Check each node for NVIDIA accelerator label and GPU capacity
+	for _, node := range nodes {
+		if accelerator, exists := node.Labels[resources.LabelKeyNvidia]; !exists || accelerator != resources.LabelValueNvidia {
+			if node.Labels == nil {
+				node.Labels = make(map[string]string)
+			}
+			node.Labels[resources.LabelKeyNvidia] = resources.LabelValueNvidia
+
+			if err := c.Client.Update(ctx, node); err != nil {
+				if updateErr := workspace.UpdateStatusConditionIfNotMatch(ctx, c.Client, wObj, kaitov1beta1.ConditionTypeResourceStatus, metav1.ConditionFalse,
+					"NodeUpdateError", fmt.Sprintf("Failed to update node %s with accelerator label: %v", node.Name, err)); updateErr != nil {
+					klog.ErrorS(updateErr, "failed to update resource status condition", "workspace", klog.KObj(wObj))
+				}
+				return false, fmt.Errorf("failed to update node %s with accelerator label: %w", node.Name, err)
+			}
+		}
+
+		gpuCapacity := node.Status.Capacity[resources.CapacityNvidiaGPU]
+		if gpuCapacity.IsZero() {
+			if updateErr := workspace.UpdateStatusConditionIfNotMatch(ctx, c.Client, wObj, kaitov1beta1.ConditionTypeResourceStatus, metav1.ConditionFalse,
+				"GPUCapacityNotReady", fmt.Sprintf("Node %s has zero GPU capacity", node.Name)); updateErr != nil {
+				klog.ErrorS(updateErr, "failed to update resource status condition", "workspace", klog.KObj(wObj))
+				return false, fmt.Errorf("failed to update resource status condition: %w", updateErr)
+			}
+
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// getReadyNodesFromNodeClaims retrieves all ready nodes that are associated with NodeClaims for the workspace.
+// This function excludes preferred nodes and only returns nodes that were provisioned through NodeClaims.
+// It's primarily used for device plugin management where we need to ensure GPU nodes created by
+// NodeClaims have the proper NVIDIA device plugins installed.
+func (c *NodeManager) getReadyNodesFromNodeClaims(ctx context.Context, wObj *kaitov1beta1.Workspace, readyNodeClaims []*karpenterv1.NodeClaim) ([]*corev1.Node, error) {
+	nodes := make([]*corev1.Node, 0, len(readyNodeClaims))
+	for _, nodeClaim := range readyNodeClaims {
+		if nodeClaim.Status.NodeName == "" {
+			continue
+		}
+
+		node, err := resources.GetNode(ctx, nodeClaim.Status.NodeName, c.Client)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				continue
+			}
+			return nil, fmt.Errorf("failed to get node %s: %w", nodeClaim.Status.NodeName, err)
+		}
+
+		if !resources.NodeIsReadyAndNotDeleting(node) {
+			klog.V(4).InfoS("Node is not ready, skipping",
+				"node", node.Name,
+				"workspace", klog.KObj(wObj))
+			continue
+		}
+
+		if node.Labels[corev1.LabelInstanceTypeStable] != wObj.Resource.InstanceType {
+			klog.V(4).InfoS("Node instance type does not match workspace, skipping",
+				"node", node.Name,
+				"workspace", klog.KObj(wObj))
+			continue
+		}
+
+		nodes = append(nodes, node)
+	}
+
+	return nodes, nil
+}

--- a/pkg/workspace/resource/node_test.go
+++ b/pkg/workspace/resource/node_test.go
@@ -1,0 +1,625 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/awslabs/operatorpkg/status"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/utils/resources"
+	"github.com/kaito-project/kaito/pkg/utils/test"
+)
+
+func TestNewNodeResourceManager(t *testing.T) {
+	mockClient := test.NewClient()
+
+	manager := NewNodeManager(mockClient)
+
+	assert.NotNil(t, manager)
+	assert.Equal(t, mockClient, manager.Client)
+}
+
+func TestEnsureNodeResource(t *testing.T) {
+	tests := []struct {
+		name               string
+		workspace          *kaitov1beta1.Workspace
+		existingNodeClaims []*karpenterv1.NodeClaim
+		workerNodes        []string
+		setup              func(*test.MockClient)
+		expectedReady      bool
+		expectedError      bool
+	}{
+		{
+			name: "Should succeed when instance type has no known GPU config",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType:  "Standard_D2s_v3", // Non-GPU instance type
+					LabelSelector: &metav1.LabelSelector{},
+				},
+				Status: kaitov1beta1.WorkspaceStatus{
+					WorkerNodes: []string{"node1"},
+				},
+			},
+			existingNodeClaims: []*karpenterv1.NodeClaim{},
+			workerNodes:        []string{"node1", "node2"},
+			setup: func(mockClient *test.MockClient) {
+				// Mock Get for workspace status update
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				// Mock status update for worker nodes and resource status
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedReady: true,
+			expectedError: false,
+		},
+		{
+			name: "Should succeed when GPU instance type and device plugins are ready",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType:  "Standard_NC12s_v3", // GPU instance type
+					LabelSelector: &metav1.LabelSelector{},
+				},
+				Status: kaitov1beta1.WorkspaceStatus{
+					WorkerNodes: []string{},
+				},
+			},
+			existingNodeClaims: []*karpenterv1.NodeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-nodeclaim"},
+					Status: karpenterv1.NodeClaimStatus{
+						Conditions: []status.Condition{
+							{Type: "Ready", Status: metav1.ConditionTrue},
+						},
+						NodeName: "test-node",
+					},
+				},
+			},
+			workerNodes: []string{"test-node"},
+			setup: func(mockClient *test.MockClient) {
+				// Create a ready node with GPU capacity and correct labels
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Labels: map[string]string{
+							corev1.LabelInstanceTypeStable: "Standard_NC12s_v3",
+							resources.LabelKeyNvidia:       resources.LabelValueNvidia,
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+						Capacity: corev1.ResourceList{
+							resources.CapacityNvidiaGPU: resource.MustParse("1"),
+						},
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(node)
+
+				// Mock Get for node and workspace status update
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				// Mock status update
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedReady: true,
+			expectedError: false,
+		},
+		{
+			name: "Should fail when device plugins check fails due to node get error",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType:  "Standard_NC12s_v3", // GPU instance type
+					LabelSelector: &metav1.LabelSelector{},
+				},
+			},
+			existingNodeClaims: []*karpenterv1.NodeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-nodeclaim"},
+					Status: karpenterv1.NodeClaimStatus{
+						Conditions: []status.Condition{
+							{Type: "Ready", Status: metav1.ConditionTrue},
+						},
+						NodeName: "test-node",
+					},
+				},
+			},
+			workerNodes: []string{"test-node"},
+			setup: func(mockClient *test.MockClient) {
+				// Mock Get for workspace status update
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("node get failed"))
+
+				// Mock status update for error condition
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedReady: false,
+			expectedError: true,
+		},
+		{
+			name: "Should update worker nodes when they differ",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType:  "Standard_D2s_v3",
+					LabelSelector: &metav1.LabelSelector{},
+				},
+				Status: kaitov1beta1.WorkspaceStatus{
+					WorkerNodes: []string{"old-node"},
+				},
+			},
+			existingNodeClaims: []*karpenterv1.NodeClaim{},
+			workerNodes:        []string{"new-node1", "new-node2"},
+			setup: func(mockClient *test.MockClient) {
+				// Mock Get for workspace status update
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				// Mock status update for worker nodes and resource status
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedReady: true,
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := test.NewClient()
+			tt.setup(mockClient)
+
+			manager := NewNodeManager(mockClient)
+			ready, err := manager.EnsureNodeResource(context.Background(), tt.workspace, tt.existingNodeClaims, tt.workerNodes)
+
+			assert.Equal(t, tt.expectedReady, ready)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestEnsureNodePlugin(t *testing.T) {
+	tests := []struct {
+		name            string
+		workspace       *kaitov1beta1.Workspace
+		readyNodeClaims []*karpenterv1.NodeClaim
+		setup           func(*test.MockClient)
+		expectedReady   bool
+		expectedError   bool
+	}{
+		{
+			name: "Should fail when getReadyNodesFromNodeClaims fails",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType:  "Standard_NC12s_v3",
+					LabelSelector: &metav1.LabelSelector{},
+				},
+			},
+			readyNodeClaims: []*karpenterv1.NodeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-nodeclaim"},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "test-node",
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock failing node Get
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("node get failed"))
+
+				// Mock status update for error condition
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedReady: false,
+			expectedError: true,
+		},
+		{
+			name: "Should add accelerator label and succeed when node lacks it",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType:  "Standard_NC12s_v3",
+					LabelSelector: &metav1.LabelSelector{},
+				},
+			},
+			readyNodeClaims: []*karpenterv1.NodeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-nodeclaim"},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "test-node",
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Create a node without accelerator label but with GPU capacity
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Labels: map[string]string{
+							corev1.LabelInstanceTypeStable: "Standard_NC12s_v3",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+						Capacity: corev1.ResourceList{
+							resources.CapacityNvidiaGPU: resource.MustParse("1"),
+						},
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(node)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				// Mock node update
+				mockClient.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedReady: true,
+			expectedError: false,
+		},
+		{
+			name: "Should wait when node has zero GPU capacity",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType:  "Standard_NC12s_v3",
+					LabelSelector: &metav1.LabelSelector{},
+				},
+			},
+			readyNodeClaims: []*karpenterv1.NodeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-nodeclaim"},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "test-node",
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Create a node with accelerator label but zero GPU capacity
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Labels: map[string]string{
+							corev1.LabelInstanceTypeStable: "Standard_NC12s_v3",
+							resources.LabelKeyNvidia:       resources.LabelValueNvidia,
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+						Capacity: corev1.ResourceList{
+							resources.CapacityNvidiaGPU: resource.MustParse("0"),
+						},
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(node)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+				// Mock status update for GPU capacity not ready
+				mockClient.StatusMock.On("Update", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedReady: false,
+			expectedError: false,
+		},
+		{
+			name: "Should succeed when all nodes have GPU capacity and labels",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType:  "Standard_NC12s_v3",
+					LabelSelector: &metav1.LabelSelector{},
+				},
+			},
+			readyNodeClaims: []*karpenterv1.NodeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-nodeclaim"},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "test-node",
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Create a ready node with GPU capacity and correct labels
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Labels: map[string]string{
+							corev1.LabelInstanceTypeStable: "Standard_NC12s_v3",
+							resources.LabelKeyNvidia:       resources.LabelValueNvidia,
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+						Capacity: corev1.ResourceList{
+							resources.CapacityNvidiaGPU: resource.MustParse("1"),
+						},
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(node)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedReady: true,
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := test.NewClient()
+			tt.setup(mockClient)
+
+			manager := NewNodeManager(mockClient)
+			ready, err := manager.ensureNodePlugin(context.Background(), tt.workspace, tt.readyNodeClaims)
+
+			assert.Equal(t, tt.expectedReady, ready)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestGetReadyNodesFromNodeClaims(t *testing.T) {
+	tests := []struct {
+		name            string
+		workspace       *kaitov1beta1.Workspace
+		readyNodeClaims []*karpenterv1.NodeClaim
+		setup           func(*test.MockClient)
+		expectedNodes   int
+		expectedError   bool
+	}{
+		{
+			name: "Should skip NodeClaim without assigned node",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType:  "Standard_NC12s_v3",
+					LabelSelector: &metav1.LabelSelector{},
+				},
+			},
+			readyNodeClaims: []*karpenterv1.NodeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-nodeclaim"},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "", // No node assigned
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// No setup needed - will skip NodeClaim without NodeName
+			},
+			expectedNodes: 0,
+			expectedError: false,
+		},
+		{
+			name: "Should skip when node doesn't exist",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType:  "Standard_NC12s_v3",
+					LabelSelector: &metav1.LabelSelector{},
+				},
+			},
+			readyNodeClaims: []*karpenterv1.NodeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-nodeclaim"},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "nonexistent-node",
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock Get to return NotFound error
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(apierrors.NewNotFound(schema.GroupResource{Resource: "nodes"}, "nonexistent-node"))
+			},
+			expectedNodes: 0,
+			expectedError: false,
+		},
+		{
+			name: "Should return error when node Get fails with non-NotFound error",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType:  "Standard_NC12s_v3",
+					LabelSelector: &metav1.LabelSelector{},
+				},
+			},
+			readyNodeClaims: []*karpenterv1.NodeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-nodeclaim"},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "test-node",
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Mock Get to return a different error
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(errors.New("api server error"))
+			},
+			expectedNodes: 0,
+			expectedError: true,
+		},
+		{
+			name: "Should skip node that is not ready",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType:  "Standard_NC12s_v3",
+					LabelSelector: &metav1.LabelSelector{},
+				},
+			},
+			readyNodeClaims: []*karpenterv1.NodeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-nodeclaim"},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "test-node",
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Create a node that is not ready
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionFalse,
+							},
+						},
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(node)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedNodes: 0,
+			expectedError: false,
+		},
+		{
+			name: "Should skip node with different instance type",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType:  "Standard_NC12s_v3",
+					LabelSelector: &metav1.LabelSelector{},
+				},
+			},
+			readyNodeClaims: []*karpenterv1.NodeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-nodeclaim"},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "test-node",
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Create a ready node with different instance type
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Labels: map[string]string{
+							corev1.LabelInstanceTypeStable: "Standard_D2s_v3", // Different instance type
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(node)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedNodes: 0,
+			expectedError: false,
+		},
+		{
+			name: "Should return ready node with matching instance type",
+			workspace: &kaitov1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
+				Resource: kaitov1beta1.ResourceSpec{
+					InstanceType:  "Standard_NC12s_v3",
+					LabelSelector: &metav1.LabelSelector{},
+				},
+			},
+			readyNodeClaims: []*karpenterv1.NodeClaim{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "test-nodeclaim"},
+					Status: karpenterv1.NodeClaimStatus{
+						NodeName: "test-node",
+					},
+				},
+			},
+			setup: func(mockClient *test.MockClient) {
+				// Create a ready node with matching instance type
+				node := &corev1.Node{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-node",
+						Labels: map[string]string{
+							corev1.LabelInstanceTypeStable: "Standard_NC12s_v3",
+						},
+					},
+					Status: corev1.NodeStatus{
+						Conditions: []corev1.NodeCondition{
+							{
+								Type:   corev1.NodeReady,
+								Status: corev1.ConditionTrue,
+							},
+						},
+					},
+				}
+				mockClient.CreateOrUpdateObjectInMap(node)
+				mockClient.On("Get", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			},
+			expectedNodes: 1,
+			expectedError: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := test.NewClient()
+			tt.setup(mockClient)
+
+			manager := NewNodeManager(mockClient)
+			nodes, err := manager.getReadyNodesFromNodeClaims(context.Background(), tt.workspace, tt.readyNodeClaims)
+
+			assert.Len(t, nodes, tt.expectedNodes)
+			if tt.expectedError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
1. add node manager for ensuring device plugin and accelerator label

2. Workspace controller reconcile will be refactored as follows(not in this pull request):

- Configure Workspace Replicas Setting(https://github.com/kaito-project/kaito/pull/1473)
     ⬇️
-  DiffNodeClaims(https://github.com/kaito-project/kaito/pull/1461 done)
     ⬇️
- ScaleUpNodeClaims(https://github.com/kaito-project/kaito/pull/1461 done)
     ⬇️
- MeetReadyNodeClaimsTarget(https://github.com/kaito-project/kaito/pull/1461 done)
     ⬇️
- EnusreNodeResource(this pull request)
     ⬇️
- Scaleup/scaledown workloads (include in the workspace controller refactor)
     ⬇️
- Update Workspace Inference Status (include in the workspace controller refactor)
     ⬇️
- ScaleDownNodeClaims(https://github.com/kaito-project/kaito/pull/1461 done)

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: