### PR TITLE
fix: use intermediate image tags to avoid race condition (#1746)

### DIFF
--- a/.github/workflows/publish-rag-controller-gh-image.yaml
+++ b/.github/workflows/publish-rag-controller-gh-image.yaml
@@ -111,13 +111,13 @@ jobs:
         run: |
           INDEX_REF="${REGISTRY}/${RAGENGINE_IMAGE_NAME}:${IMG_TAG}"
 
-          make docker-build-ragengine
-          IMAGE_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+          make docker-build-ragengine IMG_TAG="${IMG_TAG}-linux"
+          LINUX_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}-linux")"
 
-          make helm-package-ragengine
-          CHART_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+          make helm-package-ragengine IMG_TAG="${IMG_TAG}-chart"
+          CHART_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}-chart")"
 
-          oras manifest index create "${INDEX_REF}" "${IMAGE_DIG}" "${CHART_DIG}"
+          oras manifest index create "${INDEX_REF}" "${LINUX_DIG}" "${CHART_DIG}"
         env:
           VERSION: ${{ needs.check-tag.outputs.tag }}
           REGISTRY: ${{ steps.get-registry.outputs.registry_repository }}

--- a/.github/workflows/publish-rag-controller-mcr-image.yaml
+++ b/.github/workflows/publish-rag-controller-mcr-image.yaml
@@ -60,13 +60,13 @@ jobs:
         run: |
           INDEX_REF="${REGISTRY}/${RAGENGINE_IMAGE_NAME}:${IMG_TAG}"
 
-          make docker-build-ragengine
-          IMAGE_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+          make docker-build-ragengine IMG_TAG="${IMG_TAG}-linux"
+          LINUX_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}-linux")"
 
-          make helm-package-ragengine
-          CHART_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+          make helm-package-ragengine IMG_TAG="${IMG_TAG}-chart"
+          CHART_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}-chart")"
 
-          oras manifest index create "${INDEX_REF}" "${IMAGE_DIG}" "${CHART_DIG}"
+          oras manifest index create "${INDEX_REF}" "${LINUX_DIG}" "${CHART_DIG}"
         env:
           VERSION: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
           REGISTRY: ${{ secrets.KAITO_MCR_REGISTRY }}/public/aks/kaito

--- a/.github/workflows/publish-workspace-gh-image.yaml
+++ b/.github/workflows/publish-workspace-gh-image.yaml
@@ -111,13 +111,13 @@ jobs:
         run: |
           INDEX_REF="${REGISTRY}/${IMG_NAME}:${IMG_TAG}"
 
-          make docker-build-workspace
-          IMAGE_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+          make docker-build-workspace IMG_TAG="${IMG_TAG}-linux"
+          LINUX_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}-linux")"
 
-          make helm-package-workspace
-          CHART_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+          make helm-package-workspace IMG_TAG="${IMG_TAG}-chart"
+          CHART_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}-chart")"
 
-          oras manifest index create "${INDEX_REF}" "${IMAGE_DIG}" "${CHART_DIG}"
+          oras manifest index create "${INDEX_REF}" "${LINUX_DIG}" "${CHART_DIG}"
         env:
           VERSION: ${{ needs.check-tag.outputs.tag }}
           REGISTRY: ${{ steps.get-registry.outputs.registry_repository }}

--- a/.github/workflows/publish-workspace-mcr-image.yaml
+++ b/.github/workflows/publish-workspace-mcr-image.yaml
@@ -60,13 +60,13 @@ jobs:
         run: |
           INDEX_REF="${REGISTRY}/${IMG_NAME}:${IMG_TAG}"
 
-          make docker-build-workspace
-          IMAGE_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+          make docker-build-workspace IMG_TAG="${IMG_TAG}-linux"
+          LINUX_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}-linux")"
 
-          make helm-package-workspace
-          CHART_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}")"
+          make helm-package-workspace IMG_TAG="${IMG_TAG}-chart"
+          CHART_DIG="$(oras manifest fetch --format 'go-template={{ .digest }}' "${INDEX_REF}-chart")"
 
-          oras manifest index create "${INDEX_REF}" "${IMAGE_DIG}" "${CHART_DIG}"
+          oras manifest index create "${INDEX_REF}" "${LINUX_DIG}" "${CHART_DIG}"
         env:
           VERSION: ${{ github.event.client_payload.tag || github.event.inputs.tag }}
           REGISTRY: ${{ secrets.KAITO_MCR_REGISTRY }}/public/aks/kaito


### PR DESCRIPTION
**Reason for Change**:
When pushing to MCR, tag creation is asynchronous. Reusing the same tag across multiple pushes leads to a race condition in which the registry ends up associating the tag with an older digest. This patch addresses the issue by introducing unique intermediate tags for the Linux image and Helm chart.