### PR TITLE
chore: bump llama-index to v0.14.1 for ragengine

### DIFF
--- a/presets/ragengine/requirements.txt
+++ b/presets/ragengine/requirements.txt
@@ -1,17 +1,17 @@
 # RAG Library Requirements
-llama-index==0.12.41
+llama-index==0.14.1
 # HF Embeddings
-llama-index-embeddings-huggingface==0.5.4
-llama-index-embeddings-huggingface-api==0.3.1
+llama-index-embeddings-huggingface==0.6.1
+llama-index-embeddings-huggingface-api==0.4.1
 # HF LLMs
-llama-index-llms-huggingface==0.5.0
-llama-index-llms-huggingface-api==0.4.3
+llama-index-llms-huggingface==0.6.1
+llama-index-llms-huggingface-api==0.6.1
 
 fastapi==0.115.9
 faiss-cpu==1.11.0
-llama-index-vector-stores-faiss==0.4.0
-llama-index-vector-stores-chroma==0.4.1
-llama-index-vector-stores-azurecosmosmongo==0.6.0
+llama-index-vector-stores-faiss==0.5.1
+llama-index-vector-stores-chroma==0.5.3
+llama-index-vector-stores-azurecosmosmongo==0.7.1
 uvicorn==0.34.2
 asyncio==3.4.3
 aiorwlock==1.5.0
@@ -20,7 +20,6 @@ openai==1.97.1
 
 tiktoken==0.11.0
 tree-sitter==0.23.2
-tree_sitter_languages==1.10.2
-tree-sitter-language-pack==0.7.3
+tree-sitter-language-pack==0.9.0
 # Metrics collection
 prometheus-client>=0.17.0


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Manually update version like in #1485 since it failed CI and requires updates to other packages as well.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: