### PR TITLE
fix: cancel latest release when it's perrelease

### DIFF
--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -34,7 +34,7 @@ release:
   prerelease: auto
   header: |
     ## {{.Tag}} - {{ time "2006-01-02" }}
-  make_latest: true
+  make_latest: "{{ not .Prerelease }}"
 changelog:
   groups:
     - title: Breaking Changes 💥


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

```bash
scm releases: failed to publish artifacts: could not update existing release: PATCH https://api.github.com/repos/kaito-project/kaito/releases/268286605: 422 Validation Failed [{Resource:Release Field: Code:custom Message:Latest release cannot be draft or prerelease.}]
```

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

https://github.com/kaito-project/kaito/actions/runs/20025464371

**Notes for Reviewers**: