### PR TITLE
chore: bump NVIDIA K8s Device Plugin to v0.18.2-1 (#1843)

### DIFF
--- a/charts/kaito/workspace/values.yaml
+++ b/charts/kaito/workspace/values.yaml
@@ -45,7 +45,7 @@ defaultNodeImageFamily: ""
 nvidiaDevicePlugin:
   enabled: true
   daemonsetName: "nvidia-device-plugin-daemonset"
-  image: "mcr.microsoft.com/oss/v2/nvidia/k8s-device-plugin:v0.17.0"
+  image: "mcr.microsoft.com/oss/v2/nvidia/k8s-device-plugin:v0.18.2-1"
   imagePullPolicy: "IfNotPresent"
 localCSIDriver:
   useLocalCSIDriver: true


### PR DESCRIPTION
**Reason for Change**:
Bump NVIDIA K8s Device Plugin to v0.18.2-1.

**Requirements**
- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
N/A

**Notes for Reviewers**:
N/A