### PR TITLE
docs: install helm charts via helm repository instead of using tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 # Image URL to use all building/pushing image targets
 REGISTRY ?= YOUR_REGISTRY
 IMG_NAME ?= workspace
-VERSION ?= v0.6.0
+VERSION ?= v0.6.2
 GPU_PROVISIONER_VERSION ?= 0.3.5
 RAGENGINE_IMG_NAME ?= ragengine
 IMG_TAG ?= $(subst v,,$(VERSION))

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 | ![notification](website/static/img/bell.svg) What is NEW!                                                                                                                                                                                                |
 | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Retrieval Augmented Generation (RAG) support is live! - KAITO RagEngine uses LlamaIndex and FAISS, learn about it [here](https://kaito-project.github.io/kaito/docs/rag)! |
-| Latest Release: Aug 7th, 2025. KAITO v0.6.0                                                                                                                                                                                                  |
+| Latest Release: Sept 10th, 2025. KAITO v0.6.2                                                                                                                                                                                                  |
 | First Release: Nov 15th, 2023. KAITO v0.1.0.                                                                                                                                                                                                   |
 
 KAITO is an operator that automates the AI/ML model inference or tuning workload in a Kubernetes cluster.

--- a/charts/kaito/ragengine/README.md
+++ b/charts/kaito/ragengine/README.md
@@ -5,12 +5,11 @@ KAITO RAGEngine provides Retrieval-Augmented Generation (RAG) capabilities for A
 ## Install
 
 ```bash
-export REGISTRY=mcr.microsoft.com/aks/kaito
-export IMG_NAME=ragengine
-export IMG_TAG=0.6.0
-helm install ragengine ./charts/kaito/ragengine  \
---set image.repository=${REGISTRY}/${IMG_NAME} --set image.tag=${IMG_TAG} \
---namespace kaito-ragengine --create-namespace
+helm repo add kaito https://kaito-project.github.io/kaito/charts/kaito
+helm repo update
+helm upgrade --install kaito/ragengine \
+  --namespace kaito-ragengine \
+  --create-namespace
 ```
 
 ## Prerequisites

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -24,7 +24,7 @@ variable "kaito_gpu_provisioner_version" {
 
 variable "kaito_workspace_version" {
   type        = string
-  default     = "0.6.0"
+  default     = "0.6.2"
   description = "kaito workspace version"
 }
 

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -20,11 +20,11 @@ Before you begin, ensure you have the following tools installed:
 Install the KAITO workspace controller using Helm:
 
 ```bash
-export KAITO_WORKSPACE_VERSION=0.6.0
 export CLUSTER_NAME=kaito
 
-helm install kaito-workspace \
-  https://github.com/kaito-project/kaito/raw/gh-pages/charts/kaito/workspace-$KAITO_WORKSPACE_VERSION.tgz \
+helm repo add kaito https://kaito-project.github.io/kaito/charts/kaito
+helm repo update
+helm upgrade --install kaito/workspace \
   --namespace kaito-workspace \
   --create-namespace \
   --set clusterName="$CLUSTER_NAME" \
@@ -46,8 +46,8 @@ You should see the workspace controller pod in a `Running` state.
 
 You need to create GPU nodes in order to run a Workspace with KAITO. There are two options:
 
-- **Bring your own GPU (BYO) nodes**: Create your own GPU nodes to run KAITO deployments on. 
-- **Auto-provisioning**: Set up automatic GPU node provisioning for your cloud provider. 
+- **Bring your own GPU (BYO) nodes**: Create your own GPU nodes to run KAITO deployments on.
+- **Auto-provisioning**: Set up automatic GPU node provisioning for your cloud provider.
 
 ### Option 1: Bring your own GPU nodes
 

--- a/website/docs/rag.md
+++ b/website/docs/rag.md
@@ -9,7 +9,11 @@ This document presents how to use the KAITO `ragengine` Custom Resource Definiti
 > Be sure you've cloned this repo and followed [kaito workspace installation](./installation.md) if you plan to use local embedding model. RAGEngine needs the gpu-provisioner component to provision GPU nodes.
 
 ```bash
-helm install ragengine ./charts/kaito/ragengine --namespace kaito-ragengine --create-namespace
+helm repo add kaito https://kaito-project.github.io/kaito/charts/kaito
+helm repo update
+helm upgrade --install kaito/ragengine \
+  --namespace kaito-ragengine \
+  --create-namespace
 ```
 
 ## Verify installation

--- a/website/versioned_docs/version-v0.6.x/installation.md
+++ b/website/versioned_docs/version-v0.6.x/installation.md
@@ -20,7 +20,7 @@ Before you begin, ensure you have the following tools installed:
 Install the KAITO workspace controller using Helm:
 
 ```bash
-export KAITO_WORKSPACE_VERSION=0.6.0
+export KAITO_WORKSPACE_VERSION=0.6.2
 export CLUSTER_NAME=kaito
 
 helm install kaito-workspace \
@@ -46,8 +46,8 @@ You should see the workspace controller pod in a `Running` state.
 
 You need to create GPU nodes in order to run a Workspace with KAITO. There are two options:
 
-- **Bring your own GPU (BYO) nodes**: Create your own GPU nodes to run KAITO deployments on. 
-- **Auto-provisioning**: Set up automatic GPU node provisioning for your cloud provider. 
+- **Bring your own GPU (BYO) nodes**: Create your own GPU nodes to run KAITO deployments on.
+- **Auto-provisioning**: Set up automatic GPU node provisioning for your cloud provider.
 
 ### Option 1: Bring your own GPU nodes
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Install helm charts via helm repository instead of using tarballs so we don't have to update the tarball version in the doc every time we release a new minor/patch version

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: