### PR TITLE
feat: support minor release version format (x.y.z-rc.w)

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -3,7 +3,7 @@ on:
   workflow_dispatch:
     inputs:
       release_version:
-        description: 'Release version (e.g., v0.2.2)'
+        description: 'Release version (e.g., v0.2.2 or v0.2.2-rc.0)'
         required: true
         type: string
       release_branch:
@@ -45,8 +45,8 @@ jobs:
       - name: Validate inputs
         run: |
           echo "Creating release ${{ github.event.inputs.release_version }} from branch ${{ github.event.inputs.release_branch }}"
-          if [[ ! "${{ github.event.inputs.release_version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "Error: Release version must follow format vX.Y.Z"
+          if [[ ! "${{ github.event.inputs.release_version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+            echo "Error: Release version must follow format vX.Y.Z or vX.Y.Z-rc.W"
             exit 1
           fi
           if [[ ! "${{ github.event.inputs.release_branch }}" =~ ^release- ]]; then

--- a/.github/workflows/docs-versioning.yaml
+++ b/.github/workflows/docs-versioning.yaml
@@ -3,9 +3,10 @@ name: Create Versioned Documentation
 on:
   push:
     tags:
-      # Trigger only on new minor version tags (e.g., v0.6.0, v0.7.0, v1.0.0)
-      # This regex matches tags like v0.6.0, v1.0.0 but excludes patch releases like v0.6.1, v0.6.2
+      # Trigger on new minor version tags (e.g., v0.6.0, v0.7.0, v1.0.0) and release candidates (e.g., v0.6.0-rc.0)
+      # This regex matches tags like v0.6.0, v1.0.0, v0.6.0-rc.0 but excludes patch releases like v0.6.1, v0.6.2
       - 'v[0-9]+.[0-9]+.0'
+      - 'v[0-9]+.[0-9]+.0-rc.[0-9]+'
 
 permissions:
   contents: read
@@ -55,10 +56,20 @@ jobs:
       - name: Extract version from tag
         id: get-version
         run: |
-          # Extract version from tag (e.g., v0.6.0 -> v0.6.x)
+          # Extract version from tag (e.g., v0.6.0 -> v0.6.x or v0.6.0-rc.0)
           VERSION_TAG=${GITHUB_REF#refs/tags/}
           echo "VERSION_TAG=$VERSION_TAG" >> $GITHUB_OUTPUT
           
+          # Check if this is a release candidate version
+          if [[ $VERSION_TAG =~ -rc\. ]]; then
+            echo "IS_RC=true" >> $GITHUB_OUTPUT
+            echo "Detected release candidate version: $VERSION_TAG"
+            echo "Skipping documentation versioning for RC versions"
+            exit 0
+          else
+            echo "IS_RC=false" >> $GITHUB_OUTPUT
+          fi
+
           # Convert v0.6.0 to v0.6.x format for documentation versioning
           DOC_VERSION=$(echo $VERSION_TAG | sed -E 's/^v([0-9]+)\.([0-9]+)\.0$/v\1.\2.x/')
           echo "DOC_VERSION=$DOC_VERSION" >> $GITHUB_OUTPUT

--- a/Makefile
+++ b/Makefile
@@ -592,25 +592,26 @@ fmt: ## Run go fmt against code.
 
 ## --------------------------------------
 ## Release
-## To create a release, run `make release VERSION=vx.y.z`
+## To create a release, run `make release VERSION=vx.y.z` or `make release VERSION=vx.y.z-rc.w`
 ## --------------------------------------
 
 ##@ Release
 
 .PHONY: release-manifest
 release-manifest: ## Update manifest and Helm charts for release.
-	@sed -i -e 's/^VERSION ?= .*/VERSION ?= ${VERSION}/' ./Makefile
-	@sed -i -e "s/version: .*/version: ${IMG_TAG}/" ./charts/kaito/workspace/Chart.yaml
-	@sed -i -e "s/appVersion: .*/appVersion: ${IMG_TAG}/" ./charts/kaito/workspace/Chart.yaml
-	@sed -i -e "s/tag: .*/tag: ${IMG_TAG}/" ./charts/kaito/workspace/values.yaml
-	@sed -i -e 's/IMG_TAG=.*/IMG_TAG=${IMG_TAG}/' ./charts/kaito/workspace/README.md
-	@sed -i -e "s/version: .*/version: ${IMG_TAG}/" ./charts/kaito/ragengine/Chart.yaml
-	@sed -i -e "s/appVersion: .*/appVersion: ${IMG_TAG}/" ./charts/kaito/ragengine/Chart.yaml
-	@sed -i -e "s/tag: .*/tag: ${IMG_TAG}/" ./charts/kaito/ragengine/values.yaml
-	@sed -i -e "s/presetRagImageTag: .*/presetRagImageTag: ${IMG_TAG}/" ./charts/kaito/ragengine/values.yaml
-	@sed -i -e 's/IMG_TAG=.*/IMG_TAG=${IMG_TAG}/' ./charts/kaito/ragengine/README.md
+	$(eval RELEASE_BRANCH := release-$(shell echo ${VERSION} | sed -E 's/^v([0-9]+\.[0-9]+).*/\1/'))
+	@sed -i '' -e 's/^VERSION ?= .*/VERSION ?= ${VERSION}/' ./Makefile
+	@sed -i '' -e "s/version: .*/version: ${IMG_TAG}/" ./charts/kaito/workspace/Chart.yaml
+	@sed -i '' -e "s/appVersion: .*/appVersion: ${IMG_TAG}/" ./charts/kaito/workspace/Chart.yaml
+	@sed -i '' -e "1,20s/  tag: .*/  tag: ${IMG_TAG}/" ./charts/kaito/workspace/values.yaml
+	@sed -i '' -e 's/IMG_TAG=.*/IMG_TAG=${IMG_TAG}/' ./charts/kaito/workspace/README.md
+	@sed -i '' -e "s/version: .*/version: ${IMG_TAG}/" ./charts/kaito/ragengine/Chart.yaml
+	@sed -i '' -e "s/appVersion: .*/appVersion: ${IMG_TAG}/" ./charts/kaito/ragengine/Chart.yaml
+	@sed -i '' -e "s/tag: .*/tag: ${IMG_TAG}/" ./charts/kaito/ragengine/values.yaml
+	@sed -i '' -e "s/presetRagImageTag: .*/presetRagImageTag: ${IMG_TAG}/" ./charts/kaito/ragengine/values.yaml
+	@sed -i '' -e 's/IMG_TAG=.*/IMG_TAG=${IMG_TAG}/' ./charts/kaito/ragengine/README.md
 
-	git checkout -b release-${VERSION}
+	git checkout -b $(RELEASE_BRANCH)
 	git add ./Makefile ./charts/kaito/workspace/Chart.yaml ./charts/kaito/workspace/values.yaml ./charts/kaito/workspace/README.md ./charts/kaito/ragengine/Chart.yaml ./charts/kaito/ragengine/values.yaml ./charts/kaito/ragengine/README.md
 	git commit -s -m "release: update manifest and helm charts for ${VERSION}"
 
@@ -623,8 +624,8 @@ release-manifest: ## Update manifest and Helm charts for release.
 
 .PHONY: post-release-doc-update
 post-release-doc-update:
-	@sed -i -e 's/export KAITO_WORKSPACE_VERSION=.*/export KAITO_WORKSPACE_VERSION=${IMG_TAG}/' ./website/docs/installation.md
-	@sed -i -e 's/$(shell grep 'default' ./terraform/variables.tf | sort | uniq -c | sort -nr | head -n1 | sed -E 's/^[ ]*[0-9]+[ ]+//')/default     = "${IMG_TAG}"/' ./terraform/variables.tf
+	@sed -i '' -e 's/export KAITO_WORKSPACE_VERSION=.*/export KAITO_WORKSPACE_VERSION=${IMG_TAG}/' ./website/docs/installation.md
+	@sed -i '' -e 's/$(shell grep 'default' ./terraform/variables.tf | sort | uniq -c | sort -nr | head -n1 | sed -E 's/^[ ]*[0-9]+[ ]+//')/default     = \"${IMG_TAG}\"/' ./terraform/variables.tf
 
 
 ## --------------------------------------


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

- Update GitHub workflows to accept RC version tags
- Skip documentation versioning for RC releases
- Update Makefile release target to handle RC versions
- Fix release branch naming to extract major.minor correctly

