### PR TITLE
fix: Set GPUConfig.GPUMem to be memory per GPU * GPU Count

### DIFF
--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -184,13 +184,13 @@ func GetGPUConfigFromNodeLabels(node *corev1.Node) (*sku.GPUConfig, error) {
 		return nil, fmt.Errorf("invalid nvidia.com/gpu.count value on node %s: %s", node.Name, gpuCountStr)
 	}
 
-	// Parse GPU memory (nvidia.com/gpu.memory is in MiB, convert to GB)
+	// Parse GPU memory (nvidia.com/gpu.memory is per-GPU memory in MiB).
 	gpuMemoryMiB, err := strconv.Atoi(gpuMemoryStr)
 	if err != nil {
 		return nil, fmt.Errorf("invalid nvidia.com/gpu.memory value on node %s: %s", node.Name, gpuMemoryStr)
 	}
 
-	gpuMemGiB := int64((float64(gpuMemoryMiB) / 1024) + 0.5)
+	gpuMemGiB := int64((float64(gpuMemoryMiB)/1024)+0.5) * int64(gpuCount)
 
 	return &sku.GPUConfig{
 		SKU:      "unknown", // SKU is not available from node labels

--- a/pkg/utils/common_test.go
+++ b/pkg/utils/common_test.go
@@ -435,7 +435,7 @@ func TestGetGPUConfigFromNvidiaLabels(t *testing.T) {
 					Labels: map[string]string{
 						"nvidia.com/gpu.product": "Tesla-V100-SXM2-32GB",
 						"nvidia.com/gpu.count":   "2",
-						"nvidia.com/gpu.memory":  "32768", // 32GB in MiB
+						"nvidia.com/gpu.memory":  "32768", // 32GiB per GPU in MiB
 					},
 				},
 			},
@@ -444,7 +444,7 @@ func TestGetGPUConfigFromNvidiaLabels(t *testing.T) {
 				SKU:      "unknown",
 				GPUCount: 2,
 				GPUModel: "Tesla-V100-SXM2-32GB",
-				GPUMem:   resource.MustParse("32Gi"),
+				GPUMem:   resource.MustParse("64Gi"), // total node VRAM = 2 × 32Gi
 			},
 		},
 		{


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
The GPUConfig.GPUMem is treated as total GPU memory per node in the codebase. It is incorrectly set to `nvidia.com/gpu.memory`, which is memory per GPU. Leading to incorrect GPU memory estimate. This PR fixes it to setting it to memory per GPU * GPU Count.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Fixed #1838 
**Notes for Reviewers**: