### PR TITLE
security: pin aquasecurity/trivy-action to SHA for v0.35.0

### DIFF
--- a/.github/workflows/publish-controller-gh-nightly-images.yaml
+++ b/.github/workflows/publish-controller-gh-nightly-images.yaml
@@ -79,7 +79,7 @@ jobs:
           IMG_TAG: ${{ steps.get-image-tag.outputs.img_tag }}
 
       - name: Scan ${{ matrix.image_name }}:${{ steps.get-image-tag.outputs.img_tag }}
-        uses: aquasecurity/trivy-action@e368e328979b113139d6f9068e03accaed98a518 # 0.34.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           version: 'v0.69.2'
           image-ref: ${{ steps.get-registry.outputs.registry_repository }}/${{ matrix.image_name }}:${{ steps.get-image-tag.outputs.img_tag }}

--- a/.github/workflows/publish-rag-controller-gh-image.yaml
+++ b/.github/workflows/publish-rag-controller-gh-image.yaml
@@ -126,7 +126,7 @@ jobs:
           IMG_TAG: ${{ env.IMG_TAG }}
 
       - name: Scan ${{ steps.get-registry.outputs.registry_repository }}/${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }}
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ steps.get-registry.outputs.registry_repository }}/${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }}
           format: 'table'

--- a/.github/workflows/publish-rag-service-gh-image.yaml
+++ b/.github/workflows/publish-rag-service-gh-image.yaml
@@ -105,7 +105,7 @@ jobs:
           RAGENGINE_SERVICE_IMG_TAG: ${{ env.IMG_TAG }}
 
       - name: Scan ${{ steps.get-registry.outputs.registry_repository }}/${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }}
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ steps.get-registry.outputs.registry_repository }}/${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }}
           format: 'table'

--- a/.github/workflows/publish-workspace-gh-image.yaml
+++ b/.github/workflows/publish-workspace-gh-image.yaml
@@ -126,7 +126,7 @@ jobs:
           IMG_TAG: ${{ env.IMG_TAG }}
 
       - name: Scan ${{ steps.get-registry.outputs.registry_repository }}/${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }}
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           image-ref: ${{ steps.get-registry.outputs.registry_repository }}/${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }}
           format: 'table'

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -39,7 +39,7 @@ jobs:
           make ${{ matrix.target }} ARCH=amd64 BUILD_FLAGS="${{ matrix.build_flags }}"
 
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@b6643a29fecd7f34b3597bc6acb0a98b03d33ff8 # v0.33.1
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # v0.35.0
         with:
           version: "v0.69.2"
           image-ref: ${{ matrix.image }}


### PR DESCRIPTION
## What type of PR is this?

/kind cleanup

## What this PR does / why we need it

Updates all `aquasecurity/trivy-action` references from mutable tags (`@master`, old SHAs) to SHA-pinned `v0.35.0` (`57a97c7e`) to address the [supply chain attack vulnerability](https://github.com/aquasecurity/trivy/discussions/10425).

The `aquasecurity/trivy-action` was compromised via a supply chain attack. Using mutable references like `@master` or unpinned tags is a security risk. This PR pins all references to the immutable SHA for `v0.35.0`, which is a known-safe release.

### Changes

| File | Before | After |
|------|--------|-------|
| `trivy.yaml` | `@b6643a2...` (v0.33.1) | `@57a97c7...` (v0.35.0) |
| `publish-controller-gh-nightly-images.yaml` | `@e368e32...` (0.34.1) | `@57a97c7...` (v0.35.0) |
| `publish-rag-controller-gh-image.yaml` | `@master` | `@57a97c7...` (v0.35.0) |
| `publish-workspace-gh-image.yaml` | `@master` | `@57a97c7...` (v0.35.0) |
| `publish-rag-service-gh-image.yaml` | `@master` | `@57a97c7...` (v0.35.0) |

### References
- Supply chain attack discussion: https://github.com/aquasecurity/trivy/discussions/10425
- Similar fix: https://github.com/kubernetes-csi/csi-release-tools/pull/295