### PR TITLE
fix: remove debug fmt.Println in tuning config validation

### DIFF
--- a/api/v1beta1/tuning_config_validation.go
+++ b/api/v1beta1/tuning_config_validation.go
@@ -148,7 +148,6 @@ func validateTrainingArgsViaConfigMap(cm *corev1.ConfigMap) *apis.FieldError {
 			}
 
 			// TODO: Here we perform the tuning GPU Memory Checks!
-			fmt.Println(trainingArgsRaw)
 		}
 	}
 	return nil


### PR DESCRIPTION
**Reason for Change**:
Remove a `fmt.Println(trainingArgsRaw)` debug statement accidentally left in `validateTrainingArgsViaConfigMap` that would print raw training config data to stdout on every validation call.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:

**Notes for Reviewers**:
Single line removal. The `fmt` import is retained as it is used throughout the file for error formatting.