### PR TITLE
chore: bump vllm to 0.12.0 

### DIFF
--- a/.github/actions/e2e-base-setup/action.yaml
+++ b/.github/actions/e2e-base-setup/action.yaml
@@ -98,13 +98,14 @@ runs:
     - name: Create ACR
       shell: bash
       run: |
-          az acr create --name "$AZURE_ACR_NAME" --resource-group "$AZURE_RESOURCE_GROUP" --sku Standard --admin-enabled -o none
+          az acr create --name "$AZURE_ACR_NAME" --resource-group "$AZURE_RESOURCE_GROUP" --location "$AZURE_LOCATION" --sku Standard --admin-enabled -o none
           az acr login  --name "$AZURE_ACR_NAME"
           # Enable anonymous pull and public network access to make it easier for testing
           az acr update --name "$AZURE_ACR_NAME" --anonymous-pull-enabled true
       env:
         AZURE_RESOURCE_GROUP: ${{ env.CLUSTER_NAME }}
         AZURE_ACR_NAME: ${{ env.CLUSTER_NAME }}
+        AZURE_LOCATION: ${{ inputs.region }}
 
     - name: Create Azure Identity
       uses: azure/CLI@v2.1.0

--- a/charts/kaito/workspace/templates/supported-models-configmap.yaml
+++ b/charts/kaito/workspace/templates/supported-models-configmap.yaml
@@ -9,7 +9,7 @@ data:
       - name: base
         type: text-generation
         runtime: tfs
-        tag: 0.0.9
+        tag: 0.1.0
       - name: llama-3.1-8b-instruct
         type: text-generation
         version: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/commit/0e9e39f249a16976918f6564b8830bc894c89659

--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -6,7 +6,7 @@ ARG VERSION
 # https://docs.ray.io/en/latest/cluster/usage-stats.html
 ENV RAY_USAGE_STATS_ENABLED="1"
 
-RUN pip3 install --upgrade pip
+RUN pip3 install --upgrade pip uv
 
 # Set the working directory
 WORKDIR /workspace
@@ -20,7 +20,7 @@ FROM dependencies AS base
 COPY presets/workspace/dependencies/requirements.txt /workspace/requirements.txt
 
 RUN --mount=type=cache,target=/root/.cache/pip \
-    pip install -q -r /workspace/requirements.txt
+    uv pip install --system -q -r /workspace/requirements.txt
 
 # 1. Huggingface transformers
 COPY presets/workspace/inference/${MODEL_TYPE}/inference_api.py \

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -305,6 +305,9 @@ func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
 	// https://docs.vllm.ai/en/latest/serving/distributed_serving.html.
 	p.VLLM.ModelRunParams["pipeline-parallel-size"] = strconv.Itoa(rc.NumNodes)
 
+	// Since vllm 0.12.0, we need to set the distributed-executor-backend explicitly
+	p.VLLM.ModelRunParams["distributed-executor-backend"] = "ray"
+
 	// We need to setup multi-node Ray cluster and assume pod index 0 is the leader of the cluster.
 	// - leader: start as ray leader along with the model run command
 	// - worker: start as ray worker - don't need to provide the model run command

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -215,7 +215,7 @@ func TestGeneratePresetInference(t *testing.T) {
 				c.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
 			},
 			workload:    "StatefulSet",
-			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=3 --ray_port=6379; python3 /workspace/vllm/inference_api.py --model=test-repo/test-model --code-revision=test-revision --download-dir=/workspace/weights --gpu-memory-utilization=0.84 --max-model-len=2048 --kaito-config-file=/mnt/config/inference_config.yaml --pipeline-parallel-size=3 --tensor-parallel-size=2; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
+			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=3 --ray_port=6379; python3 /workspace/vllm/inference_api.py --model=test-repo/test-model --distributed-executor-backend=ray --code-revision=test-revision --download-dir=/workspace/weights --gpu-memory-utilization=0.84 --max-model-len=2048 --kaito-config-file=/mnt/config/inference_config.yaml --pipeline-parallel-size=3 --tensor-parallel-size=2; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
 			expectedEnvVars: []corev1.EnvVar{{
 				Name: "HF_TOKEN",
 				ValueFrom: &corev1.EnvVarSource{
@@ -251,7 +251,7 @@ func TestGeneratePresetInference(t *testing.T) {
 				c.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
 			},
 			workload:    "StatefulSet",
-			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=3 --ray_port=6379; python3 /workspace/vllm/inference_api.py --model=test-repo/test-model --code-revision=test-revision --download-dir=/workspace/weights --gpu-memory-utilization=0.84 --max-model-len=2048 --kaito-config-file=/mnt/config/inference_config.yaml --pipeline-parallel-size=3 --tensor-parallel-size=2; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
+			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=3 --ray_port=6379; python3 /workspace/vllm/inference_api.py --model=test-repo/test-model --distributed-executor-backend=ray --code-revision=test-revision --download-dir=/workspace/weights --gpu-memory-utilization=0.84 --max-model-len=2048 --kaito-config-file=/mnt/config/inference_config.yaml --pipeline-parallel-size=3 --tensor-parallel-size=2; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
 			expectedEnvVars: []corev1.EnvVar{{
 				Name: "HF_TOKEN",
 				ValueFrom: &corev1.EnvVarSource{

--- a/presets/workspace/dependencies/requirements.txt
+++ b/presets/workspace/dependencies/requirements.txt
@@ -1,11 +1,11 @@
 # Dependencies for TFS
 
 # Core Dependencies
-vllm==0.10.1.1
-transformers==4.55.2
-torch==2.7.1
+vllm==0.12.0
+transformers >= 4.56.0, < 5
+torch==2.9.0
 accelerate==1.3.0
-fastapi==0.116.1
+fastapi[standard] >= 0.115.0
 pydantic>=2.9
 uvicorn[standard]>=0.29.0,<0.30.0  # Allow patch updates
 uvloop
@@ -13,8 +13,8 @@ peft==0.11.1
 numpy<3.0,>=1.25.0
 sentencepiece==0.2.0
 jinja2>=3.1.0
-starlette==0.47.2
-lmcache==0.3.5
+starlette>=0.49.1
+lmcache==0.3.10
 
 # For accessing Ray dashboard. ray[default] version should be consistent with the one in vllm/vllm-openai:<vllm-version>.
 # Check with `docker run --entrypoint "" vllm/vllm-openai:<vllm-version> pip freeze | grep ray`

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -12,25 +12,18 @@
 # limitations under the License.
 
 import argparse
-import copy
-import gc
 import logging
 import os
-from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
 import psutil
 import pynvml
-import torch
 import uvloop
 import vllm.entrypoints.openai.api_server as api_server
-import vllm.envs as envs
 import yaml
-from vllm.engine.llm_engine import EngineArgs, LLMEngine, VllmConfig
 from vllm.entrypoints.openai.serving_models import LoRAModulePath
-from vllm.executor.executor_base import ExecutorBase
-from vllm.utils import FlexibleArgumentParser
+from vllm.utils.argparse_utils import FlexibleArgumentParser
 
 # Initialize logger
 logger = logging.getLogger(__name__)
@@ -170,128 +163,6 @@ def load_lora_adapters(adapters_dir: str) -> LoRAModulePath | None:
     return lora_list
 
 
-def find_max_available_seq_len(vllm_config: VllmConfig, max_probe_steps: int) -> int:
-    """
-    Load model and run profiler to find max available seq len.
-    """
-    executor_class = LLMEngine._get_executor_cls(vllm_config)
-    if vllm_config.scheduler_config.enable_chunked_prefill:
-        logger.info("Chunked Prefill is enabled, skip probing.")
-        return vllm_config.model_config.max_model_len
-    executor = executor_class(vllm_config=vllm_config)
-
-    res = binary_search_with_limited_steps(
-        vllm_config.model_config.max_model_len,
-        max_probe_steps,
-        lambda x: is_context_length_safe(executor, x),
-    )
-
-    # release memory
-    del executor
-    gc.collect()
-    torch.cuda.empty_cache()
-
-    return res
-
-
-def binary_search_with_limited_steps(
-    upper: int, max_probe_steps: int, is_valid_fn: Callable[[int], bool]
-) -> int:
-    """
-    Finds the maximum valid value with limited number of steps.
-
-    Parameters:
-    - upper (int): The upper bound of the search space([0, upper]).
-    - max_probe_steps (int): Maximum number of steps to try.
-    - is_valid_fn (Callable[[int], bool]): A function that checks if a given value is valid.
-
-    Returns: - int: The maximum valid value.
-    """
-    probe_steps = 0
-    low = 0
-    # double the upper bound and firstly search at upper value later.
-    # because the valid value is likely to be close to the upper bound.
-    high = upper * 2
-    while low < high and probe_steps < max_probe_steps:
-        mid = (low + high + 1) // 2
-        if mid > upper:
-            break
-
-        if is_valid_fn(mid):
-            low = mid
-        else:
-            high = mid - 1
-
-        probe_steps += 1
-
-    return low
-
-
-def is_context_length_safe(executor: ExecutorBase, context_length: int) -> bool:
-    """
-    Check if the available gpu blocks is enough for the given num_gpu_blocks.
-    """
-    # Profile memory usage with max_num_sequences sequences and the total
-    # number of tokens equal to max_num_batched_tokens.
-    executor.scheduler_config.max_num_batched_tokens = context_length
-    try:
-        logger.info(
-            f"Try to determine available gpu blocks for context length {context_length}"
-        )
-        # see https://github.com/vllm-project/vllm/blob/v0.7.2/vllm/engine/llm_engine.py#L416
-        available_gpu_blocks, _ = executor.determine_num_available_blocks()
-    except torch.OutOfMemoryError:
-        return False
-
-    num_gpu_blocks = context_length // executor.cache_config.block_size
-    return available_gpu_blocks >= num_gpu_blocks
-
-
-def try_get_max_available_seq_len(args: argparse.Namespace) -> int | None:
-    if args.max_model_len is not None:
-        logger.info(f"max_model_len is set to {args.max_model_len}, skip probing.")
-        return None
-
-    if args.tensor_parallel_size > 1 or args.pipeline_parallel_size > 1:
-        logger.info("Multi-GPU serving is enabled, skip probing.")
-        return None
-
-    max_probe_steps = 0
-    if args.kaito_max_probe_steps is not None:
-        try:
-            max_probe_steps = int(args.kaito_max_probe_steps)
-        except ValueError:
-            raise ValueError("kaito_max_probe_steps must be an integer.")
-
-    if max_probe_steps <= 0:
-        return None
-
-    engine_args = EngineArgs.from_cli_args(args)
-    # read the model config from hf weights path.
-    # vllm will perform different parser for different model architectures
-    # and read it into a unified EngineConfig.
-    vllm_config = engine_args.create_engine_config()
-
-    max_model_len = vllm_config.model_config.max_model_len
-    available_seq_len = max_model_len
-    logger.info("Try run profiler to find max available seq len")
-    available_seq_len = find_max_available_seq_len(vllm_config, max_probe_steps)
-    # see https://github.com/vllm-project/vllm/blob/v0.7.2/vllm/worker/worker.py#L539
-    if available_seq_len <= 0:
-        raise ValueError(
-            "No available memory for the cache blocks. "
-            "Try increasing `gpu_memory_utilization` when "
-            "initializing the engine."
-        )
-
-    if available_seq_len != max_model_len:
-        logger.info(f"Set max_model_len from {max_model_len} to {available_seq_len}")
-        return available_seq_len
-    else:
-        logger.info(f"Using model default max_model_len {max_model_len}")
-        return None
-
-
 def get_max_gpu_memory_utilization(device_index: int = 0) -> float:
     # Calculate gpu_memory_utilization based on available GPU memory.
     # This ensures vLLM only uses currently free memory to avoid OOM errors.
@@ -317,49 +188,38 @@ def get_max_gpu_memory_utilization(device_index: int = 0) -> float:
 def set_kv_cache_offloading_if_appliable(args: argparse.Namespace) -> None:
     """
     Set KV cache offloading to CPU RAM if applicable.
-    This is only applicable when VLLM_USE_V1 is enabled and
-    kaito_kv_cache_cpu_memory_utilization is set.
+    This is only applicable when kaito_kv_cache_cpu_memory_utilization is set.
     """
     if (
-        not envs.is_set("VLLM_USE_V1")
-        and args.kaito_kv_cache_cpu_memory_utilization > 0
+        args.kaito_kv_cache_cpu_memory_utilization is None
+        or args.kaito_kv_cache_cpu_memory_utilization <= 0
     ):
         logger.info(
-            f"VLLM_USE_V1 is not set, but kaito_kv_cache_cpu_memory_utilization is set as {args.kaito_kv_cache_cpu_memory_utilization}, "
-            "run create_engine_config to check whether VLLM_USE_V1 should be set."
+            "kv_cache_cpu_memory_utilization is not set, do not use KV cache offload to CPU RAM."
         )
-        EngineArgs.from_cli_args(copy.deepcopy(args)).create_engine_config()
+        return
 
-    if (
-        envs.is_set("VLLM_USE_V1")
-        and envs.VLLM_USE_V1
-        and args.kaito_kv_cache_cpu_memory_utilization > 0
-    ):
-        os.environ["LMCACHE_CHUNK_SIZE"] = "256"
-        os.environ["LMCACHE_LOCAL_CPU"] = "True"
-        available_memory_gb = (
-            psutil.virtual_memory().total - psutil.virtual_memory().used
-        ) / (1024**3)
-        logger.info(
-            f"VLLM_USE_V1 is set, Offload KV cache to CPU RAM, size limit: {available_memory_gb} * {args.kaito_kv_cache_cpu_memory_utilization} GB split among {args.tensor_parallel_size} GPUs"
-        )
+    os.environ["LMCACHE_CHUNK_SIZE"] = "256"
+    os.environ["LMCACHE_LOCAL_CPU"] = "True"
+    available_memory_gb = (
+        psutil.virtual_memory().total - psutil.virtual_memory().used
+    ) / (1024**3)
+    logger.info(
+        f"Offload KV cache to CPU RAM, size limit: {available_memory_gb} * {args.kaito_kv_cache_cpu_memory_utilization} GB split among {args.tensor_parallel_size} GPUs"
+    )
 
-        # When using tensor parallelism, the KV cache CPU memory allocation must be divided evenly
-        # across all GPUs. Each GPU should only allocate its portion (1/tensor_parallel_size) of the
-        # total available CPU memory to prevent OOM.
-        os.environ["LMCACHE_MAX_LOCAL_CPU_SIZE"] = (
-            f"{available_memory_gb * args.kaito_kv_cache_cpu_memory_utilization / args.tensor_parallel_size}"
-        )
+    # When using tensor parallelism, the KV cache CPU memory allocation must be divided evenly
+    # across all GPUs. Each GPU should only allocate its portion (1/tensor_parallel_size) of the
+    # total available CPU memory to prevent OOM.
+    os.environ["LMCACHE_MAX_LOCAL_CPU_SIZE"] = (
+        f"{available_memory_gb * args.kaito_kv_cache_cpu_memory_utilization / args.tensor_parallel_size}"
+    )
 
-        if args.kv_transfer_config is None:
-            args.kv_transfer_config = {
-                "kv_connector": "LMCacheConnectorV1",
-                "kv_role": "kv_both",
-            }
-    else:
-        logger.info(
-            "VLLM_USE_V1 or kv_cache_cpu_memory_utilization is not set, do not use KV cache offload to CPU RAM."
-        )
+    if args.kv_transfer_config is None:
+        args.kv_transfer_config = {
+            "kv_connector": "LMCacheConnectorV1",
+            "kv_role": "kv_both",
+        }
 
 
 if __name__ == "__main__":
@@ -370,24 +230,10 @@ if __name__ == "__main__":
     if args.lora_modules is None:
         args.lora_modules = load_lora_adapters(args.kaito_adapters_dir)
 
-    # notes: avoid dirty args that breaks vllm runtime check. deepcopy here.
-    max_available_seq_len = try_get_max_available_seq_len(copy.deepcopy(args))
-    if max_available_seq_len is not None:
-        args.max_model_len = max_available_seq_len
-
     set_kv_cache_offloading_if_appliable(args)
 
     # Run the serving server
     logger.info(f"Starting server on port {args.port}")
     # See https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html for more
     # details about serving server.
-    # endpoints:
-    # - /health
-    # - /tokenize
-    # - /detokenize
-    # - /v1/models
-    # - /version
-    # - /v1/chat/completions
-    # - /v1/completions
-    # - /v1/embeddings
     uvloop.run(api_server.run_server(args))

--- a/presets/workspace/inference/vllm/tests/test_vllm_inference_api.py
+++ b/presets/workspace/inference/vllm/tests/test_vllm_inference_api.py
@@ -29,7 +29,7 @@ parent_dir = str(Path(__file__).resolve().parent.parent)
 sys.path.append(parent_dir)
 
 try:
-    from inference_api import KaitoConfig, binary_search_with_limited_steps
+    from inference_api import KaitoConfig
 except ImportError as e:
     raise ImportError(f"Error importing required module(s): {e}") from e
 
@@ -216,33 +216,3 @@ def test_model_list(setup_server):
     assert data["data"][2]["parent"] == TEST_MODEL_NAME, (
         f"The third model should have the test model as parent, but got {data['data'][2]['parent']}"
     )
-
-
-def test_binary_search_with_limited_steps():
-    def is_safe_fn(x):
-        return x <= 10
-
-    # Test case 1: all values are safe
-    result = binary_search_with_limited_steps(10, 1, is_safe_fn)
-    assert result == 10, f"Expected 10, but got {result}"
-
-    result = binary_search_with_limited_steps(10, 10, is_safe_fn)
-    assert result == 10, f"Expected 10, but got {result}"
-
-    # Test case 2: partial safe, find the exact value
-    result = binary_search_with_limited_steps(20, 3, is_safe_fn)
-    assert result == 10, f"Expected 10, but got {result}"
-
-    result = binary_search_with_limited_steps(30, 6, is_safe_fn)
-    assert result == 10, f"Expected 10, but got {result}"
-
-    # Test case 3: partial safe, find an approximate value
-    result = binary_search_with_limited_steps(30, 3, is_safe_fn)
-    assert result == 7, f"Expected 7, but got {result}"
-
-    # Test case 4: all values are unsafe
-    result = binary_search_with_limited_steps(10, 1, lambda x: False)
-    assert result == 0, f"Expected 0, but got {result}"
-
-    result = binary_search_with_limited_steps(20, 100, lambda x: False)
-    assert result == 0, f"Expected 0, but got {result}"

--- a/presets/workspace/models/llama3/model.go
+++ b/presets/workspace/models/llama3/model.go
@@ -53,6 +53,8 @@ var (
 		"tool-call-parser":        "llama3_json",
 		"enable-auto-tool-choice": "",
 	}
+	// pin the attention backend to triton for llama3 models, as flashinfer is unavailable in KAITO base image.
+	llama3VLLMCommand = "VLLM_ATTENTION_BACKEND=TRITON_ATTN python3 /workspace/vllm/inference_api.py"
 )
 
 var llama3_1_8b_instructA llama3_1_8BInstruct
@@ -75,7 +77,7 @@ func (*llama3_1_8BInstruct) GetInferenceParameters() *model.PresetParam {
 				ModelRunParams:    llamaRunParams,
 			},
 			VLLM: model.VLLMParam{
-				BaseCommand:          inference.DefaultVLLMCommand,
+				BaseCommand:          llama3VLLMCommand,
 				ModelName:            PresetLlama3_1_8BInstructModel,
 				ModelRunParams:       llamaRunParamsVLLM,
 				RayLeaderBaseCommand: inference.DefaultVLLMRayLeaderBaseCommand,
@@ -120,7 +122,7 @@ func (*llama3_3_70Binstruct) GetInferenceParameters() *model.PresetParam {
 				ModelRunParams:    llamaRunParams,
 			},
 			VLLM: model.VLLMParam{
-				BaseCommand:          inference.DefaultVLLMCommand,
+				BaseCommand:          llama3VLLMCommand,
 				ModelName:            PresetLlama3_3_70BInstructModel,
 				ModelRunParams:       llamaRunParamsVLLM,
 				RayLeaderBaseCommand: inference.DefaultVLLMRayLeaderBaseCommand,

--- a/presets/workspace/models/mistral/model.go
+++ b/presets/workspace/models/mistral/model.go
@@ -48,7 +48,6 @@ var (
 	}
 	mistralRunParamsVLLM = map[string]string{
 		"dtype":                   "float16",
-		"chat-template":           "/workspace/chat_templates/tool-chat-mistral.jinja",
 		"tool-call-parser":        "mistral",
 		"enable-auto-tool-choice": "",
 	}

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -3,8 +3,9 @@ models:
   - name: base
     type: text-generation
     runtime: tfs
-    tag: 0.0.9
+    tag: 0.1.0
     # Tag history:
+    # 0.1.0 - bump vLLM to 0.12.0. remove the support for vllm v0
     # 0.0.9 - bump pip to 25.3
     # 0.0.8 - Fix multi-node-health-check issue
     # 0.0.7 - bump lmcache to 0.3.5

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -317,7 +317,7 @@ func createPhi3TuningWorkspaceWithPresetPublicMode(configMapName string, numOfNo
 	return workspaceObj, uniqueID, outputRegistryUrl
 }
 
-func createAndValidateWorkspace(workspaceObj *kaitov1beta1.Workspace, configMapData ...map[string]string) {
+func createAndValidateWorkspace(workspaceObj *kaitov1beta1.Workspace) {
 
 	By("Creating workspace", func() {
 		Eventually(func() error {
@@ -459,7 +459,7 @@ func validateResourceStatus(workspaceObj *kaitov1beta1.Workspace) {
 					condition.Status == metav1.ConditionTrue
 			})
 			return conditionFound
-		}, 10*time.Minute, utils.PollInterval).Should(BeTrue(), "Failed to wait for resource status to be ready")
+		}, 15*time.Minute, utils.PollInterval).Should(BeTrue(), "Failed to wait for resource status to be ready")
 	})
 }
 

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -341,7 +341,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateCompletionsEndpoint(workspaceObj)
 	})
 
-	It("should create a gpt-oss-20b workspace with preset public mode successfully", utils.GinkgoLabelFastCheck, func() {
+	It("should create a gpt-oss-20b workspace with preset public mode successfully", utils.GinkgoLabelA100Required, func() {
 		numOfNode := 1
 		workspaceObj := createGPTOss20BWorkspaceWithPresetPublicModeAndVLLM(numOfNode)
 
@@ -566,19 +566,12 @@ func createGPTOss20BWorkspaceWithPresetPublicModeAndVLLM(numOfNode int) *kaitov1
 
 	By("Creating a workspace CR with GPT-OSS-20B preset public mode and vLLM", func() {
 		uniqueID := fmt.Sprint("preset-gpt-oss-20b-", rand.Intn(1000))
-		workspaceObj = utils.GenerateInferenceWorkspaceManifestWithVLLM(uniqueID, namespaceName, "", numOfNode, "Standard_NV36ads_A10_v5",
+		workspaceObj = utils.GenerateInferenceWorkspaceManifestWithVLLM(uniqueID, namespaceName, "", numOfNode, "Standard_NC24ads_A100_v4",
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "public-preset-e2e-test-gpt-oss-20b-vllm"},
 			}, nil, PresetGPT_OSS_20BModel, nil, nil, nil, "")
 
-		// Pass custom config data with gpu-memory-utilization and max-model-len
-		customConfigData := map[string]string{
-			"inference_config.yaml": `vllm:
-  gpu-memory-utilization: 0.84  # Controls GPU memory usage (0.0-1.0)
-  max-model-len: 1024`,
-		}
-
-		createAndValidateWorkspace(workspaceObj, customConfigData)
+		createAndValidateWorkspace(workspaceObj)
 	})
 
 	return workspaceObj


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

related breaking changes from upstream
- vllm v0 support was removed
- [Chat template cannot be set for mistral models](https://github.com/vllm-project/vllm/issues/25401)
- "distributed-executor-backend" should be explicitly set
- flashinfer attention backend is chosen by default for LLaMA 3 models, which 
requires the FlashInfer library to be installed lively. Pin to triton backend as a workaround.