### PR TITLE
fix: ResourceReady condition is never set to true for BYO [release-0.7] 

### DIFF
--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -485,6 +485,13 @@ func ResolveReadyNodesAndTargetNodeClaimCount(ctx context.Context, c client.Clie
 	// Calculate the number of target NodeClaims(nodes) (target - BYO nodes)
 	targetNodeClaimCount := max(0, targetNodeCount-len(availableBYONodes))
 
+	klog.InfoS("Resolved node counts for workspace",
+		"workspace", klog.KObj(wObj),
+		"targetNodeCount", targetNodeCount,
+		"availableBYONodes", len(availableBYONodes),
+		"targetNodeClaimCount", targetNodeClaimCount,
+		"autoProvisioningDisabled", featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning])
+
 	// if node provision is disabled, NodeClaims(nodes) are not needed.
 	if featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] {
 		targetNodeClaimCount = 0

--- a/pkg/utils/resources/nodes.go
+++ b/pkg/utils/resources/nodes.go
@@ -126,7 +126,12 @@ func ExtractObjFields(obj client.Object) (instanceType, namespace, name string, 
 
 // GetBYOAndReadyNodes finds all BYO nodes and ready nodes that match the workspace's label selector
 func GetBYOAndReadyNodes(ctx context.Context, c client.Client, wObj *kaitov1beta1.Workspace) ([]*corev1.Node, []string, error) {
-	nodeList, err := ListNodes(ctx, c, wObj.Resource.LabelSelector.MatchLabels)
+	var matchLabels client.MatchingLabels
+	if wObj.Resource.LabelSelector != nil {
+		matchLabels = wObj.Resource.LabelSelector.MatchLabels
+	}
+
+	nodeList, err := ListNodes(ctx, c, matchLabels)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/pkg/workspace/resource/node_claim_test.go
+++ b/pkg/workspace/resource/node_claim_test.go
@@ -269,6 +269,12 @@ func setupWorkspaceStatusMock(mockClient *test.MockClient, workspace *kaitov1bet
 		*ws = *workspace
 	}).Return(nil).Maybe()
 
+	// Mock List call for nodes (needed by GetBYOAndReadyNodes)
+	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Run(func(args mock.Arguments) {
+		nodeList := args.Get(1).(*corev1.NodeList)
+		nodeList.Items = []corev1.Node{} // Return empty node list for test
+	}).Return(nil).Maybe()
+
 	// Mock status update
 	mockClient.On("Status").Return(&mockClient.StatusMock).Maybe()
 	if statusUpdateError != nil {


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

The resource ready condition is never set to true after the refactor as it compares the # ready node claims to the # nodes needed rather than the # node claims needed. This breaks as if 1 node is needed and one existing node is brought, it will expect 1 node claim that will never be provisioned as the # nodes is already met.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Fixes #1544 

**Notes for Reviewers**:

**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: