### PR TITLE
ci: add stale issues and PRs GitHub Action

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -22,6 +22,8 @@ jobs:
 
       - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
           stale-issue-message: >
             This issue has been automatically marked as stale because it has not had
             activity in the last 90 days. It will be closed in 14 days if no further


### PR DESCRIPTION
## Summary

- Add `.github/workflows/stale.yaml` using [actions/stale](https://github.com/actions/stale) to automatically triage inactive issues and PRs

### Configuration

| Setting | Value |
|---|---|
| Days before stale | 90 |
| Days before close | 14 (after stale label) |
| Stale label | `stale` |
| Exempt labels | `enhancement`, `help wanted`, `good first issue`, `security` |
| Schedule | Daily at midnight UTC |
| Manual trigger | Supported via `workflow_dispatch` |

Follows existing Kaito CI patterns (harden-runner, pinned action SHAs).

Partial fix for #1813