### PR TITLE
ci: add workflow_dispatch options to publish pipelines

### DIFF
--- a/.github/workflows/publish-rag-controller-mcr-image.yaml
+++ b/.github/workflows/publish-rag-controller-mcr-image.yaml
@@ -1,5 +1,10 @@
 name: Publish RAGEngine MCR image
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'tag to be created for this image (e.g. v0.6.0)'
+        required: true
   repository_dispatch:
     types: [ publish-rag-controller-mcr-image ]
 
@@ -24,14 +29,14 @@ jobs:
 
       - name: Set Image tag
         run: |
-          ver=${{ github.event.client_payload.tag }}
+          ver=${{ github.event.client_payload.tag || github.event.inputs.tag }}
           echo "IMG_TAG=${ver#"v"}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0
           submodules: true
-          ref: ${{ github.event.client_payload.tag }}
+          ref: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
 
       - name: Authenticate to ACR
         run: |
@@ -43,7 +48,7 @@ jobs:
         run: |
           OUTPUT_TYPE=type=registry make docker-build-ragengine
         env:
-          VERSION: ${{ github.event.client_payload.tag }}
+          VERSION: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
           REGISTRY: ${{ secrets.KAITO_MCR_REGISTRY }}/public/aks/kaito
           RAGENGINE_IMAGE_NAME: ragengine
           IMG_TAG: ${{ env.IMG_TAG }}
@@ -57,4 +62,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-ragengine-helm-chart
-          client-payload: '{"tag": "${{ github.event.client_payload.tag }}"}'
+          client-payload: '{"tag": "${{ github.event.client_payload.tag || github.event.inputs.tag }}"}'

--- a/.github/workflows/publish-rag-service-mcr-image.yaml
+++ b/.github/workflows/publish-rag-service-mcr-image.yaml
@@ -1,5 +1,10 @@
 name: Publish RAG Service MCR image
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'tag to be created for this image (e.g. v0.6.0)'
+        required: true
   repository_dispatch:
     types: [ publish-rag-service-mcr-image ]
 
@@ -24,14 +29,14 @@ jobs:
 
       - name: Set Image tag
         run: |
-          ver=${{ github.event.client_payload.tag }}
+          ver=${{ github.event.client_payload.tag || github.event.inputs.tag }}
           echo "IMG_TAG=${ver#"v"}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0
           submodules: true
-          ref: ${{ github.event.client_payload.tag }}
+          ref: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
 
       - name: Authenticate to ACR
         run: |
@@ -43,7 +48,7 @@ jobs:
         run: |
           OUTPUT_TYPE=type=registry make docker-build-ragservice
         env:
-          VERSION: ${{ github.event.client_payload.tag }}
+          VERSION: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
           REGISTRY: ${{ secrets.KAITO_MCR_REGISTRY }}/unlisted/aks/kaito
           RAGENGINE_SERVICE_IMG_NAME: kaito-rag-service
           RAGENGINE_SERVICE_IMG_TAG: ${{ env.IMG_TAG }}
@@ -57,4 +62,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-ragengine-helm-chart
-          client-payload: '{"tag": "${{ github.event.client_payload.tag }}"}'
+          client-payload: '{"tag": "${{ github.event.client_payload.tag || github.event.inputs.tag }}"}'

--- a/.github/workflows/publish-workspace-mcr-image.yaml
+++ b/.github/workflows/publish-workspace-mcr-image.yaml
@@ -1,5 +1,10 @@
 name: Publish KAITO MCR image
 on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'tag to be created for this image (e.g. v0.6.0)'
+        required: true
   repository_dispatch:
     types: [ publish-workspace-mcr-image ]
 
@@ -24,14 +29,14 @@ jobs:
 
       - name: Set Image tag
         run: |
-          ver=${{ github.event.client_payload.tag }}
+          ver=${{ github.event.client_payload.tag || github.event.inputs.tag }}
           echo "IMG_TAG=${ver#"v"}" >> $GITHUB_ENV
 
       - uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0
           submodules: true
-          ref: ${{ github.event.client_payload.tag }}
+          ref: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
 
       - name: Authenticate to ACR
         run: |
@@ -43,7 +48,7 @@ jobs:
         run: |
           OUTPUT_TYPE=type=registry make docker-build-workspace
         env:
-          VERSION: ${{ github.event.client_payload.tag }}
+          VERSION: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
           REGISTRY: ${{ secrets.KAITO_MCR_REGISTRY }}/public/aks/kaito
           IMG_NAME: workspace
           IMG_TAG: ${{ env.IMG_TAG }}
@@ -57,4 +62,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           event-type: publish-workspace-helm-chart
-          client-payload: '{"tag": "${{ github.event.client_payload.tag }}"}'
+          client-payload: '{"tag": "${{ github.event.client_payload.tag || github.event.inputs.tag }}"}'


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

ci: add workflow_dispatch options to publish pipelines so we can publish MCR images without running full e2e test

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: