### PR TITLE
fix(docs): gwaie doc example manifests

### DIFF
--- a/examples/gateway-api-inference-extension/destinationrule-mistral-7b-instruct.yaml
+++ b/examples/gateway-api-inference-extension/destinationrule-mistral-7b-instruct.yaml
@@ -1,9 +1,9 @@
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
-  name: mistral-7b-instruct-inference-epp
+  name: mistral-7b-instruct-inferencepool-epp
 spec:
-  host: mistral-7b-instruct-inference-epp
+  host: mistral-7b-instruct-inferencepool-epp
   trafficPolicy:
     tls:
       mode: SIMPLE

--- a/examples/gateway-api-inference-extension/gateway.yaml
+++ b/examples/gateway-api-inference-extension/gateway.yaml
@@ -4,6 +4,13 @@ metadata:
   name: inference-gateway
 spec:
   gatewayClassName: istio
+  # NOTE: Uncomment the following section allow incoming traffic from Azure external load balancers.
+  #       See: https://istio.io/latest/docs/setup/platform-setup/azure/ for more details.
+  # infrastructure:
+  #   annotations:
+  #     service.beta.kubernetes.io/port_80_health-probe_protocol: tcp
+  #     service.beta.kubernetes.io/port_443_health-probe_protocol: tcp
+  #     service.beta.kubernetes.io/port_15021_health-probe_protocol: tcp
   listeners:
   - name: http
     port: 80


### PR DESCRIPTION
- fix name and host in DestinationRule for mistral-7b-instruct
- add note to add infra annotation to enable external traffic on external lb

**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: