### PR TITLE
fix: helm upgrade --install needs release name

### DIFF
--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -24,7 +24,7 @@ export CLUSTER_NAME=kaito
 
 helm repo add kaito https://kaito-project.github.io/kaito/charts/kaito
 helm repo update
-helm upgrade --install kaito/workspace \
+helm upgrade --install kaito-workspace kaito/workspace \
   --namespace kaito-workspace \
   --create-namespace \
   --set clusterName="$CLUSTER_NAME" \

--- a/website/docs/rag.md
+++ b/website/docs/rag.md
@@ -11,7 +11,7 @@ This document presents how to use the KAITO `ragengine` Custom Resource Definiti
 ```bash
 helm repo add kaito https://kaito-project.github.io/kaito/charts/kaito
 helm repo update
-helm upgrade --install kaito/ragengine \
+helm upgrade --install kaito-ragengine kaito/ragengine \
   --namespace kaito-ragengine \
   --create-namespace
 ```


### PR DESCRIPTION
**Reason for Change**:
`helm upgrade [RELEASE] [CHART] [flags]` is the usage and we are missing a release name
