### PR TITLE
fix: handle no context found with passthrough to LLM (#1542) [release-0.7] 

### DIFF
--- a/website/docs/rag-chat-completions-wrapper.md
+++ b/website/docs/rag-chat-completions-wrapper.md
@@ -368,6 +368,8 @@ chat_result = await chat_engine.achat(user_prompt, chat_history=chat_history)
 4. **Prompt Construction**: Selected documents are formatted into the final prompt
 5. **LLM Generation**: Complete prompt (context + history + user query) sent to LLM
 
+**In the event that no relevant context is found, the LlamaIndex library will return an empty response. We look out for this and send the request directly to the LLM without context as described in the bypass handling above.**
+
 ### 4. Token Budget Example
 
 Here's how token allocation works in practice:

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -53,6 +53,7 @@ const sidebars = {
                     },
                     items: [
                         'rag-api',
+                        'rag-chat-completions-wrapper'
                     ],
                 },
                 'custom-model',


### PR DESCRIPTION
**Reason for Change**:
Both `CONTEXT` and `CONDENSE_PLUS_CONTEXT` Chat types in LlamaIndex use the same CompactAndRefine [response
synthesizers](https://github.com/run-llama/llama_index/blob/main/llama-index-core/llama_index/core/response_synthesizers/compact_and_refine.py)
 
Which in turn, both `achat` functions would call `response = await synthesizer.asynthesize(message, nodes)` and return an empty response if they have [no
nodes](https://github.com/run-llama/llama_index/blob/8469a034226d20b70a667dc7faf013770716709f/llama-index-core/llama_index/core/response_synthesizers/base.py#L271), all without calling the LLM.

This change checks for the Empty Response from the response synthesizer and validates no source_nodes were found, and if this case is hit, we send the request directly to the LLM with the passthrough function and without context.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Fixes #1543

**Notes for Reviewers**:

**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: