### PR TITLE
feat: [BREAKING] use statefulset for all workspace

### DIFF
--- a/docker/workspace/Dockerfile
+++ b/docker/workspace/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24 as dependencies
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/oss/go/microsoft/golang:1.24 AS dependencies
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -15,7 +15,7 @@ RUN \
     --mount=type=cache,target=/go/pkg/mod \
     go mod download
 
-FROM dependencies as builder
+FROM dependencies AS builder
 
 ARG VERSION
 ARG BUILD_DATE

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -48,11 +48,9 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/inferenceset"
-	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/utils/workspace"
 	"github.com/kaito-project/kaito/pkg/workspace/controllers"
-	"github.com/kaito-project/kaito/pkg/workspace/inference"
 	"github.com/kaito-project/kaito/pkg/workspace/manifests"
 )
 
@@ -348,17 +346,8 @@ func (c *InferenceSetReconciler) ensureGatewayAPIInferenceExtension(ctx context.
 		return nil
 	}
 
-	model := plugin.KaitoModelRegister.MustGet(string(iObj.Spec.Template.Inference.Preset.Name))
-
-	// Dry-run the inference workload generation to determine if it will be a StatefulSet or not.
-	workloadObj, err := inference.GeneratePresetInference(ctx, &wsList.Items[0], "", model, c.Client)
-	if err != nil {
-		return fmt.Errorf("failed to generate preset inference workload for Gateway API Inference Extension: %w", err)
-	}
-	_, isStatefulSet := workloadObj.(*appsv1.StatefulSet)
-
 	ociRepository := manifests.GenerateInferencePoolOCIRepository(iObj)
-	helmRelease, err := manifests.GenerateInferencePoolHelmRelease(iObj, isStatefulSet)
+	helmRelease, err := manifests.GenerateInferencePoolHelmRelease(iObj)
 	if err != nil {
 		return err
 	}

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -293,7 +293,7 @@ func TestEnsureGatewayAPIInferenceExtension(t *testing.T) {
 				ociRepository.Status.Conditions = []v1.Condition{{Type: consts.ConditionReady, Status: v1.ConditionTrue}}
 				c.CreateOrUpdateObjectInMap(ociRepository)
 
-				helmRelease, _ := manifests.GenerateInferencePoolHelmRelease(test.MockInferenceSetWithPresetVLLM, false)
+				helmRelease, _ := manifests.GenerateInferencePoolHelmRelease(test.MockInferenceSetWithPresetVLLM)
 				helmRelease.Status.Conditions = []v1.Condition{{Type: consts.ConditionReady, Status: v1.ConditionTrue}}
 				c.CreateOrUpdateObjectInMap(helmRelease)
 

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -297,6 +297,9 @@ func TestEnsureGatewayAPIInferenceExtension(t *testing.T) {
 				helmRelease.Status.Conditions = []v1.Condition{{Type: consts.ConditionReady, Status: v1.ConditionTrue}}
 				c.CreateOrUpdateObjectInMap(helmRelease)
 
+				// Mock Update call for HelmRelease (in case specs are not equal)
+				c.On("Update", mock.Anything, mock.IsType(&helmv2.HelmRelease{}), mock.Anything).Return(nil)
+
 				// mock inferenceset.ListWorkspaces return one workspace with preset VLLM
 				wsList := &v1beta1.WorkspaceList{}
 				wsList.Items = append(wsList.Items, *test.MockWorkspaceWithPresetVLLM)

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -36,9 +36,6 @@ type Model interface {
 	GetTuningParameters() *PresetParam
 
 	// SupportDistributedInference checks if the model supports distributed inference.
-	// If true, the inference workload will use 'StatefulSet' instead of 'Deployment'
-	// as the workload type. See https://github.com/kaito-project/kaito/blob/main/docs/proposals/20250325-distributed-inference.md
-	// for more details.
 	SupportDistributedInference() bool
 
 	// SupportTuning checks if the model supports tuning.

--- a/pkg/utils/resources/resources.go
+++ b/pkg/utils/resources/resources.go
@@ -50,11 +50,12 @@ func CreateResource(ctx context.Context, resource client.Object, kubeClient clie
 	}
 
 	// Create the resource.
-	return retry.OnError(retry.DefaultBackoff, func(err error) bool {
-		return true
+	err := retry.OnError(retry.DefaultBackoff, func(err error) bool {
+		return !errors.IsAlreadyExists(err)
 	}, func() error {
 		return kubeClient.Create(ctx, resource, &client.CreateOptions{})
 	})
+	return client.IgnoreAlreadyExists(err)
 }
 
 func GetResource(ctx context.Context, name, namespace string, kubeClient client.Client, resource client.Object) error {

--- a/pkg/utils/test/test_utils.go
+++ b/pkg/utils/test/test_utils.go
@@ -1002,6 +1002,60 @@ var (
 			ReadyReplicas: 1,
 		},
 	}
+	MockStatefulSetUpdated = appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "testWorkspace",
+			Namespace:   "kaito",
+			Annotations: map[string]string{v1beta1.WorkspaceRevisionAnnotation: "1"},
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Replicas: &numRep,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app": "test-app",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test-container",
+							Image: "nginx:latest",
+							Ports: []corev1.ContainerPort{
+								{
+									ContainerPort: 80,
+									Protocol:      corev1.ProtocolTCP,
+								},
+							},
+							Env: []corev1.EnvVar{
+								{
+									Name:  "ENV_VAR_NAME",
+									Value: "ENV_VAR_VALUE",
+								},
+							},
+							VolumeMounts: []corev1.VolumeMount{
+								{
+									Name:      "volume-name",
+									MountPath: "/mount/path",
+								},
+							},
+						},
+					},
+					Volumes: []corev1.Volume{
+						{
+							Name: "volume-name",
+							VolumeSource: corev1.VolumeSource{
+								EmptyDir: &corev1.EmptyDirVolumeSource{},
+							},
+						},
+					},
+				},
+			},
+		},
+		Status: appsv1.StatefulSetStatus{
+			ReadyReplicas: 1,
+		},
+	}
 	MockDeploymentWithAnnotationsAndContainer1 = appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{},

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -503,6 +503,8 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1b
 		if err != nil && !apierrors.IsNotFound(err) {
 			return fmt.Errorf("failed to delete old inference deployment: %w", err)
 		}
+	} else if !apierrors.IsNotFound(err) {
+		return fmt.Errorf("failed to get existing inference deployment: %w", err)
 	}
 
 	var err error

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -547,17 +547,8 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1b
 				return
 			}
 
-			// Assign the correct type to existingObj based on the type of workloadObj.
-			var existingObj client.Object
-			var desiredPodSpec *corev1.PodSpec
-			switch workloadObj := workloadObj.(type) {
-			case *appsv1.StatefulSet:
-				existingObj = &appsv1.StatefulSet{}
-				desiredPodSpec = &workloadObj.Spec.Template.Spec
-			case *appsv1.Deployment:
-				existingObj = &appsv1.Deployment{}
-				desiredPodSpec = &workloadObj.Spec.Template.Spec
-			}
+			existingObj := &appsv1.StatefulSet{}
+			desiredPodSpec := workloadObj.(*appsv1.StatefulSet).Spec.Template.Spec
 
 			if err = resources.GetResource(ctx, wObj.Name, wObj.Namespace, c.Client, existingObj); err == nil {
 				klog.InfoS("An inference workload already exists for workspace", "workspace", klog.KObj(wObj))
@@ -573,13 +564,7 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1b
 					return
 				}
 
-				var spec *corev1.PodSpec
-				switch existingObj := existingObj.(type) {
-				case *appsv1.StatefulSet:
-					spec = &existingObj.Spec.Template.Spec
-				case *appsv1.Deployment:
-					spec = &existingObj.Spec.Template.Spec
-				}
+				spec := &existingObj.Spec.Template.Spec
 
 				// Selectively update the pod spec fields that are relevant to inference,
 				// and leave the rest unchanged in case user has customized them.

--- a/pkg/workspace/controllers/workspace_controller_test.go
+++ b/pkg/workspace/controllers/workspace_controller_test.go
@@ -520,7 +520,7 @@ func TestApplyInferenceWithTemplate(t *testing.T) {
 		"Fail to apply inference from workspace template": {
 			callMocks: func(c *test.MockClient) {
 				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
-				c.On("Create", mock.IsType(context.Background()), mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(errors.New("Failed to create deployment"))
+				c.On("Create", mock.IsType(context.Background()), mock.IsType(&appsv1.StatefulSet{}), mock.Anything).Return(errors.New("Failed to create deployment"))
 				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1beta1.Workspace{}), mock.Anything).Return(nil)
 				c.StatusMock.On("Update", mock.IsType(context.Background()), mock.IsType(&v1beta1.Workspace{}), mock.Anything).Return(nil)
 			},
@@ -529,8 +529,8 @@ func TestApplyInferenceWithTemplate(t *testing.T) {
 		},
 		"Apply inference from workspace template": {
 			callMocks: func(c *test.MockClient) {
-				c.On("Create", mock.IsType(context.Background()), mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(nil)
-				c.On("Get", mock.Anything, mock.Anything, mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(nil)
+				c.On("Create", mock.IsType(context.Background()), mock.IsType(&appsv1.StatefulSet{}), mock.Anything).Return(nil)
+				c.On("Get", mock.Anything, mock.Anything, mock.IsType(&appsv1.StatefulSet{}), mock.Anything).Return(nil)
 				c.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&v1beta1.Workspace{}), mock.Anything).Return(nil)
 				c.StatusMock.On("Update", mock.IsType(context.Background()), mock.IsType(&v1beta1.Workspace{}), mock.Anything).Return(nil)
 			},
@@ -542,7 +542,7 @@ func TestApplyInferenceWithTemplate(t *testing.T) {
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
 			mockClient := test.NewClient()
-			depObj := &appsv1.Deployment{}
+			depObj := &appsv1.StatefulSet{}
 
 			mockClient.UpdateCb = func(key types.NamespacedName) {
 				mockClient.GetObjectFromMap(depObj, key)

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kaito-project/kaito/api/v1beta1"
@@ -49,7 +50,6 @@ func TestGeneratePresetInference(t *testing.T) {
 		nodeCount          int
 		modelName          string
 		callMocks          func(c *test.MockClient)
-		workload           string
 		expectedCmd        string
 		hasAdapters        bool
 		expectedModelImage string
@@ -62,12 +62,8 @@ func TestGeneratePresetInference(t *testing.T) {
 			modelName: "test-model",
 			callMocks: func(c *test.MockClient) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
-				// Mock node get for TryGetGPUConfigFromNode
-				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Node{}), mock.Anything).Return(nil)
-				// Mock node list for BYO node discovery
-				c.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
 			},
-			workload:           "Deployment",
 			expectedModelImage: "test-registry/kaito-test-model:1.0.0",
 			// No BaseCommand, AccelerateParams, or ModelRunParams
 			// So expected cmd consists of shell command and inference file
@@ -81,12 +77,8 @@ func TestGeneratePresetInference(t *testing.T) {
 			modelName: "test-no-tensor-parallel-model",
 			callMocks: func(c *test.MockClient) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
-				// Mock node get for TryGetGPUConfigFromNode
-				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Node{}), mock.Anything).Return(nil)
-				// Mock node list for BYO node discovery
-				c.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
 			},
-			workload:           "Deployment",
 			expectedModelImage: "test-registry/kaito-test-no-tensor-parallel-model:1.0.0",
 			// No BaseCommand, AccelerateParams, or ModelRunParams
 			// So expected cmd consists of shell command and inference file
@@ -100,12 +92,8 @@ func TestGeneratePresetInference(t *testing.T) {
 			modelName: "test-no-lora-support-model",
 			callMocks: func(c *test.MockClient) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
-				// Mock node get for TryGetGPUConfigFromNode
-				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Node{}), mock.Anything).Return(nil)
-				// Mock node list for BYO node discovery
-				c.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
 			},
-			workload:           "Deployment",
 			expectedModelImage: "test-registry/kaito-test-no-lora-support-model:1.0.0",
 			// No BaseCommand, AccelerateParams, or ModelRunParams
 			// So expected cmd consists of shell command and inference file
@@ -119,12 +107,8 @@ func TestGeneratePresetInference(t *testing.T) {
 			modelName: "test-model",
 			callMocks: func(c *test.MockClient) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
-				// Mock node get for TryGetGPUConfigFromNode
-				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Node{}), mock.Anything).Return(nil)
-				// Mock node list for BYO node discovery
-				c.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
 			},
-			workload:           "Deployment",
 			expectedModelImage: "test-registry/kaito-test-model:1.0.0",
 			expectedCmd:        "/bin/sh -c python3 /workspace/vllm/inference_api.py --enable-lora --gpu-memory-utilization=0.84 --max-model-len=2048 --tensor-parallel-size=2 --served-model-name=mymodel --kaito-config-file=/mnt/config/inference_config.yaml",
 			hasAdapters:        true,
@@ -141,12 +125,8 @@ func TestGeneratePresetInference(t *testing.T) {
 			modelName: "test-model",
 			callMocks: func(c *test.MockClient) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
-				// Mock node get for TryGetGPUConfigFromNode
-				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Node{}), mock.Anything).Return(nil)
-				// Mock node list for BYO node discovery
-				c.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
 			},
-			workload:           "Deployment",
 			expectedModelImage: "test-registry/kaito-test-model:1.0.0",
 			// No BaseCommand, AccelerateParams, or ModelRunParams
 			// So expected cmd consists of shell command and inference file
@@ -160,12 +140,8 @@ func TestGeneratePresetInference(t *testing.T) {
 			modelName: "test-model",
 			callMocks: func(c *test.MockClient) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
-				// Mock node get for TryGetGPUConfigFromNode
-				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Node{}), mock.Anything).Return(nil)
-				// Mock node list for BYO node discovery
-				c.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
 			},
-			workload:           "Deployment",
 			expectedModelImage: "test-registry/kaito-test-model:1.0.0",
 			expectedCmd:        "/bin/sh -c accelerate launch /workspace/tfs/inference_api.py",
 			hasAdapters:        true,
@@ -182,12 +158,8 @@ func TestGeneratePresetInference(t *testing.T) {
 			modelName: "test-model-download-a100",
 			callMocks: func(c *test.MockClient) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
-				// Mock node get for TryGetGPUConfigFromNode
-				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Node{}), mock.Anything).Return(nil)
-				// Mock node list for BYO node discovery
-				c.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
 			},
-			workload:    "Deployment",
 			expectedCmd: `/bin/sh -c python3 /workspace/vllm/inference_api.py --gpu-memory-utilization=0.84 --max-model-len=2048 --tensor-parallel-size=2 --model=test-repo/test-model-a100 --code-revision=test-revision --download-dir=/workspace/weights --kaito-config-file=/mnt/config/inference_config.yaml`,
 			expectedEnvVars: []corev1.EnvVar{{
 				Name: "HF_TOKEN",
@@ -209,13 +181,9 @@ func TestGeneratePresetInference(t *testing.T) {
 			callMocks: func(c *test.MockClient) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Service{}), mock.Anything).Return(nil)
-				// Mock node get for TryGetGPUConfigFromNode
-				c.On("Get", mock.Anything, mock.Anything, mock.IsType(&corev1.Node{}), mock.Anything).Return(nil)
-				// Mock node list for BYO node discovery
-				c.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
 			},
-			workload:    "StatefulSet",
-			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=3 --ray_port=6379; python3 /workspace/vllm/inference_api.py --model=test-repo/test-model --distributed-executor-backend=ray --code-revision=test-revision --download-dir=/workspace/weights --gpu-memory-utilization=0.84 --max-model-len=2048 --kaito-config-file=/mnt/config/inference_config.yaml --pipeline-parallel-size=3 --tensor-parallel-size=2; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
+			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=3 --ray_port=6379; python3 /workspace/vllm/inference_api.py --distributed-executor-backend=ray --model=test-repo/test-model --code-revision=test-revision --download-dir=/workspace/weights --gpu-memory-utilization=0.84 --max-model-len=2048 --kaito-config-file=/mnt/config/inference_config.yaml --pipeline-parallel-size=3 --tensor-parallel-size=2; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
 			expectedEnvVars: []corev1.EnvVar{{
 				Name: "HF_TOKEN",
 				ValueFrom: &corev1.EnvVarSource{
@@ -250,8 +218,7 @@ func TestGeneratePresetInference(t *testing.T) {
 				// Mock node list for BYO node discovery
 				c.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
 			},
-			workload:    "StatefulSet",
-			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=3 --ray_port=6379; python3 /workspace/vllm/inference_api.py --model=test-repo/test-model --distributed-executor-backend=ray --code-revision=test-revision --download-dir=/workspace/weights --gpu-memory-utilization=0.84 --max-model-len=2048 --kaito-config-file=/mnt/config/inference_config.yaml --pipeline-parallel-size=3 --tensor-parallel-size=2; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
+			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=3 --ray_port=6379; python3 /workspace/vllm/inference_api.py --distributed-executor-backend=ray --model=test-repo/test-model --code-revision=test-revision --download-dir=/workspace/weights --gpu-memory-utilization=0.84 --max-model-len=2048 --kaito-config-file=/mnt/config/inference_config.yaml --pipeline-parallel-size=3 --tensor-parallel-size=2; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
 			expectedEnvVars: []corev1.EnvVar{{
 				Name: "HF_TOKEN",
 				ValueFrom: &corev1.EnvVarSource{
@@ -278,12 +245,8 @@ func TestGeneratePresetInference(t *testing.T) {
 			modelName: "test-model-download",
 			callMocks: func(c *test.MockClient) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
-				// Mock node get for TryGetGPUConfigFromNode
-				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Node{}), mock.Anything).Return(nil)
-				// Mock node list for BYO node discovery
-				c.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
 			},
-			workload:    "Deployment",
 			expectedCmd: "/bin/sh -c accelerate launch /workspace/tfs/inference_api.py --pretrained_model_name_or_path=test-repo/test-model --revision=test-revision",
 			expectedEnvVars: []corev1.EnvVar{{
 				Name: "HF_TOKEN",
@@ -356,25 +319,11 @@ func TestGeneratePresetInference(t *testing.T) {
 			mockClient.CreateOrUpdateObjectInMap(svc)
 
 			createdObject, _ := GeneratePresetInference(context.TODO(), workspace, test.MockWorkspaceWithPresetHash, model, mockClient)
-			createdWorkload := ""
-			image := ""
-			envVars := []corev1.EnvVar{}
-			var initContainer []corev1.Container
-			switch t := createdObject.(type) {
-			case *appsv1.Deployment:
-				createdWorkload = "Deployment"
-				image = t.Spec.Template.Spec.Containers[0].Image
-				envVars = t.Spec.Template.Spec.Containers[0].Env
-				initContainer = t.Spec.Template.Spec.InitContainers
-			case *appsv1.StatefulSet:
-				createdWorkload = "StatefulSet"
-				image = t.Spec.Template.Spec.Containers[0].Image
-				envVars = t.Spec.Template.Spec.Containers[0].Env
-				initContainer = t.Spec.Template.Spec.InitContainers
-			}
-			if tc.workload != createdWorkload {
-				t.Errorf("%s: returned workload type is wrong", k)
-			}
+
+			statefulset := createdObject.(*appsv1.StatefulSet)
+			image := statefulset.Spec.Template.Spec.Containers[0].Image
+			envVars := statefulset.Spec.Template.Spec.Containers[0].Env
+			initContainer := statefulset.Spec.Template.Spec.InitContainers
 
 			if tc.expectedModelImage != "" {
 				var pullerContainer corev1.Container
@@ -403,12 +352,7 @@ func TestGeneratePresetInference(t *testing.T) {
 				t.Errorf("%s: EnvVars are not expected, got %v, expect %v", k, envVars, tc.expectedEnvVars)
 			}
 
-			var workloadCmd string
-			if tc.workload == "Deployment" {
-				workloadCmd = strings.Join((createdObject.(*appsv1.Deployment)).Spec.Template.Spec.Containers[0].Command, " ")
-			} else {
-				workloadCmd = strings.Join((createdObject.(*appsv1.StatefulSet)).Spec.Template.Spec.Containers[0].Command, " ")
-			}
+			workloadCmd := strings.Join(statefulset.Spec.Template.Spec.Containers[0].Command, " ")
 
 			mainCmd := strings.Split(workloadCmd, "--")[0]
 			params := toParameterMap(strings.Split(workloadCmd, "--")[1:])
@@ -427,20 +371,16 @@ func TestGeneratePresetInference(t *testing.T) {
 			// Check for adapter volume
 			if tc.hasAdapters {
 				var actualSecrets []string
-				if tc.workload == "Deployment" {
-					for _, secret := range createdObject.(*appsv1.Deployment).Spec.Template.Spec.ImagePullSecrets {
-						actualSecrets = append(actualSecrets, secret.Name)
-					}
-				} else {
-					for _, secret := range createdObject.(*appsv1.StatefulSet).Spec.Template.Spec.ImagePullSecrets {
-						actualSecrets = append(actualSecrets, secret.Name)
-					}
+				for _, secret := range statefulset.Spec.Template.Spec.ImagePullSecrets {
+					actualSecrets = append(actualSecrets, secret.Name)
 				}
+
 				if !reflect.DeepEqual(expectedSecrets, actualSecrets) {
 					t.Errorf("%s: ImagePullSecrets are not expected, got %v, expect %v", k, actualSecrets, expectedSecrets)
 				}
 				found := false
-				for _, volume := range createdObject.(*appsv1.Deployment).Spec.Template.Spec.Volumes {
+
+				for _, volume := range statefulset.Spec.Template.Spec.Volumes {
 					if volume.Name == tc.expectedVolume {
 						found = true
 						break

--- a/pkg/workspace/inference/template_inference.go
+++ b/pkg/workspace/inference/template_inference.go
@@ -24,7 +24,7 @@ import (
 )
 
 func CreateTemplateInference(ctx context.Context, workspaceObj *kaitov1beta1.Workspace, kubeClient client.Client) (client.Object, error) {
-	depObj := manifests.GenerateDeploymentManifestWithPodTemplate(workspaceObj, tolerations)
+	depObj := manifests.GenerateManifestWithPodTemplate(workspaceObj, tolerations)
 	err := resources.CreateResource(ctx, client.Object(depObj), kubeClient)
 	if client.IgnoreAlreadyExists(err) != nil {
 		return nil, err

--- a/pkg/workspace/inference/template_inference_test.go
+++ b/pkg/workspace/inference/template_inference_test.go
@@ -32,19 +32,19 @@ func TestCreateTemplateInference(t *testing.T) {
 	}{
 		"Fail to create template inference because deployment creation fails": {
 			callMocks: func(c *test.MockClient) {
-				c.On("Create", mock.IsType(context.Background()), mock.IsType(&v1.Deployment{}), mock.Anything).Return(errors.New("Failed to create resource"))
+				c.On("Create", mock.IsType(context.Background()), mock.IsType(&v1.StatefulSet{}), mock.Anything).Return(errors.New("Failed to create resource"))
 			},
 			expectedError: errors.New("Failed to create resource"),
 		},
 		"Successfully creates template inference because deployment already exists": {
 			callMocks: func(c *test.MockClient) {
-				c.On("Create", mock.IsType(context.Background()), mock.IsType(&v1.Deployment{}), mock.Anything).Return(test.IsAlreadyExistsError())
+				c.On("Create", mock.IsType(context.Background()), mock.IsType(&v1.StatefulSet{}), mock.Anything).Return(test.IsAlreadyExistsError())
 			},
 			expectedError: nil,
 		},
 		"Successfully creates template inference by creating a new deployment": {
 			callMocks: func(c *test.MockClient) {
-				c.On("Create", mock.IsType(context.Background()), mock.IsType(&v1.Deployment{}), mock.Anything).Return(nil)
+				c.On("Create", mock.IsType(context.Background()), mock.IsType(&v1.StatefulSet{}), mock.Anything).Return(nil)
 			},
 			expectedError: nil,
 		},
@@ -60,9 +60,9 @@ func TestCreateTemplateInference(t *testing.T) {
 				assert.Check(t, err == nil, "Not expected to return error")
 				assert.Check(t, obj != nil, "Return object should not be nil")
 
-				deploymentObj, ok := obj.(*v1.Deployment)
-				assert.Check(t, ok, "Returned object should be of type *v1.Deployment")
-				assert.Check(t, deploymentObj != nil, "Returned object should not be nil")
+				statefulSetObj, ok := obj.(*v1.StatefulSet)
+				assert.Check(t, ok, "Returned object should be of type *v1.StatefulSet")
+				assert.Check(t, statefulSetObj != nil, "Returned object should not be nil")
 			} else {
 				assert.Equal(t, tc.expectedError.Error(), err.Error())
 			}

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -306,7 +306,7 @@ func GeneratePullerContainers(wObj *kaitov1beta1.Workspace, volumeMounts []corev
 	return initContainers, envVars, volumes
 }
 
-func GenerateDeploymentManifestWithPodTemplate(workspaceObj *kaitov1beta1.Workspace, tolerations []corev1.Toleration) *appsv1.Deployment {
+func GenerateManifestWithPodTemplate(workspaceObj *kaitov1beta1.Workspace, tolerations []corev1.Toleration) *appsv1.StatefulSet {
 	nodeRequirements := make([]corev1.NodeSelectorRequirement, 0, len(workspaceObj.Resource.LabelSelector.MatchLabels))
 	for key, value := range workspaceObj.Resource.LabelSelector.MatchLabels {
 		nodeRequirements = append(nodeRequirements, corev1.NodeSelectorRequirement{
@@ -357,7 +357,7 @@ func GenerateDeploymentManifestWithPodTemplate(workspaceObj *kaitov1beta1.Worksp
 		templateCopy.Spec.Tolerations = append(templateCopy.Spec.Tolerations, tolerations...)
 	}
 
-	return &appsv1.Deployment{
+	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      workspaceObj.Name,
 			Namespace: workspaceObj.Namespace,
@@ -365,7 +365,7 @@ func GenerateDeploymentManifestWithPodTemplate(workspaceObj *kaitov1beta1.Worksp
 				*metav1.NewControllerRef(workspaceObj, kaitov1beta1.GroupVersion.WithKind("Workspace")),
 			},
 		},
-		Spec: appsv1.DeploymentSpec{
+		Spec: appsv1.StatefulSetSpec{
 			Replicas: lo.ToPtr(workspaceObj.Status.TargetNodeCount),
 			Selector: labelselector,
 			Template: *templateCopy,

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -56,41 +56,14 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 	base.Namespace = "kaito"
 
 	tests := []struct {
-		name          string
-		workspace     *kaitov1alpha1.InferenceSet
-		isStatefulSet bool
-		expected      map[string]any
+		name      string
+		workspace *kaitov1alpha1.InferenceSet
+		expected  map[string]any
 	}{
+
 		{
-			name:          "deployment inference pool helm values",
-			workspace:     base.DeepCopy(),
-			isStatefulSet: false,
-			expected: map[string]any{
-				"inferenceExtension": map[string]any{
-					"image": map[string]any{
-						"hub":        consts.GatewayAPIInferenceExtensionImageRepository,
-						"tag":        consts.InferencePoolChartVersion,
-						"pullPolicy": string(corev1.PullIfNotPresent),
-					},
-				},
-				"inferencePool": map[string]any{
-					"targetPorts": []any{
-						map[string]any{
-							"number": float64(consts.PortInferenceServer),
-						},
-					},
-					"modelServers": map[string]any{
-						"matchLabels": map[string]any{
-							consts.WorkspaceCreatedByInferenceSetLabel: base.Name,
-						},
-					},
-				},
-			},
-		},
-		{
-			name:          "statefulset inference pool helm values",
-			workspace:     base.DeepCopy(),
-			isStatefulSet: true,
+			name:      "statefulset inference pool helm values",
+			workspace: base.DeepCopy(),
 			expected: map[string]any{
 				"inferenceExtension": map[string]any{
 					"image": map[string]any{
@@ -118,7 +91,7 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			helmRelease, err := GenerateInferencePoolHelmRelease(tc.workspace, tc.isStatefulSet)
+			helmRelease, err := GenerateInferencePoolHelmRelease(tc.workspace)
 			assert.NoError(t, err)
 			assert.NotNil(t, helmRelease)
 

--- a/presets/workspace/models/mistral/model.go
+++ b/presets/workspace/models/mistral/model.go
@@ -184,7 +184,7 @@ type ministral3_3bInstruct struct{}
 func (*ministral3_3bInstruct) GetInferenceParameters() *model.PresetParam {
 	return &model.PresetParam{
 		Metadata:                metadata.MustGet(PresetMinistral33BInstructModel),
-		DiskStorageRequirement:  "50Gi",
+		DiskStorageRequirement:  "70Gi",
 		GPUCountRequirement:     "1",
 		TotalSafeTensorFileSize: "8.70Gi",
 		BytesPerToken:           106496,

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -565,11 +565,7 @@ func validateInferenceSetReplicas(inferenceSetObj *kaitov1alpha1.InferenceSet, e
 				totalReadyReplicas += sts.Status.ReadyReplicas
 			}
 
-			if totalReadyReplicas == expectedReplicas {
-				return true
-			}
-
-			return false
+			return totalReadyReplicas == expectedReplicas
 		}, 20*time.Minute, utils.PollInterval).Should(BeTrue(), "Failed to wait for InferenceSet replicas to be ready")
 	})
 }

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), false)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
@@ -87,7 +87,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), false)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
@@ -111,7 +111,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), true)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		time.Sleep(1 * time.Minute)
 		validateWorkspaceReadiness(workspaceObj)
@@ -134,7 +134,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), false)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
@@ -156,7 +156,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), false)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
@@ -178,7 +178,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), false)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
@@ -192,7 +192,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		time.Sleep(120 * time.Second)
 
 		validateInferenceSetStatus(inferenceSetObj)
-		validateInferenceSetReplicas(inferenceSetObj, int32(numOfReplicas), false)
+		validateInferenceSetReplicas(inferenceSetObj, int32(numOfReplicas))
 		validateGatewayAPIInferenceExtensionResources(inferenceSetObj)
 	})
 
@@ -211,7 +211,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), false)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
@@ -234,7 +234,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), false)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
@@ -256,7 +256,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), false)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
@@ -290,7 +290,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), true)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
@@ -312,7 +312,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), false)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
@@ -334,7 +334,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), false)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
@@ -356,7 +356,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), false)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
@@ -378,7 +378,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), false)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
@@ -400,7 +400,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateAssociatedService(workspaceObj)
 		validateInferenceConfig(workspaceObj)
 
-		validateInferenceResource(workspaceObj, int32(numOfNode), false)
+		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
 		validateModelsEndpoint(workspaceObj)

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -100,16 +100,16 @@ func GetPodNameForJob(coreClient *kubernetes.Clientset, namespace, jobName strin
 	return podList.Items[0].Name, nil
 }
 
-func GetPodNameForDeployment(coreClient *kubernetes.Clientset, namespace, deploymentName string) (string, error) {
+func GetPodNameForWorkspace(coreClient *kubernetes.Clientset, namespace, workspaceName string) (string, error) {
 	podList, err := coreClient.CoreV1().Pods(namespace).List(context.TODO(), metav1.ListOptions{
-		LabelSelector: fmt.Sprintf("kaito.sh/workspace=%s", deploymentName),
+		LabelSelector: fmt.Sprintf("kaito.sh/workspace=%s", workspaceName),
 	})
 	if err != nil {
 		return "", err
 	}
 
 	if len(podList.Items) == 0 {
-		return "", fmt.Errorf("no pods found for job %s", deploymentName)
+		return "", fmt.Errorf("no pods found for workspace %s", workspaceName)
 	}
 
 	return podList.Items[0].Name, nil


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

- enable nvme disk acceleration for normal workspace.
   if nvme disk is unavailable, use emptyDir instead.
- cleanup deployment workload for existing workspace.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: