### PR TITLE
feat: creating initial autoindexer service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,6 +138,12 @@ rag-service-test: ## Run RAG Engine service tests with pytest.
 	pip install pytest-cov
 	pytest --cov -o log_cli=true -o log_cli_level=INFO presets/ragengine/tests
 
+.PHONY: autoindexer-service-test
+autoindexer-service-test: ## Run AutoIndexer service tests with pytest.
+	pip install -r presets/autoindexer/requirements-test.txt
+	pip install pytest-cov
+	pytest --cov -o log_cli=true -o log_cli_level=INFO presets/autoindexer/tests
+
 .PHONY: tuning-metrics-server-test
 tuning-metrics-server-test: ## Run Tuning Metrics Server tests with pytest.
 	pip install -r ./presets/workspace/dependencies/requirements-test.txt
@@ -274,6 +280,9 @@ RAGENGINE_IMAGE_TAG ?= v0.0.1
 RAGENGINE_SERVICE_IMG_NAME ?= kaito-rag-service
 RAGENGINE_SERVICE_IMG_TAG ?= v0.0.1
 
+AUTOINDEXER_SERVICE_IMG_NAME ?= autoindexer-service
+AUTOINDEXER_SERVICE_IMG_TAG ?= latest
+
 E2E_IMAGE_NAME ?= kaito-e2e
 E2E_IMAGE_TAG ?= v0.0.1
 
@@ -315,6 +324,16 @@ docker-build-ragservice: docker-buildx ## Build Docker image for RAG Engine serv
         --pull \
 		$(BUILD_FLAGS) \
         --tag $(REGISTRY)/$(RAGENGINE_SERVICE_IMG_NAME):$(RAGENGINE_SERVICE_IMG_TAG) .
+
+.PHONY: docker-build-autoindexer-service
+docker-build-autoindexer-service: docker-buildx ## Build Docker image for Auto Indexer service.
+	docker buildx build \
+        --platform="linux/$(ARCH)" \
+        --output=$(OUTPUT_TYPE) \
+        --file ./docker/autoindexer/service/Dockerfile \
+        --pull \
+		$(BUILD_FLAGS) \
+        --tag $(REGISTRY)/$(AUTOINDEXER_SERVICE_IMG_NAME):$(AUTOINDEXER_SERVICE_IMG_TAG) .
 
 .PHONY: docker-build-adapter
 docker-build-adapter: docker-buildx ## Build Docker images for adapters.

--- a/docker/autoindexer/service/Dockerfile
+++ b/docker/autoindexer/service/Dockerfile
@@ -1,0 +1,28 @@
+FROM python:3.12-slim AS dependencies
+
+# Install system dependencies for building Python packages
+RUN apt-get update && apt-get upgrade -y \
+    && apt-get install -y --no-install-recommends  \
+    build-essential \
+    gcc \
+    g++ \
+    make \
+    perl \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+FROM dependencies AS base
+
+WORKDIR /app
+
+# Copy all files from autoindexer/services into the app/services folder
+COPY presets/autoindexer/ autoindexer/
+
+# Set the PYTHONPATH environment variable
+ENV PYTHONPATH=/app
+
+# Install dependencies from requirements.txt
+RUN pip install --no-cache-dir -r autoindexer/requirements.txt
+
+# Set the final working directory
+WORKDIR /app/autoindexer

--- a/presets/autoindexer/__init__.py
+++ b/presets/autoindexer/__init__.py
@@ -1,0 +1,14 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+

--- a/presets/autoindexer/config.py
+++ b/presets/autoindexer/config.py
@@ -1,0 +1,13 @@
+import os
+
+
+def get_required_env_var(var_name: str) -> str:
+    value = os.getenv(var_name)
+    if not value:
+        raise Exception(f"Required environment variable '{var_name}' is not set.")
+    return value
+
+# Use defaults for testing, but require them at runtime
+NAMESPACE = get_required_env_var("NAMESPACE")
+AUTOINDEXER_NAME = get_required_env_var("AUTOINDEXER_NAME")
+ACCESS_SECRET = os.getenv("ACCESS_SECRET")

--- a/presets/autoindexer/data_source_handler/__init__.py
+++ b/presets/autoindexer/data_source_handler/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/presets/autoindexer/data_source_handler/git_handler.py
+++ b/presets/autoindexer/data_source_handler/git_handler.py
@@ -1,0 +1,58 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import logging
+from typing import Any
+
+from autoindexer.data_source_handler.handler import DataSourceHandler
+from autoindexer.k8s.k8s_client import AutoIndexerK8sClient
+from autoindexer.rag.rag_client import KAITORAGClient
+
+logger = logging.getLogger(__name__)
+
+class GitDataSourceHandler(DataSourceHandler):
+    """
+    Handler for Git data sources.
+    
+    This handler supports:
+    - Cloning Git repositories
+    - Checking out specific branches or commits
+    - Reading files from the repository
+    
+    NOTE: This is a placeholder for future implementation
+    """
+
+    def __init__(self, index_name: str, config: dict[str, Any], rag_client: KAITORAGClient, autoindexer_client: AutoIndexerK8sClient, credentials: dict[str, Any] | None = None):
+        """Initialize the Git data source handler."""
+        self.index_name = index_name
+        self.config = config
+        self.credentials = credentials or {}
+        self.rag_client = rag_client
+        self.autoindexer_client = autoindexer_client
+        raise NotImplementedError("Git data source handler is not yet implemented")
+
+    def update_index(self) -> list[str]:
+        """
+        Update the index with documents from the data source.
+
+        Returns:
+            list[str]: List of error messages, if any
+        """
+        raise NotImplementedError("Git data source handler is not yet implemented")
+    
+    def update_autoindexer_status(self):
+        """
+        Update the AutoIndexer CRD status based on the current index state and indexing status.
+        """
+        raise NotImplementedError("Git data source handler is not yet implemented")

--- a/presets/autoindexer/data_source_handler/handler.py
+++ b/presets/autoindexer/data_source_handler/handler.py
@@ -1,0 +1,44 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from abc import ABC, abstractmethod
+
+from autoindexer.k8s.k8s_client import AutoIndexerK8sClient
+from autoindexer.rag.rag_client import KAITORAGClient
+
+
+class DataSourceError(Exception):
+    """Exception raised for data source related errors."""
+    pass
+
+
+class DataSourceHandler(ABC):
+    """Abstract base class for data source handlers."""
+
+    @abstractmethod
+    def update_index(self) -> list[str]:
+        """
+        Update the index with documents from the data source.
+
+        Returns:
+            list[str]: List of error messages, if any
+        """
+        pass
+
+    @abstractmethod
+    def update_autoindexer_status(self):
+        """
+        Update the AutoIndexer CRD status based on the current index state and indexing status.
+        """
+        pass

--- a/presets/autoindexer/data_source_handler/static_handler.py
+++ b/presets/autoindexer/data_source_handler/static_handler.py
@@ -1,0 +1,619 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import contextlib
+import io
+import json
+import logging
+import os
+from datetime import UTC, datetime
+from typing import Any
+from urllib.parse import urlparse
+
+import chardet
+import requests
+
+from autoindexer.data_source_handler.handler import (
+    DataSourceError,
+    DataSourceHandler,
+)
+from autoindexer.k8s.k8s_client import AutoIndexerK8sClient
+from autoindexer.rag.rag_client import KAITORAGClient
+from autoindexer.rag.utils import get_file_extension_language
+
+logger = logging.getLogger(__name__)
+
+
+class StaticDataSourceHandler(DataSourceHandler):
+    """
+    Handler for static data sources (direct file URLs or content).
+    
+    This handler supports:
+    - HTTP/HTTPS URLs pointing to text files (.txt, .md, .rst, etc.)
+    - PDF files with automatic text extraction (.pdf)
+    - Configuration files (.json, .yaml, .toml, etc.)
+    - Source code files (.py, .go, .js, etc.)
+    - Raw files from GitHub, GitLab, and other repositories
+    - Direct text content provided in configuration
+    
+    PDF Processing Features:
+    - Automatic text extraction from PDF files using PyPDF2 and pdfplumber
+    - Table extraction from PDFs (when using pdfplumber)
+    - Multi-page document support with page markers
+    - Fallback between extraction methods for better compatibility
+    - Configurable file size limits for PDF downloads
+    """
+
+    def __init__(self, index_name: str, config: dict[str, Any], rag_client: KAITORAGClient, autoindexer_client: AutoIndexerK8sClient, credentials: dict[str, Any] | None = None):
+        """
+        Initialize the static data source handler.
+        
+        Args:
+            config: Configuration dictionary containing static data source settings
+            credentials: Optional credentials for accessing the data source
+        """
+
+        self.index_name = index_name
+        self.config = config
+        self.credentials = credentials or {}
+        self.rag_client = rag_client
+        self.autoindexer_client = autoindexer_client
+        
+        if not self.config.get("autoindexer_name"):
+            raise DataSourceError("Static data source configuration missing 'autoindexer_name' value")
+
+        self.autoindexer_name = self.config.get("autoindexer_name")
+
+        logger.info(f"Initialized static data source handler with config: {self.config}")
+    
+    def update_autoindexer_status(self):
+        """
+        Update the AutoIndexer CRD status based on the current index state and indexing status.
+        """
+        current_ai = self.autoindexer_client.get_autoindexer()
+        current_status = current_ai["status"]
+
+
+        status_update = {
+            "lastIndexingTimestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
+            "lastIndexingDurationSeconds": self.total_time.seconds,
+            "indexingPhase": "Completed",
+            "successfulIndexingCount": current_status["successfulIndexingCount"] + 1,
+            "numOfDocumentInIndex": 0,
+            "conditions": current_status.get("conditions", [])
+        }
+        try:
+            list_docs_resp = self.rag_client.list_documents(self.index_name, metadata_filter={"autoindexer": self.autoindexer_name}, limit=1)
+            logger.info(f"Document list response: {list_docs_resp}")
+            status_update["numOfDocumentInIndex"] = list_docs_resp["total_items"]
+        except Exception as e:
+            logger.error(f"Failed to list documents: {e}")
+
+        conditions = {}
+        conditions["AutoIndexerSucceeded"] = self.autoindexer_client._create_condition("AutoIndexerSucceeded", "True", "IndexingCompleted", "Indexing completed successfully")
+        if self.errors:
+            conditions["AutoIndexerError"] = self.autoindexer_client._create_condition("AutoIndexerError", "True", "IndexingErrors", f"Indexing completed with errors: {self.errors}")
+        else:
+            conditions["AutoIndexerError"] = self.autoindexer_client._create_condition("AutoIndexerError", "False", "IndexingCompleted", "No errors during indexing")
+        conditions["AutoIndexerFailed"] = self.autoindexer_client._create_condition("AutoIndexerFailed", "False", "IndexingCompleted", "Indexing completed successfully")
+        conditions["AutoIndexerIndexing"] = self.autoindexer_client._create_condition("AutoIndexerIndexing", "False", "IndexingCompleted", "Document indexing process completed successfully")
+
+        for condition_type, condition_data in conditions.items():
+                # Find existing condition of the same type
+                found = False
+                for i, existing_condition in enumerate(status_update["conditions"]):
+                    if existing_condition.get("type") == condition_type:
+                        # Update existing condition
+                        status_update["conditions"][i] = condition_data
+                        found = True
+                        break
+                
+                if not found:
+                    status_update["conditions"].append(condition_data)
+
+        if not self.autoindexer_client.update_autoindexer_status(status_update, update_success_or_failure=True):
+            logger.error("Failed to update AutoIndexer status")
+
+
+    def update_index(self) -> list[str]:
+        """
+        Update the index with documents from the data source.
+
+        Returns:
+            list[str]: List of error messages, if any
+        """
+        self.errors = []
+        start_time = datetime.now(UTC)
+        
+        try:
+            documents = []
+
+            if "urls" in self.config:
+                url_list = self.config["urls"]
+                if isinstance(url_list, str):
+                    url_list = [url_list]
+                
+                for url in url_list:
+                    try:
+                        content = self._fetch_content_from_url(url)
+                        if content:
+                            curr_doc = {
+                                "text": content,
+                                "metadata": {
+                                    "autoindexer": self.autoindexer_name,
+                                    "source_type": "url",
+                                    "source_url": url,
+                                    "timestamp": self._get_current_timestamp()
+                                }
+                            }
+
+                            file_extension_from_url = ""
+                            url_parts = os.path.splitext(urlparse(url).path)
+                            if len(url_parts) > 1:
+                                file_extension_from_url = url_parts[1]
+                            language = get_file_extension_language(file_extension_from_url)
+                            if language:
+                                curr_doc["metadata"]["language"] = language
+                                curr_doc["metadata"]["split_type"] = "code"
+                            documents.append(curr_doc)
+                            logger.info(f"Successfully fetched content from {url}")
+
+                            if len(documents) >= 10:
+                                logger.info(f"Batch indexing {len(documents)} documents into index '{self.index_name}'")
+                                self.rag_client.index_documents(index_name=self.index_name, documents=documents)
+                                documents = []
+                        else:
+                            logger.warning(f"No content retrieved from {url}")
+                    except Exception as e:
+                        logger.error(f"Failed to fetch content from {url}: {e}")
+                        self.errors.append(f"Failed to fetch content from {url}: {e}")
+                        raise DataSourceError(f"Failed to fetch content from {url}: {e}")
+                        
+                # Index any remaining documents after processing all URLs
+                if len(documents) > 0:
+                    logger.info(f"Final batch indexing {len(documents)} documents into index '{self.index_name}'")
+                    self.rag_client.index_documents(index_name=self.index_name, documents=documents)
+            else:
+                logger.warning("No 'urls' found in static data source configuration")
+                return ["No documents fetched from static data source"]
+            
+        except DataSourceError as e:
+            error_msg = f"Data source error: {e}"
+            logger.error(error_msg)
+            self.errors.append(error_msg)
+        except Exception as e:
+            error_msg = f"Unexpected error during indexing: {e}"
+            logger.error(error_msg)
+            self.errors.append(error_msg)
+        
+        self.total_time = datetime.now(UTC) - start_time
+        return self.errors
+
+    def _fetch_content_from_url(self, url: str) -> str | None:
+        """
+        Fetch content from a URL, optimized for downloading files.
+        
+        Supports various file types including:
+        - Raw text files from GitHub, GitLab, etc.
+        - Documentation files (.md, .txt, .rst)
+        - Configuration files (.json, .yaml, .toml)
+        - Source code files (.py, .go, .js, etc.)
+        
+        Args:
+            url: The URL to fetch content from
+            
+        Returns:
+            str | None: The content of the URL or None if failed
+        """
+        try:
+            # Parse URL to validate
+            parsed_url = urlparse(url)
+            if not parsed_url.scheme or not parsed_url.netloc:
+                raise DataSourceError(f"Invalid URL format: {url}")
+            
+            # Determine if this looks like a file URL
+            is_file_url = self._is_file_url(url, parsed_url)
+            
+            # Prepare request headers optimized for file downloads
+            headers = {
+                'User-Agent': 'KAITO-AutoIndexer/1.0',
+                'Accept': 'text/plain, text/markdown, text/x-markdown, application/json, text/html, */*',
+                'Accept-Encoding': 'gzip, deflate, br',
+                'Cache-Control': 'no-cache'
+            }
+            
+            # # Add GitHub-specific headers for better API integration
+            # if 'github.com' in parsed_url.netloc or 'raw.githubusercontent.com' in parsed_url.netloc:
+            #     headers['Accept'] = 'application/vnd.github.v3.raw+json, text/plain, */*'
+            #     # Add GitHub token if available
+            #     if self.credentials and 'github_token' in self.credentials:
+            #         headers['Authorization'] = f"token {self.credentials['github_token']}"
+            
+            # # Add GitLab-specific headers
+            # elif 'gitlab.com' in parsed_url.netloc or 'gitlab' in parsed_url.netloc:
+            #     if self.credentials and 'gitlab_token' in self.credentials:
+            #         headers['Private-Token'] = self.credentials['gitlab_token']
+            
+            # Add authentication if available
+            auth = None
+            if self.credentials:
+                if "http_auth" in self.credentials:
+                    auth_config = self.credentials["http_auth"]
+                    if "username" in auth_config and "password" in auth_config:
+                        auth = (auth_config["username"], auth_config["password"])
+                
+                if "headers" in self.credentials:
+                    headers.update(self.credentials["headers"])
+            
+            # Make request with timeout and streaming for large files
+            timeout = self.config.get("timeout", 60)  # Increased timeout for file downloads
+            max_size = self.config.get("max_file_size", 10 * 1024 * 1024)  # 10MB default limit
+            
+            logger.info(f"Fetching content from {url} (file_url={is_file_url})")
+            
+            with requests.get(url, headers=headers, auth=auth, timeout=timeout, stream=True) as response:
+                response.raise_for_status()
+                
+                # Check content length
+                content_length = response.headers.get('content-length')
+                if content_length and int(content_length) > max_size:
+                    raise DataSourceError(f"File too large: {content_length} bytes exceeds limit of {max_size} bytes")
+                
+                # Handle different content types and file extensions
+                content_type = response.headers.get('content-type', '').lower()
+                
+                # Download content with size limit protection
+                content_chunks = []
+                total_size = 0
+                
+                for chunk in response.iter_content(chunk_size=8192, decode_unicode=False):
+                    if chunk:
+                        total_size += len(chunk)
+                        if total_size > max_size:
+                            raise DataSourceError(f"File too large: exceeds limit of {max_size} bytes")
+                        content_chunks.append(chunk)
+                
+                # Combine chunks into bytes
+                raw_content = b''.join(content_chunks)
+                
+                # Check if this is a PDF file
+                if self._is_pdf_content(raw_content, content_type, url):
+                    return self._extract_pdf_text(raw_content, url)
+                
+                # Handle encoding detection and text conversion for non-PDF content
+                return self._decode_content(raw_content, content_type, url)
+                
+        except requests.RequestException as e:
+            logger.error(f"HTTP error fetching {url}: {e}")
+            raise DataSourceError(f"HTTP error fetching {url}: {e}")
+        except Exception as e:
+            logger.error(f"Error fetching content from {url}: {e}")
+            raise DataSourceError(f"Error fetching content from {url}: {e}")
+
+    def _is_file_url(self, url: str, parsed_url) -> bool:
+        """
+        Determine if a URL likely points to a file rather than a web page.
+        
+        Args:
+            url: The original URL string
+            parsed_url: Parsed URL object
+            
+        Returns:
+            bool: True if the URL appears to be a file
+        """
+        # Check for common file extensions
+        file_extensions = {
+            '.txt', '.md', '.rst', '.json', '.yaml', '.yml', '.toml', '.ini',
+            '.py', '.go', '.js', '.ts', '.java', '.cpp', '.c', '.h',
+            '.html', '.htm', '.xml', '.csv', '.tsv', '.log',
+            '.sh', '.bat', '.ps1', '.dockerfile', '.gitignore',
+            '.conf', '.cfg', '.properties', '.env', '.pdf'
+        }
+        
+        path = parsed_url.path.lower()
+        
+        # Direct file extension match
+        for ext in file_extensions:
+            if path.endswith(ext):
+                return True
+        
+        # GitHub raw URLs
+        if 'raw.githubusercontent.com' in parsed_url.netloc:
+            return True
+        
+        # GitLab raw URLs
+        if 'gitlab' in parsed_url.netloc and '/raw/' in path:
+            return True
+        
+        # GitHub blob URLs (convert to raw)
+        return bool('github.com' in parsed_url.netloc and '/blob/' in path)
+
+    def _is_pdf_content(self, raw_content: bytes, content_type: str, url: str) -> bool:
+        """
+        Determine if the content is a PDF file.
+        
+        Args:
+            raw_content: Raw bytes content
+            content_type: HTTP content type header
+            url: Original URL for context
+            
+        Returns:
+            bool: True if the content appears to be a PDF file
+        """
+        # Check content type
+        if 'application/pdf' in content_type.lower():
+            return True
+        
+        # Check URL extension
+        if url.lower().endswith('.pdf'):
+            return True
+        
+        # Check PDF magic bytes (PDF files start with %PDF)
+        return bool(raw_content.startswith(b'%PDF'))
+
+    def _extract_pdf_text(self, raw_content: bytes, url: str) -> str:
+        """
+        Extract text content from PDF bytes.
+        
+        Args:
+            raw_content: Raw PDF bytes
+            url: Original URL for context
+            
+        Returns:
+            str: Extracted text content from the PDF
+        """
+        extracted_text = ""
+        
+        # Try PyPDF2 first (lighter weight)
+        try:
+            import PyPDF2
+            
+            pdf_stream = io.BytesIO(raw_content)
+            pdf_reader = PyPDF2.PdfReader(pdf_stream)
+            
+            logger.info(f"PDF from {url} has {len(pdf_reader.pages)} pages")
+            
+            text_parts = []
+            for page_num, page in enumerate(pdf_reader.pages, 1):
+                try:
+                    page_text = page.extract_text()
+                    if page_text.strip():
+                        text_parts.append(f"--- Page {page_num} ---\n{page_text.strip()}")
+                        logger.debug(f"Extracted {len(page_text)} characters from page {page_num}")
+                except Exception as e:
+                    logger.warning(f"Failed to extract text from page {page_num} of {url}: {e}")
+                    continue
+            
+            if text_parts:
+                extracted_text = "\n\n".join(text_parts)
+                logger.info(f"Successfully extracted {len(extracted_text)} characters from PDF using PyPDF2")
+            else:
+                logger.warning(f"No text extracted from PDF {url} using PyPDF2, trying alternative method")
+                
+        except ImportError:
+            logger.debug("PyPDF2 not available")
+        except Exception as e:
+            logger.warning(f"PyPDF2 extraction failed for {url}: {e}, trying alternative method")
+        
+        # If PyPDF2 didn't work or extracted no text, try pdfplumber
+        if not extracted_text.strip():
+            try:
+                import pdfplumber
+                
+                pdf_stream = io.BytesIO(raw_content)
+                
+                with pdfplumber.open(pdf_stream) as pdf:
+                    logger.info(f"PDF from {url} has {len(pdf.pages)} pages (pdfplumber)")
+                    
+                    text_parts = []
+                    for page_num, page in enumerate(pdf.pages, 1):
+                        try:
+                            page_text = page.extract_text()
+                            if page_text and page_text.strip():
+                                text_parts.append(f"--- Page {page_num} ---\n{page_text.strip()}")
+                                logger.debug(f"Extracted {len(page_text)} characters from page {page_num} using pdfplumber")
+                            
+                            # Also try to extract tables if available
+                            tables = page.extract_tables()
+                            if tables:
+                                for table_num, table in enumerate(tables, 1):
+                                    try:
+                                        # Convert table to text format
+                                        table_text = self._table_to_text(table)
+                                        if table_text.strip():
+                                            text_parts.append(f"--- Page {page_num} Table {table_num} ---\n{table_text.strip()}")
+                                    except Exception as e:
+                                        logger.debug(f"Failed to extract table {table_num} from page {page_num}: {e}")
+                                        
+                        except Exception as e:
+                            logger.warning(f"Failed to extract text from page {page_num} of {url} using pdfplumber: {e}")
+                            continue
+                    
+                    if text_parts:
+                        extracted_text = "\n\n".join(text_parts)
+                        logger.info(f"Successfully extracted {len(extracted_text)} characters from PDF using pdfplumber")
+                    
+            except ImportError:
+                logger.debug("pdfplumber not available")
+            except Exception as e:
+                logger.error(f"pdfplumber extraction failed for {url}: {e}")
+        
+        # Final validation
+        if not extracted_text.strip():
+            logger.error(f"Failed to extract any text from PDF {url}")
+            raise DataSourceError(f"Unable to extract text from PDF: {url}")
+        
+        logger.info(f"Successfully extracted {len(extracted_text)} characters from PDF {url}")
+        return extracted_text
+
+    def _table_to_text(self, table: list) -> str:
+        """
+        Convert a table (list of lists) to readable text format.
+        
+        Args:
+            table: Table data as list of lists
+            
+        Returns:
+            str: Formatted table as text
+        """
+        if not table:
+            return ""
+        
+        try:
+            # Filter out empty rows
+            rows = [row for row in table if row and any(cell for cell in row if cell)]
+            
+            if not rows:
+                return ""
+            
+            # Convert to strings and handle None values
+            text_rows = []
+            for row in rows:
+                text_row = []
+                for cell in row:
+                    if cell is None:
+                        text_row.append("")
+                    else:
+                        text_row.append(str(cell).strip())
+                text_rows.append(text_row)
+            
+            # Create simple text table
+            if text_rows:
+                # Use pipe separators for simple table format
+                table_lines = []
+                for row in text_rows:
+                    table_lines.append(" | ".join(row))
+                return "\n".join(table_lines)
+            
+        except Exception as e:
+            logger.debug(f"Error formatting table: {e}")
+        
+        return ""
+
+    def _decode_content(self, raw_content: bytes, content_type: str, url: str) -> str:
+        """
+        Decode raw content bytes to string, handling various encodings.
+        
+        Args:
+            raw_content: Raw bytes content
+            content_type: HTTP content type header
+            url: Original URL for context
+            
+        Returns:
+            str: Decoded text content
+        """
+        # If content is empty
+        if not raw_content:
+            logger.warning(f"Empty content received from {url}")
+            return ""
+        
+        # Try to determine encoding from content-type header
+        encoding = None
+        if 'charset=' in content_type:
+            with contextlib.suppress(Exception):
+                encoding = content_type.split('charset=')[1].split(';')[0].strip()
+        
+        # List of encodings to try in order
+        encodings_to_try = []
+        
+        if encoding:
+            encodings_to_try.append(encoding)
+        
+        # Add common encodings
+        encodings_to_try.extend(['utf-8', 'utf-8-sig', 'latin1', 'cp1252', 'iso-8859-1'])
+        
+        # Try chardet detection if available
+        try:
+            detected = chardet.detect(raw_content)
+            if detected and detected.get('encoding') and detected.get('confidence', 0) > 0.7:
+                detected_encoding = detected['encoding']
+                if detected_encoding not in encodings_to_try:
+                    encodings_to_try.insert(1, detected_encoding)
+        except Exception as e:
+            logger.debug(f"Chardet detection failed for {url}: {e}")
+        
+        # Try each encoding
+        for enc in encodings_to_try:
+            try:
+                decoded_content = raw_content.decode(enc)
+                logger.debug(f"Successfully decoded content from {url} using encoding: {enc}")
+                
+                # Handle specific content types
+                if 'application/json' in content_type:
+                    try:
+                        json_data = json.loads(decoded_content)
+                        # Try to extract text content from JSON
+                        if isinstance(json_data, dict):
+                            if 'content' in json_data:
+                                return str(json_data['content'])
+                            elif 'text' in json_data:
+                                return str(json_data['text'])
+                            elif 'body' in json_data:
+                                return str(json_data['body'])
+                        # Return formatted JSON as string
+                        return json.dumps(json_data, indent=2, ensure_ascii=False)
+                    except json.JSONDecodeError:
+                        # If JSON parsing fails, return as plain text
+                        pass
+                
+                return decoded_content
+                
+            except UnicodeDecodeError:
+                continue
+            except Exception as e:
+                logger.debug(f"Failed to decode with {enc}: {e}")
+                continue
+        
+        # If all encodings fail, try with error handling
+        try:
+            content = raw_content.decode('utf-8', errors='replace')
+            logger.warning(f"Used UTF-8 with error replacement for {url}")
+            return content
+        except Exception as e:
+            logger.error(f"Failed to decode content from {url}: {e}")
+            raise DataSourceError(f"Unable to decode content from {url}: {e}")
+
+    def _read_file_content(self, file_path: str) -> str | None:
+        """
+        Read content from a local file.
+        
+        Args:
+            file_path: Path to the file to read
+            
+        Returns:
+            str | None: The content of the file or None if failed
+        """
+        try:
+            if not os.path.exists(file_path):
+                raise DataSourceError(f"File not found: {file_path}")
+            
+            if not os.path.isfile(file_path):
+                raise DataSourceError(f"Path is not a file: {file_path}")
+            
+            with open(file_path, encoding='utf-8') as f:
+                content = f.read()
+            
+            if not content.strip():
+                logger.warning(f"File {file_path} is empty")
+                return None
+            
+            return content
+            
+        except Exception as e:
+            logger.error(f"Error reading file {file_path}: {e}")
+            raise DataSourceError(f"Error reading file {file_path}: {e}")
+
+    def _get_current_timestamp(self) -> str:
+        """Get current timestamp in ISO format."""
+        return datetime.now(UTC).isoformat().replace('+00:00', 'Z')

--- a/presets/autoindexer/k8s/__init__.py
+++ b/presets/autoindexer/k8s/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/presets/autoindexer/k8s/k8s_client.py
+++ b/presets/autoindexer/k8s/k8s_client.py
@@ -1,0 +1,343 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+Kubernetes client for interacting with KAITO AutoIndexer CRDs.
+"""
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from kubernetes import client, config
+from kubernetes.client.rest import ApiException
+
+from autoindexer.config import AUTOINDEXER_NAME, NAMESPACE
+
+logger = logging.getLogger(__name__)
+
+
+class AutoIndexerK8sClient:
+    """
+    Kubernetes client for interacting with AutoIndexer CRDs.
+    """
+
+    def __init__(self):
+        """Initialize the Kubernetes client."""
+        self.api_group = "kaito.sh"
+        self.api_version = "v1alpha1"
+        self.plural = "autoindexers"
+        self.kind = "AutoIndexer"
+        
+        # Initialize Kubernetes client
+        try:
+            # Try to load in-cluster config first (when running in a pod)
+            config.load_incluster_config()
+            logger.info("Loaded in-cluster Kubernetes configuration")
+        except config.ConfigException:
+            try:
+                # Fall back to kubeconfig for local development
+                config.load_kube_config()
+                logger.info("Loaded kubeconfig Kubernetes configuration")
+            except config.ConfigException as e:
+                logger.error(f"Failed to load Kubernetes configuration: {e}")
+                raise
+        
+        self.custom_api = client.CustomObjectsApi()
+        self.core_api = client.CoreV1Api()
+        
+        # Get current pod information if available
+        self.namespace = NAMESPACE
+        self.autoindexer_name = AUTOINDEXER_NAME
+        
+        logger.info(f"AutoIndexer K8s client initialized for namespace: {self.namespace}, autoindexer: {self.autoindexer_name}")
+
+    def get_autoindexer(self) -> dict[str, Any] | None:
+        """
+        Get an AutoIndexer CRD.
+            
+        Returns:
+            Dict containing the AutoIndexer CRD or None if not found
+        """
+        self.autoindexer_name
+        self.namespace
+
+        if not self.autoindexer_name:
+            logger.warning("No AutoIndexer name specified")
+            return None
+            
+        try:
+            response = self.custom_api.get_namespaced_custom_object(
+                group=self.api_group,
+                version=self.api_version,
+                namespace=self.namespace,
+                plural=self.plural,
+                name=self.autoindexer_name
+            )
+            logger.debug(f"Retrieved AutoIndexer {self.namespace}/{self.autoindexer_name}")
+            # logger.info(f"AutoIndexer details: {response}")
+            return response
+            
+        except ApiException as e:
+            if e.status == 404:
+                logger.warning(f"AutoIndexer {self.namespace}/{self.autoindexer_name} not found")
+                return None
+            else:
+                logger.error(f"Failed to get AutoIndexer {self.namespace}/{self.autoindexer_name}: {e}")
+                raise
+
+    def update_autoindexer_status(self, status_update: dict[str, Any], update_success_or_failure: bool = False) -> bool:
+        """
+        Update the status of an AutoIndexer CRD.
+        
+        Args:
+            status_update: Dictionary containing status updates
+            update_success_or_failure: Whether to update success/failure counters
+            
+        Returns:
+            bool: True if successful, False otherwise
+        """
+
+        if not self.autoindexer_name:
+            logger.warning("No AutoIndexer name specified for status update")
+            return False
+            
+        try:
+            # Get current AutoIndexer
+            logger.info(f"Updating AutoIndexer {self.namespace}/{self.autoindexer_name} status with: {status_update}")
+            current = self.get_autoindexer()
+            if not current:
+                logger.error(f"Cannot update status: AutoIndexer {self.namespace}/{self.autoindexer_name} not found")
+                return False
+            
+            # Update status
+            if "status" not in current:
+                current["status"] = {}
+            
+            current["status"].update(status_update)
+
+            if update_success_or_failure:
+                if status_update.get("indexingPhase") == "Completed":
+                    current["status"]["successfulIndexingCount"] = current["status"].get("successfulIndexingCount", 0) + 1
+                elif status_update.get("indexingPhase") == "Failed":
+                    current["status"]["errorIndexingCount"] = current["status"].get("errorIndexingCount", 0) + 1
+            
+            # Patch the status subresource
+            self.custom_api.patch_namespaced_custom_object_status(
+                group=self.api_group,
+                version=self.api_version,
+                namespace=self.namespace,
+                plural=self.plural,
+                name=self.autoindexer_name,
+                body=current
+            )
+
+            logger.info(f"Updated AutoIndexer {self.namespace}/{self.autoindexer_name} status")
+            return True
+            
+        except ApiException as e:
+            logger.error(f"Failed to update AutoIndexer status: {e}")
+            return False
+
+    def add_status_condition(self, condition_type: str, status: str, reason: str, message: str) -> bool:
+        """
+        Add or update a status condition on the AutoIndexer.
+        
+        Args:
+            condition_type: Type of condition - should be one of:
+                - "AutoIndexerSucceeded" 
+                - "AutoIndexerScheduled"
+                - "AutoIndexerIndexing" 
+                - "AutoIndexerError"
+                - "ResourceReady"
+            status: Status of condition ("True", "False", "Unknown")
+            reason: Short reason for the condition
+            message: Human readable message
+            
+        Returns:
+            bool: True if successful, False otherwise
+        """
+
+        if not self.autoindexer_name:
+            logger.warning("No AutoIndexer name specified for condition update")
+            return False
+            
+        try:
+            # Get current AutoIndexer
+            current = self.get_autoindexer()
+            if not current:
+                logger.error(f"Cannot add condition: AutoIndexer {self.namespace}/{self.autoindexer_name} not found")
+                return False
+            
+            # Initialize status and conditions if they don't exist
+            if "status" not in current:
+                current["status"] = {}
+            if "conditions" not in current["status"]:
+                current["status"]["conditions"] = []
+            
+            # Create new condition
+            now = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+            
+            # Find existing condition of the same type
+            conditions = current["status"]["conditions"]
+            found = False
+            for i, condition in enumerate(conditions):
+                if condition.get("type") == condition_type:
+                    # Update existing condition
+                    transition_time = now if condition.get("status") != status else condition.get("lastTransitionTime", now)
+                    conditions[i] = self._create_condition(condition_type, status, reason, message, transition_time)
+                    found = True
+                    break
+            
+            if not found:
+                # Add new condition
+                new_condition = self._create_condition(condition_type, status, reason, message, now)
+                conditions.append(new_condition)
+            
+            # Update the status
+            self.custom_api.patch_namespaced_custom_object_status(
+                group=self.api_group,
+                version=self.api_version,
+                namespace=self.namespace,
+                plural=self.plural,
+                name=self.autoindexer_name,
+                body=current
+            )
+
+            logger.info(f"Added condition '{condition_type}' to AutoIndexer {self.namespace}/{self.autoindexer_name}")
+            return True
+            
+        except ApiException as e:
+            logger.error(f"Failed to add condition to AutoIndexer: {e}")
+            return False
+
+    def _create_condition(self, condition_type: str, status: str, reason: str, message: str, last_transition_time: str | None = None) -> dict[str, str]:
+        """
+        Create a condition dictionary structure.
+        
+        Args:
+            condition_type: Type of condition
+            status: Status of condition ("True", "False", "Unknown")
+            reason: Short reason for the condition
+            message: Human readable message
+            last_transition_time: Optional timestamp, defaults to current time
+            
+        Returns:
+            dict: Condition structure
+        """
+        if last_transition_time is None:
+            last_transition_time = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+            
+        return {
+            "type": condition_type,
+            "status": status,
+            "reason": reason,
+            "message": message,
+            "lastTransitionTime": last_transition_time
+        }
+
+    def update_indexing_progress(self, total_documents: int) -> bool:
+        """
+        Update indexing progress in the AutoIndexer status.
+        
+        Args:
+            total_documents: Total number of documents processed
+            
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        progress_update = {
+            "numOfDocumentInIndex": total_documents,
+            "lastIndexingTimestamp": datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        }
+
+        return self.update_autoindexer_status(progress_update)
+
+    def update_indexing_phase(self, phase: str) -> bool:
+        """
+        Update the indexing phase in the AutoIndexer status.
+        
+        Args:
+            phase: Indexing phase - should be one of:
+                - "Pending"
+                - "Running" 
+                - "Completed"
+                - "Failed"
+                - "Retrying"
+                - "Unknown"
+            
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        phase_update = {
+            "indexingPhase": phase
+        }
+
+        return self.update_autoindexer_status(phase_update)
+
+    def update_indexing_completion(self, success: bool, duration_seconds: int, document_count: int, commit_hash: str | None = None) -> bool:
+        """
+        Update status when indexing completes.
+        
+        Args:
+            success: Whether indexing was successful
+            duration_seconds: How long indexing took
+            document_count: Number of documents indexed
+            commit_hash: Git commit hash if applicable
+            
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        now = datetime.now(UTC).isoformat().replace("+00:00", "Z")
+        
+        completion_update = {
+            "lastIndexingTimestamp": now,
+            "lastIndexingDurationSeconds": duration_seconds,
+            "numOfDocumentInIndex": document_count,
+            "indexingPhase": "Completed" if success else "Failed"
+        }
+        
+        if success:
+            completion_update["successfulIndexingCount"] = self._increment_counter("successfulIndexingCount")
+        else:
+            completion_update["errorIndexingCount"] = self._increment_counter("errorIndexingCount")
+        
+        if commit_hash:
+            completion_update["lastIndexedCommit"] = commit_hash
+
+        return self.update_autoindexer_status(completion_update)
+
+    def _increment_counter(self, counter_field: str) -> int:
+        """Helper method to increment a counter field."""
+        try:
+            current = self.get_autoindexer()
+            if current and "status" in current:
+                current_count = current["status"].get(counter_field, 0)
+                return current_count + 1
+            return 1
+        except Exception as e:
+            logger.warning(f"Failed to get current counter value: {e}")
+            return 1
+
+    def get_autoindexer_config(self) -> dict[str, Any] | None:
+        """
+        Get the configuration from an AutoIndexer CRD spec.
+
+        Returns:
+            Dict containing the AutoIndexer spec or None if not found
+        """
+        autoindexer = self.get_autoindexer()
+        if autoindexer:
+            return autoindexer.get("spec", {})
+        return None

--- a/presets/autoindexer/main.py
+++ b/presets/autoindexer/main.py
@@ -1,0 +1,364 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+AutoIndexer Service
+
+This service handles document indexing from various data sources into KAITO RAG engines.
+It supports static file data sources and uses the KAITO RAG Client for document indexing.
+"""
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from typing import Any
+
+from autoindexer.config import ACCESS_SECRET, AUTOINDEXER_NAME, NAMESPACE
+from autoindexer.data_source_handler.git_handler import GitDataSourceHandler
+from autoindexer.data_source_handler.handler import DataSourceError
+from autoindexer.data_source_handler.static_handler import (
+    StaticDataSourceHandler,
+)
+from autoindexer.k8s.k8s_client import AutoIndexerK8sClient
+from autoindexer.rag.rag_client import KAITORAGClient
+
+# Configure logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+)
+logger = logging.getLogger(__name__)
+
+
+class AutoIndexerService:
+    """
+    Main AutoIndexer service that coordinates document indexing from data sources to RAG engines.
+    """
+
+    def __init__(self, dry_run: bool = False):
+        """Initialize the AutoIndexer service with environment variables."""
+        self.dry_run = dry_run
+        self.access_secret = ACCESS_SECRET
+        self.autoindexer_name = AUTOINDEXER_NAME
+        self.namespace = NAMESPACE
+
+        # Initialize configuration attributes with defaults
+        self.index_name = None
+        self.ragengine_endpoint = None
+        self.datasource_type = None
+        self.datasource_config = None
+        self.credentials_config = None
+        
+        # Initialize Kubernetes client for CRD interaction
+        self.k8s_client = None
+        self.autoindexer_client = None  # Alias for k8s_client for compatibility
+        try:
+            self.k8s_client = AutoIndexerK8sClient()
+            self.autoindexer_client = self.k8s_client  # Set alias
+            logger.info("Kubernetes client initialized successfully")
+            
+            # Try to get configuration from the AutoIndexer CRD
+            crd_config = self.k8s_client.get_autoindexer_config()
+            if crd_config:
+                logger.info("Found AutoIndexer CRD configuration, using it to supplement environment config")
+                self._apply_crd_config(crd_config)
+            
+        except Exception as e:
+            logger.warning(f"Failed to initialize Kubernetes client: {e}")
+            logger.info("Continuing without Kubernetes integration")
+            raise
+
+        # Initialize RAG client (after CRD config is applied)
+        if not self.ragengine_endpoint:
+            raise ValueError("RAG engine endpoint must be configured via CRD or environment variables")
+        self.rag_client = KAITORAGClient(self.ragengine_endpoint)
+        
+        # Initialize data source handler
+        self.data_source_handler = self._create_data_source_handler()
+        
+        logger.info(f"AutoIndexer initialized for index '{self.index_name}' with data source type '{self.datasource_type}'")
+
+    def _get_required_env(self, key: str) -> str:
+        """Get a required environment variable."""
+        value = os.getenv(key)
+        if not value:
+            raise ValueError(f"Required environment variable {key} is not set")
+        return value
+
+    def _get_optional_env_json(self, key: str) -> dict[str, Any] | None:
+        """Get an optional environment variable and parse as JSON."""
+        value = os.getenv(key)
+        if not value:
+            return None
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError as e:
+            logger.warning(f"Failed to parse {key} as JSON: {e}")
+            return None
+
+    def _create_data_source_handler(self):
+        """Create the appropriate data source handler based on configuration."""
+        if self.datasource_type.lower() == "static":
+            return StaticDataSourceHandler(
+                index_name=self.index_name,
+                config=self.datasource_config or {},
+                rag_client=self.rag_client,
+                autoindexer_client=self.autoindexer_client,
+                credentials=self.access_secret
+            )
+        elif self.datasource_type.lower() == "git":
+            return GitDataSourceHandler(
+                config=self.datasource_config or {},
+                credentials=self.access_secret,
+                rag_client=self.rag_client,
+                autoindexer_client=self.autoindexer_client
+            )
+        else:
+            raise ValueError(f"Unsupported data source type: {self.datasource_type}")
+
+    def _apply_crd_config(self, crd_config: dict[str, Any]):
+        """Apply configuration from AutoIndexer CRD to supplement environment variables."""
+        try:
+            # Update index name from CRD if not set via environment
+            if crd_config.get("indexName"):
+                self.index_name = crd_config["indexName"]
+                logger.info(f"Using index name from CRD: {self.index_name}")
+            else:
+                raise ValueError("indexName must be specified via autoindexer CRD")
+            
+            # Update RAG engine endpoint from CRD if not set via environment
+            if crd_config.get("ragEngine"):
+                # Construct endpoint from RAG engine name (assuming same namespace)
+                rag_engine_name = crd_config["ragEngine"]
+                namespace = self.k8s_client.namespace if self.k8s_client else "default"
+                self.ragengine_endpoint = f"http://{rag_engine_name}.{namespace}.svc.cluster.local:80"
+                logger.info(f"Using RAG engine endpoint from CRD: {self.ragengine_endpoint}")
+            else:
+                raise ValueError("ragEngine must be specified via autoindexer CRD")
+            
+            # Update data source configuration from CRD
+            if crd_config.get("dataSource"):
+                ds_config = crd_config["dataSource"]
+                
+                # Override data source type if not set via environment
+                if ds_config.get("type"):
+                    self.datasource_type = ds_config["type"]
+                    logger.info(f"Using data source type from CRD: {self.datasource_type}")
+                else:
+                    raise ValueError("dataSource type must be specified via autoindexer CRD")
+                
+                # Merge data source configuration
+                if not self.datasource_config:
+                    self.datasource_config = {}
+                
+                # Add specific data source configurations based on type
+                if ds_config.get("git") and ds_config["type"] == "Git":
+                    git_config = ds_config["git"]
+                    self.datasource_config.update({
+                        "autoindexer_name": self.autoindexer_name,
+                        "repository": git_config.get("repository"),
+                        "branch": git_config.get("branch", "main"),
+                        "commit": git_config.get("commit"),
+                        "paths": git_config.get("paths", []),
+                        "excludePaths": git_config.get("excludePaths", [])
+                    })
+                    logger.info("Updated Git data source configuration from CRD")
+                
+                elif ds_config.get("static") and ds_config["type"] == "Static":
+                    static_config = ds_config["static"]
+                    self.datasource_config.update({
+                        "autoindexer_name": self.autoindexer_name,
+                        "urls": static_config.get("urls", [])
+                    })
+                    logger.info("Updated Static data source configuration from CRD")
+                
+                else:
+                    raise ValueError("Unsupported or missing data source configuration in CRD")
+                
+        except Exception as e:
+            logger.warning(f"Failed to apply CRD configuration: {e}")
+            raise
+
+    def run(self) -> bool:
+        """
+        Run the indexing process.
+        
+        Returns:
+            bool: True if successful, False otherwise
+        """
+        start_time = time.time()
+        
+        try:
+            logger.info("Starting document indexing process")
+            
+            # Update phase and status to indicate we're starting
+            self._update_indexing_phase("Running")
+            self._update_status_condition("AutoIndexerIndexing", "True", "IndexingStarted", "Document indexing process has started")
+
+            # Update the index and check for errors
+            self._update_index()
+            self._update_autoindexer_status()
+                
+        except Exception as e:
+            # Calculate duration for failure case
+            end_time = time.time()
+            duration_seconds = int(end_time - start_time)
+            
+            logger.error(f"AutoIndexer service failed: {e}", exc_info=True)
+            self._update_status_condition("AutoIndexerError", "True", "ServiceError", f"AutoIndexer service failed: {str(e)}")
+            
+            # Try to get document count even in failure case
+            try:
+                documents_response = self.rag_client.list_documents(self.index_name, metadata_filter={"autoindexer": self.autoindexer_name}, limit=1)
+                document_count = documents_response.get("total_items", 0)
+            except Exception:
+                document_count = 0
+                
+            self._update_indexing_completion(False, duration_seconds, document_count, None)
+            return False
+
+        return True
+
+    def _update_index(self) -> list[str]:
+        """
+        Update the index with documents from the data source.
+        
+        Returns:
+            List[str]: List of error messages, if any
+        """
+        try:
+            errors = self.data_source_handler.update_index()
+            return errors
+                
+        except DataSourceError as e:
+            error_msg = f"Data source error: {e}"
+            logger.error(error_msg)
+            return [error_msg]
+        except Exception as e:
+            error_msg = f"Unexpected error during indexing: {e}"
+            logger.error(error_msg, exc_info=True)
+            return [error_msg]
+    
+    def _update_autoindexer_status(self):
+        """Update the status of the AutoIndexer CRD."""
+        try:
+            self.data_source_handler.update_autoindexer_status()
+        except Exception as e:
+            logger.error(f"Failed to update AutoIndexer status: {e}")
+
+    def _ensure_index_exists(self):
+        """Ensure the target index exists in the RAG engine."""
+        try:
+            # List indexes to check if our index exists
+            indexes_response = self.rag_client.list_indexes()
+            existing_indexes = [idx.get("name", "") for idx in indexes_response.get("indexes", [])]
+            
+            if self.index_name not in existing_indexes:
+                logger.info(f"Index '{self.index_name}' does not exist, it will be created automatically during first indexing")
+            else:
+                logger.info(f"Index '{self.index_name}' already exists")
+                
+        except Exception as e:
+            # If we can't list indexes, assume the index will be created automatically
+            logger.warning(f"Could not verify index existence: {e}")
+
+    def _update_status_condition(self, condition_type: str, status: str, reason: str, message: str):
+        """Update status condition in the AutoIndexer CRD if Kubernetes client is available."""
+        if self.k8s_client:
+            try:
+                self.k8s_client.add_status_condition(condition_type, status, reason, message)
+            except Exception as e:
+                logger.warning(f"Failed to update status condition: {e}")
+        else:
+            logger.debug(f"Status update (no K8s client): {condition_type}={status} - {reason}: {message}")
+
+    def _update_indexing_progress(self, total_documents: int, processed_documents: int):
+        """Update indexing progress in the AutoIndexer CRD if Kubernetes client is available."""
+        if self.k8s_client:
+            try:
+                self.k8s_client.update_indexing_progress(total_documents, processed_documents)
+            except Exception as e:
+                logger.warning(f"Failed to update indexing progress: {e}")
+        else:
+            logger.debug(f"Progress update (no K8s client): {processed_documents}/{total_documents} documents processed")
+
+    def _update_indexing_phase(self, phase: str):
+        """Update indexing phase in the AutoIndexer CRD if Kubernetes client is available."""
+        if self.k8s_client:
+            try:
+                self.k8s_client.update_indexing_phase(phase)
+            except Exception as e:
+                logger.warning(f"Failed to update indexing phase: {e}")
+        else:
+            logger.debug(f"Phase update (no K8s client): {phase}")
+
+    def _update_indexing_completion(self, success: bool, duration_seconds: int, document_count: int, commit_hash: str | None = None):
+        """Update status when indexing completes."""
+        if self.k8s_client:
+            try:
+                self.k8s_client.update_indexing_completion(success, duration_seconds, document_count, commit_hash)
+            except Exception as e:
+                logger.warning(f"Failed to update indexing completion: {e}")
+        else:
+            status = "success" if success else "failed"
+            logger.debug(f"Completion update (no K8s client): {status}, {document_count} documents, {duration_seconds}s")
+
+
+def main():
+    """Main entry point for the AutoIndexer service."""
+    parser = argparse.ArgumentParser(description="KAITO AutoIndexer Service")
+    parser.add_argument(
+        "--mode",
+        choices=["index"],
+        default="index",
+        help="Operation mode (currently only 'index' is supported)"
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Perform a dry run without actually indexing documents"
+    )
+    parser.add_argument(
+        "--log-level",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        default="INFO",
+        help="Set the logging level"
+    )
+    
+    args = parser.parse_args()
+    
+    # Set logging level
+    logging.getLogger().setLevel(getattr(logging, args.log_level))
+    
+    try:
+        service = AutoIndexerService(dry_run=args.dry_run)
+        success = service.run()
+        
+        if success:
+            logger.info("AutoIndexer service completed successfully")
+            sys.exit(0)
+        else:
+            logger.error("AutoIndexer service failed")
+            sys.exit(1)
+            
+    except Exception as e:
+        logger.error(f"Failed to initialize AutoIndexer service: {e}", exc_info=True)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/presets/autoindexer/rag/__init__.py
+++ b/presets/autoindexer/rag/__init__.py
@@ -1,0 +1,13 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/presets/autoindexer/rag/rag_client.py
+++ b/presets/autoindexer/rag/rag_client.py
@@ -1,0 +1,136 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+
+import requests
+
+
+class KAITORAGClient:
+    """
+    A client for interacting with the KAITO RAGEngine API.
+    This client provides methods to index documents, query the engine,
+    update documents, delete documents, list documents, and manage indexes.
+    
+    This is based on the example RAG client but optimized for the AutoIndexer use case.
+    """
+
+    def __init__(self, base_url):
+        self.base_url = base_url
+        self.headers = {
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def index_documents(self, index_name, documents):
+        """
+        Index documents in the RAGEngine.
+        documents: list of dicts, each with 'text' and optional 'metadata'
+        """
+        url = f"{self.base_url}/index"
+        payload = {"index_name": index_name, "documents": documents}
+        resp = requests.post(url, json=payload, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def query(self, index_name, query, llm_temperature, llm_max_tokens, top_k=5):
+        """
+        Query the RAGEngine.
+        query: str, the query text
+        top_k: int, number of results to return
+        metadata: optional dict, additional metadata for the query
+        """
+        url = f"{self.base_url}/query"
+        payload = {
+            "index_name": index_name,
+            "query": query,
+            "top_k": top_k,
+            "llm_params": {
+                "temperature": llm_temperature,
+                "max_tokens": llm_max_tokens,
+            },
+        }
+        resp = requests.post(url, json=payload, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def update_documents(self, index_name, documents):
+        """
+        Update a document in the RAGEngine.
+        documents: list of dicts, each with 'id', 'text', and optional 'metadata'
+        """
+        url = f"{self.base_url}/indexes/{index_name}/documents"
+        payload = {"documents": documents}
+        resp = requests.post(url, json=payload, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def delete_documents(self, index_name, document_ids):
+        """
+        Delete a document from the RAGEngine by its ID.
+        """
+        url = f"{self.base_url}/indexes/{index_name}/documents/delete"
+        payload = {"doc_ids": document_ids}
+        resp = requests.post(url, json=payload, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def list_documents(self, index_name, metadata_filter, limit=10, offset=0):
+        """
+        List documents in the RAGEngine.
+        """
+        url = f"{self.base_url}/indexes/{index_name}/documents"
+        params = {"limit": limit, "offset": offset}
+        if metadata_filter:
+            params["metadata_filter"] = json.dumps(metadata_filter)
+        resp = requests.get(url, headers=self.headers, params=params)
+        resp.raise_for_status()
+        return resp.json()
+
+    def list_indexes(self):
+        """
+        List all indexes in the RAGEngine.
+        """
+        url = f"{self.base_url}/indexes"
+        resp = requests.get(url, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def persist_index(self, index_name, path="/tmp"):
+        """
+        Persist an index in the RAGEngine.
+        """
+        url = f"{self.base_url}/persist/{index_name}"
+        params = {"path": path}
+        resp = requests.post(url, params=params, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def load_index(self, index_name, path="/tmp", overwrite=True):
+        """
+        Load an index in the RAGEngine.
+        """
+        url = f"{self.base_url}/load/{index_name}"
+        params = {"path": path, "overwrite": overwrite}
+        resp = requests.post(url, params=params, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()
+
+    def delete_index(self, index_name):
+        """
+        Delete an index from the RAGEngine.
+        """
+        url = f"{self.base_url}/indexes/{index_name}"
+        resp = requests.delete(url, headers=self.headers)
+        resp.raise_for_status()
+        return resp.json()

--- a/presets/autoindexer/rag/utils.py
+++ b/presets/autoindexer/rag/utils.py
@@ -1,0 +1,27 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+valid_languages = ['bash', 'c', 'c_sharp','commonlisp', 'cpp', 'css', 'dockerfile', 'dot', 'elisp', 'elixir', 'elm', 'embedded_template', 'erlang', 'fixed_form_fortran', 'fortran', 'go', 'gomod', 'hack', 'haskell', 'hcl', 'html', 'java', 'javascript', 'jsdoc', 'json', 'julia', 'kotlin', 'lua', 'make', 'markdown', 'objc', 'ocaml', 'perl', 'php', 'python', 'ql', 'r', 'regex', 'rst', 'ruby', 'rust', 'scala', 'sql', 'sqlite', 'toml', 'tsq', 'typescript', 'yaml']
+file_extension_to_language_map = { ".sh": "bash", ".bash": "bash", ".c": "c", ".cs": "c_sharp", ".lisp": "commonlisp", ".lsp": "commonlisp", ".cpp": "cpp", ".cc": "cpp", ".cxx": "cpp", ".hpp": "cpp", ".h": "c", ".css": "css", ".dockerfile": "dockerfile", "Dockerfile": "dockerfile", ".dot": "dot", ".el": "elisp", ".ex": "elixir", ".exs": "elixir", ".elm": "elm", ".ejs": "embedded_template", ".erl": "erlang", ".hrl": "erlang", ".f": "fixed_form_fortran", ".for": "fixed_form_fortran", ".f90": "fortran", ".f95": "fortran", ".go": "go", ".mod": "gomod", "go.mod": "gomod", ".hack": "hack", ".hs": "haskell", ".hcl": "hcl", ".tf": "hcl", ".html": "html", ".htm": "html", ".java": "java", ".js": "javascript", ".jsx": "javascript", ".jsdoc": "jsdoc", ".json": "json", ".jl": "julia", ".kt": "kotlin", ".kts": "kotlin", ".lua": "lua", ".mk": "make", "Makefile": "make", ".md": "markdown", ".m": "objc", ".mm": "objc", ".ml": "ocaml", ".mli": "ocaml", ".pl": "perl", ".pm": "perl", ".php": "php", ".py": "python", ".ql": "ql", ".r": "r", ".regex": "regex", ".rst": "rst", ".rb": "ruby", ".rs": "rust", ".scala": "scala", ".sc": "scala", ".sql": "sql", ".sqlite": "sqlite", ".db": "sqlite", ".toml": "toml", ".tsq": "tsq", ".ts": "typescript", ".tsx": "typescript", ".yaml": "yaml", ".yml": "yaml"}
+
+
+def get_file_extension_language(file_extension: str) -> str:
+    if not file_extension.startswith("."):
+        file_extension = "." + file_extension
+    return file_extension_to_language_map.get(file_extension, "")
+
+def create_rag_document(text: str, metadata: dict[str, str] | None = None) -> dict[str, str]:
+    document = {"text": text}
+    if metadata:
+        document["metadata"] = metadata
+    return document

--- a/presets/autoindexer/requirements-test.txt
+++ b/presets/autoindexer/requirements-test.txt
@@ -1,0 +1,5 @@
+# Development and testing dependencies for autoindexer
+pytest>=7.4.0
+pytest-cov>=4.1.0
+pytest-mock>=3.11.0
+pytest-asyncio>=0.21.0

--- a/presets/autoindexer/requirements.txt
+++ b/presets/autoindexer/requirements.txt
@@ -1,0 +1,7 @@
+requests>=2.31.0
+urllib3>=2.0.0
+chardet==5.2.0
+PyPDF2>=3.0.0
+pdfplumber>=0.9.0
+kubernetes>=28.1.0
+pyyaml>=6.0.0

--- a/presets/autoindexer/tests/__init__.py
+++ b/presets/autoindexer/tests/__init__.py
@@ -1,0 +1,17 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+Tests package for autoindexer.
+"""

--- a/presets/autoindexer/tests/conftest.py
+++ b/presets/autoindexer/tests/conftest.py
@@ -1,0 +1,54 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+Shared test configuration and fixtures.
+"""
+
+import os
+
+import pytest
+
+# Set up environment variables at module level so they're available during imports
+os.environ["NAMESPACE"] = "test-namespace"
+os.environ["AUTOINDEXER_NAME"] = "test-autoindexer"
+os.environ["ACCESS_SECRET"] = "test-secret"
+
+
+@pytest.fixture(autouse=True, scope="session")
+def setup_test_environment():
+    """Ensure test environment variables remain set throughout the session."""
+    # Environment variables are already set at module level
+    # This fixture just ensures they stay set and cleans up at the end
+    yield
+    # Clean up after all tests are done
+    for var in ["NAMESPACE", "AUTOINDEXER_NAME", "ACCESS_SECRET"]:
+        os.environ.pop(var, None)
+
+
+@pytest.fixture(autouse=True)
+def reset_environment():
+    """Reset environment variables before each test but preserve test globals."""
+    original_env = os.environ.copy()
+    yield
+    # Restore environment but keep our test globals
+    os.environ.clear()
+    os.environ.update(original_env)
+    # Ensure test environment variables are still set
+    if "NAMESPACE" not in os.environ:
+        os.environ["NAMESPACE"] = "test-namespace"
+    if "AUTOINDEXER_NAME" not in os.environ:
+        os.environ["AUTOINDEXER_NAME"] = "test-autoindexer"
+    if "ACCESS_SECRET" not in os.environ:
+        os.environ["ACCESS_SECRET"] = "test-access-secret"

--- a/presets/autoindexer/tests/test_k8s_client.py
+++ b/presets/autoindexer/tests/test_k8s_client.py
@@ -1,0 +1,474 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""
+Tests for AutoIndexerK8sClient.
+"""
+
+import os
+from unittest.mock import patch
+
+import pytest
+from kubernetes.client.rest import ApiException
+from kubernetes.config.config_exception import ConfigException
+
+from autoindexer.k8s.k8s_client import AutoIndexerK8sClient
+
+
+@pytest.fixture(autouse=True)
+def mock_k8s_config():
+    """Mock the kubernetes config module."""
+    with patch("autoindexer.k8s.k8s_client.config") as mock_config:
+        # Make ConfigException available on the mock
+        mock_config.ConfigException = ConfigException
+        yield mock_config
+
+
+@pytest.fixture
+def mock_custom_api():
+    """Mock CustomObjectsApi."""
+    with patch('autoindexer.k8s.k8s_client.client.CustomObjectsApi') as mock_api:
+        yield mock_api.return_value
+
+
+@pytest.fixture
+def mock_core_api():
+    """Mock CoreV1Api."""
+    with patch('autoindexer.k8s.k8s_client.client.CoreV1Api') as mock_api:
+        yield mock_api.return_value
+
+
+@pytest.fixture
+def sample_autoindexer_crd():
+    """Sample AutoIndexer CRD object."""
+    return {
+        "apiVersion": "kaito.sh/v1alpha1",
+        "kind": "AutoIndexer",
+        "metadata": {
+            "name": "test-autoindexer",
+            "namespace": "default"
+        },
+        "spec": {
+            "indexName": "test-index",
+            "ragEngine": "test-rag-engine",
+            "dataSource": {
+                "type": "Git",
+                "git": {
+                    "repository": "https://github.com/example/repo.git",
+                    "branch": "main",
+                    "paths": ["/docs"],
+                    "excludePaths": ["/docs/private"]
+                }
+            }
+        },
+        "status": {
+            "conditions": [],
+            "indexingPhase": "Pending",
+            "numOfDocumentInIndex": 0,
+            "successfulIndexingCount": 0,
+            "errorIndexingCount": 0
+        }
+    }
+
+
+class TestAutoIndexerK8sClient:
+    """Test cases for AutoIndexerK8sClient."""
+
+    def test_init_in_cluster_config(self, mock_k8s_config, mock_custom_api, mock_core_api):
+        """Test initialization with in-cluster config."""
+        # Mock successful in-cluster config loading
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        # Mock environment variables
+        with patch.dict(os.environ, {
+            'NAMESPACE': 'test-namespace',
+            'AUTOINDEXER_NAME': 'test-autoindexer'
+        }):
+            client = AutoIndexerK8sClient()
+            
+            assert client.api_group == "kaito.sh"
+            assert client.api_version == "v1alpha1"
+            assert client.plural == "autoindexers"
+            assert client.kind == "AutoIndexer"
+            assert client.namespace == "test-namespace"
+            assert client.autoindexer_name == "test-autoindexer"
+            
+            mock_k8s_config.load_incluster_config.assert_called_once()
+
+    def test_init_kubeconfig_fallback(self, mock_k8s_config, mock_custom_api, mock_core_api):
+        """Test initialization with kubeconfig fallback when incluster config fails."""
+        # Mock incluster config to fail, kubeconfig to succeed
+        mock_k8s_config.load_incluster_config.side_effect = ConfigException("Not in cluster")
+        mock_k8s_config.load_kube_config.return_value = None  # Success
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'test-ns'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-ai'):
+            client = AutoIndexerK8sClient()
+            
+        # Verify both config methods were called
+        mock_k8s_config.load_incluster_config.assert_called_once()
+        mock_k8s_config.load_kube_config.assert_called_once()
+        
+        assert client.namespace == "test-ns"
+        assert client.autoindexer_name == "test-ai"
+
+    def test_init_config_failure(self, mock_k8s_config, mock_custom_api, mock_core_api):
+        """Test initialization failure when both config methods fail."""
+        # Mock both config methods to fail
+        mock_k8s_config.load_incluster_config.side_effect = ConfigException("Not in cluster")
+        mock_k8s_config.load_kube_config.side_effect = ConfigException("No kubeconfig")
+        
+        with pytest.raises(ConfigException):
+            AutoIndexerK8sClient()
+
+    def test_get_current_namespace_from_env(self, mock_k8s_config, mock_custom_api, mock_core_api):
+        """Test getting namespace from environment variable."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'custom-namespace'):
+            client = AutoIndexerK8sClient()
+            assert client.namespace == "custom-namespace"
+
+    def test_get_current_namespace_from_service_account(self, mock_k8s_config, mock_custom_api, mock_core_api):
+        """Test getting namespace from service account token."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'service-account-namespace'):
+            client = AutoIndexerK8sClient()
+            assert client.namespace == "service-account-namespace"
+
+    def test_get_current_namespace_default_fallback(self, mock_k8s_config, mock_custom_api, mock_core_api):
+        """Test fallback to default namespace."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'):
+            client = AutoIndexerK8sClient()
+            assert client.namespace == "default"
+
+    def test_get_autoindexer_success(self, mock_k8s_config, mock_custom_api, mock_core_api, sample_autoindexer_crd):
+        """Test successful retrieval of AutoIndexer CRD."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        mock_custom_api.get_namespaced_custom_object.return_value = sample_autoindexer_crd
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-autoindexer'):
+            client = AutoIndexerK8sClient()
+            result = client.get_autoindexer()
+            
+            assert result == sample_autoindexer_crd
+            mock_custom_api.get_namespaced_custom_object.assert_called_once_with(
+                group="kaito.sh",
+                version="v1alpha1",
+                namespace="default",
+                plural="autoindexers",
+                name="test-autoindexer"
+            )
+
+    def test_get_autoindexer_not_found(self, mock_k8s_config, mock_custom_api, mock_core_api):
+        """Test AutoIndexer CRD not found."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        # Mock 404 error
+        api_error = ApiException(status=404)
+        mock_custom_api.get_namespaced_custom_object.side_effect = api_error
+        
+        with patch.dict(os.environ, {
+            'NAMESPACE': 'default',
+            'AUTOINDEXER_NAME': 'test-autoindexer'
+        }):
+            client = AutoIndexerK8sClient()
+            result = client.get_autoindexer()
+            
+            assert result is None
+
+    def test_get_autoindexer_api_error(self, mock_k8s_config, mock_custom_api, mock_core_api):
+        """Test AutoIndexer CRD API error."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        # Mock non-404 error
+        api_error = ApiException(status=500)
+        mock_custom_api.get_namespaced_custom_object.side_effect = api_error
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-autoindexer'):
+            client = AutoIndexerK8sClient()
+            
+            with pytest.raises(ApiException):
+                client.get_autoindexer()
+
+    def test_get_autoindexer_no_name(self, mock_k8s_config, mock_custom_api, mock_core_api):
+        """Test getting AutoIndexer with no name specified."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', ''):
+            client = AutoIndexerK8sClient()
+            result = client.get_autoindexer()
+            
+            assert result is None
+
+    def test_update_autoindexer_status_success(self, mock_k8s_config, mock_custom_api, mock_core_api, sample_autoindexer_crd):
+        """Test successful status update."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        # Mock successful get and patch
+        mock_custom_api.get_namespaced_custom_object.return_value = sample_autoindexer_crd.copy()
+        mock_custom_api.patch_namespaced_custom_object_status.return_value = sample_autoindexer_crd
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-autoindexer'):
+            client = AutoIndexerK8sClient()
+            
+            status_update = {"indexingPhase": "Running"}
+            result = client.update_autoindexer_status(status_update)
+            
+            assert result is True
+            mock_custom_api.patch_namespaced_custom_object_status.assert_called_once()
+
+    def test_update_autoindexer_status_not_found(self, mock_k8s_config, mock_custom_api, mock_core_api):
+        """Test status update when AutoIndexer not found."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        # Mock 404 error on get
+        api_error = ApiException(status=404)
+        mock_custom_api.get_namespaced_custom_object.side_effect = api_error
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-autoindexer'):
+            client = AutoIndexerK8sClient()
+            
+            status_update = {"indexingPhase": "Running"}
+            result = client.update_autoindexer_status(status_update)
+            
+            assert result is False
+
+    def test_add_status_condition_new(self, mock_k8s_config, mock_custom_api, mock_core_api, sample_autoindexer_crd):
+        """Test adding a new status condition."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        # Mock successful get and patch
+        crd_copy = sample_autoindexer_crd.copy()
+        crd_copy["status"]["conditions"] = []
+        mock_custom_api.get_namespaced_custom_object.return_value = crd_copy
+        mock_custom_api.patch_namespaced_custom_object_status.return_value = crd_copy
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-autoindexer'):
+            client = AutoIndexerK8sClient()
+            
+            result = client.add_status_condition(
+                "AutoIndexerIndexing", 
+                "True", 
+                "IndexingStarted", 
+                "Document indexing process has started"
+            )
+            
+            assert result is True
+            mock_custom_api.patch_namespaced_custom_object_status.assert_called_once()
+
+    def test_add_status_condition_update_existing(self, mock_k8s_config, mock_custom_api, mock_core_api, sample_autoindexer_crd):
+        """Test updating an existing status condition."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        # Mock CRD with existing condition
+        crd_copy = sample_autoindexer_crd.copy()
+        crd_copy["status"]["conditions"] = [{
+            "type": "AutoIndexerIndexing",
+            "status": "False",
+            "reason": "NotStarted",
+            "message": "Not started yet",
+            "lastTransitionTime": "2023-01-01T00:00:00Z"
+        }]
+        mock_custom_api.get_namespaced_custom_object.return_value = crd_copy
+        mock_custom_api.patch_namespaced_custom_object_status.return_value = crd_copy
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-autoindexer'):
+            client = AutoIndexerK8sClient()
+            
+            result = client.add_status_condition(
+                "AutoIndexerIndexing", 
+                "True", 
+                "IndexingStarted", 
+                "Document indexing process has started"
+            )
+            
+            assert result is True
+
+    def test_update_indexing_progress(self, mock_k8s_config, mock_custom_api, mock_core_api, sample_autoindexer_crd):
+        """Test updating indexing progress."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        mock_custom_api.get_namespaced_custom_object.return_value = sample_autoindexer_crd.copy()
+        mock_custom_api.patch_namespaced_custom_object_status.return_value = sample_autoindexer_crd
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-autoindexer'):
+            client = AutoIndexerK8sClient()
+            
+            result = client.update_indexing_progress(100)
+            
+            assert result is True
+            mock_custom_api.patch_namespaced_custom_object_status.assert_called_once()
+
+    def test_update_indexing_phase(self, mock_k8s_config, mock_custom_api, mock_core_api, sample_autoindexer_crd):
+        """Test updating indexing phase."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        mock_custom_api.get_namespaced_custom_object.return_value = sample_autoindexer_crd.copy()
+        mock_custom_api.patch_namespaced_custom_object_status.return_value = sample_autoindexer_crd
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-autoindexer'):
+            client = AutoIndexerK8sClient()
+            
+            result = client.update_indexing_phase("Running")
+            
+            assert result is True
+
+    def test_update_indexing_completion_success(self, mock_k8s_config, mock_custom_api, mock_core_api, sample_autoindexer_crd):
+        """Test updating indexing completion for success."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        # Mock get calls for counter increment
+        mock_custom_api.get_namespaced_custom_object.return_value = sample_autoindexer_crd.copy()
+        mock_custom_api.patch_namespaced_custom_object_status.return_value = sample_autoindexer_crd
+        
+        with patch.dict(os.environ, {
+            'NAMESPACE': 'default',
+            'AUTOINDEXER_NAME': 'test-autoindexer'
+        }):
+            client = AutoIndexerK8sClient()
+            
+            result = client.update_indexing_completion(
+                success=True,
+                duration_seconds=120,
+                document_count=50,
+                commit_hash="abc123"
+            )
+            
+            assert result is True
+
+    def test_update_indexing_completion_failure(self, mock_k8s_config, mock_custom_api, mock_core_api, sample_autoindexer_crd):
+        """Test updating indexing completion for failure."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        mock_custom_api.get_namespaced_custom_object.return_value = sample_autoindexer_crd.copy()
+        mock_custom_api.patch_namespaced_custom_object_status.return_value = sample_autoindexer_crd
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-autoindexer'):
+            client = AutoIndexerK8sClient()
+            
+            result = client.update_indexing_completion(
+                success=False,
+                duration_seconds=60,
+                document_count=0
+            )
+            
+            assert result is True
+
+    def test_get_autoindexer_config(self, mock_k8s_config, mock_custom_api, mock_core_api, sample_autoindexer_crd):
+        """Test getting AutoIndexer configuration from spec."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        mock_custom_api.get_namespaced_custom_object.return_value = sample_autoindexer_crd
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-autoindexer'):
+            client = AutoIndexerK8sClient()
+            config = client.get_autoindexer_config()
+            
+            assert config == sample_autoindexer_crd["spec"]
+            assert config["indexName"] == "test-index"
+            assert config["ragEngine"] == "test-rag-engine"
+
+    def test_get_autoindexer_config_not_found(self, mock_k8s_config, mock_custom_api, mock_core_api):
+        """Test getting AutoIndexer configuration when CRD not found."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        api_error = ApiException(status=404)
+        mock_custom_api.get_namespaced_custom_object.side_effect = api_error
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-autoindexer'):
+            client = AutoIndexerK8sClient()
+            config = client.get_autoindexer_config()
+            
+            assert config is None
+
+    def test_increment_counter_success(self, mock_k8s_config, mock_custom_api, mock_core_api, sample_autoindexer_crd):
+        """Test incrementing counter with existing value."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        # Set up CRD with existing counter value
+        crd_copy = sample_autoindexer_crd.copy()
+        crd_copy["status"]["successfulIndexingCount"] = 5
+        mock_custom_api.get_namespaced_custom_object.return_value = crd_copy
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-autoindexer'):
+            client = AutoIndexerK8sClient()
+            result = client._increment_counter("successfulIndexingCount")
+            
+            assert result == 6
+
+    def test_increment_counter_no_existing_value(self, mock_k8s_config, mock_custom_api, mock_core_api, sample_autoindexer_crd):
+        """Test incrementing counter with no existing value."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        mock_custom_api.get_namespaced_custom_object.return_value = sample_autoindexer_crd.copy()
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-autoindexer'):
+            client = AutoIndexerK8sClient()
+            result = client._increment_counter("newCounter")
+            
+            assert result == 1
+
+    def test_increment_counter_error(self, mock_k8s_config, mock_custom_api, mock_core_api):
+        """Test incrementing counter with error getting current value."""
+        mock_k8s_config.load_incluster_config.return_value = None
+        mock_k8s_config.ConfigException = Exception
+        
+        api_error = ApiException(status=500)
+        mock_custom_api.get_namespaced_custom_object.side_effect = api_error
+        
+        with patch('autoindexer.k8s.k8s_client.NAMESPACE', 'default'), \
+             patch('autoindexer.k8s.k8s_client.AUTOINDEXER_NAME', 'test-autoindexer'):
+            client = AutoIndexerK8sClient()
+            result = client._increment_counter("errorCounter")
+            
+            assert result == 1

--- a/presets/autoindexer/tests/test_main_integration.py
+++ b/presets/autoindexer/tests/test_main_integration.py
@@ -1,0 +1,534 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import json
+import os
+from unittest.mock import Mock, patch
+
+import pytest
+from requests.exceptions import RequestException
+
+from autoindexer.data_source_handler.handler import DataSourceError
+from autoindexer.main import AutoIndexerService, main
+
+
+class TestAutoIndexerService:
+    """Integration tests for AutoIndexer service."""
+
+    @pytest.fixture
+    def valid_env_vars(self):
+        """Fixture providing valid environment variables."""
+        return {
+            "ACCESS_SECRET": "test-secret",
+            "AUTOINDEXER_NAME": "test-autoindexer",
+            "NAMESPACE": "test-namespace"
+        }
+
+    @pytest.fixture
+    def mock_k8s_client(self):
+        """Fixture providing a mock Kubernetes client."""
+        with patch('autoindexer.main.AutoIndexerK8sClient') as mock_class:
+            mock_client = Mock()
+            mock_client.namespace = "test-namespace"
+            mock_client.get_autoindexer_config.return_value = {
+                "indexName": "test-index",
+                "ragEngine": "test-rag-engine",
+                "dataSource": {
+                    "type": "Static",
+                    "static": {
+                        "urls": ["https://example.com/doc.txt"]
+                    }
+                }
+            }
+            mock_client.add_status_condition.return_value = None
+            mock_client.update_indexing_progress.return_value = None
+            mock_client.update_indexing_phase.return_value = None
+            mock_client.update_indexing_completion.return_value = None
+            mock_class.return_value = mock_client
+            yield mock_client
+
+    @pytest.fixture
+    def mock_rag_client(self):
+        """Fixture providing a mock RAG client."""
+        with patch('autoindexer.main.KAITORAGClient') as mock_class:
+            mock_client = Mock()
+            mock_client.list_indexes.return_value = {"indexes": [{"name": "test-index"}]}
+            mock_client.list_documents.return_value = {"total": 5, "documents": []}
+            mock_class.return_value = mock_client
+            yield mock_class
+
+    @pytest.fixture
+    def mock_static_handler(self):
+        """Fixture providing a mock static data source handler."""
+        with patch('autoindexer.main.StaticDataSourceHandler') as mock_class:
+            mock_handler = Mock()
+            mock_handler.update_index.return_value = []  # No errors
+            mock_class.return_value = mock_handler
+            yield mock_class
+
+    @pytest.fixture
+    def mock_git_handler(self):
+        """Fixture providing a mock git data source handler."""
+        with patch('autoindexer.main.GitDataSourceHandler') as mock_class:
+            mock_handler = Mock()
+            mock_handler.update_index.return_value = []  # No errors
+            mock_class.return_value = mock_handler
+            yield mock_class
+
+    def test_init_success_with_static_data_source(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_static_handler):
+        """Test successful initialization with static data source."""
+        with patch.dict(os.environ, valid_env_vars):
+            try:
+                service = AutoIndexerService()
+
+                assert service.access_secret == "test-secret"
+                assert service.autoindexer_name == "test-autoindexer"
+                assert service.namespace == "test-namespace"
+                assert service.index_name == "test-index"
+                assert service.datasource_type == "Static"
+                assert service.ragengine_endpoint == "http://test-rag-engine.test-namespace.svc.cluster.local:80"
+
+                # Verify K8s client was initialized
+                mock_k8s_client.get_autoindexer_config.assert_called_once()
+
+                # Verify RAG client was initialized
+                mock_rag_client.assert_called_once_with("http://test-rag-engine.test-namespace.svc.cluster.local:80")
+                assert hasattr(service, 'rag_client')
+                assert service.rag_client == mock_rag_client.return_value
+                
+                # Verify static handler was created with expected config
+                expected_config = {
+                    "autoindexer_name": "test-autoindexer",
+                    "urls": ["https://example.com/doc.txt"]
+                }
+                mock_static_handler.assert_called_once_with(
+                    index_name="test-index",
+                    config=expected_config, 
+                    rag_client=mock_rag_client.return_value,
+                    autoindexer_client=mock_k8s_client,
+                    credentials="test-secret"
+                )
+                assert hasattr(service, 'data_source_handler')
+                assert service.data_source_handler == mock_static_handler.return_value
+                
+            except Exception as e:
+                print(f"Exception during service initialization: {e}")
+                import traceback
+                traceback.print_exc()
+                raise
+
+    def test_init_success_with_git_data_source(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_git_handler):
+        """Test successful initialization with git data source."""
+        # Update mock to return git config
+        mock_k8s_client.get_autoindexer_config.return_value = {
+            "indexName": "test-index",
+            "ragEngine": "test-rag-engine", 
+            "dataSource": {
+                "type": "Git",
+                "git": {
+                    "repository": "https://github.com/test/repo.git",
+                    "branch": "main",
+                    "paths": ["/docs"]
+                }
+            }
+        }
+        
+        with patch.dict(os.environ, valid_env_vars):
+            service = AutoIndexerService()
+            
+            assert service.datasource_type == "Git"
+            assert service.datasource_config["repository"] == "https://github.com/test/repo.git"
+            
+            # Verify git handler was created
+            mock_git_handler.assert_called_once()
+
+    def test_init_missing_required_env_var(self):
+        """Test initialization failure with missing required environment variables."""
+        incomplete_env = {"ACCESS_SECRET": "test-secret"}  # Missing other required vars
+        
+        with patch.dict(os.environ, incomplete_env, clear=True), \
+             pytest.raises(ValueError, match="RAG engine endpoint must be configured"):
+            AutoIndexerService()
+
+    def test_init_k8s_client_failure(self, valid_env_vars):
+        """Test handling of Kubernetes client initialization failure."""
+        with patch('autoindexer.main.AutoIndexerK8sClient') as mock_class:
+            mock_class.side_effect = Exception("K8s connection failed")
+            
+            with patch.dict(os.environ, valid_env_vars), \
+                 pytest.raises(Exception, match="K8s connection failed"):
+                AutoIndexerService()
+
+    def test_init_invalid_crd_config_missing_index_name(self, valid_env_vars, mock_rag_client, mock_static_handler):
+        """Test initialization failure with invalid CRD config missing index name."""
+        with patch('autoindexer.main.AutoIndexerK8sClient') as mock_class:
+            mock_client = Mock()
+            mock_client.get_autoindexer_config.return_value = {
+                "ragEngine": "test-rag-engine",
+                # Missing indexName
+                "dataSource": {
+                    "type": "Static",
+                    "static": {"urls": ["https://example.com/doc.txt"]}
+                }
+            }
+            mock_class.return_value = mock_client
+            
+            with patch.dict(os.environ, valid_env_vars), \
+                 pytest.raises(ValueError, match="indexName must be specified"):
+                AutoIndexerService()
+
+    def test_init_unsupported_data_source_type(self, valid_env_vars, mock_k8s_client, mock_rag_client):
+        """Test initialization failure with unsupported data source type."""
+        mock_k8s_client.get_autoindexer_config.return_value = {
+            "indexName": "test-index",
+            "ragEngine": "test-rag-engine",
+            "dataSource": {
+                "type": "UnsupportedType",
+                "unsupported": {}
+            }
+        }
+        
+        with patch.dict(os.environ, valid_env_vars), \
+             pytest.raises(ValueError, match="Unsupported or missing data source configuration in CRD"):
+            AutoIndexerService()
+
+    def test_run_success(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_static_handler):
+        """Test successful indexing run."""
+        with patch.dict(os.environ, valid_env_vars):
+            service = AutoIndexerService()
+            
+            # Mock successful indexing on the actual instances
+            service.data_source_handler.update_index.return_value = []  # No errors
+            service.rag_client.list_documents.return_value = {"total": 5}
+            
+            with patch('time.time', side_effect=[1000.0, 1030.0]):  # 30 second duration
+                result = service.run()
+            
+            assert result is True
+            
+            # Verify status updates were called
+            service.k8s_client.update_indexing_phase.assert_called()
+            service.k8s_client.add_status_condition.assert_called()
+            service.k8s_client.update_indexing_completion.assert_called_with(True, 30, 5, None)
+            
+            # Verify indexing was performed
+            service.data_source_handler.update_index.assert_called_once_with()
+
+    def test_run_with_indexing_errors(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_static_handler):
+        """Test run with indexing errors."""
+        with patch.dict(os.environ, valid_env_vars):
+            service = AutoIndexerService()
+            
+            # Mock indexing with errors
+            service.data_source_handler.update_index.return_value = ["Error fetching document", "Network timeout"]
+            service.rag_client.list_documents.return_value = {"total": 0}
+            
+            with patch('time.time', side_effect=[1000.0] + [1025.0] * 10):  # 25 second duration, multiple calls
+                result = service.run()
+            
+            assert result is False
+            
+            # Verify failure status was set
+            service.k8s_client.update_indexing_completion.assert_called_with(False, 25, 0, None)
+            
+            # Verify error condition was set
+            status_calls = mock_k8s_client.add_status_condition.call_args_list
+            error_calls = [call for call in status_calls if call[0][0] == "AutoIndexerError"]
+            assert len(error_calls) > 0
+
+    def test_run_with_exception(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_static_handler):
+        """Test run with unexpected exception."""
+        with patch.dict(os.environ, valid_env_vars):
+            service = AutoIndexerService()
+            
+            # Mock exception during indexing
+            service.data_source_handler.update_index.side_effect = Exception("Unexpected error")
+            service.rag_client.list_documents.return_value = {"total": 0}
+            
+            with patch('time.time', side_effect=[1000.0] + [1020.0] * 10):  # 20 second duration, multiple calls
+                result = service.run()
+            
+            assert result is False
+            
+            # Verify failure status was set
+            service.k8s_client.update_indexing_completion.assert_called_with(False, 20, 0, None)
+
+    def test_run_dry_run_mode(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_static_handler):
+        """Test dry run mode."""
+        with patch.dict(os.environ, valid_env_vars):
+            service = AutoIndexerService(dry_run=True)
+            
+            assert service.dry_run is True
+            
+            # Dry run should still execute the same logic
+            result = service.run()
+            assert result is True
+
+    def test_update_index_data_source_error(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_static_handler):
+        """Test _update_index with DataSourceError."""
+        with patch.dict(os.environ, valid_env_vars):
+            service = AutoIndexerService()
+            
+            # Mock DataSourceError
+            service.data_source_handler.update_index.side_effect = DataSourceError("Data source failed")
+            
+            errors = service._update_index()
+            
+            assert len(errors) == 1
+            assert "Data source error: Data source failed" in errors[0]
+
+    def test_update_index_unexpected_error(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_static_handler):
+        """Test _update_index with unexpected error."""
+        with patch.dict(os.environ, valid_env_vars):
+            service = AutoIndexerService()
+            
+            # Mock unexpected error
+            service.data_source_handler.update_index.side_effect = RuntimeError("Unexpected runtime error")
+            
+            errors = service._update_index()
+            
+            assert len(errors) == 1
+            assert "Unexpected error during indexing: Unexpected runtime error" in errors[0]
+
+    def test_ensure_index_exists_index_present(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_static_handler):
+        """Test _ensure_index_exists when index already exists."""
+        with patch.dict(os.environ, valid_env_vars):
+            service = AutoIndexerService()
+            
+            service.rag_client.list_indexes.return_value = {
+                "indexes": [{"name": "test-index"}, {"name": "other-index"}]
+            }
+            
+            # Should not raise any exception
+            service._ensure_index_exists()
+            
+            service.rag_client.list_indexes.assert_called_once()
+
+    def test_ensure_index_exists_index_missing(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_static_handler):
+        """Test _ensure_index_exists when index doesn't exist."""
+        with patch.dict(os.environ, valid_env_vars):
+            service = AutoIndexerService()
+            
+            service.rag_client.list_indexes.return_value = {
+                "indexes": [{"name": "other-index"}]
+            }
+            
+            # Should not raise any exception
+            service._ensure_index_exists()
+            
+            service.rag_client.list_indexes.assert_called_once()
+
+    def test_ensure_index_exists_rag_error(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_static_handler):
+        """Test _ensure_index_exists when RAG client raises error."""
+        with patch.dict(os.environ, valid_env_vars):
+            service = AutoIndexerService()
+            
+            mock_rag_client.list_indexes.side_effect = RequestException("RAG engine unavailable")
+            
+            # Should not raise any exception, just log warning
+            service._ensure_index_exists()
+
+    def test_status_updates_without_k8s_client(self, valid_env_vars, mock_rag_client, mock_static_handler):
+        """Test status update methods when K8s client is not available."""
+        with patch('autoindexer.main.AutoIndexerK8sClient') as mock_class:
+            mock_class.side_effect = Exception("K8s unavailable")
+            
+            with patch.dict(os.environ, valid_env_vars), \
+                 pytest.raises(Exception):
+                AutoIndexerService()
+
+    def test_status_updates_k8s_client_errors(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_static_handler):
+        """Test status update methods when K8s client operations fail."""
+        with patch.dict(os.environ, valid_env_vars):
+            service = AutoIndexerService()
+            
+            # Mock K8s client methods to raise exceptions
+            mock_k8s_client.add_status_condition.side_effect = Exception("K8s API error")
+            mock_k8s_client.update_indexing_progress.side_effect = Exception("K8s API error")
+            mock_k8s_client.update_indexing_phase.side_effect = Exception("K8s API error")
+            mock_k8s_client.update_indexing_completion.side_effect = Exception("K8s API error")
+            
+            # These should not raise exceptions, just log warnings
+            service._update_status_condition("Test", "True", "Reason", "Message")
+            service._update_indexing_progress(10, 5)
+            service._update_indexing_phase("Running")
+            service._update_indexing_completion(True, 30, 5)
+            
+            # Verify methods were called despite errors
+            mock_k8s_client.add_status_condition.assert_called()
+            mock_k8s_client.update_indexing_progress.assert_called()
+            mock_k8s_client.update_indexing_phase.assert_called()
+            mock_k8s_client.update_indexing_completion.assert_called()
+
+    def test_apply_crd_config_git_source(self, valid_env_vars, mock_rag_client, mock_git_handler):
+        """Test applying CRD configuration for Git data source."""
+        with patch('autoindexer.main.AutoIndexerK8sClient') as mock_class:
+            mock_client = Mock()
+            mock_client.namespace = "test-namespace"
+            mock_client.get_autoindexer_config.return_value = {
+                "indexName": "git-index",
+                "ragEngine": "rag-engine",
+                "dataSource": {
+                    "type": "Git",
+                    "git": {
+                        "repository": "https://github.com/test/repo.git",
+                        "branch": "develop",
+                        "commit": "abc123",
+                        "paths": ["/docs", "/examples"],
+                        "excludePaths": ["/docs/internal"]
+                    }
+                }
+            }
+            mock_class.return_value = mock_client
+            
+            with patch.dict(os.environ, valid_env_vars):
+                service = AutoIndexerService()
+                
+                assert service.index_name == "git-index"
+                assert service.datasource_type == "Git"
+                assert service.datasource_config["repository"] == "https://github.com/test/repo.git"
+                assert service.datasource_config["branch"] == "develop"
+                assert service.datasource_config["commit"] == "abc123"
+                assert service.datasource_config["paths"] == ["/docs", "/examples"]
+                assert service.datasource_config["excludePaths"] == ["/docs/internal"]
+
+    def test_optional_env_json_valid(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_static_handler):
+        """Test parsing of optional JSON environment variables."""
+        json_config = {"key": "value", "number": 42}
+        env_vars = {**valid_env_vars, "TEST_JSON_CONFIG": json.dumps(json_config)}
+        
+        with patch.dict(os.environ, env_vars):
+            service = AutoIndexerService()
+            
+            result = service._get_optional_env_json("TEST_JSON_CONFIG")
+            assert result == json_config
+
+    def test_optional_env_json_invalid(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_static_handler):
+        """Test parsing of invalid JSON environment variables."""
+        env_vars = {**valid_env_vars, "INVALID_JSON": "not valid json {"}
+        
+        with patch.dict(os.environ, env_vars):
+            service = AutoIndexerService()
+            
+            result = service._get_optional_env_json("INVALID_JSON")
+            assert result is None
+
+    def test_optional_env_json_missing(self, valid_env_vars, mock_k8s_client, mock_rag_client, mock_static_handler):
+        """Test parsing of missing JSON environment variables."""
+        with patch.dict(os.environ, valid_env_vars):
+            service = AutoIndexerService()
+            
+            result = service._get_optional_env_json("MISSING_JSON")
+            assert result is None
+
+
+class TestMainFunction:
+    """Tests for the main() function and CLI interface."""
+
+    def test_main_success_default_args(self):
+        """Test main function with default arguments."""
+        test_args = ["main.py"]  # Default mode=index, no dry-run
+        
+        with patch('sys.argv', test_args), \
+             patch('autoindexer.main.AutoIndexerService') as mock_service_class, \
+             patch('sys.exit') as mock_exit:
+            mock_service = Mock()
+            mock_service.run.return_value = True
+            mock_service_class.return_value = mock_service
+            
+            main()
+            
+            mock_service_class.assert_called_once_with(dry_run=False)
+            mock_service.run.assert_called_once()
+            mock_exit.assert_called_once_with(0)
+
+    def test_main_success_with_dry_run(self):
+        """Test main function with dry-run flag."""
+        test_args = ["main.py", "--dry-run"]
+        
+        with patch('sys.argv', test_args), \
+             patch('autoindexer.main.AutoIndexerService') as mock_service_class, \
+             patch('sys.exit') as mock_exit:
+            mock_service = Mock()
+            mock_service.run.return_value = True
+            mock_service_class.return_value = mock_service
+            
+            main()
+            
+            mock_service_class.assert_called_once_with(dry_run=True)
+            mock_exit.assert_called_once_with(0)
+
+    def test_main_failure_service_returns_false(self):
+        """Test main function when service returns False."""
+        test_args = ["main.py"]
+        
+        with patch('sys.argv', test_args), \
+             patch('autoindexer.main.AutoIndexerService') as mock_service_class, \
+             patch('sys.exit') as mock_exit:
+            mock_service = Mock()
+            mock_service.run.return_value = False
+            mock_service_class.return_value = mock_service
+            
+            main()
+            
+            mock_exit.assert_called_once_with(1)
+
+    def test_main_failure_service_initialization_error(self):
+        """Test main function when service initialization fails."""
+        test_args = ["main.py"]
+        
+        with patch('sys.argv', test_args), \
+             patch('autoindexer.main.AutoIndexerService') as mock_service_class, \
+             patch('sys.exit') as mock_exit:
+            mock_service_class.side_effect = Exception("Initialization failed")
+            
+            main()
+            
+            mock_exit.assert_called_once_with(1)
+
+    def test_main_with_log_level(self):
+        """Test main function with custom log level."""
+        test_args = ["main.py", "--log-level", "DEBUG"]
+        
+        with patch('sys.argv', test_args), \
+             patch('autoindexer.main.AutoIndexerService') as mock_service_class, \
+             patch('logging.getLogger') as mock_get_logger, \
+             patch('sys.exit'):
+            mock_service = Mock()
+            mock_service.run.return_value = True
+            mock_service_class.return_value = mock_service
+            
+            mock_logger = Mock()
+            mock_get_logger.return_value = mock_logger
+            
+            main()
+            
+            # Verify log level was set
+            mock_logger.setLevel.assert_called_once()
+
+    def test_main_index_mode(self):
+        """Test main function with explicit index mode."""
+        test_args = ["main.py", "--mode", "index"]
+        
+        with patch('sys.argv', test_args), \
+             patch('autoindexer.main.AutoIndexerService') as mock_service_class, \
+             patch('sys.exit') as mock_exit:
+            mock_service = Mock()
+            mock_service.run.return_value = True
+            mock_service_class.return_value = mock_service
+            
+            main()
+            
+            mock_service_class.assert_called_once_with(dry_run=False)
+            mock_exit.assert_called_once_with(0)

--- a/presets/autoindexer/tests/test_static_handler.py
+++ b/presets/autoindexer/tests/test_static_handler.py
@@ -1,0 +1,606 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import json
+from unittest.mock import Mock, mock_open, patch
+
+import pytest
+from requests.exceptions import RequestException
+
+from autoindexer.data_source_handler.handler import DataSourceError
+from autoindexer.data_source_handler.static_handler import StaticDataSourceHandler
+from autoindexer.k8s.k8s_client import AutoIndexerK8sClient
+from autoindexer.rag.rag_client import KAITORAGClient
+
+
+class TestStaticDataSourceHandler:
+    """Test class for StaticDataSourceHandler."""
+
+    @pytest.fixture
+    def valid_config(self):
+        """Fixture providing a valid configuration."""
+        return {
+            "autoindexer_name": "test-autoindexer",
+            "urls": ["https://example.com/document.md"],
+            "timeout": 30,
+            "max_file_size": 5 * 1024 * 1024  # 5MB
+        }
+
+    @pytest.fixture
+    def credentials(self):
+        """Fixture providing test credentials."""
+        return {
+            "http_auth": {
+                "username": "testuser",
+                "password": "testpass"
+            },
+            "headers": {
+                "X-Custom-Header": "test-value"
+            }
+        }
+
+    @pytest.fixture
+    def mock_rag_client(self):
+        """Fixture providing a mock RAG client."""
+        client = Mock(spec=KAITORAGClient)
+        client.index_documents.return_value = {"success": True, "indexed": 1}
+        return client
+
+    @pytest.fixture
+    def mock_autoindexer_client(self):
+        """Fixture providing a mock AutoIndexer K8s client."""
+        client = Mock(spec=AutoIndexerK8sClient)
+        client.update_indexing_progress.return_value = None
+        return client
+
+    def test_init_success(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test successful initialization."""
+        handler = StaticDataSourceHandler(
+            index_name="test-index",
+            config=valid_config,
+            rag_client=mock_rag_client,
+            autoindexer_client=mock_autoindexer_client
+        )
+        
+        assert handler.config == valid_config
+        assert handler.credentials == {}
+        assert handler.autoindexer_name == "test-autoindexer"
+
+    def test_init_with_credentials(self, valid_config, credentials, mock_rag_client, mock_autoindexer_client):
+        """Test initialization with credentials."""
+        handler = StaticDataSourceHandler(
+            index_name="test-index",
+            config=valid_config,
+            rag_client=mock_rag_client,
+            autoindexer_client=mock_autoindexer_client,
+            credentials=credentials
+        )
+        
+        assert handler.credentials == credentials
+
+    def test_init_missing_autoindexer_name(self, mock_rag_client, mock_autoindexer_client):
+        """Test initialization failure with missing autoindexer_name."""
+        config = {
+            "static": {
+                "urls": ["https://example.com/document.md"]
+            }
+        }
+        
+        with pytest.raises(DataSourceError, match="missing 'autoindexer_name' value"):
+            StaticDataSourceHandler(
+                index_name="test-index",
+                config=config,
+                rag_client=mock_rag_client,
+                autoindexer_client=mock_autoindexer_client
+            )
+
+    def test_init_missing_static_section(self, mock_rag_client, mock_autoindexer_client):
+        """Test initialization failure with missing autoindexer_name."""
+        config = {}
+        
+        with pytest.raises(DataSourceError, match="missing 'autoindexer_name' value"):
+            StaticDataSourceHandler(
+                index_name="test-index",
+                config=config,
+                rag_client=mock_rag_client,
+                autoindexer_client=mock_autoindexer_client
+            )
+
+    @patch('autoindexer.data_source_handler.static_handler.requests.get')
+    def test_update_index_single_url_success(self, mock_get, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test successful index update with a single URL."""
+        # Setup mock response
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.headers = {'content-type': 'text/plain'}
+        mock_response.iter_content.return_value = [b'Test content from URL']
+        mock_get.return_value.__enter__.return_value = mock_response
+        
+        handler = StaticDataSourceHandler(
+            index_name="test-index",
+            config=valid_config,
+            rag_client=mock_rag_client,
+            autoindexer_client=mock_autoindexer_client
+        )
+        errors = handler.update_index()
+        
+        assert errors == []
+        mock_rag_client.index_documents.assert_called_once()
+        
+        call_args = mock_rag_client.index_documents.call_args
+        assert call_args[1]["index_name"] == "test-index"
+        documents = call_args[1]["documents"]
+        assert len(documents) == 1
+        assert documents[0]["text"] == "Test content from URL"
+        assert documents[0]["metadata"]["source_type"] == "url"
+        assert documents[0]["metadata"]["source_url"] == "https://example.com/document.md"
+        assert documents[0]["metadata"]["autoindexer"] == "test-autoindexer"
+
+    @patch('autoindexer.data_source_handler.static_handler.requests.get')
+    def test_update_index_multiple_urls(self, mock_get, mock_rag_client, mock_autoindexer_client):
+        """Test index update with multiple URLs."""
+        config = {
+            "autoindexer_name": "test-autoindexer",
+            "urls": [
+                "https://example.com/doc1.md",
+                "https://example.com/doc2.txt"
+            ]
+        }
+        
+        # Setup mock responses
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.headers = {'content-type': 'text/plain'}
+        mock_response.iter_content.side_effect = [
+            [b'Content from doc1'],
+            [b'Content from doc2']
+        ]
+        mock_get.return_value.__enter__.return_value = mock_response
+        
+        handler = StaticDataSourceHandler(
+            index_name="test-index",
+            config=config,
+            rag_client=mock_rag_client,
+            autoindexer_client=mock_autoindexer_client
+        )
+        errors = handler.update_index()
+        
+        assert errors == []
+        assert mock_rag_client.index_documents.call_count == 1
+        
+        call_args = mock_rag_client.index_documents.call_args
+        documents = call_args[1]["documents"]
+        assert len(documents) == 2
+
+    @patch('autoindexer.data_source_handler.static_handler.requests.get')
+    def test_update_index_batch_processing(self, mock_get, mock_rag_client, mock_autoindexer_client):
+        """Test batch processing when document count exceeds batch size."""
+        # Create config with 12 URLs to trigger batch processing (batch size is 10)
+        urls = [f"https://example.com/doc{i}.md" for i in range(12)]
+        config = {
+            "autoindexer_name": "test-autoindexer",
+            "urls": urls
+        }
+        
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.headers = {'content-type': 'text/plain'}
+        mock_response.iter_content.return_value = [b'Test content']
+        mock_get.return_value.__enter__.return_value = mock_response
+        
+        handler = StaticDataSourceHandler("test-index", config, mock_rag_client, mock_autoindexer_client)
+        errors = handler.update_index()
+        
+        assert errors == []
+        # Should be called twice: once for first 10, once for remaining 2
+        assert mock_rag_client.index_documents.call_count == 2
+
+    @patch('autoindexer.data_source_handler.static_handler.requests.get')
+    def test_update_index_http_error(self, mock_get, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test handling of HTTP errors during index update."""
+        mock_get.return_value.__enter__.side_effect = RequestException("Network error")
+        
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        # The method catches exceptions and returns them as errors instead of raising
+        errors = handler.update_index()
+        
+        assert len(errors) >= 1  # May return multiple error entries for the same failure
+        assert any("Failed to fetch content" in error for error in errors)
+
+    def test_update_index_no_urls(self, mock_rag_client, mock_autoindexer_client):
+        """Test handling when no URLs are configured."""
+        config = {
+            "autoindexer_name": "test-autoindexer"
+        }
+        
+        handler = StaticDataSourceHandler("test-index", config, mock_rag_client, mock_autoindexer_client)
+        errors = handler.update_index()
+        
+        assert len(errors) == 1
+        assert "No documents fetched" in errors[0]
+
+    @patch('autoindexer.data_source_handler.static_handler.requests.get')
+    def test_fetch_content_from_url_success(self, mock_get, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test successful content fetching from URL."""
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.headers = {'content-type': 'text/plain; charset=utf-8'}
+        mock_response.iter_content.return_value = [b'Test content']
+        mock_get.return_value.__enter__.return_value = mock_response
+        
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        content = handler._fetch_content_from_url("https://example.com/test.txt")
+        
+        assert content == "Test content"
+
+    @patch('autoindexer.data_source_handler.static_handler.requests.get')
+    def test_fetch_content_invalid_url(self, mock_get, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test handling of invalid URLs."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        with pytest.raises(DataSourceError, match="Invalid URL format"):
+            handler._fetch_content_from_url("not-a-valid-url")
+
+    @patch('autoindexer.data_source_handler.static_handler.requests.get')
+    def test_fetch_content_file_too_large_header(self, mock_get, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test handling of files that are too large based on Content-Length header."""
+        mock_response = Mock()
+        mock_response.headers = {'content-length': str(20 * 1024 * 1024)}  # 20MB
+        mock_get.return_value.__enter__.return_value = mock_response
+        
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        with pytest.raises(DataSourceError, match="File too large"):
+            handler._fetch_content_from_url("https://example.com/large-file.txt")
+
+    @patch('autoindexer.data_source_handler.static_handler.requests.get')
+    def test_fetch_content_file_too_large_streaming(self, mock_get, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test handling of files that are too large during streaming."""
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.headers = {'content-type': 'text/plain'}
+        # Create a large chunk that exceeds the limit
+        large_chunk = b'x' * (6 * 1024 * 1024)  # 6MB chunk
+        mock_response.iter_content.return_value = [large_chunk]
+        mock_get.return_value.__enter__.return_value = mock_response
+        
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        with pytest.raises(DataSourceError, match="File too large"):
+            handler._fetch_content_from_url("https://example.com/large-file.txt")
+
+    @patch('autoindexer.data_source_handler.static_handler.requests.get')
+    def test_fetch_content_with_authentication(self, mock_get, valid_config, credentials, mock_rag_client, mock_autoindexer_client):
+        """Test content fetching with HTTP authentication."""
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.headers = {'content-type': 'text/plain'}
+        mock_response.iter_content.return_value = [b'Authenticated content']
+        mock_get.return_value.__enter__.return_value = mock_response
+        
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client, credentials)
+        handler._fetch_content_from_url("https://example.com/secure.txt")
+        
+        # Verify authentication was used
+        mock_get.assert_called_once()
+        call_kwargs = mock_get.call_args[1]
+        assert call_kwargs['auth'] == ('testuser', 'testpass')
+        assert 'X-Custom-Header' in call_kwargs['headers']
+
+    @patch('autoindexer.data_source_handler.static_handler.requests.get')
+    def test_fetch_content_json_processing(self, mock_get, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test handling of JSON content with special processing."""
+        json_data = {"content": "This is the main content", "other": "ignored"}
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.headers = {'content-type': 'application/json'}
+        mock_response.iter_content.return_value = [json.dumps(json_data).encode('utf-8')]
+        mock_get.return_value.__enter__.return_value = mock_response
+        
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        content = handler._fetch_content_from_url("https://example.com/data.json")
+        
+        assert content == "This is the main content"
+
+    def test_is_file_url_file_extensions(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test file URL detection based on file extensions."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        # Test various file extensions
+        file_urls = [
+            "https://example.com/doc.txt",
+            "https://example.com/readme.md",
+            "https://example.com/config.json",
+            "https://example.com/data.csv",
+            "https://example.com/script.py",
+            "https://example.com/document.pdf"
+        ]
+        
+        for url in file_urls:
+            from urllib.parse import urlparse
+            parsed_url = urlparse(url)
+            assert handler._is_file_url(url, parsed_url) is True
+
+    def test_is_file_url_github_raw(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test file URL detection for GitHub raw URLs."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        url = "https://raw.githubusercontent.com/user/repo/main/README.md"
+        from urllib.parse import urlparse
+        parsed_url = urlparse(url)
+        
+        assert handler._is_file_url(url, parsed_url) is True
+
+    def test_is_file_url_non_file(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test file URL detection for non-file URLs."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        non_file_urls = [
+            "https://example.com/",
+            "https://example.com/page",
+            "https://example.com/search?q=test"
+        ]
+        
+        for url in non_file_urls:
+            from urllib.parse import urlparse
+            parsed_url = urlparse(url)
+            assert handler._is_file_url(url, parsed_url) is False
+
+    def test_is_pdf_content_content_type(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test PDF detection based on content type."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        assert handler._is_pdf_content(b'', 'application/pdf', 'test.pdf') is True
+        assert handler._is_pdf_content(b'', 'text/plain', 'test.txt') is False
+
+    def test_is_pdf_content_url_extension(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test PDF detection based on URL extension."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        assert handler._is_pdf_content(b'', '', 'document.pdf') is True
+        assert handler._is_pdf_content(b'', '', 'document.txt') is False
+
+    def test_is_pdf_content_magic_bytes(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test PDF detection based on magic bytes."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        pdf_content = b'%PDF-1.4\n...'
+        text_content = b'This is plain text'
+        
+        assert handler._is_pdf_content(pdf_content, '', 'unknown') is True
+        assert handler._is_pdf_content(text_content, '', 'unknown') is False
+
+    def test_extract_pdf_text_pypdf2_success(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test successful PDF text extraction using PyPDF2."""
+        with patch('builtins.__import__') as mock_import:
+            # Mock PyPDF2 module
+            mock_pypdf2 = Mock()
+            mock_page = Mock()
+            mock_page.extract_text.return_value = "Page content"
+            
+            mock_reader = Mock()
+            mock_reader.pages = [mock_page]
+            
+            mock_pypdf2.PdfReader.return_value = mock_reader
+            
+            def import_side_effect(name, *args, **kwargs):
+                if name == 'PyPDF2':
+                    return mock_pypdf2
+                return __import__(name, *args, **kwargs)
+            
+            mock_import.side_effect = import_side_effect
+            
+            handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+            result = handler._extract_pdf_text(b'%PDF-1.4...', 'test.pdf')
+            
+            assert "Page content" in result
+            assert "--- Page 1 ---" in result
+
+    def test_extract_pdf_text_pdfplumber_fallback(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test PDF text extraction fallback to pdfplumber."""
+        with patch('builtins.__import__') as mock_import:
+            # Mock pdfplumber module and PyPDF2 import error
+            mock_pdfplumber = Mock()
+            mock_page = Mock()
+            mock_page.extract_text.return_value = "Page content from pdfplumber"
+            mock_page.extract_tables.return_value = []
+            
+            mock_pdf = Mock()
+            mock_pdf.pages = [mock_page]
+            mock_pdf.__enter__ = Mock(return_value=mock_pdf)
+            mock_pdf.__exit__ = Mock(return_value=None)
+            
+            mock_pdfplumber.open.return_value = mock_pdf
+            
+            def import_side_effect(name, *args, **kwargs):
+                if name == 'PyPDF2':
+                    raise ImportError("PyPDF2 not available")
+                elif name == 'pdfplumber':
+                    return mock_pdfplumber
+                return __import__(name, *args, **kwargs)
+            
+            mock_import.side_effect = import_side_effect
+            
+            handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+            result = handler._extract_pdf_text(b'%PDF-1.4...', 'test.pdf')
+            
+            assert "Page content from pdfplumber" in result
+
+    def test_extract_pdf_text_no_libraries(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test PDF text extraction failure when no libraries are available."""
+        with patch('builtins.__import__') as mock_import:
+            def import_side_effect(name, *args, **kwargs):
+                if name in ['PyPDF2', 'pdfplumber']:
+                    raise ImportError(f"{name} not available")
+                return __import__(name, *args, **kwargs)
+            
+            mock_import.side_effect = import_side_effect
+            
+            handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+            
+            with pytest.raises(DataSourceError, match="Unable to extract text from PDF"):
+                handler._extract_pdf_text(b'%PDF-1.4...', 'test.pdf')
+
+    def test_table_to_text_success(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test successful table conversion to text."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        table = [
+            ['Header1', 'Header2', 'Header3'],
+            ['Row1Col1', 'Row1Col2', 'Row1Col3'],
+            ['Row2Col1', 'Row2Col2', 'Row2Col3']
+        ]
+        
+        result = handler._table_to_text(table)
+        
+        assert "Header1 | Header2 | Header3" in result
+        assert "Row1Col1 | Row1Col2 | Row1Col3" in result
+
+    def test_table_to_text_empty_table(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test table conversion with empty table."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        assert handler._table_to_text([]) == ""
+        assert handler._table_to_text(None) == ""
+
+    def test_table_to_text_with_none_values(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test table conversion with None values."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        table = [['A', None, 'C'], [None, 'B', None]]
+        result = handler._table_to_text(table)
+        
+        assert "A |  | C" in result
+        assert " | B | " in result
+
+    @patch('autoindexer.data_source_handler.static_handler.chardet.detect')
+    def test_decode_content_encoding_detection(self, mock_detect, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test content decoding with encoding detection."""
+        mock_detect.return_value = {'encoding': 'utf-8', 'confidence': 0.9}
+        
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        content = "Test content with unicode: café"
+        encoded_content = content.encode('utf-8')
+        
+        result = handler._decode_content(encoded_content, 'text/plain', 'test.txt')
+        
+        assert result == content
+
+    def test_decode_content_content_type_encoding(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test content decoding using encoding from content-type header."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        content = "Test content"
+        encoded_content = content.encode('latin1')
+        
+        result = handler._decode_content(
+            encoded_content, 
+            'text/plain; charset=latin1', 
+            'test.txt'
+        )
+        
+        assert result == content
+
+    def test_decode_content_empty_content(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test decoding of empty content."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        result = handler._decode_content(b'', 'text/plain', 'empty.txt')
+        
+        assert result == ""
+
+    def test_decode_content_fallback_with_errors(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test content decoding fallback when all encodings fail."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        # Use bytes that can't be decoded properly
+        invalid_content = b'\xff\xfe\x00\x00invalid'
+        
+        result = handler._decode_content(invalid_content, 'text/plain', 'test.txt')
+        
+        # Should use UTF-8 with error replacement
+        assert isinstance(result, str)
+
+    @patch('builtins.open', new_callable=mock_open, read_data='File content')
+    @patch('os.path.exists', return_value=True)
+    @patch('os.path.isfile', return_value=True)
+    def test_read_file_content_success(self, mock_isfile, mock_exists, mock_file, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test successful file content reading."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        result = handler._read_file_content('/path/to/file.txt')
+        
+        assert result == 'File content'
+
+    @patch('os.path.exists', return_value=False)
+    def test_read_file_content_not_found(self, mock_exists, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test file reading when file doesn't exist."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        with pytest.raises(DataSourceError, match="File not found"):
+            handler._read_file_content('/nonexistent/file.txt')
+
+    @patch('os.path.exists', return_value=True)
+    @patch('os.path.isfile', return_value=False)
+    def test_read_file_content_not_file(self, mock_isfile, mock_exists, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test file reading when path is not a file."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        with pytest.raises(DataSourceError, match="Path is not a file"):
+            handler._read_file_content('/path/to/directory')
+
+    @patch('builtins.open', new_callable=mock_open, read_data='')
+    @patch('os.path.exists', return_value=True)
+    @patch('os.path.isfile', return_value=True)
+    def test_read_file_content_empty_file(self, mock_isfile, mock_exists, mock_file, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test reading empty file."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        result = handler._read_file_content('/path/to/empty.txt')
+        
+        assert result is None
+
+    def test_get_current_timestamp(self, valid_config, mock_rag_client, mock_autoindexer_client):
+        """Test timestamp generation."""
+        handler = StaticDataSourceHandler("test-index", valid_config, mock_rag_client, mock_autoindexer_client)
+        
+        timestamp = handler._get_current_timestamp()
+        
+        assert isinstance(timestamp, str)
+        assert timestamp.endswith('Z')
+        assert 'T' in timestamp  # ISO format should contain 'T'
+
+    @patch('autoindexer.data_source_handler.static_handler.requests.get')
+    def test_fetch_content_with_code_language_detection(self, mock_get, mock_rag_client, mock_autoindexer_client):
+        """Test language detection for code files during index update."""
+        config = {
+            "autoindexer_name": "test-autoindexer",
+            "urls": ["https://example.com/script.py"]
+        }
+        
+        mock_response = Mock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.headers = {'content-type': 'text/plain'}
+        mock_response.iter_content.return_value = [b'print("Hello, World!")']
+        mock_get.return_value.__enter__.return_value = mock_response
+        
+        handler = StaticDataSourceHandler("test-index", config, mock_rag_client, mock_autoindexer_client)
+        errors = handler.update_index()
+        
+        assert errors == []
+        
+        call_args = mock_rag_client.index_documents.call_args
+        documents = call_args[1]["documents"]
+        assert len(documents) == 1
+        assert documents[0]["metadata"]["language"] == "python"
+        assert documents[0]["metadata"]["split_type"] == "code"


### PR DESCRIPTION
**Reason for Change**:
This is a PR in line with the [AutoIndexer Proposal](https://github.com/kaito-project/kaito/blob/main/docs/proposals/20251001-rag-auto-indexer.md) that create the AutoIndexer service that will run as a job within users clusters.  The proposal lays out the definitions and reasons for them.  This PR includes the initial service with support for Static data source types, PDF handling, and k8s AutoIndexer CRD status updates.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: