### PR TITLE
docs: refine naming in docs and examples

### DIFF
--- a/examples/inference/kaito_inferenceset_llama-3.1_8b_instruct.yaml
+++ b/examples/inference/kaito_inferenceset_llama-3.1_8b_instruct.yaml
@@ -12,6 +12,7 @@ kind: InferenceSet
 metadata:
   annotations:
     scaledobject.kaito.sh/auto-provision: "true"
+    scaledobject.kaito.sh/metricName: "vllm:num_requests_waiting"
     scaledobject.kaito.sh/threshold: "10"
   name: llama-3-1-8b
 spec:

--- a/examples/inference/kaito_inferenceset_mistral_7b-instruct.yaml
+++ b/examples/inference/kaito_inferenceset_mistral_7b-instruct.yaml
@@ -2,8 +2,13 @@ apiVersion: kaito.sh/v1alpha1
 kind: InferenceSet
 metadata:
   name: mistral-7b-instruct
+  annotations:
+    scaledobject.kaito.sh/auto-provision: "true"
+    scaledobject.kaito.sh/metricName: "vllm:num_requests_waiting"
+    scaledobject.kaito.sh/threshold: "10"
 spec:
   replicas: 1
+  nodeCountLimit: 5
   labelSelector:
     matchLabels:
       apps: mistral-7b-instruct

--- a/examples/inference/kaito_inferenceset_phi_4_mini.yaml
+++ b/examples/inference/kaito_inferenceset_phi_4_mini.yaml
@@ -1,15 +1,22 @@
 apiVersion: kaito.sh/v1alpha1
 kind: InferenceSet
 metadata:
+  annotations:
+    scaledobject.kaito.sh/auto-provision: "true"
+    scaledobject.kaito.sh/metricName: "vllm:num_requests_waiting"
+    scaledobject.kaito.sh/threshold: "10"
   name: phi-4-mini
+  namespace: default
 spec:
   replicas: 1
+  nodeCountLimit: 5
   labelSelector:
     matchLabels:
       apps: phi-4-mini
   template:
-    resource:
-      instanceType: "Standard_NC24ads_A100_v4"
     inference:
       preset:
+        accessMode: public
         name: phi-4-mini-instruct
+    resource:
+      instanceType: Standard_NC24ads_A100_v4

--- a/website/docs/keda-autoscaler-inference.md
+++ b/website/docs/keda-autoscaler-inference.md
@@ -65,12 +65,12 @@ metadata:
     scaledobject.kaito.sh/auto-provision: "true"
     scaledobject.kaito.sh/metricName: "vllm:num_requests_waiting"
     scaledobject.kaito.sh/threshold: "10"
-  name: phi-4
+  name: phi-4-mini
   namespace: default
 spec:
   labelSelector:
     matchLabels:
-      apps: phi-4
+      apps: phi-4-mini
   replicas: 1
   nodeCountLimit: 5
   template:
@@ -87,11 +87,11 @@ EOF
 ```bash
 # kubectl get scaledobject
 NAME           SCALETARGETKIND                  SCALETARGETNAME   MIN   MAX   READY   ACTIVE    FALLBACK   PAUSED   TRIGGERS   AUTHENTICATIONS           AGE
-phi-4          kaito.sh/v1alpha1.InferenceSet   phi-4             1     5     True    True     False      False    external   keda-kaito-scaler-creds   10m
+phi-4-mini     kaito.sh/v1alpha1.InferenceSet   phi-4-mini        1     5     True    True     False      False    external   keda-kaito-scaler-creds   10m
 
 # kubectl get hpa
 NAME                    REFERENCE                   TARGETS      MINPODS   MAXPODS   REPLICAS   AGE
-keda-hpa-phi-4          InferenceSet/phi-4          0/10 (avg)   1         5         1          11m
+keda-hpa-phi-4-mini     InferenceSet/phi-4-mini     0/10 (avg)   1         5         1          11m
 ```
 
 That's it! Your KAITO workloads will now automatically scale based on the number of waiting inference requests(`vllm:num_requests_waiting`).


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
docs: refine naming in docs and examples, thus user could use one InferenceSet name and config in the following two example pages:
 - Gateway API Inference Extension
 - KEDA Auto-Scaler for inference workloads

This could improve the user experience

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: