### PR TITLE
feat: use skopeo mcr images [release-0.7]

### DIFF
--- a/pkg/workspace/image/puller.go
+++ b/pkg/workspace/image/puller.go
@@ -64,7 +64,7 @@ func renderPullerSH(imgRef string, volDir string) string {
 func NewPullerContainer(inputImage string, outputDirectory string) *corev1.Container {
 	return &corev1.Container{
 		Name:  "puller",
-		Image: "quay.io/skopeo/stable:v1.18.0-immutable",
+		Image: "mcr.microsoft.com/aks/skopeo:1.14.4-6",
 		Command: []string{
 			"/bin/sh",
 			"-c",

--- a/pkg/workspace/image/puller_test.go
+++ b/pkg/workspace/image/puller_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Puller", func() {
 			ret := NewPullerContainer(imgRef, volDir)
 			Expect(ret).NotTo(BeNil())
 			Expect(ret.Name).To(Equal("puller"))
-			Expect(ret.Image).To(Equal("quay.io/skopeo/stable:v1.18.0-immutable"))
+			Expect(ret.Image).To(Equal("mcr.microsoft.com/aks/skopeo:1.14.4-6"))
 			Expect(ret.Command).To(Equal([]string{"/bin/sh", "-c"}))
 			Expect(ret.Args).To(Equal([]string{pullerSH}))
 		})

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -185,7 +185,7 @@ func TestGeneratePullerContainers(t *testing.T) {
 				if assert.Len(t, containers, 1) {
 					c := containers[0]
 					assert.Equal(t, "puller-adapterA", c.Name)
-					assert.Equal(t, "quay.io/skopeo/stable:v1.18.0-immutable", c.Image)
+					assert.Equal(t, "mcr.microsoft.com/aks/skopeo:1.14.4-6", c.Image)
 					if assert.Len(t, c.Args, 1) {
 						assert.Contains(t, c.Args[0], "/mnt/adapter/adapterA")
 					}


### PR DESCRIPTION
**Reason for Change**:
Use MCR images for Skopeo to be compliant with Microsoft's policy.

**Requirements**
- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
N/A

**Notes for Reviewers**:
None