### PR TITLE
ci: pin trivy binary version to v0.69.2 in trivy workflow

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -28,7 +28,6 @@ jobs:
             build_flags: "--target dependencies"
 
     steps:
-
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
 
@@ -43,6 +42,7 @@ jobs:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
         with:
+          version: "v0.69.2"
           image-ref: ${{ matrix.image }}
           format: "table"
           exit-code: "1"


### PR DESCRIPTION
**Reason for Change**:
Check issue:  #1816

**Issue Fixed**:
Fixes #1816

**Notes for Reviewers**: