### PR TITLE
docs: fix preset_generator.py doc links due to rename

### DIFF
--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -133,7 +133,7 @@ type PresetParam struct {
 	ModelTokenLimit               int            // Maximum number of tokens (context window) supported by the model. Maps to 'max_position_embeddings' in the model's Hugging Face config.json.
 
 	// To determine TotalSafeTensorFileSize and BytesPerToken values for a new model,
-	// run the sku-calculation/calculate_model_weight_and_bytes_per_token.py script
+	// run the presets/workspace/generator/preset_generator.py script
 	// with the model's Hugging Face repository ID as an argument.
 
 	RuntimeParam

--- a/presets/workspace/generator/model-sku-calculation.md
+++ b/presets/workspace/generator/model-sku-calculation.md
@@ -40,7 +40,7 @@ Where:
 
 #### Model Parameter Space
 
-The model weight size can be calculated using the model configuration methods implemented in the [`calculate_model_weight_and_bytes_per_token.py`](./calculate_model_weight_and_bytes_per_token.py) file. This model weight size corresponds to the total size of all safetensors files from the model's Hugging Face repository. This represents the static memory footprint required to load the model parameters into GPU memory. In experimental observations, the actual VRAM usage is approximately 102% of the model weight size.
+The model weight size can be calculated using the model configuration methods implemented in the [`preset_generator.py`](./preset_generator.py) file. This model weight size corresponds to the total size of all safetensors files from the model's Hugging Face repository. This represents the static memory footprint required to load the model parameters into GPU memory. In experimental observations, the actual VRAM usage is approximately 102% of the model weight size.
 
 **Multi-GPU Distribution:**
 When using multiple GPUs with tensor parallelism, the model weight is evenly distributed across all GPUs. Therefore, each GPU receives:
@@ -74,7 +74,7 @@ Bytes_per_token = 2 × hidden_layers × kv_heads × head_dim × dtype_size
 
 The `max_token_length` can be configured in the configMap. If not specified, the default value is 2048.
 
-The `Bytes_per_token` can also be calculated using the [`calculate_model_weight_and_bytes_per_token.py`](./calculate_model_weight_and_bytes_per_token.py) file.
+The `Bytes_per_token` can also be calculated using the [`preset_generator.py`](./preset_generator.py) file.
 
 The `tensor_parallel_size` is the number of effective GPU nodes.
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
docs: fix preset_generator.py doc links due to rename from `calculate_model_weight_and_bytes_per_token.py`

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: