### PR TITLE
refactor: remove dead Deployment manifest code (StatefulSet migration cleanup)

### DIFF
--- a/pkg/utils/generator/generator.go
+++ b/pkg/utils/generator/generator.go
@@ -38,7 +38,7 @@ type GeneratorContext interface {
 }
 
 type ManifestType interface {
-	appsv1.StatefulSet | appsv1.Deployment | batchv1.Job | corev1.PodSpec
+	appsv1.StatefulSet | batchv1.Job | corev1.PodSpec
 }
 
 type TypedManifestModifier[C GeneratorContext, T ManifestType] func(ctx *C, obj *T) error

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -209,68 +209,6 @@ func SetJobPodSpec(podSpec *corev1.PodSpec) func(*generator.WorkspaceGeneratorCo
 	}
 }
 
-func GenerateDeploymentManifest(revisionNum string, replicas int) func(*generator.WorkspaceGeneratorContext, *appsv1.Deployment) error {
-	return func(ctx *generator.WorkspaceGeneratorContext, d *appsv1.Deployment) error {
-		selector := map[string]string{
-			kaitov1beta1.LabelWorkspaceName: ctx.Workspace.Name,
-		}
-		// if workspaceObj.Labels contains "inferenceset.kaito.sh/created-by", add it to selector for VPA/HPA purpose
-		if ctx.Workspace.Labels != nil {
-			if createdBy, exists := ctx.Workspace.Labels[consts.WorkspaceCreatedByInferenceSetLabel]; exists {
-				klog.Infof("Adding label %s=%s to deployment selector", consts.WorkspaceCreatedByInferenceSetLabel, createdBy)
-				selector[consts.WorkspaceCreatedByInferenceSetLabel] = createdBy
-			}
-		}
-		labelselector := &metav1.LabelSelector{
-			MatchLabels: selector,
-		}
-
-		d.ObjectMeta = metav1.ObjectMeta{
-			Name:      ctx.Workspace.Name,
-			Namespace: ctx.Workspace.Namespace,
-			OwnerReferences: []metav1.OwnerReference{
-				*metav1.NewControllerRef(ctx.Workspace, kaitov1beta1.GroupVersion.WithKind("Workspace")),
-			},
-			Annotations: map[string]string{
-				kaitov1beta1.WorkspaceRevisionAnnotation: revisionNum,
-			},
-		}
-		d.Spec = appsv1.DeploymentSpec{
-			Replicas: lo.ToPtr(int32(replicas)),
-			Strategy: appsv1.DeploymentStrategy{
-				Type: appsv1.RollingUpdateDeploymentStrategyType,
-				RollingUpdate: &appsv1.RollingUpdateDeployment{
-					MaxSurge: &intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 1,
-					},
-					MaxUnavailable: &intstr.IntOrString{
-						Type:   intstr.Int,
-						IntVal: 0,
-					},
-				}, // Configuration for rolling updates: allows one extra pod during
-				// the update while keeping all existing pods available, ensuring
-				// zero-downtime deployments. The new pod must become ready before
-				// the old pod is terminated. (Fixes #1132)
-			},
-			Selector: labelselector,
-			Template: corev1.PodTemplateSpec{
-				ObjectMeta: metav1.ObjectMeta{
-					Labels: selector,
-				},
-			},
-		}
-		return nil
-	}
-}
-
-func SetDeploymentPodSpec(podSpec *corev1.PodSpec) func(*generator.WorkspaceGeneratorContext, *appsv1.Deployment) error {
-	return func(ctx *generator.WorkspaceGeneratorContext, d *appsv1.Deployment) error {
-		d.Spec.Template.Spec = *podSpec
-		return nil
-	}
-}
-
 func GeneratePullerContainers(wObj *kaitov1beta1.Workspace, volumeMounts []corev1.VolumeMount) ([]corev1.Container, []corev1.EnvVar, []corev1.Volume) {
 	size := len(wObj.Inference.Adapters)
 
@@ -332,7 +270,7 @@ func GenerateManifestWithPodTemplate(workspaceObj *kaitov1beta1.Workspace, toler
 	// if workspaceObj.Labels contains "inferenceset.kaito.sh/created-by", add it to selector for VPA/HPA purpose
 	if workspaceObj.Labels != nil {
 		if createdBy, exists := workspaceObj.Labels[consts.WorkspaceCreatedByInferenceSetLabel]; exists {
-			klog.Infof("Adding label %s=%s to deployment selector", consts.WorkspaceCreatedByInferenceSetLabel, createdBy)
+			klog.Infof("Adding label %s=%s to statefulset selector", consts.WorkspaceCreatedByInferenceSetLabel, createdBy)
 			templateCopy.ObjectMeta.Labels[consts.WorkspaceCreatedByInferenceSetLabel] = createdBy
 			labelselector.MatchLabels[consts.WorkspaceCreatedByInferenceSetLabel] = createdBy
 		}

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -23,71 +23,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
-	"github.com/kaito-project/kaito/pkg/utils/generator"
 	"github.com/kaito-project/kaito/pkg/utils/test"
 )
-
-func TestGenerateDeploymentManifest(t *testing.T) {
-	workspace := test.MockWorkspaceWithPreset.DeepCopy()
-	workspace.Name = "test-deploy"
-	workspace.Namespace = "kaito"
-
-	revisionNum := "1"
-	replicas := 1
-
-	genFunc := GenerateDeploymentManifest(revisionNum, replicas)
-
-	ctx := &generator.WorkspaceGeneratorContext{
-		Workspace: workspace,
-	}
-	d := &appsv1.Deployment{}
-	err := genFunc(ctx, d)
-	assert.NoError(t, err)
-
-	// Verify basic metadata
-	assert.Equal(t, workspace.Name, d.Name)
-	assert.Equal(t, workspace.Namespace, d.Namespace)
-	assert.Equal(t, revisionNum, d.Annotations[kaitov1beta1.WorkspaceRevisionAnnotation])
-
-	// Verify owner reference
-	assert.Len(t, d.OwnerReferences, 1)
-	assert.Equal(t, "Workspace", d.OwnerReferences[0].Kind)
-
-	// Verify replicas
-	assert.Equal(t, int32(replicas), *d.Spec.Replicas)
-
-	// Verify RollingUpdate strategy for zero-downtime deployments (#1132)
-	assert.Equal(t, appsv1.RollingUpdateDeploymentStrategyType, d.Spec.Strategy.Type)
-	if assert.NotNil(t, d.Spec.Strategy.RollingUpdate, "RollingUpdate strategy should be set") {
-		ru := d.Spec.Strategy.RollingUpdate
-
-		// MaxSurge=1: allow one extra pod during update so new pod starts
-		// before old pod is terminated
-		if assert.NotNil(t, ru.MaxSurge, "MaxSurge should be set") {
-			assert.Equal(t, intstr.Int, ru.MaxSurge.Type)
-			assert.Equal(t, int32(1), ru.MaxSurge.IntVal,
-				"MaxSurge should be 1 to allow a new pod to start before the old one is terminated")
-		}
-
-		// MaxUnavailable=0: never take down the existing pod until the new
-		// one is ready, preventing downtime
-		if assert.NotNil(t, ru.MaxUnavailable, "MaxUnavailable should be set") {
-			assert.Equal(t, intstr.Int, ru.MaxUnavailable.Type)
-			assert.Equal(t, int32(0), ru.MaxUnavailable.IntVal,
-				"MaxUnavailable should be 0 to prevent downtime during rolling updates")
-		}
-	}
-
-	// Verify selector labels
-	assert.Equal(t, workspace.Name, d.Spec.Selector.MatchLabels[kaitov1beta1.LabelWorkspaceName])
-	assert.Equal(t, workspace.Name, d.Spec.Template.Labels[kaitov1beta1.LabelWorkspaceName])
-}
 
 func TestGenerateInferencePoolOCIRepository(t *testing.T) {
 	workspace := test.MockInferenceSetWithPreset


### PR DESCRIPTION
## Summary

Removes dead Deployment-related code from the workspace manifests package, as requested by @zhuangqh.

Since the migration to StatefulSets (v0.8.0+), `GenerateDeploymentManifest` and `SetDeploymentPodSpec` have had zero callers anywhere in the codebase. This PR cleans them up.

## Changes

### `pkg/workspace/manifests/manifests.go`

- **Removed** `GenerateDeploymentManifest` — generated a Deployment manifest with RollingUpdate strategy; zero callers
- **Removed** `SetDeploymentPodSpec` — set the pod spec on a Deployment; zero callers
- **Fixed** misleading log message in `GenerateManifestWithPodTemplate`: `"deployment selector"` → `"statefulset selector"` (this function creates a StatefulSet, not a Deployment)

### `pkg/workspace/manifests/manifests_test.go`

- **Removed** `TestGenerateDeploymentManifest` (added in a prior commit, now unnecessary)
- Reverted test imports to match upstream `main`

### `pkg/utils/generator/generator.go`

- **Removed** `appsv1.Deployment` from the `ManifestType` generic type constraint, since no Deployment manifests are generated anywhere

## Verification

- All existing tests (`TestGenerateStatefulSetManifest`, `TestGeneratePullerContainers`, `TestGenerateInferencePoolOCIRepository`, `TestGenerateInferencePoolHelmRelease`, `TestGenerator`) are unaffected
- No compile errors — the removed code had zero references
- No behavioral changes for any active code paths