### PR TITLE
feat: add status field into WorkspaceStatus for presenting Workspace current state.

### DIFF
--- a/api/v1beta1/workspace_types.go
+++ b/api/v1beta1/workspace_types.go
@@ -199,9 +199,9 @@ type WorkspaceStatus struct {
 	// +optional
 	WorkerNodes []string `json:"workerNodes,omitempty"`
 
-	// Status represents the current high-level state of the workspace.
+	// State represents the current high-level state of the workspace.
 	// +optional
-	Status WorkspaceState `json:"status,omitempty"`
+	State WorkspaceState `json:"state,omitempty"`
 
 	// Conditions report the current conditions of the workspace.
 	// +optional
@@ -218,8 +218,12 @@ type WorkspaceStatus struct {
 // +kubebuilder:resource:path=workspaces,scope=Namespaced,categories=workspace,shortName={wk,wks}
 // +kubebuilder:storageversion
 // +kubebuilder:printcolumn:name="Instance",type="string",JSONPath=".resource.instanceType",description=""
+// +kubebuilder:printcolumn:name="ResourceReady",type="string",JSONPath=".status.conditions[?(@.type==\"ResourceReady\")].status",description=""
+// +kubebuilder:printcolumn:name="InferenceReady",type="string",JSONPath=".status.conditions[?(@.type==\"InferenceReady\")].status",description=""
+// +kubebuilder:printcolumn:name="JobStarted",type="string",JSONPath=".status.conditions[?(@.type==\"JobStarted\")].status",description=""
+// +kubebuilder:printcolumn:name="WorkspaceSucceeded",type="string",JSONPath=".status.conditions[?(@.type==\"WorkspaceSucceeded\")].status",description=""
 // +kubebuilder:printcolumn:name="TargetNodeCount",type="integer",JSONPath=".status.targetNodeCount",description=""
-// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.status",description=""
+// +kubebuilder:printcolumn:name="State",type="string",JSONPath=".status.state",description=""
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description=""
 type Workspace struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/charts/kaito/workspace/crds/kaito.sh_workspaces.yaml
+++ b/charts/kaito/workspace/crds/kaito.sh_workspaces.yaml
@@ -407,11 +407,23 @@ spec:
     - jsonPath: .resource.instanceType
       name: Instance
       type: string
+    - jsonPath: .status.conditions[?(@.type=="ResourceReady")].status
+      name: ResourceReady
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="InferenceReady")].status
+      name: InferenceReady
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="JobStarted")].status
+      name: JobStarted
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="WorkspaceSucceeded")].status
+      name: WorkspaceSucceeded
+      type: string
     - jsonPath: .status.targetNodeCount
       name: TargetNodeCount
       type: integer
-    - jsonPath: .status.status
-      name: Status
+    - jsonPath: .status.state
+      name: State
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -685,8 +697,8 @@ spec:
                   - type
                   type: object
                 type: array
-              status:
-                description: Status represents the current high-level state of the
+              state:
+                description: State represents the current high-level state of the
                   workspace.
                 type: string
               targetNodeCount:

--- a/config/crd/bases/kaito.sh_workspaces.yaml
+++ b/config/crd/bases/kaito.sh_workspaces.yaml
@@ -407,11 +407,23 @@ spec:
     - jsonPath: .resource.instanceType
       name: Instance
       type: string
+    - jsonPath: .status.conditions[?(@.type=="ResourceReady")].status
+      name: ResourceReady
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="InferenceReady")].status
+      name: InferenceReady
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="JobStarted")].status
+      name: JobStarted
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="WorkspaceSucceeded")].status
+      name: WorkspaceSucceeded
+      type: string
     - jsonPath: .status.targetNodeCount
       name: TargetNodeCount
       type: integer
-    - jsonPath: .status.status
-      name: Status
+    - jsonPath: .status.state
+      name: State
       type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
@@ -685,8 +697,8 @@ spec:
                   - type
                   type: object
                 type: array
-              status:
-                description: Status represents the current high-level state of the
+              state:
+                description: State represents the current high-level state of the
                   workspace.
                 type: string
               targetNodeCount:

--- a/docs/proposals/20260121-workspace-status-phase.md
+++ b/docs/proposals/20260121-workspace-status-phase.md
@@ -1,4 +1,4 @@
-# Workspace Status Field Proposal
+# Workspace State Field Proposal
 
 ## Background
 
@@ -8,11 +8,11 @@ Currently, the `Workspace` Custom Resource (CR) status relies heavily on a list 
 2.  **No High-Level Summary**: There is no single field that answers "Is my workspace working?" 
 3.  **CLI Output**: `kubectl get workspace` typically requires complex `JSONPath` or custom printers to show meaningful status, often resulting in multiple columns (`ResourceReady`, `InferenceReady`) instead of one status column.
 
-To address this, we propose adding a `Status` field to the `WorkspaceStatus`. This field effectively aggregates the various conditions into a single, high-level finite state machine (FSM) enumeration, similar to how standard Kubernetes resources like `Pod` (Pending, Running, Succeeded, Failed) or `PersistentVolumeClaim` (Bound, Available) work.
+To address this, we propose adding a `State` field to the `WorkspaceStatus`. This field effectively aggregates the various conditions into a single, high-level finite state machine (FSM) enumeration, similar to how standard Kubernetes resources like `Pod` (Pending, Running, Succeeded, Failed) or `PersistentVolumeClaim` (Bound, Available) work.
 
 ## Design Proposal
 
-We propose adding a `Status` field to `WorkspaceStatus`.
+We propose adding a `State` field to `WorkspaceStatus`.
 
 ### Workspace API Change
 
@@ -38,15 +38,15 @@ const (
 type WorkspaceStatus struct {
     // ... existing fields
     
-    // Status represents the current high-level state of the workspace.
+    // State represents the current high-level state of the workspace.
     // +optional
-    Status WorkspaceState `json:"status,omitempty"`
+    State WorkspaceState `json:"state,omitempty"`
 }
 ```
 
-### Inference Workspace Status Workflow
+### Inference Workspace State Workflow
 
-For inference workloads, the `Status` indicates whether the service is available.
+For inference workloads, the `State` indicates whether the service is available.
 
 *   **Pending**: The workspace is in the initialization phase (e.g., provisioning infrastructure, pulling images).
     *   *Constraint*: Can only transition to `Ready`. If initialization fails, it remains `Pending`.
@@ -54,21 +54,21 @@ For inference workloads, the `Status` indicates whether the service is available
 *   **Ready**: The workspace is fully operational and serving requests.
 *   **NotReady**: The workspace is currently unable to serve requests due to runtime issues (e.g., NodeClaim lost, OOM, crash).
     *   *Transition*: Can transition back to `Ready` if the issue resolves (e.g., node auto-healing).
-    *   *Debugging*: When `Status` is `NotReady`, users should check `WorkspaceStatus.Conditions`. Any condition with `Status=False` serves as the root cause (e.g., `InferenceReady=False` due to `CrashLoopBackOff`).
+    *   *Debugging*: When `State` is `NotReady`, users should check `WorkspaceStatus.Conditions`. Any condition with `Status=False` serves as the root cause (e.g., `InferenceReady=False` due to `CrashLoopBackOff`).
 
 
-![inference status workflow](../../website/static/img/workspace-inference-status-workflow.png)
+![inference state workflow](../../website/static/img/workspace-inference-status-workflow.png)
 
-### Fine-tuning Workspace Status Workflow
+### Fine-tuning Workspace State Workflow
 
-For fine-tuning workloads, the `Status` tracks the execution lifecycle of the job.
+For fine-tuning workloads, the `State` tracks the execution lifecycle of the job.
 
 *   **Pending**: The workspace is in the initialization phase.
 *   **Running**: The fine-tuning job is actively executing.
 *   **Succeeded**: The tuning job completed successfully. (Terminal State)
 *   **Failed**: The tuning job failed. (Terminal State)
 
-![fine-tuning status workflow](../../website/static/img/workspace-fine-tuning-status-workflow.png)
+![fine-tuning state workflow](../../website/static/img/workspace-fine-tuning-status-workflow.png)
 
 ## Pros and Cons
 
@@ -76,7 +76,7 @@ For fine-tuning workloads, the `Status` tracks the execution lifecycle of the jo
 *   **Simplified User View**: Provides a single reliable field for checking availability (`Ready`) or job status.
 *   **Clear Separation**: Distinct states for Service availability (Ready/NotReady) vs Job lifecycle (Running/Succeeded).
 *   **Stable Initialization**: `Pending` implies "not established yet". Once established, we track availability via `Ready`/`NotReady`.
-*   **Forward Compatibility**: Future requirements can introduce new `Conditions` without needing UI updates. The UI only needs to check the `Status` field, as the workspace controller abstracts the complexity.
+*   **Forward Compatibility**: Future requirements can introduce new `Conditions` without needing UI updates. The UI only needs to check the `State` field, as the workspace controller abstracts the complexity.
 
 ### Cons
 *   **"Pending" Trap**: Permanent provisioning failures manifest as infinite `Pending`.


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

According to the proposal: https://github.com/kaito-project/kaito/blob/main/docs/proposals/20260121-workspace-status-phase.md, Field status is added into WorkspaceStatus for presenting current state of Workspace instance.

btw: The improvement of Workspace in kubectl tool output: TargetNodeCount and Status are output instead of original each conditions. 

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: