### PR TITLE
chore: add more parameters to helm chart (#1724)

### DIFF
--- a/charts/kaito/workspace/templates/_helpers.tpl
+++ b/charts/kaito/workspace/templates/_helpers.tpl
@@ -34,6 +34,9 @@ Create chart name and version as used by the chart label.
 Common labels
 */}}
 {{- define "kaito.labels" -}}
+{{- if .Values.commonLabels }}
+{{- toYaml .Values.commonLabels }}
+{{- else }}
 helm.sh/chart: {{ include "kaito.chart" . }}
 app.kubernetes.io/created-by: {{ include "kaito.chart" . }}
 {{ include "kaito.selectorLabels" . }}
@@ -42,14 +45,129 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end }}
+{{- end }}
 
 {{/*
 Selector labels
 */}}
 {{- define "kaito.selectorLabels" -}}
+{{- if .Values.selectorLabels }}
+{{- toYaml .Values.selectorLabels }}
+{{- else }}
 app.kubernetes.io/name: {{ include "kaito.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+{{- end }}
+
+{{/*
+ServiceAccount name
+*/}}
+{{- define "kaito.serviceAccountName" -}}
+{{- if .Values.serviceAccountName -}}
+{{- .Values.serviceAccountName -}}
+{{- else -}}
+{{- include "kaito.fullname" . }}-sa
+{{- end -}}
+{{- end -}}
+
+{{/*
+Service name
+*/}}
+{{- define "kaito.serviceName" -}}
+{{- if .Values.serviceName -}}
+{{- .Values.serviceName -}}
+{{- else -}}
+{{- include "kaito.fullname" . }}-svc
+{{- end -}}
+{{- end -}}
+
+{{/*
+Logging ConfigMap name
+*/}}
+{{- define "kaito.loggingConfigMapName" -}}
+{{- if .Values.loggingConfigMapName -}}
+{{- .Values.loggingConfigMapName -}}
+{{- else -}}
+kaito-logging-config
+{{- end -}}
+{{- end -}}
+
+{{/*
+ClusterRole name
+*/}}
+{{- define "kaito.clusterRoleName" -}}
+{{- if .Values.clusterRoleName -}}
+{{- .Values.clusterRoleName -}}
+{{- else -}}
+{{- include "kaito.fullname" . }}-clusterrole
+{{- end -}}
+{{- end -}}
+
+{{/*
+ClusterRoleBinding name
+*/}}
+{{- define "kaito.clusterRoleBindingName" -}}
+{{- if .Values.clusterRoleBindingName -}}
+{{- .Values.clusterRoleBindingName -}}
+{{- else -}}
+{{- include "kaito.fullname" . }}-rolebinding
+{{- end -}}
+{{- end -}}
+
+{{/*
+Role name
+*/}}
+{{- define "kaito.roleName" -}}
+{{- if .Values.roleName -}}
+{{- .Values.roleName -}}
+{{- else -}}
+{{- include "kaito.fullname" . }}-role
+{{- end -}}
+{{- end -}}
+
+{{/*
+RoleBinding name
+*/}}
+{{- define "kaito.roleBindingName" -}}
+{{- if .Values.roleBindingName -}}
+{{- .Values.roleBindingName -}}
+{{- else -}}
+{{- include "kaito.fullname" . }}-rolebinding
+{{- end -}}
+{{- end -}}
+
+{{/*
+Deployment name
+*/}}
+{{- define "kaito.deploymentName" -}}
+{{- if .Values.deploymentName -}}
+{{- .Values.deploymentName -}}
+{{- else -}}
+{{- include "kaito.fullname" . }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+InferenceSet ClusterRole name
+*/}}
+{{- define "kaito.inferenceSetClusterRoleName" -}}
+{{- if .Values.inferenceSetClusterRoleName -}}
+{{- .Values.inferenceSetClusterRoleName -}}
+{{- else -}}
+{{- include "kaito.fullname" . }}-inferenceset-clusterrole
+{{- end -}}
+{{- end -}}
+
+{{/*
+InferenceSet ClusterRoleBinding name
+*/}}
+{{- define "kaito.inferenceSetClusterRoleBindingName" -}}
+{{- if .Values.inferenceSetClusterRoleBindingName -}}
+{{- .Values.inferenceSetClusterRoleBindingName -}}
+{{- else -}}
+{{- include "kaito.fullname" . }}-inferenceset-rolebinding
+{{- end -}}
+{{- end -}}
 
 {{/*
 Utils function

--- a/charts/kaito/workspace/templates/clusterrole.yaml
+++ b/charts/kaito/workspace/templates/clusterrole.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kaito.fullname" . }}-clusterrole
+  name: {{ include "kaito.clusterRoleName" . }}
   labels:
     {{- include "kaito.labels" . | nindent 4 }}
 rules:

--- a/charts/kaito/workspace/templates/clusterrole_binding.yaml
+++ b/charts/kaito/workspace/templates/clusterrole_binding.yaml
@@ -1,14 +1,14 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kaito.fullname" . }}-rolebinding
+  name: {{ include "kaito.clusterRoleBindingName" . }}
   labels:
-   {{- include "kaito.labels" . | nindent 4 }}
+    {{- include "kaito.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kaito.fullname" . }}-clusterrole
+  name: {{ include "kaito.clusterRoleName" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "kaito.fullname" . }}-sa
+  name: {{ include "kaito.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/kaito/workspace/templates/deployment.yaml
+++ b/charts/kaito/workspace/templates/deployment.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "kaito.fullname" . }}
+  name: {{ include "kaito.deploymentName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kaito.labels" . | nindent 4 }}
@@ -10,6 +10,8 @@ spec:
   selector:
     matchLabels:
       {{- include "kaito.selectorLabels" . | nindent 6 }}
+  strategy:
+    {{- toYaml .Values.deploymentStrategy | nindent 4 }}
   template:
     metadata:
       {{- with .Values.podAnnotations }}
@@ -18,12 +20,15 @@ spec:
       {{- end }}
       labels:
         {{- include "kaito.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podTemplateLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      serviceAccountName: {{ include "kaito.fullname" . }}-sa
+      serviceAccountName: {{ include "kaito.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
@@ -36,9 +41,9 @@ spec:
             - --feature-gates={{ include "utils.joinKeyValuePairs" .Values.featureGates }}
           env:
             - name: CONFIG_LOGGING_NAME
-              value: "kaito-logging-config"
+              value: {{ include "kaito.loggingConfigMapName" . | quote }}
             - name: WEBHOOK_SERVICE
-              value: {{ include "kaito.fullname" . }}-svc
+              value: {{ include "kaito.serviceName" . | quote }}
             - name: WEBHOOK_PORT
               value: "{{ .Values.webhook.port }}"
             - name: SYSTEM_NAMESPACE
@@ -46,11 +51,11 @@ spec:
                 fieldRef:
                   fieldPath: metadata.namespace
             - name: PRESET_REGISTRY_NAME
-              value: {{ .Values.presetRegistryName }}
+              value: {{ .Values.presetRegistryName | quote }}
             - name: CLOUD_PROVIDER
-              value: {{ .Values.cloudProviderName }}
+              value: {{ .Values.cloudProviderName | quote }}
             - name: CLUSTER_NAME
-              value: {{ .Values.clusterName }}
+              value: {{ .Values.clusterName | quote }}
           ports:
             - name: http-metrics
               containerPort: 8080

--- a/charts/kaito/workspace/templates/inferenceset_clusterrole.yaml
+++ b/charts/kaito/workspace/templates/inferenceset_clusterrole.yaml
@@ -3,7 +3,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kaito.fullname" . }}-inferenceset-clusterrole
+  name: {{ include "kaito.inferenceSetClusterRoleName" . }}
   labels:
     {{- include "kaito.labels" . | nindent 4 }}
 rules:

--- a/charts/kaito/workspace/templates/inferenceset_clusterrole_binding.yaml
+++ b/charts/kaito/workspace/templates/inferenceset_clusterrole_binding.yaml
@@ -2,15 +2,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kaito.fullname" . }}-inferenceset-rolebinding
+  name: {{ include "kaito.inferenceSetClusterRoleBindingName" . }}
   labels:
    {{- include "kaito.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kaito.fullname" . }}-inferenceset-clusterrole
+  name: {{ include "kaito.inferenceSetClusterRoleName" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "kaito.fullname" . }}-sa
+  name: {{ include "kaito.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
 {{- end -}}

--- a/charts/kaito/workspace/templates/knative-logging-configmap.yaml
+++ b/charts/kaito/workspace/templates/knative-logging-configmap.yaml
@@ -1,8 +1,10 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: kaito-logging-config
+  name: {{ include "kaito.loggingConfigMapName" . }}
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- toYaml .Values.commonLabels | nindent 4 }}
 data:
   loglevel.controller: {{ .Values.logging.level | quote }}
   loglevel.webhook: {{ .Values.logging.level | quote }}

--- a/charts/kaito/workspace/templates/nvidia-device-plugin-ds.yaml
+++ b/charts/kaito/workspace/templates/nvidia-device-plugin-ds.yaml
@@ -1,7 +1,7 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: nvidia-device-plugin-daemonset
+  name: {{ .Values.nvidiaDevicePlugin.daemonsetName | quote }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kaito.labels" . | nindent 4 }}
@@ -48,7 +48,8 @@ spec:
           effect: "NoSchedule"
       priorityClassName: "system-node-critical"
       containers:
-        - image: mcr.microsoft.com/oss/v2/nvidia/k8s-device-plugin:v0.17.0
+        - image: {{ .Values.nvidiaDevicePlugin.image | quote }}
+          imagePullPolicy: {{ .Values.nvidiaDevicePlugin.imagePullPolicy | quote }}
           name: nvidia-device-plugin-ctr
           env:
             - name: FAIL_ON_INIT_ERROR

--- a/charts/kaito/workspace/templates/role.yaml
+++ b/charts/kaito/workspace/templates/role.yaml
@@ -2,7 +2,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "kaito.fullname" . }}-role
+  name: {{ include "kaito.roleName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kaito.labels" . | nindent 4 }}
@@ -20,3 +20,6 @@ rules:
     resources: ["secrets"]
     verbs: ["update"]
     resourceNames: ["workspace-webhook-cert"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "watch", "create"]

--- a/charts/kaito/workspace/templates/role_binding.yaml
+++ b/charts/kaito/workspace/templates/role_binding.yaml
@@ -1,15 +1,15 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "kaito.fullname" . }}-rolebinding
+  name: {{ include "kaito.roleBindingName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-   {{- include "kaito.labels" . | nindent 4 }}
+    {{- include "kaito.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "kaito.fullname" . }}-role
+  name: {{ include "kaito.roleName" . }}
 subjects:
 - kind: ServiceAccount
-  name: {{ include "kaito.fullname" . }}-sa
+  name: {{ include "kaito.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}

--- a/charts/kaito/workspace/templates/secret-webhook-cert.yaml
+++ b/charts/kaito/workspace/templates/secret-webhook-cert.yaml
@@ -6,6 +6,6 @@ metadata:
   labels:
     {{- include "kaito.labels" . | nindent 4 }}
 data:
-   server-key.pem: ""
-   server-cert.pem: ""
-   ca-cert.pem: ""
+  server-key.pem: ""
+  server-cert.pem: ""
+  ca-cert.pem: ""

--- a/charts/kaito/workspace/templates/service.yaml
+++ b/charts/kaito/workspace/templates/service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ include "kaito.fullname" . }}-svc
+  name: {{ include "kaito.serviceName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kaito.labels" . | nindent 4 }}
@@ -9,7 +9,7 @@ spec:
   type: ClusterIP
   ports:
     - name: http-metrics
-      port: 8080 
+      port: 8080
       targetPort: http-metrics
       protocol: TCP
     - name: https-webhook

--- a/charts/kaito/workspace/templates/serviceaccount.yaml
+++ b/charts/kaito/workspace/templates/serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "kaito.fullname" . }}-sa
+  name: {{ include "kaito.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kaito.labels" . | nindent 4 }}

--- a/charts/kaito/workspace/templates/supported-models-configmap.yaml
+++ b/charts/kaito/workspace/templates/supported-models-configmap.yaml
@@ -3,6 +3,8 @@ kind: ConfigMap
 metadata:
   name: kaito-supported-models
   namespace: {{ .Release.Namespace }}
+  labels:
+    {{- toYaml .Values.commonLabels | nindent 4 }}
 data:
   SupportedModels: |
     models:

--- a/charts/kaito/workspace/templates/webhooks.yaml
+++ b/charts/kaito/workspace/templates/webhooks.yaml
@@ -9,7 +9,7 @@ webhooks:
     admissionReviewVersions: ["v1"]
     clientConfig:
       service:
-        name: {{ include "kaito.fullname" . }}-svc
+        name: {{ include "kaito.serviceName" . }}
         namespace: {{ .Release.Namespace }}
         port: {{ .Values.webhook.port }}
     failurePolicy: Fail
@@ -38,7 +38,7 @@ webhooks:
     admissionReviewVersions: ["v1"]
     clientConfig:
       service:
-        name: {{ include "kaito.fullname" . }}-svc
+        name: {{ include "kaito.serviceName" . }}
         namespace: {{ .Release.Namespace }}
         port: {{ .Values.webhook.port }}
     failurePolicy: Fail

--- a/charts/kaito/workspace/values.yaml
+++ b/charts/kaito/workspace/values.yaml
@@ -1,7 +1,22 @@
 # Default values for KAITO.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+clusterRoleBindingName: ""
+clusterRoleName: ""
+deploymentName: ""
+inferenceSetClusterRoleBindingName: ""
+inferenceSetClusterRoleName: ""
+loggingConfigMapName: ""
+roleBindingName: ""
+roleName: ""
+serviceAccountName: ""
+serviceName: ""
+commonLabels: {}
+selectorLabels: {}
 replicaCount: 1
+deploymentStrategy:
+  rollingUpdate:
+    maxUnavailable: 1
 image:
   repository: mcr.microsoft.com/aks/kaito/workspace
   pullPolicy: IfNotPresent
@@ -9,9 +24,15 @@ image:
 imagePullSecrets: []
 podAnnotations: {}
 podSecurityContext:
+  runAsUser: 1000
+  runAsGroup: 1000
   runAsNonRoot: true
+  seccompProfile:
+    type: RuntimeDefault
+podTemplateLabels: {}
 securityContext:
   allowPrivilegeEscalation: false
+  readOnlyRootFilesystem: true
   capabilities:
     drop:
       - "ALL"
@@ -20,6 +41,10 @@ featureGates:
   disableNodeAutoProvisioning: false
   gatewayAPIInferenceExtension: false
   enableInferenceSetController: false
+nvidiaDevicePlugin:
+  daemonsetName: "nvidia-device-plugin-daemonset"
+  image: "mcr.microsoft.com/oss/v2/nvidia/k8s-device-plugin:v0.17.0"
+  imagePullPolicy: "IfNotPresent"
 localCSIDriver:
   useLocalCSIDriver: true
 webhook:


### PR DESCRIPTION
**Reason for Change**:
Add extra Helm Chart values to enable more customization, allowing you to generate manifests for the AKS-managed add-on using this chart.

**Notes for Reviewers**:

- **Differences when rendering the Helm Chart using the default values (`helm template release-name ./charts/kaito/workspace`):**

1. Add the following rule to the Workspace Role to match managed add-on permissions:

```yaml
  - apiGroups: ["coordination.k8s.io"]
    resources: ["leases"]
    verbs: ["get", "watch", "create"]
```

2. The image pull policy for the NVIDIA Device Plugin DaemonSet now has a default value:

```yaml
          imagePullPolicy: "IfNotPresent"
```

3. The rolling update strategy for the Workspace Deployment is now defined:

```yaml
  strategy:
    rollingUpdate:
      maxUnavailable: 1
```

4. The following was added to the Pod Security Context of the Workspace Deployment to comply with Microsoft policies:

```yaml
        runAsGroup: 1000
        runAsUser: 1000
        seccompProfile:
          type: RuntimeDefault
```

5. The following was added to the Container Security Context of the Workspace Deployment to comply with Microsoft policies:

```yaml
            readOnlyRootFilesystem: true
```

- **Differences when rendering the Helm Chart using a values file for the AKS-Managed Add-On (`helm template kaito-workspace ./charts/kaito/workspace --namespace kube-system --values ./values.yaml`):**

1. The following was added to the Pod Security Context of the Workspace Deployment to comply with Microsoft policies:

```yaml
        runAsGroup: 1000
        runAsNonRoot: true
        runAsUser: 1000
        seccompProfile:
          type: RuntimeDefault
```

2. The following was added to the Container Security Context of the Workspace Deployment to comply with Microsoft policies:

```yaml
            allowPrivilegeEscalation: false
```

3. The following was removed from the Container Security Context of the Workspace Deployment to comply with Microsoft policies:

```yaml
            runAsGroup: 1000
            runAsNonRoot: true
            runAsUser: 1000
```

4. The following was removed from the arguments of the Driver Container of the CSI Local Node DaemonSet without change of behavior (unable to configure that via the chart we depend on, but that value is already the default for that argument):

```yaml
        - --webhook-port=9443
```

5. The following was removed from the ports of the Driver Container of the CSI Local Node DaemonSet without change of behavior (unable to configure that via the chart we depend on):

```yaml
        - containerPort: 9443
          name: webhook-server
          protocol: TCP
```

6. Multiple labels were changed as it's not possible to configure them on the charts we depend on. Example:

```diff
-     app: ai-toolchain-operator
-     app.kubernetes.io/component: ai-toolchain-operator
-     app.kubernetes.io/name: ai-toolchain-operator
-     app.kubernetes.io/part-of: ai-toolchain-operator
-     kubernetes.azure.com/managedby: aks
+     helm.sh/chart: local-csi-driver-0.2.9
+     app.kubernetes.io/name: local-csi-driver
+     app.kubernetes.io/instance: kaito-workspace
+     app.kubernetes.io/version: "v0.2.9"
+     app.kubernetes.io/managed-by: Helm
```