### PR TITLE
chore: publish helm charts as oci artifacts (#1717)

### DIFF
--- a/.github/workflows/publish-rag-controller-gh-image.yaml
+++ b/.github/workflows/publish-rag-controller-gh-image.yaml
@@ -72,6 +72,13 @@ jobs:
     outputs:
       registry_repository: ${{ steps.get-registry.outputs.registry_repository }}
     steps:
+      - name: Install ORAS
+        run: |
+          VER='1.3.0'
+          curl -LO "https://github.com/oras-project/oras/releases/download/v${VER}/oras_${VER}_linux_amd64.tar.gz"
+          sudo tar -zxf "./oras_${VER}_linux_amd64.tar.gz" -C '/usr/local/bin'
+          rm -f "./oras_${VER}_linux_amd64.tar.gz"
+
       - id: get-registry
         run: |
           # registry must be in lowercase
@@ -97,7 +104,15 @@ jobs:
 
       - name: Build image
         run: |
-          OUTPUT_TYPE=type=registry make docker-build-ragengine
+          INDEX_REF="${REGISTRY}/${RAGENGINE_IMAGE_NAME}:${IMG_TAG}"
+
+          make docker-build-ragengine
+          IMAGE_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+
+          make helm-package-ragengine
+          CHART_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+
+          oras manifest index create "${INDEX_REF}" "${IMAGE_DIG}" "${CHART_DIG}"
         env:
           VERSION: ${{ needs.check-tag.outputs.tag }}
           REGISTRY: ${{ steps.get-registry.outputs.registry_repository }}

--- a/.github/workflows/publish-rag-controller-mcr-image.yaml
+++ b/.github/workflows/publish-rag-controller-mcr-image.yaml
@@ -22,6 +22,13 @@ jobs:
       labels: [ "self-hosted", "1ES.Pool=1es-aks-kaito-agent-pool-ubuntu" ]
     environment: publish-mcr
     steps:
+      - name: Install ORAS
+        run: |
+          VER='1.3.0'
+          curl -LO "https://github.com/oras-project/oras/releases/download/v${VER}/oras_${VER}_linux_amd64.tar.gz"
+          sudo tar -zxf "./oras_${VER}_linux_amd64.tar.gz" -C '/usr/local/bin'
+          rm -f "./oras_${VER}_linux_amd64.tar.gz"
+
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5.5.0
         with:
@@ -46,7 +53,15 @@ jobs:
       - name: 'Build and Publish RAGEngine to MCR'
         id: Publish
         run: |
-          OUTPUT_TYPE=type=registry make docker-build-ragengine
+          INDEX_REF="${REGISTRY}/${RAGENGINE_IMAGE_NAME}:${IMG_TAG}"
+
+          make docker-build-ragengine
+          IMAGE_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+
+          make helm-package-ragengine
+          CHART_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+
+          oras manifest index create "${INDEX_REF}" "${IMAGE_DIG}" "${CHART_DIG}"
         env:
           VERSION: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
           REGISTRY: ${{ secrets.KAITO_MCR_REGISTRY }}/public/aks/kaito

--- a/.github/workflows/publish-workspace-gh-image.yaml
+++ b/.github/workflows/publish-workspace-gh-image.yaml
@@ -72,6 +72,13 @@ jobs:
     outputs:
       registry_repository: ${{ steps.get-registry.outputs.registry_repository }}
     steps:
+      - name: Install ORAS
+        run: |
+          VER='1.3.0'
+          curl -LO "https://github.com/oras-project/oras/releases/download/v${VER}/oras_${VER}_linux_amd64.tar.gz"
+          sudo tar -zxf "./oras_${VER}_linux_amd64.tar.gz" -C '/usr/local/bin'
+          rm -f "./oras_${VER}_linux_amd64.tar.gz"
+
       - id: get-registry
         run: |
           # registry must be in lowercase
@@ -97,7 +104,15 @@ jobs:
 
       - name: Build image
         run: |
-          OUTPUT_TYPE=type=registry make docker-build-workspace
+          INDEX_REF="${REGISTRY}/${IMG_NAME}:${IMG_TAG}"
+
+          make docker-build-workspace
+          IMAGE_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+
+          make helm-package-workspace
+          CHART_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+
+          oras manifest index create "${INDEX_REF}" "${IMAGE_DIG}" "${CHART_DIG}"
         env:
           VERSION: ${{ needs.check-tag.outputs.tag }}
           REGISTRY: ${{ steps.get-registry.outputs.registry_repository }}

--- a/.github/workflows/publish-workspace-mcr-image.yaml
+++ b/.github/workflows/publish-workspace-mcr-image.yaml
@@ -22,6 +22,13 @@ jobs:
       labels: [ "self-hosted", "1ES.Pool=1es-aks-kaito-agent-pool-ubuntu" ]
     environment: publish-mcr
     steps:
+      - name: Install ORAS
+        run: |
+          VER='1.3.0'
+          curl -LO "https://github.com/oras-project/oras/releases/download/v${VER}/oras_${VER}_linux_amd64.tar.gz"
+          sudo tar -zxf "./oras_${VER}_linux_amd64.tar.gz" -C '/usr/local/bin'
+          rm -f "./oras_${VER}_linux_amd64.tar.gz"
+
       - name: Set up Go ${{ env.GO_VERSION }}
         uses: actions/setup-go@v5.5.0
         with:
@@ -46,7 +53,15 @@ jobs:
       - name: 'Build and Publish to MCR'
         id: Publish
         run: |
-          OUTPUT_TYPE=type=registry make docker-build-workspace
+          INDEX_REF="${REGISTRY}/${IMG_NAME}:${IMG_TAG}"
+
+          make docker-build-workspace
+          IMAGE_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+
+          make helm-package-workspace
+          CHART_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+
+          oras manifest index create "${INDEX_REF}" "${IMAGE_DIG}" "${CHART_DIG}"
         env:
           VERSION: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
           REGISTRY: ${{ secrets.KAITO_MCR_REGISTRY }}/public/aks/kaito

--- a/Makefile
+++ b/Makefile
@@ -388,6 +388,22 @@ docker-build-dataset: docker-buildx ## Build Docker images for datasets.
 		--tag $(REGISTRY)/e2e-dataset2:0.0.1 .
 
 ## --------------------------------------
+## Helm
+## --------------------------------------
+
+##@ Helm
+
+.PHONY: helm-package-workspace
+helm-package-workspace: ## Build Helm chart for workspace.
+	cd ./charts/kaito/workspace && helm package .
+	helm push ./charts/kaito/workspace/$(IMG_NAME)-$(IMG_TAG).tgz oci://$(REGISTRY)
+
+.PHONY: helm-package-ragengine
+helm-package-ragengine: ## Build Helm chart for RAG Engine.
+	cd ./charts/kaito/ragengine && helm package .
+	helm push ./charts/kaito/ragengine/$(RAGENGINE_IMAGE_NAME)-$(IMG_TAG).tgz oci://$(REGISTRY)
+
+## --------------------------------------
 ## KAITO Installation
 ## --------------------------------------
 


### PR DESCRIPTION
**Reason for Change**:
This patch publishes Helm charts as OCI artifacts alongside Container images, making it possible to pull Kaito's charts from GHCR and MCR.

**Notes for Reviewers**:
Tested in this run:
https://github.com/t0rr3sp3dr0/kaito/actions/runs/20670474490. Both `docker pull ghcr.io/t0rr3sp3dr0/kaito/workspace:0.8.0` and `helm pull ghcr.io/t0rr3sp3dr0/kaito/workspace --version 0.8.0` work as a result of this patch and that run.