### PR TITLE
feat: Make NVIDIA device plugin deployment optional via feature gate (#1707) [release-0.8]

### DIFF
--- a/charts/kaito/workspace/README.md
+++ b/charts/kaito/workspace/README.md
@@ -34,3 +34,4 @@ helm install workspace ./charts/kaito/workspace  \
 | tolerations                              | list   | `[]`                                    |                                                               |
 | webhook.port                             | int    | `9443`                                  |                                                               |
 | cloudProviderName                        | string | `"azure"`                               | Karpenter cloud provider name. Values can be "azure" or "aws" |
+| nvidiaDevicePlugin.enabled               | bool   | `true`                                  | Enable deployment of NVIDIA device plugin DaemonSet. Set to false if your cluster already has the NVIDIA device plugin installed (e.g., via GPU Operator). |

--- a/charts/kaito/workspace/templates/nvidia-device-plugin-ds.yaml
+++ b/charts/kaito/workspace/templates/nvidia-device-plugin-ds.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.nvidiaDevicePlugin.enabled }}
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
@@ -67,3 +68,4 @@ spec:
         - name: device-plugin
           hostPath:
             path: /var/lib/kubelet/device-plugins
+{{- end }}

--- a/charts/kaito/workspace/values.yaml
+++ b/charts/kaito/workspace/values.yaml
@@ -42,6 +42,7 @@ featureGates:
   gatewayAPIInferenceExtension: false
   enableInferenceSetController: false
 nvidiaDevicePlugin:
+  enabled: true
   daemonsetName: "nvidia-device-plugin-daemonset"
   image: "mcr.microsoft.com/oss/v2/nvidia/k8s-device-plugin:v0.17.0"
   imagePullPolicy: "IfNotPresent"


### PR DESCRIPTION
Kaito unconditionally deploys the NVIDIA device plugin DaemonSet, causing duplicate deployments when clusters already have it installed via GPU Operator or other means. This PR makes the deployment optional via a feature gate, allowing users to disable it when needed.

- Added `nvidiaDevicePlugin.enabled` flag to `values.yaml` (default: `true`)
- Wrapped device plugin DaemonSet template with conditional rendering
- Updated chart README with configuration documentation

Defaulting to enabled ensures Kaito works out of the box for users without GPU Operator. Users with existing device plugin installations can explicitly disable it to prevent conflicts.

```bash
helm install kaito-workspace kaito/workspace

helm install kaito-workspace kaito/workspace --set nvidiaDevicePlugin.enabled=false
```

<!-- START COPILOT ORIGINAL PROMPT -->

<details>

<summary>Original prompt</summary>

>
> ----
>
> *This section details on the original issue you should resolve*
>
> <issue_title>kaito deploys nvidia device plugin when cluster already
includes it</issue_title>
> <issue_description>**Describe the bug**
>
> kaito deploys nvidia device plugin when cluster already includes it
>
> <img width="981" height="158" alt="Image"
src="https://github.com/user-attachments/assets/0cbfe3fc-edf6-4fa4-b037-017c819da1c2" />
>
> they are also deployed on the cpu nodes
>
> **Steps To Reproduce**
>
> `helm install kaito-workspace kaito/workspace --namespace
kaito-workspace --create-namespace`
>
> **Expected behavior**
>
> **Logs**
>
> **Environment**
>
> - Kubernetes version (use `kubectl version`):
> - OS (e.g: `cat /etc/os-release`):
> - Install tools:
> - Others:
>
> **Additional context**</issue_description>
>
> ## Comments on the Issue (you are @copilot in this section)
>
> <comments>
> </comments>
>

</details>

<!-- START COPILOT CODING AGENT SUFFIX -->

- Fixes kaito-project/kaito#1700

<!-- START COPILOT CODING AGENT TIPS -->
---

✨ Let Copilot coding agent [set things up for
you](https://github.com/kaito-project/kaito/issues/new?title=✨+Set+up+Copilot+instructions&body=Configure%20instructions%20for%20this%20repository%20as%20documented%20in%20%5BBest%20practices%20for%20Copilot%20coding%20agent%20in%20your%20repository%5D%28https://gh.io/copilot-coding-agent-tips%29%2E%0A%0A%3COnboard%20this%20repo%3E&assignees=copilot) — coding agent works faster and does higher quality work when set up for your repo.

---------

**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: