### PR TITLE
fix: add new label to inference pods generated by InfefenceSet

### DIFF
--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -157,7 +157,7 @@ func GeneratePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspac
 	if shouldUseDistributedInference(gctx, numNodes) {
 		podOpts = append(podOpts, SetDistributedInferenceProbe)
 		ssOpts := []generator.TypedManifestModifier[generator.WorkspaceGeneratorContext, appsv1.StatefulSet]{
-			manifests.GenerateStatefulSetManifest(workspaceObj, revisionNum, numNodes),
+			manifests.GenerateStatefulSetManifest(revisionNum, numNodes),
 		}
 
 		if checkIfNVMeAvailable(ctx, gpuConfig, kubeClient) {
@@ -182,7 +182,7 @@ func GeneratePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspac
 		}
 
 		return generator.GenerateManifest(gctx,
-			manifests.GenerateDeploymentManifest(workspaceObj, revisionNum, numNodes),
+			manifests.GenerateDeploymentManifest(revisionNum, numNodes),
 			manifests.SetDeploymentPodSpec(podSpec),
 		)
 	}

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -31,7 +31,6 @@ import (
 	"k8s.io/klog/v2"
 	"k8s.io/utils/ptr"
 
-	"github.com/kaito-project/kaito/api/v1beta1"
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils"
@@ -112,7 +111,7 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 	}
 }
 
-func GenerateStatefulSetManifest(workspaceObj *v1beta1.Workspace, revisionNum string, replicas int) func(*generator.WorkspaceGeneratorContext, *appsv1.StatefulSet) error {
+func GenerateStatefulSetManifest(revisionNum string, replicas int) func(*generator.WorkspaceGeneratorContext, *appsv1.StatefulSet) error {
 	return func(ctx *generator.WorkspaceGeneratorContext, ss *appsv1.StatefulSet) error {
 		selector := map[string]string{
 			kaitov1beta1.LabelWorkspaceName: ctx.Workspace.Name,
@@ -211,14 +210,14 @@ func SetJobPodSpec(podSpec *corev1.PodSpec) func(*generator.WorkspaceGeneratorCo
 	}
 }
 
-func GenerateDeploymentManifest(workspaceObj *v1beta1.Workspace, revisionNum string, replicas int) func(*generator.WorkspaceGeneratorContext, *appsv1.Deployment) error {
+func GenerateDeploymentManifest(revisionNum string, replicas int) func(*generator.WorkspaceGeneratorContext, *appsv1.Deployment) error {
 	return func(ctx *generator.WorkspaceGeneratorContext, d *appsv1.Deployment) error {
 		selector := map[string]string{
 			kaitov1beta1.LabelWorkspaceName: ctx.Workspace.Name,
 		}
 		// if workspaceObj.Labels contains "inferenceset.kaito.sh/created-by", add it to selector for VPA/HPA purpose
-		if workspaceObj.Labels != nil {
-			if createdBy, exists := workspaceObj.Labels[consts.WorkspaceCreatedByInferenceSetLabel]; exists {
+		if ctx.Workspace.Labels != nil {
+			if createdBy, exists := ctx.Workspace.Labels[consts.WorkspaceCreatedByInferenceSetLabel]; exists {
 				klog.Infof("Adding label %s=%s to deployment selector", consts.WorkspaceCreatedByInferenceSetLabel, createdBy)
 				selector[consts.WorkspaceCreatedByInferenceSetLabel] = createdBy
 			}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
fix: add new label to inference pods generated by InfefenceSet
**context**:
In KEDA (Kubernetes Event-driven Autoscaling), the `status.selector` field is used to specify a label selector that identifies the Kubernetes resources (such as pods or deployments) that are being scaled by a particular ScaledObject or ScaledJob.

More specifically, `status.selector` provides the label selector string that matches the target workload which KEDA is monitoring and scaling. This helps users and the system to understand which resources are associated with the scaling configuration.

For example, if you have a ScaledObject that scales a Deployment, the `status.selector` will contain the labels that select that Deployment's pods. This is useful for debugging and for KEDA's internal operations to track the scaled resources.

   during keda-autoscaler integration with InfefenceSet, keda requires InfefenceSet exposing status.selector for monitoring scaling, while currently all inference pods do not have unique label, current pod label is like this: `kaito.sh/workspace: phi-2-fljpv` which is not a const (workspace name changes in different pods),  this PR adds a new const pod label, `inferenceset.kaito.sh/created-by: InfefenceSetName`, thus keda hpa would work like following. btw, if InferenceSet is not used, this lable won't be added into InferenceSet pods.

```
Every 2.0s: k describe hpa                                                                                                  andydev: Sun Nov 16 03:36:42 2025

Name:                                                     keda-hpa-phi-2
Namespace:                                                default
Labels:                                                   app.kubernetes.io/managed-by=keda-operator
                                                          app.kubernetes.io/name=keda-hpa-phi-2
                                                          app.kubernetes.io/part-of=phi-2
                                                          app.kubernetes.io/version=2.18.1
                                                          scaledobject.keda.sh/name=phi-2
Annotations:                                              scaledobject.kaito.sh/managed-by: keda-kaito-scaler
CreationTimestamp:                                        Thu, 13 Nov 2025 13:37:59 +0000
Reference:                                                InferenceSet/phi-2
Metrics:                                                  ( current / target )
  "s0-vllm:num_requests_waiting" (target average value):  5 / 10
Min replicas:                                             1
Max replicas:                                             10
Behavior:
  Scale Up:
    Stabilization Window: 60 seconds
    Select Policy: Max
    Policies:
      - Type: Pods  Value: 1  Period: 300 seconds
  Scale Down:
    Stabilization Window: 300 seconds
    Select Policy: Max
    Policies:
      - Type: Pods  Value: 1  Period: 600 seconds
InferenceSet pods:  1 current / 1 desired
Conditions:
  Type            Status  Reason              Message
  ----            ------  ------              -------
  AbleToScale     True    ReadyForNewScale    recommended size matches current size
  ScalingActive   True    ValidMetricFound    the HPA was able to successfully calculate a replica count from external metric s0-vllm:num_requests_waiting(&L
abelSelector{MatchLabels:map[string]string{scaledobject.keda.sh/name: phi-2,},MatchExpressions:[]LabelSelectorRequirement{},})
  ScalingLimited  False   DesiredWithinRange  the desired count is within the acceptable range
Events:
  Type     Reason             Age                      From                       Message
  ----     ------             ----                     ----                       -------
  Warning  SelectorRequired   23m (x14760 over 2d13h)  horizontal-pod-autoscaler  selector is required
  Normal   SuccessfulRescale  7m56s                    horizontal-pod-autoscaler  New size: 2; reason: external metric s0-vllm:num_requests_waiting(&LabelSel
ector{MatchLabels:map[string]string{scaledobject.keda.sh/name: phi-2,},MatchExpressions:[]LabelSelectorRequirement{},}) above target
  Normal   SuccessfulRescale  39s                      horizontal-pod-autoscaler  New size: 1; reason: All metrics below target
```



**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: