### PR TITLE
chore: bump local-csi-driver to v0.2.6

### DIFF
--- a/charts/kaito/workspace/templates/local-csi-driver-ds.yaml
+++ b/charts/kaito/workspace/templates/local-csi-driver-ds.yaml
@@ -209,7 +209,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: spec.nodeName
-        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.5"
+        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.6"
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -318,7 +318,7 @@ spec:
         args:
         - --csi-address=/csi/csi.sock
         - --timeout=240s
-        - --handle-volume-inuse-error=true
+        - --handle-volume-inuse-error=false
         - --http-endpoint=:8091
         - --v=2
         env:

--- a/hack/local-csi-driver-charts-sync/local-csi-driver-charts-sync.sh
+++ b/hack/local-csi-driver-charts-sync/local-csi-driver-charts-sync.sh
@@ -12,7 +12,7 @@
 SCRIPT_DIR="$(realpath "$(dirname "$0")")"
 
 REPO=https://github.com/Azure/local-csi-driver.git
-REVISION="06932013f5ab544172636a3d907a551914f64b68"
+REVISION="55a538ca60ed639ffd329d554506eae8866aea36"
 
 TEMP_DIR=$(mktemp -d)
 REPO_DIR="$TEMP_DIR/local-csi-driver"

--- a/hack/local-csi-driver-charts-sync/local-csi-driver-charts.diff
+++ b/hack/local-csi-driver-charts-sync/local-csi-driver-charts.diff
@@ -85,7 +85,7 @@ index 44411b40..9b9877c8 100644
              fieldRef:
                fieldPath: spec.nodeName
 -        image: "localcsidriver.azurecr.io/acstor/local-csi-driver:0.0.1-latest"
-+        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.5"
++        image: "mcr.microsoft.com/acstor/local-csi-driver:v0.2.6"
          imagePullPolicy: IfNotPresent
          livenessProbe:
            httpGet:


### PR DESCRIPTION
 **Reason for Change**:
 
 Updates local-csi-driver to v0.2.6.

**Requirements**

 * [ ]  added unit tests and e2e tests (if applicable).

**Issue Fixed**:

fix: count unassigned and assigned pv to vg for total capacity by @jmclong in https://github.com/Azure/local-csi-driver/pull/173
fix: remove corrupted logical volume when lvcreate killed by @jmclong in https://github.com/Azure/local-csi-driver/pull/193
Set csi-resizer --handle-volume-inuse-error=false to reduce memory footprint in large clusters by @Copilot in https://github.com/Azure/local-csi-driver/pull/210

Updated images and dependencies

**Notes for Reviewers**:

Release notes: https://github.com/Azure/local-csi-driver/releases/tag/v0.2.6