### PR TITLE
fix: change the default GFD chart values

### DIFF
--- a/charts/kaito/workspace/values.yaml
+++ b/charts/kaito/workspace/values.yaml
@@ -59,6 +59,13 @@ flux2:
   notificationController:
     create: false
 gpu-feature-discovery:
+  affinity:
+    nodeAffinity: null
+  nfd:
+    master:
+      tolerations:
+      - key: CriticalAddonsOnly
+        operator: Exists
   devicePlugin:
     enabled: false
   gfd:


### PR DESCRIPTION
**Reason for Change**:
The default GFD chat has a few problems:

1) It adds node affinity for the gpu-feature-discovery daemonset: 
    https://github.com/NVIDIA/k8s-device-plugin/blob/1d775390872000dd3e0f0effc53d7bb0e0c5d7e5/deployments/helm/nvidia-device-plugin/values.yaml#L65
   Those affinities are added based on the assumption that certain node labels are available for nvidia GPU nodes which usually do not hold true in cloud vendors.
2) The node-feature-discovery-master deployment misses the toleration for well-known addon taint `CriticalAddonOnly`.

This change fixes the above problems. 

