### PR TITLE
fix: use crypto/rand package to generate random string

### DIFF
--- a/pkg/utils/workspace/workspace.go
+++ b/pkg/utils/workspace/workspace.go
@@ -15,10 +15,10 @@ package workspace
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"reflect"
-	"time"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -159,12 +159,12 @@ func generateRandomString(length int) string {
 	if length <= 0 {
 		return ""
 	}
-	source := rand.NewSource(time.Now().UnixNano())
-	r := rand.New(source)
+
 	charset := "abcdefghijklmnopqrstuvwxyz0123456789"
 	result := make([]byte, length)
 	for i := range result {
-		result[i] = charset[r.Intn(len(charset))]
+		n, _ := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+		result[i] = charset[n.Int64()]
 	}
 	return string(result)
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
fix: use crypto/rand package to generate random string

per https://docs.datadoghq.com/security/code_security/static_analysis/static_analysis_rules/go-security/math-rand-insecure/, crypto/rand package is more secure when generate random numbers

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: