### PR TITLE
chore: force annotation and label values to be strings

### DIFF
--- a/charts/kaito/workspace/templates/_helpers.tpl
+++ b/charts/kaito/workspace/templates/_helpers.tpl
@@ -170,7 +170,7 @@ InferenceSet ClusterRoleBinding name
 {{- end -}}
 
 {{/*
-Utils function
+joinKeyValuePairs function
 */}}
 {{- define "utils.joinKeyValuePairs" -}}
 {{- $pairs := list -}}
@@ -178,4 +178,16 @@ Utils function
 {{- $pairs = append $pairs (printf "%s=%t" $key $value) -}}
 {{- end -}}
 {{- join "," $pairs -}}
+{{- end -}}
+
+{{/*
+toYamlStrMap function
+*/}}
+{{- define "utils.toYamlStrMap" -}}
+{{- $anyMap := . -}}
+{{- $strMap := dict -}}
+{{- range $key, $val := $anyMap -}}
+{{- $_ := set $strMap $key (toString $val) -}}
+{{- end -}}
+{{- toYaml $strMap -}}
 {{- end -}}

--- a/charts/kaito/workspace/templates/deployment.yaml
+++ b/charts/kaito/workspace/templates/deployment.yaml
@@ -16,12 +16,12 @@ spec:
     metadata:
       {{- with .Values.podAnnotations }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- include "utils.toYamlStrMap" . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "kaito.selectorLabels" . | nindent 8 }}
         {{- with .Values.podTemplateLabels }}
-        {{- toYaml . | nindent 8 }}
+        {{- include "utils.toYamlStrMap" . | nindent 8 }}
         {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}

--- a/charts/kaito/workspace/templates/knative-logging-configmap.yaml
+++ b/charts/kaito/workspace/templates/knative-logging-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "kaito.loggingConfigMapName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- toYaml .Values.commonLabels | nindent 4 }}
+    {{- include "utils.toYamlStrMap" .Values.commonLabels | nindent 4 }}
 data:
   loglevel.controller: {{ .Values.logging.level | quote }}
   loglevel.webhook: {{ .Values.logging.level | quote }}

--- a/charts/kaito/workspace/templates/supported-models-configmap.yaml
+++ b/charts/kaito/workspace/templates/supported-models-configmap.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kaito-supported-models
   namespace: {{ .Release.Namespace }}
   labels:
-    {{- toYaml .Values.commonLabels | nindent 4 }}
+    {{- include "utils.toYamlStrMap" .Values.commonLabels | nindent 4 }}
 data:
   SupportedModels: |
     models:


### PR DESCRIPTION
**Reason for Change**:
Due to a limitation of the Extensions RP, we need to force annotations and labels to have string values even when a different type is passed to Helm. This will allow us to set Prometheus annotations that would otherwise be impossible to set when installing KAITO as an extension:

```yaml
prometheus.io/port: "1234"
prometheus.io/scrape: "true"
```