### PR TITLE
Revert "chore: bump python from 3.12-slim to 3.13-slim in /docker/presets/models/tfs"

### DIFF
--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim AS dependencies
+FROM python:3.12-slim AS dependencies
 
 ARG MODEL_TYPE
 ARG VERSION

--- a/docker/ragengine/service/Dockerfile
+++ b/docker/ragengine/service/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim AS dependencies
+FROM python:3.12-slim AS dependencies
 
 # Install system dependencies for building Python packages
 RUN apt-get update && apt-get upgrade -y \


### PR DESCRIPTION
Reverts kaito-project/kaito#1451