### PR TITLE
refactor: decouple estimator package to be usable as an external library

### DIFF
--- a/pkg/utils/workspace/helper.go
+++ b/pkg/utils/workspace/helper.go
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package estimator
+package workspace
 
 import (
 	"context"
@@ -23,6 +23,7 @@ import (
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
+	estimatorpkg "github.com/kaito-project/kaito/pkg/workspace/estimator"
 	"github.com/kaito-project/kaito/presets/workspace/models"
 )
 
@@ -30,10 +31,10 @@ import (
 // It fetches the HuggingFace access token from Kubernetes when ModelAccessSecret is set,
 // so the returned request carries the resolved token value rather than a secret reference.
 // This is a convenience helper for callers that already have a Workspace and a kube client.
-func NodeEstimateRequestFromWorkspace(ctx context.Context, w *kaitov1beta1.Workspace, kubeClient client.Client) (NodeEstimateRequest, error) {
-	req := NodeEstimateRequest{
+func NodeEstimateRequestFromWorkspace(ctx context.Context, w *kaitov1beta1.Workspace, kubeClient client.Client) (estimatorpkg.NodeEstimateRequest, error) {
+	req := estimatorpkg.NodeEstimateRequest{
 		WorkspaceName: w.Name,
-		ResourceProfile: ResourceProfile{
+		ResourceProfile: estimatorpkg.ResourceProfile{
 			InstanceType:                w.Resource.InstanceType,
 			LabelSelector:               w.Resource.LabelSelector,
 			DisableNodeAutoProvisioning: featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning],
@@ -55,12 +56,12 @@ func NodeEstimateRequestFromWorkspace(ctx context.Context, w *kaitov1beta1.Works
 			var err error
 			token, err = models.GetHFTokenFromSecret(ctx, kubeClient, secretName, w.Namespace)
 			if err != nil {
-				return NodeEstimateRequest{}, fmt.Errorf("failed to resolve access token for model %q: %w", name, err)
+				return estimatorpkg.NodeEstimateRequest{}, fmt.Errorf("failed to resolve access token for model %q: %w", name, err)
 			}
 		}
-		req.ModelProfile = ModelProfile{
-			Name:         name,
-			AccessSecret: token,
+		req.ModelProfile = estimatorpkg.ModelProfile{
+			Name:        name,
+			AccessToken: token,
 		}
 	}
 	return req, nil

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -982,7 +982,7 @@ func (c *WorkspaceReconciler) UpdateWorkspaceTargetNodeCount(ctx context.Context
 	targetNodeCount := int32(1)
 	if wObj.Status.TargetNodeCount == 0 {
 		// Build the estimate request once, outside the status-update closure.
-		req, reqErr := estimator.NodeEstimateRequestFromWorkspace(ctx, wObj, c.Client)
+		req, reqErr := workspace.NodeEstimateRequestFromWorkspace(ctx, wObj, c.Client)
 		if reqErr != nil {
 			return fmt.Errorf("failed to build node estimate request: %w", reqErr)
 		}

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -981,10 +981,30 @@ func (c *WorkspaceReconciler) UpdateWorkspaceTargetNodeCount(ctx context.Context
 	var err error
 	targetNodeCount := int32(1)
 	if wObj.Status.TargetNodeCount == 0 {
+		// Build the estimate request once, outside the status-update closure.
+		req, reqErr := estimator.NodeEstimateRequestFromWorkspace(ctx, wObj, c.Client)
+		if reqErr != nil {
+			return fmt.Errorf("failed to build node estimate request: %w", reqErr)
+		}
+
+		// Resolve the context window size from the workspace's inference ConfigMap (if any)
+		// and pass it through RuntimeProfile so the estimator does not need to do I/O.
+		if wObj.Inference != nil && wObj.Inference.Config != "" {
+			configMap := &corev1.ConfigMap{}
+			if cmErr := resources.GetResource(ctx, wObj.Inference.Config, wObj.Namespace, c.Client, configMap); cmErr != nil {
+				klog.Warningf("[UpdateWorkspaceTargetNodeCount] workspace=%s: failed to get ConfigMap %s: %v, using estimator default context size",
+					wObj.Name, wObj.Inference.Config, cmErr)
+			} else if configData, exists := configMap.Data["inference_config.yaml"]; exists {
+				if contextSize, found := utils.ParseExplicitMaxModelLen(configData); found {
+					req.RuntimeProfile = estimator.RuntimeProfile{ContextSize: contextSize}
+				}
+			}
+		}
+
 		if err := workspace.UpdateWorkspaceStatus(ctx, c.Client, &client.ObjectKey{Name: wObj.Name, Namespace: wObj.Namespace}, func(status *kaitov1beta1.WorkspaceStatus) error {
 			if wObj.Inference != nil {
 				if v1beta1.GetWorkspaceRuntimeName(wObj) == pkgmodel.RuntimeNameVLLM {
-					targetNodeCount, err = c.Estimator.EstimateNodeCount(ctx, wObj, c.Client)
+					targetNodeCount, err = c.Estimator.EstimateNodeCount(ctx, req, c.Client)
 					if err != nil {
 						return fmt.Errorf("failed to calculate target node count: %w", err)
 					}

--- a/pkg/workspace/controllers/workspace_controller_test.go
+++ b/pkg/workspace/controllers/workspace_controller_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/test"
+	"github.com/kaito-project/kaito/pkg/workspace/estimator"
 	"github.com/kaito-project/kaito/pkg/workspace/estimator/basicnodesestimator"
 )
 
@@ -522,7 +523,12 @@ func TestApplyInferenceWithPreset(t *testing.T) {
 
 			t.Setenv("CLOUD_PROVIDER", consts.AzureCloudName)
 			if tc.workspace.Status.TargetNodeCount == 0 {
-				cnt, err := reconciler.Estimator.EstimateNodeCount(t.Context(), &tc.workspace, mockClient)
+				req, reqErr := estimator.NodeEstimateRequestFromWorkspace(t.Context(), &tc.workspace, mockClient)
+				if reqErr != nil {
+					t.Errorf("Failed to build estimate request: %v", reqErr)
+					return
+				}
+				cnt, err := reconciler.Estimator.EstimateNodeCount(t.Context(), req, mockClient)
 				if err != nil {
 					t.Errorf("Failed to estimate node count: %v", err)
 					return
@@ -819,8 +825,8 @@ func (m *mockEstimator) Name() string {
 	return args.String(0)
 }
 
-func (m *mockEstimator) EstimateNodeCount(ctx context.Context, workspace *v1beta1.Workspace, client client.Client) (int32, error) {
-	args := m.Called(ctx, workspace, client)
+func (m *mockEstimator) EstimateNodeCount(ctx context.Context, req estimator.NodeEstimateRequest, client client.Client) (int32, error) {
+	args := m.Called(ctx, req, client)
 	return args.Get(0).(int32), args.Error(1)
 }
 
@@ -869,7 +875,7 @@ func TestUpdateWorkspaceTargetNodeCount(t *testing.T) {
 				Status:     v1beta1.WorkspaceStatus{TargetNodeCount: 0},
 			},
 			setupMocks: func(c *test.MockClient, e *mockEstimator, updatedTarget *int32) {
-				e.On("EstimateNodeCount", mock.Anything, mock.IsType(&v1beta1.Workspace{}), mock.Anything).Return(int32(3), nil)
+				e.On("EstimateNodeCount", mock.Anything, mock.IsType(estimator.NodeEstimateRequest{}), mock.Anything).Return(int32(3), nil)
 				c.On("Get", mock.Anything, mock.Anything, mock.IsType(&v1beta1.Workspace{}), mock.Anything).
 					Run(func(args mock.Arguments) {
 						ws := args.Get(2).(*v1beta1.Workspace)
@@ -892,7 +898,7 @@ func TestUpdateWorkspaceTargetNodeCount(t *testing.T) {
 				Status:     v1beta1.WorkspaceStatus{TargetNodeCount: 0},
 			},
 			setupMocks: func(c *test.MockClient, e *mockEstimator, _ *int32) {
-				e.On("EstimateNodeCount", mock.Anything, mock.IsType(&v1beta1.Workspace{}), mock.Anything).Return(int32(0), fmt.Errorf("estimator error"))
+				e.On("EstimateNodeCount", mock.Anything, mock.IsType(estimator.NodeEstimateRequest{}), mock.Anything).Return(int32(0), fmt.Errorf("estimator error"))
 				c.On("Get", mock.Anything, mock.Anything, mock.IsType(&v1beta1.Workspace{}), mock.Anything).
 					Run(func(args mock.Arguments) {
 						ws := args.Get(2).(*v1beta1.Workspace)

--- a/pkg/workspace/controllers/workspace_controller_test.go
+++ b/pkg/workspace/controllers/workspace_controller_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/test"
+	workspaceutil "github.com/kaito-project/kaito/pkg/utils/workspace"
 	"github.com/kaito-project/kaito/pkg/workspace/estimator"
 	"github.com/kaito-project/kaito/pkg/workspace/estimator/basicnodesestimator"
 )
@@ -523,7 +524,7 @@ func TestApplyInferenceWithPreset(t *testing.T) {
 
 			t.Setenv("CLOUD_PROVIDER", consts.AzureCloudName)
 			if tc.workspace.Status.TargetNodeCount == 0 {
-				req, reqErr := estimator.NodeEstimateRequestFromWorkspace(t.Context(), &tc.workspace, mockClient)
+				req, reqErr := workspaceutil.NodeEstimateRequestFromWorkspace(t.Context(), &tc.workspace, mockClient)
 				if reqErr != nil {
 					t.Errorf("Failed to build estimate request: %v", reqErr)
 					return

--- a/pkg/workspace/estimator/advancednodesestimator/estimator.go
+++ b/pkg/workspace/estimator/advancednodesestimator/estimator.go
@@ -22,12 +22,11 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
-	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/sku"
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
+	estimator "github.com/kaito-project/kaito/pkg/workspace/estimator"
 	"github.com/kaito-project/kaito/presets/workspace/models"
 )
 
@@ -40,118 +39,97 @@ func (c *AdvancedNodesEstimator) Name() string {
 	return "advanced"
 }
 
-func (c *AdvancedNodesEstimator) EstimateNodeCount(ctx context.Context, workspace *kaitov1beta1.Workspace, client client.Client) (int32, error) {
-	// If inference is not configured, default to resource count or 1
-	if workspace.Inference == nil || workspace.Inference.Preset == nil || workspace.Inference.Preset.Name == "" {
-		//nolint:staticcheck //SA1019: deprecate Resource.Count field
-		if workspace.Resource.Count != nil {
-			//nolint:staticcheck //SA1019: deprecate Resource.Count field
-			return int32(*workspace.Resource.Count), nil
+func (c *AdvancedNodesEstimator) EstimateNodeCount(ctx context.Context, req estimator.NodeEstimateRequest, cl client.Client) (int32, error) {
+	// If no preset is configured, default to the requested node count or 1.
+	if req.ModelProfile.Name == "" {
+		if req.ResourceProfile.RequestedNodeCount > 0 {
+			return int32(req.ResourceProfile.RequestedNodeCount), nil
 		}
 		return 1, nil
 	}
 
-	presetName := string(workspace.Inference.Preset.Name)
-	secretName := workspace.Inference.Preset.PresetOptions.ModelAccessSecret
-	model, err := models.GetModelByName(ctx, presetName, secretName, workspace.Namespace, client)
+	model, err := models.GetModelByNameWithToken(ctx, req.ModelProfile.Name, req.ModelProfile.AccessSecret)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get model by name: %w", err)
 	}
 
 	var gpuConfig *sku.GPUConfig
 
-	if featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] {
-		if readyNodes, err := resources.GetReadyNodes(ctx, client, workspace); err != nil {
-			return 0, fmt.Errorf("failed to list ready nodes: %w", err)
-		} else if len(readyNodes) == 0 {
-			return 0, fmt.Errorf("no ready nodes found, unable to determine GPU configuration")
-		} else {
-			gpuConfig, err = utils.GetGPUConfigFromNodeLabels(readyNodes[0])
-			if err != nil {
-				return 0, fmt.Errorf("failed to get GPU config from existing nodes: %w", err)
+	if req.ResourceProfile.DisableNodeAutoProvisioning {
+		// NAP is disabled (BYO scenario) — derive GPU config from existing ready nodes.
+		var matchLabels client.MatchingLabels
+		if req.ResourceProfile.LabelSelector != nil {
+			matchLabels = req.ResourceProfile.LabelSelector.MatchLabels
+		}
+		nodeList, listErr := resources.ListNodes(ctx, cl, matchLabels)
+		if listErr != nil {
+			return 0, fmt.Errorf("failed to list ready nodes: %w", listErr)
+		}
+		var readyNodes []*corev1.Node
+		for i := range nodeList.Items {
+			if resources.NodeIsReadyAndNotDeleting(&nodeList.Items[i]) {
+				readyNodes = append(readyNodes, &nodeList.Items[i])
 			}
+		}
+		if len(readyNodes) == 0 {
+			return 0, fmt.Errorf("no ready nodes found, unable to determine GPU configuration")
+		}
+		gpuConfig, err = utils.GetGPUConfigFromNodeLabels(readyNodes[0])
+		if err != nil {
+			return 0, fmt.Errorf("failed to get GPU config from existing nodes: %w", err)
 		}
 	} else {
-		// NAP is enabled - instanceType is required and must be valid
-		gpuConfig, err = utils.GetGPUConfigBySKU(workspace.Resource.InstanceType)
+		// NAP is enabled — instanceType is required and must be valid.
+		gpuConfig, err = utils.GetGPUConfigBySKU(req.ResourceProfile.InstanceType)
 		if err != nil {
-			return 0, fmt.Errorf("failed to get GPU config for instance type %s: %w", workspace.Resource.InstanceType, err)
+			return 0, fmt.Errorf("failed to get GPU config for instance type %s: %w", req.ResourceProfile.InstanceType, err)
 		}
 	}
 
-	// Start with the user-requested node count (default is 1)
-	//nolint:staticcheck //SA1019: deprecate Resource.Count field
-	nodeCountPerReplica := 1 // Default to 1 if not specified
-	//nolint:staticcheck //SA1019: deprecate Resource.Count field
-	if workspace.Resource.Count != nil {
-		//nolint:staticcheck //SA1019: deprecate Resource.Count field
-		nodeCountPerReplica = int(*workspace.Resource.Count)
+	// Start with the user-requested node count (default is 1).
+	nodeCountPerReplica := 1
+	if req.ResourceProfile.RequestedNodeCount > 0 {
+		nodeCountPerReplica = req.ResourceProfile.RequestedNodeCount
 	}
 
-	// maxModelLen logic:
-	// 1. If user has no custom config, use default 2048
-	// 2. If user has custom configmap but no max-model-len, use 2048
-	// 3. If user has configmap with max-model-len, use user's value
+	// maxModelLen: use the value resolved by the caller (RuntimeProfile.ContextSize), falling back to 2048.
 	maxModelLen := 2048
-
-	if workspace.Inference.Config != "" {
-		// User has custom ConfigMap, try to read it
-		configMapName := workspace.Inference.Config
-		configMap := &corev1.ConfigMap{}
-		err := resources.GetResource(ctx, configMapName, workspace.Namespace, client, configMap)
-		if err != nil {
-			klog.Warningf("[AdvancedEstimator] Failed to get ConfigMap %s: %v, using default maxModelLen=%d", configMapName, err, maxModelLen)
-		} else {
-			// Parse the ConfigMap content for max-model-len
-			if configData, exists := configMap.Data["inference_config.yaml"]; exists {
-				if userMaxModelLen, found := utils.ParseExplicitMaxModelLen(configData); found {
-					maxModelLen = userMaxModelLen
-					klog.Infof("[AdvancedEstimator] workspace=%s using user explicit max-model-len=%d from ConfigMap %s", workspace.Name, maxModelLen, configMapName)
-				}
-			}
-		}
+	if req.RuntimeProfile.ContextSize > 0 {
+		maxModelLen = req.RuntimeProfile.ContextSize
 	}
 
-	klog.Infof("[AdvancedEstimator] workspace=%s maxModelLen=%d", workspace.Name, maxModelLen)
+	klog.Infof("[AdvancedEstimator] workspace=%s maxModelLen=%d", req.WorkspaceName, maxModelLen)
 
 	// If GPU memory information is available, calculate the optimal node count
 	if !gpuConfig.GPUMem.IsZero() && gpuConfig.GPUCount > 0 {
-		totalGPUMemoryRequired := resource.MustParse(model.GetInferenceParameters().TotalSafeTensorFileSize)
-		requiredMemoryBytes := int64(float64(totalGPUMemoryRequired.Value()) * 1.02) // vllm model size is about 102% percent of hugging face size
-		totalGPUMemoryPerGPUBytes := gpuConfig.GPUMem.Value() / int64(gpuConfig.GPUCount)
-		availableGPUMemoryPerGPUBytes := int64(float64(totalGPUMemoryPerGPUBytes) * 0.84) // utilization is set to default 0.84
+		inferParams := model.GetInferenceParameters()
+		totalGPUMemRequired := resource.MustParse(inferParams.TotalSafeTensorFileSize)
+		modelSize := float64(totalGPUMemRequired.Value()) * 1.02 // vllm model size is about 102% of HuggingFace size
+		gpuMemPerGPU := float64(gpuConfig.GPUMem.Value() / int64(gpuConfig.GPUCount))
+		availGPUMem := gpuMemPerGPU * 0.84 // utilization is set to default 0.84
 
-		// Overhead calculation: fixed base overhead (2.3GB) + model length overhead
-		// Following the same algorithm as preset_inferences.go
-		baseOverhead := 2.3 * consts.GiBToBytes // Convert 2.3 GB to bytes
-		kvCache := float64(maxModelLen*model.GetInferenceParameters().BytesPerToken) / float64(gpuConfig.GPUCount)
-		overhead := baseOverhead + kvCache // KV cache overhead for the given token length
+		// Overhead: fixed base (2.3GB) + KV cache for context length
+		kvCache := float64(maxModelLen*inferParams.BytesPerToken) / float64(gpuConfig.GPUCount)
+		overhead := 2.3*consts.GiBToBytes + kvCache
 
-		// Special case for models that disable tensor parallelism: check if required memory + overhead fits in GPU memory
-		if model.GetInferenceParameters().DisableTensorParallelism {
-			if int64(requiredMemoryBytes)+int64(overhead) > availableGPUMemoryPerGPUBytes {
-				return 0, fmt.Errorf("GPU memory %d bytes is too small for model, needs %d bytes (model: %d + overhead: %.0f)",
-					totalGPUMemoryPerGPUBytes, int64(requiredMemoryBytes)+int64(overhead), requiredMemoryBytes, overhead)
-			}
+		if inferParams.DisableTensorParallelism && modelSize+overhead > availGPUMem {
+			return 0, fmt.Errorf("GPU memory %.0f bytes is too small for model, needs %.0f bytes (model: %.0f + overhead: %.0f)",
+				gpuMemPerGPU, modelSize+overhead, modelSize, overhead)
 		}
 
-		if float64(availableGPUMemoryPerGPUBytes) <= overhead {
-			return 0, fmt.Errorf("GPU memory %d bytes is too small, needs at least %.1f GB overhead (base: 2.3GB + Advanced KV Cache: %.1f GB)",
-				totalGPUMemoryPerGPUBytes, overhead/float64(consts.GiBToBytes), kvCache/float64(consts.GiBToBytes))
+		if availGPUMem <= overhead {
+			return 0, fmt.Errorf("GPU memory %.0f bytes is too small, needs at least %.1f GB overhead (base: 2.3GB + Advanced KV Cache: %.1f GB)",
+				gpuMemPerGPU, overhead/float64(consts.GiBToBytes), kvCache/float64(consts.GiBToBytes))
 		}
 
-		availableMemoryPerGPU := float64(availableGPUMemoryPerGPUBytes) - overhead
-		minGPUs := int(float64(requiredMemoryBytes)/availableMemoryPerGPU) + 1 // Ceiling
-
-		// Calculate minimum nodes: we need minGPUs GPU groups
-		// If each node has gpuConfig.GPUCount GPUs, we need ceil(minGPUs / gpuConfig.GPUCount) nodes
+		availMemPerGPU := availGPUMem - overhead
+		minGPUs := int(modelSize/availMemPerGPU) + 1
 		nodeCountPerReplica = (minGPUs + gpuConfig.GPUCount - 1) / gpuConfig.GPUCount
 
-		klog.Infof("totalGPUMemoryRequired(%s), requiredMemoryBytes(%d), totalGPUMemoryPerGPUBytes(%d), availableGPUMemoryPerGPUBytes(%d), overhead(%.0f), availableMemoryPerGPU(%.0f), minGPUs(%d) => nodeCountPerReplica(%d) for workspace %s",
-			totalGPUMemoryRequired.String(), requiredMemoryBytes, totalGPUMemoryPerGPUBytes, availableGPUMemoryPerGPUBytes, overhead, availableMemoryPerGPU, minGPUs, nodeCountPerReplica, workspace.Name)
+		klog.Infof("modelSize(%.0f), gpuMemPerGPU(%.0f), availGPUMem(%.0f), overhead(%.0f), availMemPerGPU(%.0f), minGPUs(%d) => nodeCountPerReplica(%d) for workspace %s",
+			modelSize, gpuMemPerGPU, availGPUMem, overhead, availMemPerGPU, minGPUs, nodeCountPerReplica, req.WorkspaceName)
 
-		// Special case for models with disabled tensor parallelism: they cannot be distributed across multiple nodes
-		if nodeCountPerReplica > 1 && model.GetInferenceParameters().DisableTensorParallelism {
+		if nodeCountPerReplica > 1 && inferParams.DisableTensorParallelism {
 			return 0, fmt.Errorf("models with disabled tensor parallelism cannot be distributed across more than 1 GPU node, calculated nodes: %d", nodeCountPerReplica)
 		}
 
@@ -160,6 +138,6 @@ func (c *AdvancedNodesEstimator) EstimateNodeCount(ctx context.Context, workspac
 		}
 	}
 
-	klog.Infof("[AdvancedEstimator] Final result: nodeCountPerReplica=%d for workspace %s", nodeCountPerReplica, workspace.Name)
+	klog.Infof("[AdvancedEstimator] Final result: nodeCountPerReplica=%d for workspace %s", nodeCountPerReplica, req.WorkspaceName)
 	return int32(nodeCountPerReplica), nil
 }

--- a/pkg/workspace/estimator/advancednodesestimator/estimator.go
+++ b/pkg/workspace/estimator/advancednodesestimator/estimator.go
@@ -48,7 +48,7 @@ func (c *AdvancedNodesEstimator) EstimateNodeCount(ctx context.Context, req esti
 		return 1, nil
 	}
 
-	model, err := models.GetModelByNameWithToken(ctx, req.ModelProfile.Name, req.ModelProfile.AccessSecret)
+	model, err := models.GetModelByNameWithToken(ctx, req.ModelProfile.Name, req.ModelProfile.AccessToken)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get model by name: %w", err)
 	}

--- a/pkg/workspace/estimator/advancednodesestimator/estimator_test.go
+++ b/pkg/workspace/estimator/advancednodesestimator/estimator_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/utils/test"
-	estimatorpkg "github.com/kaito-project/kaito/pkg/workspace/estimator"
+	workspaceutil "github.com/kaito-project/kaito/pkg/utils/workspace"
 )
 
 func init() {
@@ -229,7 +229,7 @@ func TestAdvancedNodesEstimator_EstimateNodeCount(t *testing.T) {
 				featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] = originalValue
 			}()
 
-			req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, nil)
+			req, reqErr := workspaceutil.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, nil)
 			require.NoError(t, reqErr)
 			count, err := calculator.EstimateNodeCount(ctx, req, nil)
 
@@ -431,7 +431,7 @@ func TestAdvancedNodesEstimator_EstimateNodeCount_BYO(t *testing.T) {
 				tt.setupMocks(mockClient)
 			}
 
-			req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, mockClient)
+			req, reqErr := workspaceutil.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, mockClient)
 			require.NoError(t, reqErr)
 			count, err := calculator.EstimateNodeCount(ctx, req, mockClient)
 
@@ -542,7 +542,7 @@ func TestAdvancedNodesEstimator_EstimateNodeCount_Falcon7B(t *testing.T) {
 				featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] = originalValue
 			}()
 
-			req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, nil)
+			req, reqErr := workspaceutil.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, nil)
 			require.NoError(t, reqErr)
 			count, err := calculator.EstimateNodeCount(ctx, req, nil)
 
@@ -607,7 +607,7 @@ func TestAdvancedNodesEstimator_EstimateNodeCount_Qwen25Coder32B(t *testing.T) {
 				featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] = originalValue
 			}()
 
-			req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, nil)
+			req, reqErr := workspaceutil.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, nil)
 			require.NoError(t, reqErr)
 			count, err := calculator.EstimateNodeCount(ctx, req, nil)
 

--- a/pkg/workspace/estimator/advancednodesestimator/estimator_test.go
+++ b/pkg/workspace/estimator/advancednodesestimator/estimator_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/utils/test"
+	estimatorpkg "github.com/kaito-project/kaito/pkg/workspace/estimator"
 )
 
 func init() {
@@ -228,7 +229,9 @@ func TestAdvancedNodesEstimator_EstimateNodeCount(t *testing.T) {
 				featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] = originalValue
 			}()
 
-			count, err := calculator.EstimateNodeCount(ctx, tt.workspace, nil)
+			req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, nil)
+			require.NoError(t, reqErr)
+			count, err := calculator.EstimateNodeCount(ctx, req, nil)
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -428,7 +431,9 @@ func TestAdvancedNodesEstimator_EstimateNodeCount_BYO(t *testing.T) {
 				tt.setupMocks(mockClient)
 			}
 
-			count, err := calculator.EstimateNodeCount(ctx, tt.workspace, mockClient)
+			req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, mockClient)
+			require.NoError(t, reqErr)
+			count, err := calculator.EstimateNodeCount(ctx, req, mockClient)
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -537,7 +542,9 @@ func TestAdvancedNodesEstimator_EstimateNodeCount_Falcon7B(t *testing.T) {
 				featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] = originalValue
 			}()
 
-			count, err := calculator.EstimateNodeCount(ctx, tt.workspace, nil)
+			req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, nil)
+			require.NoError(t, reqErr)
+			count, err := calculator.EstimateNodeCount(ctx, req, nil)
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -600,7 +607,9 @@ func TestAdvancedNodesEstimator_EstimateNodeCount_Qwen25Coder32B(t *testing.T) {
 				featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] = originalValue
 			}()
 
-			count, err := calculator.EstimateNodeCount(ctx, tt.workspace, nil)
+			req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, nil)
+			require.NoError(t, reqErr)
+			count, err := calculator.EstimateNodeCount(ctx, req, nil)
 
 			if tt.expectedError {
 				require.Error(t, err)

--- a/pkg/workspace/estimator/basicnodesestimator/estimator.go
+++ b/pkg/workspace/estimator/basicnodesestimator/estimator.go
@@ -46,7 +46,7 @@ func (e *BasicNodesEstimator) EstimateNodeCount(ctx context.Context, req estimat
 		return 1, nil
 	}
 
-	model, err := models.GetModelByNameWithToken(ctx, req.ModelProfile.Name, req.ModelProfile.AccessSecret)
+	model, err := models.GetModelByNameWithToken(ctx, req.ModelProfile.Name, req.ModelProfile.AccessToken)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get model by name: %w", err)
 	}

--- a/pkg/workspace/estimator/basicnodesestimator/estimator.go
+++ b/pkg/workspace/estimator/basicnodesestimator/estimator.go
@@ -17,16 +17,14 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/samber/lo"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
-	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/sku"
 	"github.com/kaito-project/kaito/pkg/utils"
-	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
+	estimator "github.com/kaito-project/kaito/pkg/workspace/estimator"
 	"github.com/kaito-project/kaito/presets/workspace/models"
 )
 
@@ -39,53 +37,57 @@ func (e *BasicNodesEstimator) Name() string {
 	return "basic"
 }
 
-func (e *BasicNodesEstimator) EstimateNodeCount(ctx context.Context, wObj *kaitov1beta1.Workspace, client client.Client) (int32, error) {
-	// If inference is not configured, default to resource count or 1
-	if wObj.Inference == nil || wObj.Inference.Preset == nil || wObj.Inference.Preset.Name == "" {
-		//nolint:staticcheck //SA1019: deprecate Resource.Count field
-		if wObj.Resource.Count != nil {
-			//nolint:staticcheck //SA1019: deprecate Resource.Count field
-			return int32(*wObj.Resource.Count), nil
+func (e *BasicNodesEstimator) EstimateNodeCount(ctx context.Context, req estimator.NodeEstimateRequest, c client.Client) (int32, error) {
+	// If no preset is configured, default to the requested node count or 1.
+	if req.ModelProfile.Name == "" {
+		if req.ResourceProfile.RequestedNodeCount > 0 {
+			return int32(req.ResourceProfile.RequestedNodeCount), nil
 		}
 		return 1, nil
 	}
 
-	presetName := string(wObj.Inference.Preset.Name)
-	secretName := wObj.Inference.Preset.PresetOptions.ModelAccessSecret
-	model, err := models.GetModelByName(ctx, presetName, secretName, wObj.Namespace, client)
+	model, err := models.GetModelByNameWithToken(ctx, req.ModelProfile.Name, req.ModelProfile.AccessSecret)
 	if err != nil {
 		return 0, fmt.Errorf("failed to get model by name: %w", err)
 	}
 
-	// Import featuregates and consts for NAP check
 	var gpuConfig *sku.GPUConfig
 
-	if featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] {
-		// NAP is disabled (BYO scenario) - instanceType is optional
-		// Try to get GPU config from existing nodes
-		if readyNodes, err := resources.GetReadyNodes(ctx, client, wObj); err != nil {
-			return 0, fmt.Errorf("failed to list ready nodes: %w", err)
-		} else if len(readyNodes) == 0 {
-			return 0, fmt.Errorf("no ready nodes found, unable to determine GPU configuration")
-		} else {
-			gpuConfig, err = utils.GetGPUConfigFromNodeLabels(readyNodes[0])
-			if err != nil {
-				return 0, fmt.Errorf("failed to get GPU config from existing nodes: %w", err)
+	if req.ResourceProfile.DisableNodeAutoProvisioning {
+		// NAP is disabled (BYO scenario) — derive GPU config from existing ready nodes.
+		var matchLabels client.MatchingLabels
+		if req.ResourceProfile.LabelSelector != nil {
+			matchLabels = req.ResourceProfile.LabelSelector.MatchLabels
+		}
+		nodeList, listErr := resources.ListNodes(ctx, c, matchLabels)
+		if listErr != nil {
+			return 0, fmt.Errorf("failed to list ready nodes: %w", listErr)
+		}
+		var readyNodes []*corev1.Node
+		for i := range nodeList.Items {
+			if resources.NodeIsReadyAndNotDeleting(&nodeList.Items[i]) {
+				readyNodes = append(readyNodes, &nodeList.Items[i])
 			}
 		}
-	} else {
-		// NAP is enabled - instanceType is required and must be valid
-		gpuConfig, err = utils.GetGPUConfigBySKU(wObj.Resource.InstanceType)
+		if len(readyNodes) == 0 {
+			return 0, fmt.Errorf("no ready nodes found, unable to determine GPU configuration")
+		}
+		gpuConfig, err = utils.GetGPUConfigFromNodeLabels(readyNodes[0])
 		if err != nil {
-			return 0, fmt.Errorf("failed to get GPU config for instance type %s: %w", wObj.Resource.InstanceType, err)
+			return 0, fmt.Errorf("failed to get GPU config from existing nodes: %w", err)
+		}
+	} else {
+		// NAP is enabled — instanceType is required and must be valid.
+		gpuConfig, err = utils.GetGPUConfigBySKU(req.ResourceProfile.InstanceType)
+		if err != nil {
+			return 0, fmt.Errorf("failed to get GPU config for instance type %s: %w", req.ResourceProfile.InstanceType, err)
 		}
 	}
 
-	// Start with the user-requested node count (default is 1)
-	//nolint:staticcheck //SA1019: deprecate Resource.Count field
-	nodeCountPerReplica := lo.FromPtr(wObj.Resource.Count)
+	// Start with the user-requested node count.
+	nodeCountPerReplica := req.ResourceProfile.RequestedNodeCount
 
-	// If GPU memory information is available, calculate the optimal node count
+	// If GPU memory information is available, calculate the optimal node count.
 	if !gpuConfig.GPUMem.IsZero() && gpuConfig.GPUCount > 0 {
 		totalGPUMemoryRequired := resource.MustParse(model.GetInferenceParameters().TotalSafeTensorFileSize)
 		totalGPUMemoryPerNodeBytes := gpuConfig.GPUMem.Value()

--- a/pkg/workspace/estimator/basicnodesestimator/estimator_test.go
+++ b/pkg/workspace/estimator/basicnodesestimator/estimator_test.go
@@ -30,7 +30,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/utils/test"
-	estimatorpkg "github.com/kaito-project/kaito/pkg/workspace/estimator"
+	workspaceutil "github.com/kaito-project/kaito/pkg/utils/workspace"
 )
 
 func init() {
@@ -230,7 +230,7 @@ func TestBasicNodesEstimator_EstimateNodeCount(t *testing.T) {
 				featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] = originalValue
 			}()
 
-			req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, nil)
+			req, reqErr := workspaceutil.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, nil)
 			require.NoError(t, reqErr)
 			count, err := estimator.EstimateNodeCount(ctx, req, nil)
 
@@ -283,7 +283,7 @@ func TestBasicNodesEstimator_EstimateNodeCount_GPUMemoryCalculation(t *testing.T
 			},
 		}
 
-		req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, workspace, nil)
+		req, reqErr := workspaceutil.NodeEstimateRequestFromWorkspace(ctx, workspace, nil)
 		require.NoError(t, reqErr)
 		count, err := estimator.EstimateNodeCount(ctx, req, nil)
 		require.NoError(t, err)
@@ -483,7 +483,7 @@ func TestBasicNodesEstimator_EstimateNodeCount_BYO(t *testing.T) {
 				tt.setupMocks(mockClient)
 			}
 
-			req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, mockClient)
+			req, reqErr := workspaceutil.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, mockClient)
 			require.NoError(t, reqErr)
 			count, err := estimator.EstimateNodeCount(ctx, req, mockClient)
 
@@ -541,7 +541,7 @@ func TestBasicNodesEstimator_EstimateNodeCount_EdgeCases(t *testing.T) {
 			},
 		}
 
-		req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, workspace, nil)
+		req, reqErr := workspaceutil.NodeEstimateRequestFromWorkspace(ctx, workspace, nil)
 		require.NoError(t, reqErr)
 		count, err := estimator.EstimateNodeCount(ctx, req, nil)
 		require.NoError(t, err)
@@ -577,7 +577,7 @@ func TestBasicNodesEstimator_EstimateNodeCount_EdgeCases(t *testing.T) {
 			},
 		}
 
-		req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, workspace, nil)
+		req, reqErr := workspaceutil.NodeEstimateRequestFromWorkspace(ctx, workspace, nil)
 		require.NoError(t, reqErr)
 		count, err := estimator.EstimateNodeCount(ctx, req, nil)
 		require.NoError(t, err)
@@ -614,7 +614,7 @@ func TestBasicNodesEstimator_EstimateNodeCount_EdgeCases(t *testing.T) {
 			},
 		}
 
-		req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, workspace, nil)
+		req, reqErr := workspaceutil.NodeEstimateRequestFromWorkspace(ctx, workspace, nil)
 		require.NoError(t, reqErr)
 		count, err := estimator.EstimateNodeCount(ctx, req, nil)
 		require.NoError(t, err)

--- a/pkg/workspace/estimator/basicnodesestimator/estimator_test.go
+++ b/pkg/workspace/estimator/basicnodesestimator/estimator_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/utils/test"
+	estimatorpkg "github.com/kaito-project/kaito/pkg/workspace/estimator"
 )
 
 func init() {
@@ -229,7 +230,9 @@ func TestBasicNodesEstimator_EstimateNodeCount(t *testing.T) {
 				featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] = originalValue
 			}()
 
-			count, err := estimator.EstimateNodeCount(ctx, tt.workspace, nil)
+			req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, nil)
+			require.NoError(t, reqErr)
+			count, err := estimator.EstimateNodeCount(ctx, req, nil)
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -280,7 +283,9 @@ func TestBasicNodesEstimator_EstimateNodeCount_GPUMemoryCalculation(t *testing.T
 			},
 		}
 
-		count, err := estimator.EstimateNodeCount(ctx, workspace, nil)
+		req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, workspace, nil)
+		require.NoError(t, reqErr)
+		count, err := estimator.EstimateNodeCount(ctx, req, nil)
 		require.NoError(t, err)
 
 		// The estimator should calculate optimal node count based on GPU memory
@@ -478,7 +483,9 @@ func TestBasicNodesEstimator_EstimateNodeCount_BYO(t *testing.T) {
 				tt.setupMocks(mockClient)
 			}
 
-			count, err := estimator.EstimateNodeCount(ctx, tt.workspace, mockClient)
+			req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, tt.workspace, mockClient)
+			require.NoError(t, reqErr)
+			count, err := estimator.EstimateNodeCount(ctx, req, mockClient)
 
 			if tt.expectedError {
 				require.Error(t, err)
@@ -534,7 +541,9 @@ func TestBasicNodesEstimator_EstimateNodeCount_EdgeCases(t *testing.T) {
 			},
 		}
 
-		count, err := estimator.EstimateNodeCount(ctx, workspace, nil)
+		req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, workspace, nil)
+		require.NoError(t, reqErr)
+		count, err := estimator.EstimateNodeCount(ctx, req, nil)
 		require.NoError(t, err)
 
 		// With the new logic, when minimumNodes < nodeCountPerReplica,
@@ -568,7 +577,9 @@ func TestBasicNodesEstimator_EstimateNodeCount_EdgeCases(t *testing.T) {
 			},
 		}
 
-		count, err := estimator.EstimateNodeCount(ctx, workspace, nil)
+		req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, workspace, nil)
+		require.NoError(t, reqErr)
+		count, err := estimator.EstimateNodeCount(ctx, req, nil)
 		require.NoError(t, err)
 
 		// The function should update nodeCountPerReplica to minimumNodes when minimumNodes < nodeCountPerReplica,
@@ -603,7 +614,9 @@ func TestBasicNodesEstimator_EstimateNodeCount_EdgeCases(t *testing.T) {
 			},
 		}
 
-		count, err := estimator.EstimateNodeCount(ctx, workspace, nil)
+		req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(ctx, workspace, nil)
+		require.NoError(t, reqErr)
+		count, err := estimator.EstimateNodeCount(ctx, req, nil)
 		require.NoError(t, err)
 
 		// When a model requires more nodes than the minimum calculation suggests,

--- a/pkg/workspace/estimator/helper.go
+++ b/pkg/workspace/estimator/helper.go
@@ -1,0 +1,67 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package estimator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/featuregates"
+	"github.com/kaito-project/kaito/pkg/utils/consts"
+	"github.com/kaito-project/kaito/presets/workspace/models"
+)
+
+// NodeEstimateRequestFromWorkspace builds a NodeEstimateRequest from a Workspace object.
+// It fetches the HuggingFace access token from Kubernetes when ModelAccessSecret is set,
+// so the returned request carries the resolved token value rather than a secret reference.
+// This is a convenience helper for callers that already have a Workspace and a kube client.
+func NodeEstimateRequestFromWorkspace(ctx context.Context, w *kaitov1beta1.Workspace, kubeClient client.Client) (NodeEstimateRequest, error) {
+	req := NodeEstimateRequest{
+		WorkspaceName: w.Name,
+		ResourceProfile: ResourceProfile{
+			InstanceType:                w.Resource.InstanceType,
+			LabelSelector:               w.Resource.LabelSelector,
+			DisableNodeAutoProvisioning: featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning],
+		},
+	}
+	//nolint:staticcheck //SA1019: deprecate Resource.Count field
+	if w.Resource.Count != nil {
+		//nolint:staticcheck //SA1019: deprecate Resource.Count field
+		req.ResourceProfile.RequestedNodeCount = int(*w.Resource.Count)
+	}
+	if w.Inference != nil && w.Inference.Preset != nil {
+		name := string(w.Inference.Preset.Name)
+		token := ""
+		// Only HuggingFace models (names containing "/") require an access token for model lookup.
+		// Standard preset models use ModelAccessSecret only for runtime env-var injection,
+		// which is outside the estimator's concern.
+		if strings.Contains(name, "/") {
+			secretName := w.Inference.Preset.PresetOptions.ModelAccessSecret
+			var err error
+			token, err = models.GetHFTokenFromSecret(ctx, kubeClient, secretName, w.Namespace)
+			if err != nil {
+				return NodeEstimateRequest{}, fmt.Errorf("failed to resolve access token for model %q: %w", name, err)
+			}
+		}
+		req.ModelProfile = ModelProfile{
+			Name:         name,
+			AccessSecret: token,
+		}
+	}
+	return req, nil
+}

--- a/pkg/workspace/estimator/interfaces.go
+++ b/pkg/workspace/estimator/interfaces.go
@@ -16,16 +16,60 @@ package estimator
 import (
 	"context"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
 )
 
-// NodesEstimator is an interface for estimating the number of nodes required for a workspace.
+// RuntimeProfile carries runtime serving parameters resolved by the caller
+// before invoking the estimator.
+type RuntimeProfile struct {
+	// ContextSize is the model context window length (max-model-len).
+	// A zero value signals that the estimator should apply its built-in default.
+	ContextSize int
+}
+
+// ModelProfile identifies the model to be served.
+type ModelProfile struct {
+	// Name is the preset model name; an empty string means no preset inference.
+	Name string
+	// AccessSecret is the pre-resolved access token for gated models (e.g. a HuggingFace API token).
+	// Pass an empty string for public models that require no authentication.
+	AccessSecret string
+}
+
+// ResourceProfile describes the compute resources available for the workload.
+type ResourceProfile struct {
+	// InstanceType is the GPU SKU identifier (e.g. "Standard_NC4as_T4_v3").
+	InstanceType string
+	// RequestedNodeCount is the caller-preferred node count; 0 means unspecified.
+	RequestedNodeCount int
+	// LabelSelector is used in BYO (Bring Your Own) node scenarios to locate existing nodes.
+	LabelSelector *metav1.LabelSelector
+	// DisableNodeAutoProvisioning indicates BYO (Bring Your Own) mode: no new nodes will be
+	// provisioned and the estimator must derive GPU config from existing ready nodes.
+	DisableNodeAutoProvisioning bool
+}
+
+// NodeEstimateRequest holds all inputs needed to estimate the required node count.
+// It abstracts away Kubernetes CRD types, making the interface accessible to third-party callers
+// that do not depend on internal Kaito API types.
+type NodeEstimateRequest struct {
+	// WorkspaceName is used for logging and diagnostics.
+	WorkspaceName string
+	// ModelProfile identifies the model preset and any access credentials.
+	ModelProfile ModelProfile
+	// ResourceProfile describes the compute resources for the workload.
+	ResourceProfile ResourceProfile
+	// RuntimeProfile carries pre-resolved serving parameters (e.g. context window size).
+	RuntimeProfile RuntimeProfile
+}
+
+// NodesEstimator is an interface for estimating the number of nodes required for an inference workload.
 type NodesEstimator interface {
 	// Name returns the name of the nodes estimator.
 	Name() string
 
-	// EstimateNodeCount estimates nodes. Reads max-model-len from workspace ConfigMap if available.
-	EstimateNodeCount(ctx context.Context, workspace *kaitov1beta1.Workspace, client client.Client) (int32, error)
+	// EstimateNodeCount estimates how many nodes are needed to serve the model described by req.
+	// Reads max-model-len from the ConfigMap named by req.InferenceConfigMapName if provided.
+	EstimateNodeCount(ctx context.Context, req NodeEstimateRequest, client client.Client) (int32, error)
 }

--- a/pkg/workspace/estimator/interfaces.go
+++ b/pkg/workspace/estimator/interfaces.go
@@ -51,8 +51,6 @@ type ResourceProfile struct {
 }
 
 // NodeEstimateRequest holds all inputs needed to estimate the required node count.
-// It abstracts away Kubernetes CRD types, making the interface accessible to third-party callers
-// that do not depend on internal Kaito API types.
 type NodeEstimateRequest struct {
 	// WorkspaceName is used for logging and diagnostics.
 	WorkspaceName string
@@ -66,10 +64,12 @@ type NodeEstimateRequest struct {
 
 // NodesEstimator is an interface for estimating the number of nodes required for an inference workload.
 type NodesEstimator interface {
-	// Name returns the name of the nodes estimator.
+	// Name a human-readable identifier for this estimator implementation.
 	Name() string
 
-	// EstimateNodeCount estimates how many nodes are needed to serve the model described by req.
-	// Reads max-model-len from the ConfigMap named by req.InferenceConfigMapName if provided.
+	// EstimateNodeCount determines the minimum number of nodes required to serve the given model.
+	// It inspects the model, resource, and runtime profiles in req to compute the estimate,
+	// and may query the cluster via client to discover existing node capacity in BYO scenarios.
+	// Returns the estimated node count or an error if the estimation cannot be performed.
 	EstimateNodeCount(ctx context.Context, req NodeEstimateRequest, client client.Client) (int32, error)
 }

--- a/pkg/workspace/estimator/interfaces.go
+++ b/pkg/workspace/estimator/interfaces.go
@@ -32,9 +32,9 @@ type RuntimeProfile struct {
 type ModelProfile struct {
 	// Name is the preset model name; an empty string means no preset inference.
 	Name string
-	// AccessSecret is the pre-resolved access token for gated models (e.g. a HuggingFace API token).
+	// AccessToken is the pre-resolved access token for gated models (e.g. a HuggingFace API token).
 	// Pass an empty string for public models that require no authentication.
-	AccessSecret string
+	AccessToken string
 }
 
 // ResourceProfile describes the compute resources available for the workload.

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/generator"
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/pkg/utils/test"
-	estimatorpkg "github.com/kaito-project/kaito/pkg/workspace/estimator"
+	workspaceutil "github.com/kaito-project/kaito/pkg/utils/workspace"
 	"github.com/kaito-project/kaito/pkg/workspace/estimator/advancednodesestimator"
 	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
@@ -299,7 +299,7 @@ func TestGeneratePresetInference(t *testing.T) {
 
 			// Set the Status.Inference.TargetNodeCount for proper node count calculation
 			if workspace.Inference != nil {
-				req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(t.Context(), workspace, mockClient)
+				req, reqErr := workspaceutil.NodeEstimateRequestFromWorkspace(t.Context(), workspace, mockClient)
 				if reqErr != nil {
 					t.Errorf("%s: failed to build estimate request: %v", k, reqErr)
 					return

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -37,6 +37,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/generator"
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/pkg/utils/test"
+	estimatorpkg "github.com/kaito-project/kaito/pkg/workspace/estimator"
 	"github.com/kaito-project/kaito/pkg/workspace/estimator/advancednodesestimator"
 	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
@@ -298,7 +299,12 @@ func TestGeneratePresetInference(t *testing.T) {
 
 			// Set the Status.Inference.TargetNodeCount for proper node count calculation
 			if workspace.Inference != nil {
-				nodeCount, err := estimator.EstimateNodeCount(t.Context(), workspace, mockClient)
+				req, reqErr := estimatorpkg.NodeEstimateRequestFromWorkspace(t.Context(), workspace, mockClient)
+				if reqErr != nil {
+					t.Errorf("%s: failed to build estimate request: %v", k, reqErr)
+					return
+				}
+				nodeCount, err := estimator.EstimateNodeCount(t.Context(), req, mockClient)
 				if err != nil {
 					t.Errorf("%s: failed to estimate node count: %v", k, err)
 					return

--- a/presets/workspace/models/vllm_model.go
+++ b/presets/workspace/models/vllm_model.go
@@ -83,56 +83,70 @@ func registerModel(hfModelCardID string, param *model.PresetParam) model.Model {
 	return model
 }
 
-// GetModelByName returns a vLLM-compatible model for the given modelName.
-// It first looks up an existing registration in the KaitoModelRegister. If the
-// model is not already registered and modelName contains a "/", it attempts to
-// generate a preset for the corresponding HuggingFace model by optionally
-// retrieving an access token from the Kubernetes Secret identified by
-// secretName and secretNamespace using kubeClient and ctx.
-//
-// The returned model.Model represents the registered or newly generated model.
-// If preset generation fails, or if the modelName does not correspond to a
-// registered or generatable model, this method returns an error instead of panicking.
-// Callers should ensure that modelName is valid and handle the error accordingly.
-func GetModelByName(ctx context.Context, modelName, secretName, secretNamespace string, kubeClient client.Client) (model.Model, error) {
+// GetModelByNameWithToken returns a vLLM-compatible model for the given modelName using
+// a pre-resolved access token. Unlike GetModelByName, this function does not perform any
+// Kubernetes Secret lookups; the caller is responsible for obtaining the token beforehand.
+// Pass an empty string for token when working with public models that require no authentication.
+func GetModelByNameWithToken(ctx context.Context, modelName, token string) (model.Model, error) {
 	modelName = strings.ToLower(modelName)
-	model := plugin.KaitoModelRegister.MustGet(modelName)
-	if model != nil {
-		return model, nil
+	if m := plugin.KaitoModelRegister.MustGet(modelName); m != nil {
+		return m, nil
 	}
-
-	// if name contains "/", get model data from HuggingFace
 	if strings.Contains(modelName, "/") {
-		if builtinModelName, ok := builtinVLLMModels[modelName]; ok {
-			klog.InfoS("Using built-in VLLM model preset", "model", modelName, "builtinModelName", builtinModelName)
-			return plugin.KaitoModelRegister.MustGet(builtinModelName), nil
-		}
-
-		klog.InfoS("Generating VLLM model preset for HuggingFace model", "model", modelName, "secretName", secretName, "secretNamespace", secretNamespace)
-		token, err := GetHFTokenFromSecret(ctx, kubeClient, secretName, secretNamespace)
-		if err != nil {
-			// only log the error here since token may not be required for public models
-			klog.ErrorS(err, "failed to get huggingface token from secret", "secretName", secretName, "secretNamespace", secretNamespace)
-		}
-		param, err := generator.GeneratePreset(modelName, token)
-		if err != nil {
-			return nil, err
-		}
-		// check whether the model is in the supported model architecture list
-		if len(param.Metadata.Architectures) == 0 {
-			klog.InfoS("Model architecture not specified, assuming supported by VLLM", "model", modelName)
-			return registerModel(modelName, param), nil
-		}
-
-		for _, arch := range param.Metadata.Architectures {
-			if vLLMModelArchSet.Has(arch) {
-				return registerModel(modelName, param), nil
-			}
-		}
-
-		return nil, fmt.Errorf("unsupported model architecture for %s: %s", modelName, strings.Join(param.Metadata.Architectures, ", "))
+		return generateHuggingFaceModel(modelName, token)
 	}
 	return nil, fmt.Errorf("model is not registered: %s", modelName)
+}
+
+// GetModelByName returns a vLLM-compatible model for the given modelName.
+// It first looks up an existing registration in the KaitoModelRegister. If the
+// model is not already registered and modelName contains a "/", it fetches an
+// access token from the Kubernetes Secret identified by secretName and secretNamespace,
+// then generates a preset for the corresponding HuggingFace model.
+//
+// Prefer GetModelByNameWithToken when the token has already been resolved by the caller.
+func GetModelByName(ctx context.Context, modelName, secretName, secretNamespace string, kubeClient client.Client) (model.Model, error) {
+	modelName = strings.ToLower(modelName)
+	if m := plugin.KaitoModelRegister.MustGet(modelName); m != nil {
+		return m, nil
+	}
+	if !strings.Contains(modelName, "/") {
+		return nil, fmt.Errorf("model is not registered: %s", modelName)
+	}
+	klog.InfoS("Generating VLLM model preset for HuggingFace model", "model", modelName, "secretName", secretName, "secretNamespace", secretNamespace)
+	token, err := GetHFTokenFromSecret(ctx, kubeClient, secretName, secretNamespace)
+	if err != nil {
+		// only log the error here since token may not be required for public models
+		klog.ErrorS(err, "failed to get huggingface token from secret", "secretName", secretName, "secretNamespace", secretNamespace)
+	}
+	return generateHuggingFaceModel(modelName, token)
+}
+
+// generateHuggingFaceModel generates or retrieves a vLLM preset for modelName (which must
+// contain a "/") using the provided token.
+func generateHuggingFaceModel(modelName, token string) (model.Model, error) {
+	if builtinModelName, ok := builtinVLLMModels[modelName]; ok {
+		klog.InfoS("Using built-in VLLM model preset", "model", modelName, "builtinModelName", builtinModelName)
+		return plugin.KaitoModelRegister.MustGet(builtinModelName), nil
+	}
+
+	param, err := generator.GeneratePreset(modelName, token)
+	if err != nil {
+		return nil, err
+	}
+	// check whether the model is in the supported model architecture list
+	if len(param.Metadata.Architectures) == 0 {
+		klog.InfoS("Model architecture not specified, assuming supported by VLLM", "model", modelName)
+		return registerModel(modelName, param), nil
+	}
+
+	for _, arch := range param.Metadata.Architectures {
+		if vLLMModelArchSet.Has(arch) {
+			return registerModel(modelName, param), nil
+		}
+	}
+
+	return nil, fmt.Errorf("unsupported model architecture for %s: %s", modelName, strings.Join(param.Metadata.Architectures, ", "))
 }
 
 type vLLMCompatibleModel struct {


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Refactor the workspace estimator interfaces and implementations to allow external systems to use the estimator as a library. Key changes:

- Extract shared helper functions into estimator/helper.go
- Expand exported interfaces in estimator/interfaces.go
- Refactor advanced and basic node estimators for better encapsulation
- Update controller and preset model code to use the new interfaces


**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: