### PR TITLE
chore: introduce subcharts for crds

### DIFF
--- a/charts/kaito/ragengine/charts/crds/.helmignore
+++ b/charts/kaito/ragengine/charts/crds/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kaito/ragengine/charts/crds/Chart.yaml
+++ b/charts/kaito/ragengine/charts/crds/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: crds
+description: A Helm chart for CRDs
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.8.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.8.0"

--- a/charts/kaito/ragengine/charts/crds/templates/kaito.sh_ragengines.yaml
+++ b/charts/kaito/ragengine/charts/crds/templates/kaito.sh_ragengines.yaml
@@ -1,4 +1,4 @@
----
+{{- if (index .Values.include "ragengines.kaito.sh") -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -618,3 +618,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/kaito/ragengine/charts/crds/values.yaml
+++ b/charts/kaito/ragengine/charts/crds/values.yaml
@@ -1,0 +1,6 @@
+# Default values for workspace-crds.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+include:
+  ragengines.kaito.sh: true

--- a/charts/kaito/workspace/charts/crds/.helmignore
+++ b/charts/kaito/workspace/charts/crds/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/kaito/workspace/charts/crds/Chart.yaml
+++ b/charts/kaito/workspace/charts/crds/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: crds
+description: A Helm chart for CRDs
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.8.0
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "0.8.0"

--- a/charts/kaito/workspace/charts/crds/templates/inference.networking.k8s.io_inferencepools.yaml
+++ b/charts/kaito/workspace/charts/crds/templates/inference.networking.k8s.io_inferencepools.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.include "inferencepools.inference.networking.k8s.io") -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -333,3 +334,4 @@ status:
     plural: ""
   conditions: null
   storedVersions: null
+{{- end }}

--- a/charts/kaito/workspace/charts/crds/templates/inference.networking.x-k8s.io_inferenceobjectives.yaml
+++ b/charts/kaito/workspace/charts/crds/templates/inference.networking.x-k8s.io_inferenceobjectives.yaml
@@ -1,3 +1,4 @@
+{{- if (index .Values.include "inferenceobjectives.inference.networking.x-k8s.io") -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -189,3 +190,4 @@ status:
     plural: ""
   conditions: null
   storedVersions: null
+{{- end }}

--- a/charts/kaito/workspace/charts/crds/templates/kaito.sh_inferencesets.yaml
+++ b/charts/kaito/workspace/charts/crds/templates/kaito.sh_inferencesets.yaml
@@ -1,4 +1,4 @@
----
+{{- if (index .Values.include "inferencesets.kaito.sh") -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -335,3 +335,4 @@ spec:
         specReplicasPath: .spec.replicas
         statusReplicasPath: .status.replicas
       status: {}
+{{- end }}

--- a/charts/kaito/workspace/charts/crds/templates/kaito.sh_workspaces.yaml
+++ b/charts/kaito/workspace/charts/crds/templates/kaito.sh_workspaces.yaml
@@ -1,4 +1,4 @@
----
+{{- if (index .Values.include "workspaces.kaito.sh") -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -820,3 +820,4 @@ spec:
     storage: true
     subresources:
       status: {}
+{{- end }}

--- a/charts/kaito/workspace/charts/crds/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
+++ b/charts/kaito/workspace/charts/crds/templates/karpenter.k8s.aws_ec2nodeclasses.yaml
@@ -1,4 +1,4 @@
----
+{{- if (index .Values.include "ec2nodeclasses.karpenter.k8s.aws") -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -838,3 +838,4 @@ spec:
       storage: true
       subresources:
         status: {}
+{{- end }}

--- a/charts/kaito/workspace/charts/crds/templates/karpenter.sh_nodeclaims.yaml
+++ b/charts/kaito/workspace/charts/crds/templates/karpenter.sh_nodeclaims.yaml
@@ -1,4 +1,4 @@
----
+{{- if (index .Values.include "nodeclaims.karpenter.sh") -}}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
@@ -391,3 +391,4 @@ spec:
       storage: true
       subresources:
         status: {}
+{{- end }}

--- a/charts/kaito/workspace/charts/crds/values.yaml
+++ b/charts/kaito/workspace/charts/crds/values.yaml
@@ -1,0 +1,11 @@
+# Default values for workspace-crds.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+include:
+  ec2nodeclasses.karpenter.k8s.aws: true
+  inferenceobjectives.inference.networking.x-k8s.io: true
+  inferencepools.inference.networking.k8s.io: true
+  inferencesets.kaito.sh: true
+  nodeclaims.karpenter.sh: true
+  workspaces.kaito.sh: true


### PR DESCRIPTION
**Reason for Change**:
To be able to selectively install CRDs, we are required to use a separate chart dedicated to CRDs (as suggested here: https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-2-separate-charts). This patch moves all CRDs of existing charts to subcharts, so we can have toggles to decide whether or not a particular CRD should be applied to clusters.

**Requirements**
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
N/A

**Notes for Reviewers**:
N/A