### PR TITLE
fix: add findutils as runtime dependency of skopeo image

### DIFF
--- a/docker/skopeo/Dockerfile
+++ b/docker/skopeo/Dockerfile
@@ -22,6 +22,7 @@ targets:
             - ${VERSION}-${REVISION}.azl3
       runtime:
         bash: {}
+        findutils: {}
         tar: {}
 
 artifacts:


### PR DESCRIPTION
**Reason for Change**:
Add `findutils` as runtime dependency of Skopeo image to allow pulls of private images.

**Requirements**
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
N/A

**Notes for Reviewers**:
N/A