### PR TITLE
chore: add apt-get upgrade -y to preset model Dockerfile

### DIFF
--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -12,7 +12,8 @@ RUN pip3 install --upgrade pip uv
 WORKDIR /workspace
 
 # Required for torch.compile
-RUN apt-get update -y && apt-get install --no-install-recommends curl gcc libc-dev perl -y && \
+RUN apt-get update -y && apt-get upgrade -y && \
+    apt-get install --no-install-recommends curl gcc libc-dev perl -y && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
 FROM dependencies AS base


### PR DESCRIPTION
**Reason for Change**:
to fix the failure of Scan test/kaito-base:v0.0.1

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: