### PR TITLE
feat: implement preset generator in golang

### DIFF
--- a/cmd/preset-generator/main.go
+++ b/cmd/preset-generator/main.go
@@ -16,8 +16,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io"
-	"log"
 	"os"
 	"strconv"
 	"strings"
@@ -28,23 +26,15 @@ import (
 )
 
 func main() {
-	debug := flag.Bool("debug", false, "Enable debug logging")
 	token := flag.String("token", "", "Hugging Face API token")
 	flag.Parse()
 
 	if flag.NArg() < 1 {
-		fmt.Println("Usage: generator <model_repo>")
+		fmt.Println("Usage: preset-generator <model_repo>")
 		os.Exit(1)
 	}
 
 	modelRepo := flag.Arg(0)
-
-	// Configure logging based on debug flag
-	if !*debug {
-		log.SetOutput(io.Discard)
-	} else {
-		log.SetOutput(os.Stderr)
-	}
 
 	param, err := generator.GeneratePreset(modelRepo, *token)
 	if err != nil {
@@ -91,8 +81,5 @@ func main() {
 		os.Exit(1)
 	}
 
-	if *debug {
-		log.Println("--- Generated Preset YAML ---")
-	}
 	fmt.Println(string(output))
 }

--- a/cmd/preset-generator/main.go
+++ b/cmd/preset-generator/main.go
@@ -22,9 +22,9 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/kaito-project/kaito/presets/workspace/generator"
-
 	"gopkg.in/yaml.v2"
+
+	"github.com/kaito-project/kaito/presets/workspace/generator"
 )
 
 func main() {

--- a/cmd/preset-generator/main.go
+++ b/cmd/preset-generator/main.go
@@ -1,0 +1,98 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/kaito-project/kaito/presets/workspace/generator"
+
+	"gopkg.in/yaml.v2"
+)
+
+func main() {
+	debug := flag.Bool("debug", false, "Enable debug logging")
+	token := flag.String("token", "", "Hugging Face API token")
+	flag.Parse()
+
+	if flag.NArg() < 1 {
+		fmt.Println("Usage: generator <model_repo>")
+		os.Exit(1)
+	}
+
+	modelRepo := flag.Arg(0)
+
+	// Configure logging based on debug flag
+	if !*debug {
+		log.SetOutput(io.Discard)
+	} else {
+		log.SetOutput(os.Stderr)
+	}
+
+	param, err := generator.GeneratePreset(modelRepo, *token)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Use yaml.MapSlice to force exact ordering to match Python output
+	szStr := strings.TrimSuffix(param.ModelFileSize, "Gi")
+	szVal, _ := strconv.ParseFloat(szStr, 64)
+
+	// Construct MapSlice for VLLM params
+	vllmParams := yaml.MapSlice{
+		{Key: "load_format", Value: param.VLLM.ModelRunParams["load_format"]},
+		{Key: "config_format", Value: param.VLLM.ModelRunParams["config_format"]},
+		{Key: "tokenizer_mode", Value: param.VLLM.ModelRunParams["tokenizer_mode"]},
+	}
+
+	// Construct MapSlice for VLLM section
+	vllmSection := yaml.MapSlice{
+		{Key: "model_name", Value: param.VLLM.ModelName},
+		{Key: "model_run_params", Value: vllmParams},
+		{Key: "disallow_lora", Value: param.VLLM.DisallowLoRA},
+	}
+
+	// Construct the top-level MapSlice
+	out := yaml.MapSlice{
+		{Key: "attn_type", Value: param.AttnType},
+		{Key: "name", Value: param.Name},
+		{Key: "type", Value: param.ModelType},
+		{Key: "version", Value: param.Version},
+		{Key: "download_at_runtime", Value: param.DownloadAtRuntime},
+		{Key: "download_auth_required", Value: param.DownloadAuthRequired},
+		{Key: "disk_storage_requirement", Value: param.DiskStorageRequirement},
+		{Key: "model_file_size_gb", Value: szVal},
+		{Key: "bytes_per_token", Value: param.BytesPerToken},
+		{Key: "model_token_limit", Value: param.ModelTokenLimit},
+		{Key: "vllm", Value: vllmSection},
+	}
+
+	output, err := yaml.Marshal(out)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error marshaling YAML: %v\n", err)
+		os.Exit(1)
+	}
+
+	if *debug {
+		log.Println("--- Generated Preset YAML ---")
+	}
+	fmt.Println(string(output))
+}

--- a/debug.log
+++ b/debug.log
@@ -1,0 +1,1 @@
+2026/01/15 09:44:01 --- Generated Preset YAML ---

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -177,6 +177,10 @@ type PresetParam struct {
 	// run the presets/workspace/generator/preset_generator.py script
 	// with the model's Hugging Face repository ID as an argument.
 
+	// AttnType specifies the attention implementation (e.g., MHA, GQA, MLA).
+	// Calculated by the preset generator based on model config.
+	AttnType string `yaml:"attn_type,omitempty"`
+
 	RuntimeParam
 
 	// ReadinessTimeout defines the maximum duration for creating the workload.

--- a/presets/workspace/generator/README.md
+++ b/presets/workspace/generator/README.md
@@ -18,7 +18,7 @@ python3 preset_generator.py <model_repo> [--token=YOUR_HF_TOKEN] [--debug]
 **Example:**
 ```bash
 $ python3 preset_generator.py microsoft/Phi-4-mini-instruct
-attn_type: GQA (Grouped-Query Attention)
+attn_type: GQA
 name: phi-4-mini-instruct
 type: tfs
 version: 0.0.1

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -1,0 +1,325 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"math"
+	"net/http"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/kaito-project/kaito/pkg/model"
+)
+
+const (
+	SYSTEM_FILE_DISKSIZE_GIB  = 50
+	DEFAULT_MODEL_TOKEN_LIMIT = 2048
+)
+
+type Generator struct {
+	ModelRepo string
+	Token     string
+	Param     model.PresetParam
+	Config    map[string]interface{}
+
+	// Analyzed params
+	LoadFormat    string
+	ConfigFormat  string
+	TokenizerMode string
+	ModelConfig   map[string]interface{}
+}
+
+func NewGenerator(modelRepo, token string) *Generator {
+	nameParts := strings.Split(modelRepo, "/")
+	modelNameSafe := strings.ToLower(nameParts[len(nameParts)-1])
+
+	gen := &Generator{
+		ModelRepo:     modelRepo,
+		Token:         token,
+		LoadFormat:    "auto",
+		ConfigFormat:  "auto",
+		TokenizerMode: "auto",
+	}
+
+	// Initialize default PresetParam
+	gen.Param.Name = modelNameSafe
+	gen.Param.ModelType = "tfs"
+	gen.Param.Version = "0.0.1"
+	gen.Param.DownloadAtRuntime = true
+	gen.Param.DiskStorageRequirement = "50Gi"
+	gen.Param.ModelFileSize = "0Gi"
+
+	return gen
+}
+
+func (g *Generator) getAuthHeader() string {
+	if g.Token != "" {
+		return "Bearer " + g.Token
+	}
+	if envToken := os.Getenv("HF_TOKEN"); envToken != "" {
+		return "Bearer " + envToken
+	}
+	return ""
+}
+
+func (g *Generator) fetchURL(url string) ([]byte, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	auth := g.getAuthHeader()
+	if auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
+
+	client := &http.Client{Timeout: 30 * time.Second}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 401 || resp.StatusCode == 403 {
+		g.Param.DownloadAuthRequired = true
+		if auth == "" {
+			return nil, fmt.Errorf("authentication required for accessing %s", url)
+		}
+	}
+
+	if resp.StatusCode != 200 {
+		return nil, fmt.Errorf("failed to fetch %s: status %d", url, resp.StatusCode)
+	}
+
+	return io.ReadAll(resp.Body)
+}
+
+type FileInfo struct {
+	Path string `json:"path"`
+	Size int64  `json:"size"`
+	Type string `json:"type"`
+}
+
+func (g *Generator) FetchModelMetadata() error {
+	// List files using HF API
+	url := fmt.Sprintf("https://huggingface.co/api/models/%s/tree/main?recursive=true", g.ModelRepo)
+	body, err := g.fetchURL(url)
+	if err != nil {
+		return fmt.Errorf("error listing files: %v", err)
+	}
+
+	var files []FileInfo
+	if err := json.Unmarshal(body, &files); err != nil {
+		return fmt.Errorf("error parsing file list: %v", err)
+	}
+
+	// Filter files
+	var selectedFiles []FileInfo
+	var mistralFiles []FileInfo
+
+	safetensorRegex := regexp.MustCompile(`.*\.safetensors`)
+	binRegex := regexp.MustCompile(`.*\.bin`)
+	mistralRegex := regexp.MustCompile(`consolidated.*\.safetensors`)
+
+	for _, f := range files {
+		if mistralRegex.MatchString(f.Path) {
+			mistralFiles = append(mistralFiles, f)
+		}
+		if safetensorRegex.MatchString(f.Path) || binRegex.MatchString(f.Path) {
+			selectedFiles = append(selectedFiles, f)
+		}
+	}
+
+	configFile := "config.json"
+
+	// Logic to detect model format
+	if len(mistralFiles) > 0 {
+		g.LoadFormat = "mistral"
+		g.ConfigFormat = "mistral"
+		g.TokenizerMode = "mistral"
+		configFile = "params.json"
+		selectedFiles = mistralFiles
+	} else if len(selectedFiles) > 0 {
+		configFile = "config.json"
+
+		// Prefer safetensors if mixed with bin
+		hasSafetensors := false
+		for _, f := range selectedFiles {
+			if strings.HasSuffix(f.Path, ".safetensors") {
+				hasSafetensors = true
+				break
+			}
+		}
+
+		if hasSafetensors {
+			var onlySafetensors []FileInfo
+			for _, f := range selectedFiles {
+				if strings.HasSuffix(f.Path, ".safetensors") {
+					onlySafetensors = append(onlySafetensors, f)
+				}
+			}
+			selectedFiles = onlySafetensors
+		}
+	} else {
+		return fmt.Errorf("no .safetensors or .bin files found")
+	}
+
+	var totalBytes int64
+	for _, f := range selectedFiles {
+		totalBytes += f.Size
+	}
+
+	modelSizeGB := float64(totalBytes) / (1024 * 1024 * 1024)
+	g.Param.ModelFileSize = fmt.Sprintf("%.0fGi", math.Ceil(modelSizeGB))
+
+	g.Param.RuntimeParam.VLLM.ModelRunParams = make(map[string]string)
+
+	configURL := fmt.Sprintf("https://huggingface.co/%s/resolve/main/%s", g.ModelRepo, configFile)
+	configBody, err := g.fetchURL(configURL)
+	if err != nil {
+		return fmt.Errorf("error fetching config: %v", err)
+	}
+
+	if err := json.Unmarshal(configBody, &g.ModelConfig); err != nil {
+		return fmt.Errorf("error parsing config: %v", err)
+	}
+
+	return nil
+}
+
+func getInt(config map[string]interface{}, keys []string, defaultVal int) int {
+	for _, key := range keys {
+		if val, ok := config[key]; ok {
+			switch v := val.(type) {
+			case float64:
+				return int(v)
+			case int:
+				return v
+			case string:
+				if i, err := strconv.Atoi(v); err == nil {
+					return i
+				}
+			}
+		}
+	}
+	return defaultVal
+}
+
+func (g *Generator) ParseModelMetadata() {
+	maxPos := getInt(g.ModelConfig, []string{
+		"max_position_embeddings",
+		"n_ctx",
+		"seq_length",
+		"max_seq_len",
+		"max_sequence_length",
+	}, DEFAULT_MODEL_TOKEN_LIMIT)
+
+	g.Param.ModelTokenLimit = maxPos
+}
+
+func (g *Generator) calculateStorageSize() string {
+	szStr := strings.TrimSuffix(g.Param.ModelFileSize, "Gi")
+	sz, _ := strconv.ParseFloat(szStr, 64)
+	req := int(sz + SYSTEM_FILE_DISKSIZE_GIB)
+	return fmt.Sprintf("%dGi", req)
+}
+
+func (g *Generator) calculateKVCacheTokenSize() (int, string) {
+	config := g.ModelConfig
+
+	hiddenSize := getInt(config, []string{"hidden_size", "n_embd", "d_model"}, 0)
+	hiddenLayers := getInt(config, []string{"num_hidden_layers", "n_layer", "n_layers"}, 0)
+	attentionHeads := getInt(config, []string{"num_attention_heads", "n_head", "n_heads"}, 0)
+	kvHeads := getInt(config, []string{"num_key_value_heads", "n_head_kv", "n_kv_heads"}, 0)
+	headDim := getInt(config, []string{"head_dim"}, 0)
+
+	if headDim == 0 && attentionHeads > 0 {
+		headDim = hiddenSize / attentionHeads
+	}
+
+	// DeepSeek MLA
+	kvLoraRank := getInt(config, []string{"kv_lora_rank"}, -1)
+	qkRopeHeadDim := getInt(config, []string{"qk_rope_head_dim"}, 0)
+
+	// Fallback KV heads
+	if kvHeads == 0 && attentionHeads > 0 {
+		if mq, ok := config["multi_query"].(bool); ok && mq {
+			kvHeads = 1
+		} else {
+			kvHeads = attentionHeads
+		}
+	}
+
+	attnType := "Unknown"
+	elementsPerToken := 0
+
+	if kvLoraRank != -1 {
+		attnType = "MLA"
+		elementsPerToken = kvLoraRank + qkRopeHeadDim
+	} else if attentionHeads > 0 && kvHeads > 0 && headDim > 0 {
+		elementsPerToken = 2 * kvHeads * headDim
+
+		if attentionHeads == kvHeads {
+			attnType = "MHA"
+		} else if kvHeads == 1 {
+			attnType = "MQA"
+		} else {
+			attnType = "GQA"
+		}
+	}
+
+	totalElements := elementsPerToken * hiddenLayers
+	tokenSize := totalElements * 2 // fp16
+
+	return tokenSize, attnType
+}
+
+func (g *Generator) FinalizeParams() {
+	g.Param.DiskStorageRequirement = g.calculateStorageSize()
+
+	// VLLM Params
+	if g.Param.VLLM.ModelRunParams == nil {
+		g.Param.VLLM.ModelRunParams = make(map[string]string)
+	}
+	g.Param.VLLM.ModelName = g.Param.Name
+	g.Param.VLLM.ModelRunParams["load_format"] = g.LoadFormat
+	g.Param.VLLM.ModelRunParams["config_format"] = g.ConfigFormat
+	g.Param.VLLM.ModelRunParams["tokenizer_mode"] = g.TokenizerMode
+
+	bpt, attnType := g.calculateKVCacheTokenSize()
+	g.Param.BytesPerToken = bpt
+	g.Param.AttnType = attnType
+}
+
+func (g *Generator) Generate() (*model.PresetParam, error) {
+	if err := g.FetchModelMetadata(); err != nil {
+		return nil, err
+	}
+	g.ParseModelMetadata()
+	g.FinalizeParams()
+
+	return &g.Param, nil
+}
+
+// GeneratePreset is the global function to generate preset param
+func GeneratePreset(modelRepo, token string) (*model.PresetParam, error) {
+	gen := NewGenerator(modelRepo, token)
+	return gen.Generate()
+}

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -229,7 +229,7 @@ func (g *Generator) ParseModelMetadata() {
 		"seq_length",
 		"max_seq_len",
 		"max_sequence_length",
-	}, DEFAULT_MODEL_TOKEN_LIMIT)
+	}, DefaultModelTokenLimit)
 
 	g.Param.ModelTokenLimit = maxPos
 }
@@ -237,7 +237,7 @@ func (g *Generator) ParseModelMetadata() {
 func (g *Generator) calculateStorageSize() string {
 	szStr := strings.TrimSuffix(g.Param.ModelFileSize, "Gi")
 	sz, _ := strconv.ParseFloat(szStr, 64)
-	req := int(sz + SYSTEM_FILE_DISKSIZE_GIB)
+	req := int(sz + SystemFileDiskSizeGiB)
 	return fmt.Sprintf("%dGi", req)
 }
 

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -147,7 +147,7 @@ func (g *Generator) FetchModelMetadata() error {
 		}
 	}
 
-	configFile := "config.json"
+	var configFile string
 
 	// Logic to detect model format
 	if len(mistralFiles) > 0 {

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	SYSTEM_FILE_DISKSIZE_GIB  = 50
-	DEFAULT_MODEL_TOKEN_LIMIT = 2048
+	SystemFileDiskSizeGiB  = 50
+	DefaultModelTokenLimit = 2048
 )
 
 type Generator struct {
@@ -189,7 +189,7 @@ func (g *Generator) FetchModelMetadata() error {
 	modelSizeGB := float64(totalBytes) / (1024 * 1024 * 1024)
 	g.Param.ModelFileSize = fmt.Sprintf("%.0fGi", math.Ceil(modelSizeGB))
 
-	g.Param.RuntimeParam.VLLM.ModelRunParams = make(map[string]string)
+	g.Param.VLLM.ModelRunParams = make(map[string]string)
 
 	configURL := fmt.Sprintf("https://huggingface.co/%s/resolve/main/%s", g.ModelRepo, configFile)
 	configBody, err := g.fetchURL(configURL)

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -15,6 +15,7 @@ package generator
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -31,6 +32,12 @@ import (
 const (
 	SystemFileDiskSizeGiB  = 50
 	DefaultModelTokenLimit = 2048
+)
+
+var (
+	safetensorRegex = regexp.MustCompile(`.*\.safetensors`)
+	binRegex        = regexp.MustCompile(`.*\.bin`)
+	mistralRegex    = regexp.MustCompile(`consolidated.*\.safetensors`)
 )
 
 type Generator struct {
@@ -133,10 +140,6 @@ func (g *Generator) FetchModelMetadata() error {
 	// Filter files
 	var selectedFiles []FileInfo
 	var mistralFiles []FileInfo
-
-	safetensorRegex := regexp.MustCompile(`.*\.safetensors`)
-	binRegex := regexp.MustCompile(`.*\.bin`)
-	mistralRegex := regexp.MustCompile(`consolidated.*\.safetensors`)
 
 	for _, f := range files {
 		if mistralRegex.MatchString(f.Path) {
@@ -320,6 +323,9 @@ func (g *Generator) Generate() (*model.PresetParam, error) {
 
 // GeneratePreset is the global function to generate preset param
 func GeneratePreset(modelRepo, token string) (*model.PresetParam, error) {
+	if modelRepo == "" {
+		return nil, errors.New("model repo is required")
+	}
 	gen := NewGenerator(modelRepo, token)
 	return gen.Generate()
 }

--- a/presets/workspace/generator/generator_test.go
+++ b/presets/workspace/generator/generator_test.go
@@ -1,0 +1,162 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package generator
+
+import (
+	"testing"
+
+	"github.com/kaito-project/kaito/pkg/model"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGeneratePreset(t *testing.T) {
+	// These expected values are derived from presets/workspace/generator/preset_generator_test.py
+	cases := []struct {
+		modelRepo     string
+		expectedParam model.PresetParam
+		expectedVLLM  model.VLLMParam
+	}{
+		{
+			modelRepo: "microsoft/Phi-4-mini-instruct",
+			expectedParam: model.PresetParam{
+				Metadata: model.Metadata{
+					Name:                 "phi-4-mini-instruct",
+					ModelType:            "tfs",
+					Version:              "0.0.1",
+					DownloadAtRuntime:    true,
+					DownloadAuthRequired: false,
+					ModelFileSize:        "8Gi",
+				},
+				BytesPerToken:          131072,
+				ModelTokenLimit:        131072,
+				DiskStorageRequirement: "58Gi", // 8 + 50
+				AttnType:               "GQA",
+			},
+			expectedVLLM: model.VLLMParam{
+				ModelName: "phi-4-mini-instruct",
+				ModelRunParams: map[string]string{
+					"load_format":    "auto",
+					"config_format":  "auto",
+					"tokenizer_mode": "auto",
+				},
+				DisallowLoRA: false,
+			},
+		},
+		{
+			modelRepo: "tiiuae/falcon-7b-instruct",
+			expectedParam: model.PresetParam{
+				Metadata: model.Metadata{
+					Name:                 "falcon-7b-instruct",
+					ModelType:            "tfs",
+					Version:              "0.0.1",
+					DownloadAtRuntime:    true,
+					DownloadAuthRequired: false,
+					ModelFileSize:        "14Gi", // Python test expects 27Gi due to double counting (bin+safetensors). We fix this to use safetensors only.
+				},
+				BytesPerToken:          8192,
+				ModelTokenLimit:        2048,
+				DiskStorageRequirement: "64Gi", // 14 + 50
+				AttnType:               "MQA",
+			},
+			expectedVLLM: model.VLLMParam{
+				ModelName: "falcon-7b-instruct",
+				ModelRunParams: map[string]string{
+					"load_format":    "auto",
+					"config_format":  "auto",
+					"tokenizer_mode": "auto",
+				},
+				DisallowLoRA: false,
+			},
+		},
+		{
+			modelRepo: "mistralai/Ministral-3-8B-Instruct-2512",
+			expectedParam: model.PresetParam{
+				Metadata: model.Metadata{
+					Name:                 "ministral-3-8b-instruct-2512",
+					ModelType:            "tfs",
+					Version:              "0.0.1",
+					DownloadAtRuntime:    true,
+					DownloadAuthRequired: false,
+					ModelFileSize:        "10Gi",
+				},
+				BytesPerToken:          139264,
+				ModelTokenLimit:        262144,
+				DiskStorageRequirement: "60Gi", // 10 + 50
+				AttnType:               "GQA",
+			},
+			expectedVLLM: model.VLLMParam{
+				ModelName: "ministral-3-8b-instruct-2512",
+				ModelRunParams: map[string]string{
+					"load_format":    "mistral",
+					"config_format":  "mistral",
+					"tokenizer_mode": "mistral",
+				},
+				DisallowLoRA: false,
+			},
+		},
+		{
+			modelRepo: "mistralai/Mistral-Large-3-675B-Instruct-2512",
+			expectedParam: model.PresetParam{
+				Metadata: model.Metadata{
+					Name:                 "mistral-large-3-675b-instruct-2512",
+					ModelType:            "tfs",
+					Version:              "0.0.1",
+					DownloadAtRuntime:    true,
+					DownloadAuthRequired: false,
+					ModelFileSize:        "635Gi",
+				},
+				BytesPerToken:          70272,
+				ModelTokenLimit:        294912,
+				DiskStorageRequirement: "685Gi", // 635 + 50
+				AttnType:               "MLA",
+			},
+			expectedVLLM: model.VLLMParam{
+				ModelName: "mistral-large-3-675b-instruct-2512",
+				ModelRunParams: map[string]string{
+					"load_format":    "mistral",
+					"config_format":  "mistral",
+					"tokenizer_mode": "mistral",
+				},
+				DisallowLoRA: false,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.modelRepo, func(t *testing.T) {
+			param, err := GeneratePreset(tc.modelRepo, "")
+			assert.NoError(t, err)
+			assert.NotNil(t, param)
+
+			// Metadata checks
+			assert.Equal(t, tc.expectedParam.Name, param.Name)
+			assert.Equal(t, tc.expectedParam.ModelType, param.ModelType)
+			assert.Equal(t, tc.expectedParam.Version, param.Version)
+			assert.Equal(t, tc.expectedParam.DownloadAtRuntime, param.DownloadAtRuntime)
+			assert.Equal(t, tc.expectedParam.DownloadAuthRequired, param.DownloadAuthRequired)
+			assert.Equal(t, tc.expectedParam.ModelFileSize, param.ModelFileSize)
+			assert.Equal(t, tc.expectedParam.BytesPerToken, param.BytesPerToken)
+			assert.Equal(t, tc.expectedParam.ModelTokenLimit, param.ModelTokenLimit)
+
+			// Struct fields
+			assert.Equal(t, tc.expectedParam.DiskStorageRequirement, param.DiskStorageRequirement)
+			assert.Equal(t, tc.expectedParam.AttnType, param.AttnType)
+
+			// VLLM checks
+			assert.Equal(t, tc.expectedVLLM.ModelName, param.VLLM.ModelName)
+			assert.Equal(t, tc.expectedVLLM.DisallowLoRA, param.VLLM.DisallowLoRA)
+			assert.Equal(t, tc.expectedVLLM.ModelRunParams, param.VLLM.ModelRunParams)
+		})
+	}
+}

--- a/presets/workspace/generator/generator_test.go
+++ b/presets/workspace/generator/generator_test.go
@@ -16,8 +16,9 @@ package generator
 import (
 	"testing"
 
-	"github.com/kaito-project/kaito/pkg/model"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/kaito-project/kaito/pkg/model"
 )
 
 func TestGeneratePreset(t *testing.T) {

--- a/presets/workspace/generator/preset_generator.py
+++ b/presets/workspace/generator/preset_generator.py
@@ -236,7 +236,7 @@ class PresetGenerator:
 
         # CASE A: Multi-Latent Attention (MLA) - DeepSeek V2/V3
         if kv_lora_rank is not None:
-            attn_type = "MLA (Multi-Latent Attention)"
+            attn_type = "MLA"
             # MLA Cache = Compressed Latent Vector + Decoupled RoPE Key
             # DeepSeek V2/V3 caches a SINGLE latent vector + RoPE part per token (shared across heads)
             elements_per_token = kv_lora_rank + qk_rope_head_dim
@@ -250,9 +250,9 @@ class PresetGenerator:
             if attention_heads == kv_heads:
                 attn_type = "MHA (Multi-Head Attention)"
             elif kv_heads == 1:
-                attn_type = "MQA (Multi-Query Attention)"
+                attn_type = "MQA"
             else:
-                attn_type = "GQA (Grouped-Query Attention)"
+                attn_type = "GQA"
 
         # --- 3. Calculate Memory Usage ---
         # Total params per token (across all layers)

--- a/presets/workspace/generator/preset_generator_test.py
+++ b/presets/workspace/generator/preset_generator_test.py
@@ -30,7 +30,7 @@ PresetGenerator = preset_generator.PresetGenerator
 
 EXPECTED_OUTPUTS = {
     # outdated, legacy model. model files in .bin .safetensors format
-    "tiiuae/falcon-7b-instruct": """attn_type: MQA (Multi-Query Attention)
+    "tiiuae/falcon-7b-instruct": """attn_type: MQA
 name: falcon-7b-instruct
 type: tfs
 version: 0.0.1
@@ -49,7 +49,7 @@ vllm:
   disallow_lora: false
 """,
     # modern standard model with GQA attention.
-    "microsoft/Phi-4-mini-instruct": """attn_type: GQA (Grouped-Query Attention)
+    "microsoft/Phi-4-mini-instruct": """attn_type: GQA
 name: phi-4-mini-instruct
 type: tfs
 version: 0.0.1
@@ -68,7 +68,7 @@ vllm:
   disallow_lora: false
 """,
     # modern standard model with MLA attention.
-    "deepseek-ai/DeepSeek-R1": """attn_type: MLA (Multi-Latent Attention)
+    "deepseek-ai/DeepSeek-R1": """attn_type: MLA
 name: deepseek-r1
 type: tfs
 version: 0.0.1
@@ -87,7 +87,7 @@ vllm:
   disallow_lora: false
 """,
     # model in mistral format with GQA attention.
-    "mistralai/Ministral-3-8B-Instruct-2512": """attn_type: GQA (Grouped-Query Attention)
+    "mistralai/Ministral-3-8B-Instruct-2512": """attn_type: GQA
 name: ministral-3-8b-instruct-2512
 type: tfs
 version: 0.0.1
@@ -106,7 +106,7 @@ vllm:
   disallow_lora: false
 """,
     # model in mistral format with MLA attention.
-    "mistralai/Mistral-Large-3-675B-Instruct-2512": """attn_type: MLA (Multi-Latent Attention)
+    "mistralai/Mistral-Large-3-675B-Instruct-2512": """attn_type: MLA
 name: mistral-large-3-675b-instruct-2512
 type: tfs
 version: 0.0.1

--- a/test.yaml
+++ b/test.yaml
@@ -1,0 +1,18 @@
+attn_type: MHA
+name: gpt2
+type: tfs
+version: 0.0.1
+download_at_runtime: true
+download_auth_required: false
+disk_storage_requirement: 51Gi
+model_file_size_gb: 1
+bytes_per_token: 36864
+model_token_limit: 1024
+vllm:
+  model_name: gpt2
+  model_run_params:
+    load_format: auto
+    config_format: auto
+    tokenizer_mode: auto
+  disallow_lora: false
+

--- a/test_debug.yaml
+++ b/test_debug.yaml
@@ -1,0 +1,18 @@
+attn_type: MHA
+name: gpt2
+type: tfs
+version: 0.0.1
+download_at_runtime: true
+download_auth_required: false
+disk_storage_requirement: 51Gi
+model_file_size_gb: 1
+bytes_per_token: 36864
+model_token_limit: 1024
+vllm:
+  model_name: gpt2
+  model_run_params:
+    load_format: auto
+    config_format: auto
+    tokenizer_mode: auto
+  disallow_lora: false
+


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

introduces a Go-based implementation of the preset generator.
- New Go CLI: Added a new entry point at cmd/preset-generator/

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

related to #1714 

**Notes for Reviewers**: