### PR TITLE
docs: use kaito-workspace in keda install

### DIFF
--- a/website/docs/keda-autoscaler-inference.md
+++ b/website/docs/keda-autoscaler-inference.md
@@ -23,7 +23,7 @@ This document outlines the steps to enable intelligent autoscaling based on the 
 > The following example demonstrates how to install KEDA using Helm chart. For instructions on installing KEDA through other methods, please refer to the guide [here](https://github.com/kedacore/keda#deploying-keda).
 ```bash
 helm repo add kedacore https://kedacore.github.io/charts
-helm install keda kedacore/keda --namespace keda --create-namespace
+helm install keda kedacore/keda --namespace kaito-workspace --create-namespace
 ```
 
  - install keda-kaito-scaler


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
docs: use kaito-workspace in keda install

if keda is not installed in the same namespace as keda-kaito-scaler, there is problem to get server & client secrets, will fix it later, while we could make the doc example work first in v0.8.0

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: