### PR TITLE
chore: fix huggingface_hub version in preset_generator

### DIFF
--- a/presets/workspace/generator/requirements.txt
+++ b/presets/workspace/generator/requirements.txt
@@ -1,2 +1,2 @@
-huggingface_hub
+huggingface_hub >= 1.2.3
 PyYAML


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

chore: fix huggingface_hub version in preset_generator
`python3 preset_generator.py microsoft/Phi-4-mini-instruct` would fail with old huggingface_hub version

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: