### PR TITLE
fix: bump pip to 25.3 in kaito-base and ragservice images [release-0.7]

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -22,6 +22,10 @@ jobs:
             image: test/kaito-rag-service:v0.0.1
             registry: test
             build_flags: "--target dependencies"
+          - target: docker-build-kaito-base
+            image: test/kaito-base:v0.0.1
+            registry: test
+            build_flags: "--target dependencies"
 
     steps:
 

--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ create-eks-cluster: ## Create an EKS cluster.
 BUILDX_BUILDER_NAME ?= img-builder
 OUTPUT_TYPE ?= type=registry
 QEMU_VERSION ?= 7.2.0-1
-ARCH ?= amd64,arm64
+ARCH ?= amd64
 BUILDKIT_VERSION ?= v0.18.1
 
 RAGENGINE_IMAGE_NAME ?= ragengine
@@ -273,6 +273,9 @@ RAGENGINE_IMAGE_TAG ?= v0.0.1
 
 RAGENGINE_SERVICE_IMG_NAME ?= kaito-rag-service
 RAGENGINE_SERVICE_IMG_TAG ?= v0.0.1
+
+KAITO_BASE_IMG_NAME ?= kaito-base
+KAITO_BASE_IMG_TAG ?= v0.0.1
 
 E2E_IMAGE_NAME ?= kaito-e2e
 E2E_IMAGE_TAG ?= v0.0.1
@@ -306,7 +309,19 @@ docker-build-ragengine: docker-buildx ## Build Docker image for RAG Engine.
 		$(BUILD_FLAGS) \
 		--tag $(REGISTRY)/$(RAGENGINE_IMAGE_NAME):$(IMG_TAG) .
 
-.PHONY: docker-build-rag-service
+.PHONY: docker-build-kaito-base
+docker-build-kaito-base: docker-buildx ## Build Docker image for KAITO base.
+	docker buildx build \
+        --build-arg VERSION=$(KAITO_BASE_IMG_TAG) \
+		--build-arg MODEL_TYPE=text-generation \
+        --platform="linux/$(ARCH)" \
+        --output=$(OUTPUT_TYPE) \
+        --file ./docker/presets/models/tfs/Dockerfile \
+        --pull \
+		$(BUILD_FLAGS) \
+        --tag $(REGISTRY)/$(KAITO_BASE_IMG_NAME):$(KAITO_BASE_IMG_TAG) .
+
+.PHONY: docker-build-ragservice
 docker-build-ragservice: docker-buildx ## Build Docker image for RAG Engine service.
 	docker buildx build \
         --platform="linux/$(ARCH)" \

--- a/charts/kaito/workspace/templates/supported-models-configmap.yaml
+++ b/charts/kaito/workspace/templates/supported-models-configmap.yaml
@@ -9,7 +9,7 @@ data:
       - name: base
         type: text-generation
         runtime: tfs
-        tag: 0.0.8
+        tag: 0.0.9
       - name: llama-3.1-8b-instruct
         type: text-generation
         version: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/commit/0e9e39f249a16976918f6564b8830bc894c89659

--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -6,6 +6,8 @@ ARG VERSION
 # https://docs.ray.io/en/latest/cluster/usage-stats.html
 ENV RAY_USAGE_STATS_ENABLED="1"
 
+RUN pip3 install --upgrade pip
+
 # Set the working directory
 WORKDIR /workspace
 

--- a/docker/ragengine/service/Dockerfile
+++ b/docker/ragengine/service/Dockerfile
@@ -11,6 +11,8 @@ RUN apt-get update && apt-get upgrade -y \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
+RUN pip3 install --upgrade pip
+
 FROM dependencies AS base
 
 WORKDIR /app

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -3,8 +3,9 @@ models:
   - name: base
     type: text-generation
     runtime: tfs
-    tag: 0.0.8
+    tag: 0.0.9
     # Tag history:
+    # 0.0.9 - bump pip to 25.3
     # 0.0.8 - Fix multi-node-health-check issue
     # 0.0.7 - bump lmcache to 0.3.5
     # 0.0.6 - bump vLLM to 0.10.1.1, transformers to 4.55.2, torch to 2.7.1, lmcache to 0.3.3, ray to 2.48.0, accelerate to 1.3.0


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

fix: bump pip to 25.3 in kaito-base and ragservice images [release-0.7]

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: