### PR TITLE
test: add shellcheck github action

### DIFF
--- a/.github/workflows/shellcheck.yaml
+++ b/.github/workflows/shellcheck.yaml
@@ -1,0 +1,29 @@
+name: ShellCheck
+on:
+  push:
+    tags:
+      - v*
+    branches:
+      - main
+      - release-*
+  pull_request:
+    branches:
+      - main
+      - release-*
+
+jobs:
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v6
+    - name: Run ShellCheck
+      uses: ludeeus/action-shellcheck@master
+      env:
+         SHELLCHECK_OPTS: -e SC2034
+      with:
+        severity: warning
+        check_together: 'yes'
+        disable_matcher: false
+        ignore_paths: vendor release-tools hack
+        format: gcc


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
test: add shellcheck github action

```
./pkg/workspace/image/puller.sh:30:5: warning: In POSIX sh, 'local' is undefined. [SC3043]
./pkg/workspace/image/puller.sh:31:38: warning: In POSIX sh, 'local' is undefined. [SC3043]
./pkg/workspace/image/puller.sh:31:44: warning: Declare and assign separately to avoid masking return values. [SC2155]
./pkg/workspace/image/puller.sh:35:9: warning: In POSIX sh, 'local' is undefined. [SC3043]
./pkg/workspace/image/puller.sh:40:9: warning: In POSIX sh, 'local' is undefined. [SC3043]
./pkg/workspace/image/puller.sh:51:5: warning: In POSIX sh, 'local' is undefined. [SC3043]
./pkg/workspace/image/puller.sh:51:11: warning: Declare and assign separately to avoid masking return values. [SC2155]
./pkg/workspace/image/puller.sh:54:9: warning: In POSIX sh, 'local' is undefined. [SC3043]
./pkg/workspace/image/puller.sh:60:5: warning: In POSIX sh, 'local' is undefined. [SC3043]
./pkg/workspace/image/pusher.sh:25:8: error: Argument to -z is always false due to literal strings. [SC2157]
./pkg/workspace/image/pusher.sh:28:8: error: Argument to -z is always false due to literal strings. [SC2157]
./pkg/workspace/image/pusher.sh:41:5: warning: In POSIX sh, 'local' is undefined. [SC3043]
./pkg/workspace/image/pusher.sh:46:5: warning: In POSIX sh, 'local' is undefined. [SC3043]
```

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: