### PR TITLE
fix: existing Workspace cannot be deleted or modified during version upgrade due to instanceType webhook validation 

### DIFF
--- a/api/v1beta1/workspace_validation.go
+++ b/api/v1beta1/workspace_validation.go
@@ -521,7 +521,7 @@ func (r *ResourceSpec) validateUpdate(old *ResourceSpec) (errs *apis.FieldError)
 			errs = errs.Also(apis.ErrGeneric("instanceType is cannot be changed once set when node auto-provisioning is enabled", "instanceType"))
 		}
 	}
-	
+
 	newLabels, err0 := metav1.LabelSelectorAsMap(r.LabelSelector)
 	oldLabels, err1 := metav1.LabelSelectorAsMap(old.LabelSelector)
 	if err0 != nil || err1 != nil {

--- a/api/v1beta1/workspace_validation_test.go
+++ b/api/v1beta1/workspace_validation_test.go
@@ -1563,7 +1563,7 @@ func TestWorkspaceValidateCreate(t *testing.T) {
 		errField  string
 	}{
 		{
-			name:      "Neither Inference nor Tuning specified",
+			name: "Neither Inference nor Tuning specified",
 			workspace: &Workspace{
 				Resource: ResourceSpec{
 					InstanceType: "Standard_NC6s_v3",
@@ -2007,7 +2007,7 @@ func TestWorkspaceValidateUpdate(t *testing.T) {
 					},
 				},
 			},
-			disableNAP: true, // Upgrading to v0.8 with disableNAP=true
+			disableNAP: true,  // Upgrading to v0.8 with disableNAP=true
 			expectErrs: false, // Should NOT fail during UPDATE when clearing instanceType
 		},
 	}


### PR DESCRIPTION
When upgrading from 0.7 to 0.8, the existing Workspaces have an instanceType set before the disableNAP feature was introduced, and the webhook doesn't allow removing the existing instanceType in BYO scenario.

**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: