### PR TITLE
fix: trivy unknown severitis for test/kaito-base image

### DIFF
--- a/charts/kaito/workspace/templates/supported-models-configmap.yaml
+++ b/charts/kaito/workspace/templates/supported-models-configmap.yaml
@@ -11,7 +11,7 @@ data:
       - name: base
         type: text-generation
         runtime: tfs
-        tag: 0.1.1
+        tag: 0.1.2
       - name: llama-3.1-8b-instruct
         type: text-generation
         version: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/commit/0e9e39f249a16976918f6564b8830bc894c89659

--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -12,7 +12,15 @@ RUN pip3 install --upgrade pip uv
 WORKDIR /workspace
 
 # Required for torch.compile
-RUN apt-get update -y && apt-get install --no-install-recommends curl gcc libc-dev perl -y && \
+RUN apt-get update -y && \
+    if dpkg -s libssl3t64 >/dev/null 2>&1; then \
+        apt-get install --only-upgrade --no-install-recommends -y openssl libssl3t64 openssl-provider-legacy; \
+    elif dpkg -s libssl3 >/dev/null 2>&1; then \
+        apt-get install --only-upgrade --no-install-recommends -y openssl libssl3; \
+    else \
+        apt-get install --only-upgrade --no-install-recommends -y openssl; \
+    fi && \
+    apt-get install --no-install-recommends -y curl gcc libc-dev perl libglib2.0-0 libgl1 libsm6 libxext6 libxrender1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 FROM dependencies AS base

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -3,8 +3,9 @@ models:
   - name: base
     type: text-generation
     runtime: tfs
-    tag: 0.1.1
+    tag: 0.1.2
     # Tag history:
+    # 0.1.2 - fix unknown severity vulnerability in kaito-base image
     # 0.1.1 - bump ray to 2.52.1
     # 0.1.0 - bump vLLM to 0.12.0. remove the support for vllm v0
     # 0.0.9 - bump pip to 25.3


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
1. I've met the trivy error in this pull request: https://github.com/kaito-project/kaito/actions/runs/21424380339/job/61690448685, and there are 36 unknown severities for test/kaito-base:v0.0.1 image.

in this pull request, we update Debian package handling in [Dockerfile] to run apt-get install related libs, so security-fixed packages (like OpenSSL) get pulled in during image build. 

2. install opencv related libs for ministral model depends on them.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: