### PR TITLE
feat: enable KV cache events on vLLM inference pods by default

### DIFF
--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/sku"
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
@@ -410,17 +409,9 @@ func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
 	// than baked into the preset image) so we don't need an image rebuild to
 	// toggle it and users can still override via --kaito-config-file. JSON is
 	// single-quoted so the value survives shell interpolation in ShellCmd.
-	//
-	// Gated on FeatureFlagEnableMultiRoleInferenceController: the only in-cluster
-	// consumer today is the GAIE / llm-d-inference-scheduler EPP that KAITO wires
-	// up through the InferenceSet / MultiRoleInference controller. When that
-	// controller is disabled, nothing subscribes to port 5557, so keep the flag
-	// off to avoid running an idle ZMQ publisher (extra thread + open socket).
 	// See https://docs.vllm.ai/en/stable/api/vllm/config/kv_events/
-	if featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] {
-		if _, ok := p.VLLM.ModelRunParams["kv-events-config"]; !ok {
-			p.VLLM.ModelRunParams["kv-events-config"] = `'{"enable_kv_cache_events":true}'`
-		}
+	if _, ok := p.VLLM.ModelRunParams["kv-events-config"]; !ok {
+		p.VLLM.ModelRunParams["kv-events-config"] = `'{"enable_kv_cache_events":true}'`
 	}
 
 	// Disable the allreduce + RMSNorm fusion pass. Since vLLM 0.22.1 this pass is

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -403,6 +403,17 @@ func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
 	}
 	p.VLLM.ModelRunParams["gpu-memory-utilization"] = "0.84"
 
+	// Enable KV cache events by default so external consumers can subscribe
+	// to BlockStored / BlockRemoved / AllBlocksCleared events over ZMQ on
+	// tcp://*:5557. Passed from the operator side (rather than baked into the
+	// preset image) so we don't need an image rebuild to toggle it and users
+	// can still override via --kaito-config-file. JSON is single-quoted so the
+	// value survives shell interpolation in ShellCmd.
+	// See https://docs.vllm.ai/en/stable/api/vllm/config/kv_events/
+	if _, ok := p.VLLM.ModelRunParams["kv-events-config"]; !ok {
+		p.VLLM.ModelRunParams["kv-events-config"] = `'{"enable_kv_cache_events":true}'`
+	}
+
 	// Disable the allreduce + RMSNorm fusion pass. Since vLLM 0.22.1 this pass is
 	// enabled by default and routes through FlashInfer's TRT-LLM MNNVL kernel, which
 	// is JIT-compiled at runtime and requires the CUDA toolkit (nvcc). The slim

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -403,9 +403,9 @@ func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
 	}
 	p.VLLM.ModelRunParams["gpu-memory-utilization"] = "0.84"
 
-	// Enable KV cache events by default so external consumers can subscribe
-	// to BlockStored / BlockRemoved / AllBlocksCleared events over ZMQ on
-	// tcp://*:5557. Passed from the operator side (rather than baked into the
+	// Enable KV cache events by default so in-cluster subscribers can consume
+	// BlockStored / BlockRemoved / AllBlocksCleared events over ZMQ on the port
+	// defined by consts.PortKVCacheEvents. Passed from the operator side (rather than baked into the
 	// preset image) so we don't need an image rebuild to toggle it and users
 	// can still override via --kaito-config-file. JSON is single-quoted so the
 	// value survives shell interpolation in ShellCmd.

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/sku"
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
@@ -405,13 +406,21 @@ func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
 
 	// Enable KV cache events by default so in-cluster subscribers can consume
 	// BlockStored / BlockRemoved / AllBlocksCleared events over ZMQ on the port
-	// defined by consts.PortKVCacheEvents. Passed from the operator side (rather than baked into the
-	// preset image) so we don't need an image rebuild to toggle it and users
-	// can still override via --kaito-config-file. JSON is single-quoted so the
-	// value survives shell interpolation in ShellCmd.
+	// defined by consts.PortKVCacheEvents. Passed from the operator side (rather
+	// than baked into the preset image) so we don't need an image rebuild to
+	// toggle it and users can still override via --kaito-config-file. JSON is
+	// single-quoted so the value survives shell interpolation in ShellCmd.
+	//
+	// Gated on FeatureFlagEnableMultiRoleInferenceController: the only in-cluster
+	// consumer today is the GAIE / llm-d-inference-scheduler EPP that KAITO wires
+	// up through the InferenceSet / MultiRoleInference controller. When that
+	// controller is disabled, nothing subscribes to port 5557, so keep the flag
+	// off to avoid running an idle ZMQ publisher (extra thread + open socket).
 	// See https://docs.vllm.ai/en/stable/api/vllm/config/kv_events/
-	if _, ok := p.VLLM.ModelRunParams["kv-events-config"]; !ok {
-		p.VLLM.ModelRunParams["kv-events-config"] = `'{"enable_kv_cache_events":true}'`
+	if featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] {
+		if _, ok := p.VLLM.ModelRunParams["kv-events-config"]; !ok {
+			p.VLLM.ModelRunParams["kv-events-config"] = `'{"enable_kv_cache_events":true}'`
+		}
 	}
 
 	// Disable the allreduce + RMSNorm fusion pass. Since vLLM 0.22.1 this pass is

--- a/pkg/model/interface_test.go
+++ b/pkg/model/interface_test.go
@@ -21,7 +21,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/sku"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
@@ -243,15 +242,6 @@ func TestGetInferenceCommandVLLMSingleNode(t *testing.T) {
 }
 
 func TestGetInferenceCommandVLLMKVCacheEventsDefault(t *testing.T) {
-	// KV cache events are only auto-injected when the MultiRoleInference /
-	// InferenceSet controller is enabled (that's what wires the EPP that
-	// actually subscribes). Pin the gate to true for these tests.
-	origMRI := featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController]
-	featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = true
-	defer func() {
-		featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = origMRI
-	}()
-
 	// Default: --kv-events-config is injected so downstream ZMQ subscribers
 	// can consume BlockStored / BlockRemoved / AllBlocksCleared events.
 	p := &PresetParam{
@@ -289,34 +279,6 @@ func TestGetInferenceCommandVLLMKVCacheEventsDefault(t *testing.T) {
 	require.Len(t, cmd2, 3)
 	assert.Contains(t, cmd2[2], `--kv-events-config='{"enable_kv_cache_events":false}'`)
 	assert.NotContains(t, cmd2[2], `"enable_kv_cache_events":true`)
-}
-
-func TestGetInferenceCommandVLLMKVCacheEventsDisabledWithoutMRI(t *testing.T) {
-	// When the MultiRoleInference controller feature gate is off, no in-cluster
-	// consumer exists (the GAIE / llm-d EPP is not wired up), so the operator
-	// must NOT inject --kv-events-config; otherwise vLLM would spawn a ZMQ
-	// publisher thread and hold an idle socket for no reason.
-	origMRI := featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController]
-	featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = false
-	defer func() {
-		featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = origMRI
-	}()
-
-	p := &PresetParam{
-		RuntimeParam: RuntimeParam{
-			VLLM: VLLMParam{
-				BaseCommand:    "vllm serve",
-				ModelRunParams: map[string]string{},
-			},
-		},
-	}
-	cmd := p.GetInferenceCommand(RuntimeContext{
-		RuntimeName: RuntimeNameVLLM,
-		SKUNumGPUs:  1,
-		NumNodes:    1,
-	})
-	require.Len(t, cmd, 3)
-	assert.NotContains(t, cmd[2], "--kv-events-config")
 }
 
 func TestGetInferenceCommandVLLMInferencePort(t *testing.T) {

--- a/pkg/model/interface_test.go
+++ b/pkg/model/interface_test.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/sku"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
@@ -242,6 +243,15 @@ func TestGetInferenceCommandVLLMSingleNode(t *testing.T) {
 }
 
 func TestGetInferenceCommandVLLMKVCacheEventsDefault(t *testing.T) {
+	// KV cache events are only auto-injected when the MultiRoleInference /
+	// InferenceSet controller is enabled (that's what wires the EPP that
+	// actually subscribes). Pin the gate to true for these tests.
+	origMRI := featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController]
+	featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = true
+	defer func() {
+		featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = origMRI
+	}()
+
 	// Default: --kv-events-config is injected so downstream ZMQ subscribers
 	// can consume BlockStored / BlockRemoved / AllBlocksCleared events.
 	p := &PresetParam{
@@ -279,6 +289,34 @@ func TestGetInferenceCommandVLLMKVCacheEventsDefault(t *testing.T) {
 	require.Len(t, cmd2, 3)
 	assert.Contains(t, cmd2[2], `--kv-events-config='{"enable_kv_cache_events":false}'`)
 	assert.NotContains(t, cmd2[2], `"enable_kv_cache_events":true`)
+}
+
+func TestGetInferenceCommandVLLMKVCacheEventsDisabledWithoutMRI(t *testing.T) {
+	// When the MultiRoleInference controller feature gate is off, no in-cluster
+	// consumer exists (the GAIE / llm-d EPP is not wired up), so the operator
+	// must NOT inject --kv-events-config; otherwise vLLM would spawn a ZMQ
+	// publisher thread and hold an idle socket for no reason.
+	origMRI := featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController]
+	featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = false
+	defer func() {
+		featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = origMRI
+	}()
+
+	p := &PresetParam{
+		RuntimeParam: RuntimeParam{
+			VLLM: VLLMParam{
+				BaseCommand:    "vllm serve",
+				ModelRunParams: map[string]string{},
+			},
+		},
+	}
+	cmd := p.GetInferenceCommand(RuntimeContext{
+		RuntimeName: RuntimeNameVLLM,
+		SKUNumGPUs:  1,
+		NumNodes:    1,
+	})
+	require.Len(t, cmd, 3)
+	assert.NotContains(t, cmd[2], "--kv-events-config")
 }
 
 func TestGetInferenceCommandVLLMInferencePort(t *testing.T) {

--- a/pkg/model/interface_test.go
+++ b/pkg/model/interface_test.go
@@ -241,6 +241,46 @@ func TestGetInferenceCommandVLLMSingleNode(t *testing.T) {
 	assert.Contains(t, cmd[2], "tensor-parallel-size=2")
 }
 
+func TestGetInferenceCommandVLLMKVCacheEventsDefault(t *testing.T) {
+	// Default: --kv-events-config is injected so downstream ZMQ subscribers
+	// can consume BlockStored / BlockRemoved / AllBlocksCleared events.
+	p := &PresetParam{
+		RuntimeParam: RuntimeParam{
+			VLLM: VLLMParam{
+				BaseCommand:    "vllm serve",
+				ModelRunParams: map[string]string{},
+			},
+		},
+	}
+	cmd := p.GetInferenceCommand(RuntimeContext{
+		RuntimeName: RuntimeNameVLLM,
+		SKUNumGPUs:  1,
+		NumNodes:    1,
+	})
+	require.Len(t, cmd, 3)
+	assert.Contains(t, cmd[2], `--kv-events-config='{"enable_kv_cache_events":true}'`)
+
+	// User override via VLLMParam.ModelRunParams must win (no rebuild required).
+	p2 := &PresetParam{
+		RuntimeParam: RuntimeParam{
+			VLLM: VLLMParam{
+				BaseCommand: "vllm serve",
+				ModelRunParams: map[string]string{
+					"kv-events-config": `'{"enable_kv_cache_events":false}'`,
+				},
+			},
+		},
+	}
+	cmd2 := p2.GetInferenceCommand(RuntimeContext{
+		RuntimeName: RuntimeNameVLLM,
+		SKUNumGPUs:  1,
+		NumNodes:    1,
+	})
+	require.Len(t, cmd2, 3)
+	assert.Contains(t, cmd2[2], `--kv-events-config='{"enable_kv_cache_events":false}'`)
+	assert.NotContains(t, cmd2[2], `"enable_kv_cache_events":true`)
+}
+
 func TestGetInferenceCommandVLLMInferencePort(t *testing.T) {
 	p := &PresetParam{
 		RuntimeParam: RuntimeParam{

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -122,6 +122,10 @@ const (
 	// PortInferenceServer is the default port for the inference server.
 	PortInferenceServer = int32(5000)
 
+	// PortKVCacheEvents is the default ZMQ port for vLLM KV cache events.
+	// See https://docs.vllm.ai/en/stable/api/vllm/config/kv_events/
+	PortKVCacheEvents = int32(5557)
+
 	// InferencePoolChartURL is the OCI registry URL for the Gateway API Inference Extension inferencepool chart.
 	InferencePoolChartURL = "oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool"
 

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -72,10 +72,14 @@ var (
 			Name:          "http",
 			ContainerPort: int32(consts.PortInferenceServer),
 		},
-		{
-			Name:          "kv-events",
-			ContainerPort: int32(consts.PortKVCacheEvents),
-		},
+	}
+
+	// vllmContainerPort is the KV cache events ZMQ port. It is only added to the
+	// pod spec for vLLM inference workspaces; other runtimes don't expose this
+	// endpoint, so advertising it there would be misleading.
+	vllmKVEventsContainerPort = corev1.ContainerPort{
+		Name:          "kv-events",
+		ContainerPort: int32(consts.PortKVCacheEvents),
 	}
 
 	// defaultLivenessProbe has no initial delay because the startup probe ensures
@@ -629,8 +633,13 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int, streamingM
 
 		mainContainerEnv := buildMainContainerEnv(runtimeName, inferenceParam, cudaHome, localModelWeightsPath)
 
+		ports := append([]corev1.ContainerPort(nil), containerPorts...)
+		if runtimeName == pkgmodel.RuntimeNameVLLM {
+			ports = append(ports, vllmKVEventsContainerPort)
+		}
+
 		setInferenceContainers(spec, ctx.Workspace.Name, commands, resourceReq,
-			volumeMounts, mainContainerEnv, readinessTimeout, vllmPort, cudaHome)
+			volumeMounts, mainContainerEnv, readinessTimeout, vllmPort, cudaHome, ports)
 
 		applyInferenceRoleEnv(ctx.Workspace.Labels, ctx.Workspace.Name, spec)
 
@@ -806,7 +815,7 @@ func buildMainContainerEnv(runtimeName pkgmodel.RuntimeName, inferenceParam *pkg
 // commands.
 func setInferenceContainers(spec *corev1.PodSpec, containerName string, commands []string,
 	resourceReq corev1.ResourceRequirements, volumeMounts []corev1.VolumeMount, env []corev1.EnvVar,
-	readinessTimeout time.Duration, vllmPort int32, cudaHome string,
+	readinessTimeout time.Duration, vllmPort int32, cudaHome string, ports []corev1.ContainerPort,
 ) {
 	spec.Containers = []corev1.Container{
 		{
@@ -814,7 +823,7 @@ func setInferenceContainers(spec *corev1.PodSpec, containerName string, commands
 			Image:          GetBaseImageName(),
 			Command:        commands,
 			Resources:      resourceReq,
-			Ports:          append([]corev1.ContainerPort(nil), containerPorts...),
+			Ports:          ports,
 			StartupProbe:   buildStartupProbe(readinessTimeout, vllmPort),
 			LivenessProbe:  buildProbeWithPort(defaultLivenessProbe, vllmPort),
 			ReadinessProbe: buildProbeWithPort(defaultReadinessProbe, vllmPort),

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -67,9 +67,16 @@ const (
 )
 
 var (
-	containerPorts = []corev1.ContainerPort{{
-		ContainerPort: int32(consts.PortInferenceServer),
-	}}
+	containerPorts = []corev1.ContainerPort{
+		{
+			Name:          "http",
+			ContainerPort: int32(consts.PortInferenceServer),
+		},
+		{
+			Name:          "kv-events",
+			ContainerPort: int32(consts.PortKVCacheEvents),
+		},
+	}
 
 	// defaultLivenessProbe has no initial delay because the startup probe ensures
 	// the model is up before liveness evaluation begins.

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -75,8 +75,11 @@ var (
 	}
 
 	// vllmKVEventsContainerPort is the KV cache events ZMQ port. It is only added
-	// to the pod spec for vLLM inference workspaces; other runtimes don't expose
-	// this endpoint, so advertising it there would be misleading.
+	// to the pod spec for vLLM inference workspaces (and only when the
+	// MultiRoleInference / InferenceSet controller is enabled, since that's what
+	// wires up the GAIE / llm-d-inference-scheduler EPP that actually subscribes
+	// to it). Other runtimes don't expose this endpoint, so advertising it there
+	// would be misleading.
 	vllmKVEventsContainerPort = corev1.ContainerPort{
 		Name:          "kv-events",
 		ContainerPort: int32(consts.PortKVCacheEvents),
@@ -634,7 +637,8 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int, streamingM
 		mainContainerEnv := buildMainContainerEnv(runtimeName, inferenceParam, cudaHome, localModelWeightsPath)
 
 		ports := append([]corev1.ContainerPort(nil), containerPorts...)
-		if runtimeName == pkgmodel.RuntimeNameVLLM {
+		if runtimeName == pkgmodel.RuntimeNameVLLM &&
+			featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] {
 			ports = append(ports, vllmKVEventsContainerPort)
 		}
 

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -75,11 +75,8 @@ var (
 	}
 
 	// vllmKVEventsContainerPort is the KV cache events ZMQ port. It is only added
-	// to the pod spec for vLLM inference workspaces (and only when the
-	// MultiRoleInference / InferenceSet controller is enabled, since that's what
-	// wires up the GAIE / llm-d-inference-scheduler EPP that actually subscribes
-	// to it). Other runtimes don't expose this endpoint, so advertising it there
-	// would be misleading.
+	// to the pod spec for vLLM inference workspaces; other runtimes don't expose
+	// this endpoint, so advertising it there would be misleading.
 	vllmKVEventsContainerPort = corev1.ContainerPort{
 		Name:          "kv-events",
 		ContainerPort: int32(consts.PortKVCacheEvents),
@@ -637,8 +634,7 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int, streamingM
 		mainContainerEnv := buildMainContainerEnv(runtimeName, inferenceParam, cudaHome, localModelWeightsPath)
 
 		ports := append([]corev1.ContainerPort(nil), containerPorts...)
-		if runtimeName == pkgmodel.RuntimeNameVLLM &&
-			featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] {
+		if runtimeName == pkgmodel.RuntimeNameVLLM {
 			ports = append(ports, vllmKVEventsContainerPort)
 		}
 

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -74,9 +74,9 @@ var (
 		},
 	}
 
-	// vllmContainerPort is the KV cache events ZMQ port. It is only added to the
-	// pod spec for vLLM inference workspaces; other runtimes don't expose this
-	// endpoint, so advertising it there would be misleading.
+	// vllmKVEventsContainerPort is the KV cache events ZMQ port. It is only added
+	// to the pod spec for vLLM inference workspaces; other runtimes don't expose
+	// this endpoint, so advertising it there would be misleading.
 	vllmKVEventsContainerPort = corev1.ContainerPort{
 		Name:          "kv-events",
 		ContainerPort: int32(consts.PortKVCacheEvents),

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -446,6 +446,7 @@ func TestGeneratePresetInference(t *testing.T) {
 			// expectation so each vLLM case doesn't need to list the flag explicitly.
 			if strings.Contains(tc.expectedCmd, "/workspace/vllm/inference_api.py") {
 				expectedParams["compilation-config.pass_config.fuse_allreduce_rms"] = "False"
+				expectedParams["kv-events-config"] = `'{"enable_kv_cache_events":true}'`
 			}
 
 			if mainCmd != expectedMaincmd {

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -323,14 +323,6 @@ func TestGeneratePresetInference(t *testing.T) {
 	}
 
 	estimator := &nodesestimator.NodeEstimator{}
-	// Pin MultiRoleInferenceController feature gate ON for these tests so the
-	// kv-events flag is injected into the vLLM command line (matches the
-	// expectedParams below).
-	origMRI := featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController]
-	featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = true
-	defer func() {
-		featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = origMRI
-	}()
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
 			t.Setenv("CLOUD_PROVIDER", consts.AzureCloudName)

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -323,6 +323,14 @@ func TestGeneratePresetInference(t *testing.T) {
 	}
 
 	estimator := &nodesestimator.NodeEstimator{}
+	// Pin MultiRoleInferenceController feature gate ON for these tests so the
+	// kv-events flag is injected into the vLLM command line (matches the
+	// expectedParams below).
+	origMRI := featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController]
+	featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = true
+	defer func() {
+		featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = origMRI
+	}()
 	for k, tc := range testcases {
 		t.Run(k, func(t *testing.T) {
 			t.Setenv("CLOUD_PROVIDER", consts.AzureCloudName)

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -76,6 +76,41 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 	// listens directly on 5000.
 	httpTargetPort := consts.PortInferenceServer
 
+	ports := []corev1.ServicePort{
+		// HTTP API Port
+		{
+			Name:       "http",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       80,
+			TargetPort: intstr.FromInt32(httpTargetPort),
+		},
+		{
+			Name:       "ray",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       6379,
+			TargetPort: intstr.FromInt32(6379),
+		},
+		{
+			Name:       "dashboard",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       8265,
+			TargetPort: intstr.FromInt32(8265),
+		},
+	}
+
+	// KV cache events ZMQ stream is unauthenticated/unencrypted. Only expose it on
+	// in-cluster (ClusterIP) Services; skip when the workspace opts into a
+	// LoadBalancer Service so we don't accidentally publish it to the internet.
+	// Users who need external access should create their own Service + NetworkPolicy.
+	if serviceType == corev1.ServiceTypeClusterIP {
+		ports = append(ports, corev1.ServicePort{
+			Name:       "kv-events",
+			Protocol:   corev1.ProtocolTCP,
+			Port:       int32(consts.PortKVCacheEvents),
+			TargetPort: intstr.FromInt32(consts.PortKVCacheEvents),
+		})
+	}
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      workspaceObj.Name,
@@ -85,35 +120,8 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Type: serviceType,
-			Ports: []corev1.ServicePort{
-				// HTTP API Port
-				{
-					Name:       "http",
-					Protocol:   corev1.ProtocolTCP,
-					Port:       80,
-					TargetPort: intstr.FromInt32(httpTargetPort),
-				},
-				// KV cache events ZMQ port
-				{
-					Name:       "kv-events",
-					Protocol:   corev1.ProtocolTCP,
-					Port:       int32(consts.PortKVCacheEvents),
-					TargetPort: intstr.FromInt32(consts.PortKVCacheEvents),
-				},
-				{
-					Name:       "ray",
-					Protocol:   corev1.ProtocolTCP,
-					Port:       6379,
-					TargetPort: intstr.FromInt32(6379),
-				},
-				{
-					Name:       "dashboard",
-					Protocol:   corev1.ProtocolTCP,
-					Port:       8265,
-					TargetPort: intstr.FromInt32(8265),
-				},
-			},
+			Type:  serviceType,
+			Ports: ports,
 			Selector: selector,
 			// Added this to allow pods to discover each other
 			// (DNS Resolution) During their initialization phase

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -98,11 +98,13 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 		},
 	}
 
-	// KV cache events ZMQ stream is unauthenticated/unencrypted. Only expose it on
-	// in-cluster (ClusterIP) Services; skip when the workspace opts into a
-	// LoadBalancer Service so we don't accidentally publish it to the internet.
-	// Users who need external access should create their own Service + NetworkPolicy.
-	if serviceType == corev1.ServiceTypeClusterIP {
+	// KV cache events ZMQ stream is unauthenticated/unencrypted and is only
+	// produced by the vLLM runtime. Add the Service port only for vLLM
+	// workspaces, and only on in-cluster (ClusterIP) Services so we don't
+	// accidentally publish it to the internet on a LoadBalancer. Users who
+	// need external access should create their own Service + NetworkPolicy.
+	if serviceType == corev1.ServiceTypeClusterIP &&
+		kaitov1beta1.GetWorkspaceRuntimeName(workspaceObj) == pkgmodel.RuntimeNameVLLM {
 		ports = append(ports, corev1.ServicePort{
 			Name:       "kv-events",
 			Protocol:   corev1.ProtocolTCP,

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -120,8 +120,8 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 			},
 		},
 		Spec: corev1.ServiceSpec{
-			Type:  serviceType,
-			Ports: ports,
+			Type:     serviceType,
+			Ports:    ports,
 			Selector: selector,
 			// Added this to allow pods to discover each other
 			// (DNS Resolution) During their initialization phase

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -94,6 +94,13 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 					Port:       80,
 					TargetPort: intstr.FromInt32(httpTargetPort),
 				},
+				// KV cache events ZMQ port
+				{
+					Name:       "kv-events",
+					Protocol:   corev1.ProtocolTCP,
+					Port:       int32(consts.PortKVCacheEvents),
+					TargetPort: intstr.FromInt32(consts.PortKVCacheEvents),
+				},
 				{
 					Name:       "ray",
 					Protocol:   corev1.ProtocolTCP,

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -33,7 +33,6 @@ import (
 
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
-	"github.com/kaito-project/kaito/pkg/featuregates"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
@@ -101,16 +100,11 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 
 	// KV cache events ZMQ stream is unauthenticated/unencrypted and is only
 	// produced by the vLLM runtime. Add the Service port only for vLLM
-	// workspaces, only on in-cluster (ClusterIP) Services so we don't
-	// accidentally publish it to the internet on a LoadBalancer, and only
-	// when the MultiRoleInference / InferenceSet controller is enabled
-	// (that's what wires up the GAIE / llm-d-inference-scheduler EPP that
-	// actually subscribes to this port; without it the Service port would
-	// point at nothing). Users who need external access should create their
-	// own Service + NetworkPolicy.
+	// workspaces, and only on in-cluster (ClusterIP) Services so we don't
+	// accidentally publish it to the internet on a LoadBalancer. Users who
+	// need external access should create their own Service + NetworkPolicy.
 	if serviceType == corev1.ServiceTypeClusterIP &&
-		kaitov1beta1.GetWorkspaceRuntimeName(workspaceObj) == pkgmodel.RuntimeNameVLLM &&
-		featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] {
+		kaitov1beta1.GetWorkspaceRuntimeName(workspaceObj) == pkgmodel.RuntimeNameVLLM {
 		ports = append(ports, corev1.ServicePort{
 			Name:       "kv-events",
 			Protocol:   corev1.ProtocolTCP,

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -33,6 +33,7 @@ import (
 
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/featuregates"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
@@ -100,11 +101,16 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 
 	// KV cache events ZMQ stream is unauthenticated/unencrypted and is only
 	// produced by the vLLM runtime. Add the Service port only for vLLM
-	// workspaces, and only on in-cluster (ClusterIP) Services so we don't
-	// accidentally publish it to the internet on a LoadBalancer. Users who
-	// need external access should create their own Service + NetworkPolicy.
+	// workspaces, only on in-cluster (ClusterIP) Services so we don't
+	// accidentally publish it to the internet on a LoadBalancer, and only
+	// when the MultiRoleInference / InferenceSet controller is enabled
+	// (that's what wires up the GAIE / llm-d-inference-scheduler EPP that
+	// actually subscribes to this port; without it the Service port would
+	// point at nothing). Users who need external access should create their
+	// own Service + NetworkPolicy.
 	if serviceType == corev1.ServiceTypeClusterIP &&
-		kaitov1beta1.GetWorkspaceRuntimeName(workspaceObj) == pkgmodel.RuntimeNameVLLM {
+		kaitov1beta1.GetWorkspaceRuntimeName(workspaceObj) == pkgmodel.RuntimeNameVLLM &&
+		featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] {
 		ports = append(ports, corev1.ServicePort{
 			Name:       "kv-events",
 			Protocol:   corev1.ProtocolTCP,

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -324,3 +324,29 @@ func TestGeneratePullerContainers(t *testing.T) {
 		})
 	}
 }
+
+func TestGenerateServiceManifest_KVEventsPort(t *testing.T) {
+	ws := &kaitov1beta1.Workspace{}
+	ws.Name = "ws"
+	ws.Namespace = "kaito"
+
+	hasKVEvents := func(svc *corev1.Service) bool {
+		for _, p := range svc.Spec.Ports {
+			if p.Name == "kv-events" {
+				if p.Port != consts.PortKVCacheEvents {
+					t.Fatalf("kv-events port = %d, want %d", p.Port, consts.PortKVCacheEvents)
+				}
+				return true
+			}
+		}
+		return false
+	}
+
+	// ClusterIP: kv-events must be exposed for in-cluster consumers.
+	cip := GenerateServiceManifest(ws, corev1.ServiceTypeClusterIP)
+	assert.True(t, hasKVEvents(cip), "ClusterIP Service should expose kv-events port")
+
+	// LoadBalancer: kv-events must NOT be exposed (unauthenticated ZMQ stream).
+	lb := GenerateServiceManifest(ws, corev1.ServiceTypeLoadBalancer)
+	assert.False(t, hasKVEvents(lb), "LoadBalancer Service must not expose kv-events port")
+}

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -326,6 +326,15 @@ func TestGeneratePullerContainers(t *testing.T) {
 }
 
 func TestGenerateServiceManifest_KVEventsPort(t *testing.T) {
+	// Deterministically pin the vLLM feature gate for this test. Other packages'
+	// tests mutate featuregates.FeatureGates (sometimes flipping FeatureFlagVLLM
+	// to false or replacing the whole map) without restoring it, which would
+	// otherwise make kaitov1beta1.GetWorkspaceRuntimeName here flaky under
+	// parallel `go test` runs.
+	origVLLM := featuregates.FeatureGates[consts.FeatureFlagVLLM]
+	featuregates.FeatureGates[consts.FeatureFlagVLLM] = true
+	defer func() { featuregates.FeatureGates[consts.FeatureFlagVLLM] = origVLLM }()
+
 	newWS := func(runtime string) *kaitov1beta1.Workspace {
 		ws := &kaitov1beta1.Workspace{}
 		ws.Name = "ws"

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -326,9 +326,17 @@ func TestGeneratePullerContainers(t *testing.T) {
 }
 
 func TestGenerateServiceManifest_KVEventsPort(t *testing.T) {
-	ws := &kaitov1beta1.Workspace{}
-	ws.Name = "ws"
-	ws.Namespace = "kaito"
+	newWS := func(runtime string) *kaitov1beta1.Workspace {
+		ws := &kaitov1beta1.Workspace{}
+		ws.Name = "ws"
+		ws.Namespace = "kaito"
+		if runtime != "" {
+			ws.Annotations = map[string]string{
+				kaitov1beta1.AnnotationWorkspaceRuntime: runtime,
+			}
+		}
+		return ws
+	}
 
 	hasKVEvents := func(svc *corev1.Service) bool {
 		for _, p := range svc.Spec.Ports {
@@ -342,11 +350,17 @@ func TestGenerateServiceManifest_KVEventsPort(t *testing.T) {
 		return false
 	}
 
-	// ClusterIP: kv-events must be exposed for in-cluster consumers.
-	cip := GenerateServiceManifest(ws, corev1.ServiceTypeClusterIP)
-	assert.True(t, hasKVEvents(cip), "ClusterIP Service should expose kv-events port")
+	// vLLM + ClusterIP: kv-events must be exposed for in-cluster consumers.
+	vllm := newWS(string(pkgmodel.RuntimeNameVLLM))
+	cip := GenerateServiceManifest(vllm, corev1.ServiceTypeClusterIP)
+	assert.True(t, hasKVEvents(cip), "vLLM ClusterIP Service should expose kv-events port")
 
-	// LoadBalancer: kv-events must NOT be exposed (unauthenticated ZMQ stream).
-	lb := GenerateServiceManifest(ws, corev1.ServiceTypeLoadBalancer)
-	assert.False(t, hasKVEvents(lb), "LoadBalancer Service must not expose kv-events port")
+	// vLLM + LoadBalancer: kv-events must NOT be exposed (unauthenticated ZMQ stream).
+	lb := GenerateServiceManifest(vllm, corev1.ServiceTypeLoadBalancer)
+	assert.False(t, hasKVEvents(lb), "vLLM LoadBalancer Service must not expose kv-events port")
+
+	// Non-vLLM runtime (HuggingFace transformers) + ClusterIP: kv-events must NOT be exposed.
+	hf := newWS(string(pkgmodel.RuntimeNameHuggingfaceTransformers))
+	hfCIP := GenerateServiceManifest(hf, corev1.ServiceTypeClusterIP)
+	assert.False(t, hasKVEvents(hfCIP), "non-vLLM ClusterIP Service must not expose kv-events port")
 }

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -334,11 +334,6 @@ func TestGenerateServiceManifest_KVEventsPort(t *testing.T) {
 	origVLLM := featuregates.FeatureGates[consts.FeatureFlagVLLM]
 	featuregates.FeatureGates[consts.FeatureFlagVLLM] = true
 	defer func() { featuregates.FeatureGates[consts.FeatureFlagVLLM] = origVLLM }()
-	origMRI := featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController]
-	featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = true
-	defer func() {
-		featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = origMRI
-	}()
 
 	newWS := func(runtime string) *kaitov1beta1.Workspace {
 		ws := &kaitov1beta1.Workspace{}
@@ -377,11 +372,4 @@ func TestGenerateServiceManifest_KVEventsPort(t *testing.T) {
 	hf := newWS(string(pkgmodel.RuntimeNameHuggingfaceTransformers))
 	hfCIP := GenerateServiceManifest(hf, corev1.ServiceTypeClusterIP)
 	assert.False(t, hasKVEvents(hfCIP), "non-vLLM ClusterIP Service must not expose kv-events port")
-
-	// MRI feature gate off: kv-events must NOT be exposed even for vLLM ClusterIP,
-	// because nothing in the cluster is wired up to subscribe.
-	featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = false
-	vllmNoMRI := GenerateServiceManifest(vllm, corev1.ServiceTypeClusterIP)
-	assert.False(t, hasKVEvents(vllmNoMRI),
-		"vLLM ClusterIP Service must not expose kv-events port when MultiRoleInferenceController is disabled")
 }

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -334,6 +334,11 @@ func TestGenerateServiceManifest_KVEventsPort(t *testing.T) {
 	origVLLM := featuregates.FeatureGates[consts.FeatureFlagVLLM]
 	featuregates.FeatureGates[consts.FeatureFlagVLLM] = true
 	defer func() { featuregates.FeatureGates[consts.FeatureFlagVLLM] = origVLLM }()
+	origMRI := featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController]
+	featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = true
+	defer func() {
+		featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = origMRI
+	}()
 
 	newWS := func(runtime string) *kaitov1beta1.Workspace {
 		ws := &kaitov1beta1.Workspace{}
@@ -372,4 +377,11 @@ func TestGenerateServiceManifest_KVEventsPort(t *testing.T) {
 	hf := newWS(string(pkgmodel.RuntimeNameHuggingfaceTransformers))
 	hfCIP := GenerateServiceManifest(hf, corev1.ServiceTypeClusterIP)
 	assert.False(t, hasKVEvents(hfCIP), "non-vLLM ClusterIP Service must not expose kv-events port")
+
+	// MRI feature gate off: kv-events must NOT be exposed even for vLLM ClusterIP,
+	// because nothing in the cluster is wired up to subscribe.
+	featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = false
+	vllmNoMRI := GenerateServiceManifest(vllm, corev1.ServiceTypeClusterIP)
+	assert.False(t, hasKVEvents(vllmNoMRI),
+		"vLLM ClusterIP Service must not expose kv-events port when MultiRoleInferenceController is disabled")
 }

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -122,6 +122,10 @@ class KAITOArgumentParser(argparse.ArgumentParser):
             "gpu_memory_utilization": get_max_gpu_memory_utilization(),
             "disable_log_stats": False,
             "uvicorn_log_level": "error",
+            # Enable KV cache events by default for tracking block storage
+            # and removal. Events are published via ZMQ for external consumers.
+            # See https://docs.vllm.ai/en/stable/api/vllm/config/kv_events/
+            "kv_events_config": {"enable_kv_cache_events": True},
         }
         self.vllm_parser.set_defaults(**engine_default_args)
 

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -122,10 +122,6 @@ class KAITOArgumentParser(argparse.ArgumentParser):
             "gpu_memory_utilization": get_max_gpu_memory_utilization(),
             "disable_log_stats": False,
             "uvicorn_log_level": "error",
-            # Enable KV cache events by default for tracking block storage
-            # and removal. Events are published via ZMQ for external consumers.
-            # See https://docs.vllm.ai/en/stable/api/vllm/config/kv_events/
-            "kv_events_config": {"enable_kv_cache_events": True},
         }
         self.vllm_parser.set_defaults(**engine_default_args)
 

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -89,6 +89,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateMultiRoleInferenceEPPReady(mriObj)
 		validateMultiRoleInferenceDestinationRule(mriObj)
 		validateMultiRoleInferenceChatCompletions(mriObj)
+		validateMultiRoleInferenceKVEvents(mriObj)
 		validateMultiRoleInferencePDDisaggregation(mriObj)
 	})
 
@@ -750,6 +751,153 @@ func validateMultiRoleInferenceChatCompletions(mriObj *kaitov1alpha1.MultiRoleIn
 			return true
 		}, 5*time.Minute, utils.PollInterval).Should(BeTrue(),
 			"Failed to validate /v1/chat/completions endpoint on MRI decode pod")
+	})
+}
+
+// validateMultiRoleInferenceKVEvents validates that vLLM KV cache events are
+// correctly enabled + exposed for every child Workspace of a MultiRoleInference
+// (both prefill and decode roles).
+//
+// This is the producer half of the KV-cache-aware routing story: the
+// llm-d-inference-scheduler EPP (that KAITO's GAIE / InferenceSet path wires
+// up) subscribes to tcp://<pod>:5557. If any of these checks regress, the EPP
+// KVCache scorer silently starves.
+//
+// The whole feature is gated in the operator on
+// FeatureFlagEnableMultiRoleInferenceController, so by construction any MRI
+// workspace must satisfy all of the following:
+//
+//  1. StatefulSet pod spec has containerPort/kv-events=consts.PortKVCacheEvents.
+//  2. StatefulSet pod command contains --kv-events-config='{"enable_kv_cache_events":true}'.
+//  3. The child Workspace ClusterIP Service exposes a Service port named
+//     kv-events on consts.PortKVCacheEvents.
+//  4. vLLM logs contain the ZMQ publisher startup line, proving the process
+//     actually opened the socket (not just that the flag was passed).
+func validateMultiRoleInferenceKVEvents(mriObj *kaitov1alpha1.MultiRoleInference) {
+	By("Validating vLLM KV cache events are enabled + exposed for all MRI child workspaces", func() {
+		coreClient, err := utils.GetK8sClientset()
+		Expect(err).NotTo(HaveOccurred(), "Failed to create core client")
+
+		kvEventsFlag := `--kv-events-config='{"enable_kv_cache_events":true}'`
+		kvEventsPort := int32(consts.PortKVCacheEvents)
+
+		// Look up all child Workspaces (prefill + decode) via the MRI parent label.
+		var childWorkspaces []kaitov1beta1.Workspace
+		Eventually(func() bool {
+			wsList := &kaitov1beta1.WorkspaceList{}
+			if err := utils.TestingCluster.KubeClient.List(ctx, wsList,
+				client.InNamespace(mriObj.Namespace),
+				client.MatchingLabels{kaitov1alpha1.LabelMultiRoleInferenceParent: mriObj.Name},
+			); err != nil {
+				GinkgoWriter.Printf("Failed to list MRI child workspaces: %v\n", err)
+				return false
+			}
+			if len(wsList.Items) == 0 {
+				return false
+			}
+			childWorkspaces = wsList.Items
+			return true
+		}, 2*time.Minute, utils.PollInterval).Should(BeTrue(),
+			"Expected at least one child Workspace for MRI %s", mriObj.Name)
+
+		Expect(len(childWorkspaces)).To(BeNumerically(">=", 2),
+			"Expected prefill + decode child workspaces for MRI %s", mriObj.Name)
+
+		for i := range childWorkspaces {
+			ws := &childWorkspaces[i]
+			roleName := ws.Labels[kaitov1alpha1.LabelInferenceRole]
+			GinkgoWriter.Printf("Validating KV events for MRI child workspace %s/%s (role=%s)\n",
+				ws.Namespace, ws.Name, roleName)
+
+			// (1) + (2): StatefulSet pod spec must declare kv-events container port
+			// and the vLLM command must carry --kv-events-config.
+			Eventually(func() error {
+				sts := &appsv1.StatefulSet{}
+				if err := utils.TestingCluster.KubeClient.Get(ctx,
+					client.ObjectKey{Namespace: ws.Namespace, Name: ws.Name}, sts); err != nil {
+					return fmt.Errorf("get StatefulSet %s/%s: %w", ws.Namespace, ws.Name, err)
+				}
+				var mainContainer *corev1.Container
+				for idx := range sts.Spec.Template.Spec.Containers {
+					c := &sts.Spec.Template.Spec.Containers[idx]
+					if c.Name == ws.Name {
+						mainContainer = c
+						break
+					}
+				}
+				if mainContainer == nil {
+					return fmt.Errorf("StatefulSet %s/%s missing main container %s",
+						ws.Namespace, ws.Name, ws.Name)
+				}
+				foundPort := false
+				for _, p := range mainContainer.Ports {
+					if p.Name == "kv-events" {
+						if p.ContainerPort != kvEventsPort {
+							return fmt.Errorf("container port kv-events = %d, want %d",
+								p.ContainerPort, kvEventsPort)
+						}
+						foundPort = true
+						break
+					}
+				}
+				if !foundPort {
+					return fmt.Errorf("StatefulSet %s/%s main container missing kv-events container port",
+						ws.Namespace, ws.Name)
+				}
+				cmd := strings.Join(mainContainer.Command, " ")
+				if !strings.Contains(cmd, kvEventsFlag) {
+					return fmt.Errorf("StatefulSet %s/%s vLLM command missing %s; got: %s",
+						ws.Namespace, ws.Name, kvEventsFlag, cmd)
+				}
+				return nil
+			}, 2*time.Minute, utils.PollInterval).Should(Succeed(),
+				"MRI child workspace %s/%s must expose KV events on its pod spec",
+				ws.Namespace, ws.Name)
+
+			// (3): child Workspace ClusterIP Service must expose kv-events port.
+			Eventually(func() error {
+				svc := &corev1.Service{}
+				if err := utils.TestingCluster.KubeClient.Get(ctx,
+					client.ObjectKey{Namespace: ws.Namespace, Name: ws.Name}, svc); err != nil {
+					return fmt.Errorf("get Service %s/%s: %w", ws.Namespace, ws.Name, err)
+				}
+				if svc.Spec.Type != corev1.ServiceTypeClusterIP {
+					return fmt.Errorf("Service %s/%s is %s, expected ClusterIP",
+						ws.Namespace, ws.Name, svc.Spec.Type)
+				}
+				for _, p := range svc.Spec.Ports {
+					if p.Name == "kv-events" {
+						if p.Port != kvEventsPort {
+							return fmt.Errorf("Service %s/%s kv-events port = %d, want %d",
+								ws.Namespace, ws.Name, p.Port, kvEventsPort)
+						}
+						return nil
+					}
+				}
+				return fmt.Errorf("Service %s/%s missing kv-events port", ws.Namespace, ws.Name)
+			}, 2*time.Minute, utils.PollInterval).Should(Succeed(),
+				"MRI child workspace %s/%s Service must expose kv-events port",
+				ws.Namespace, ws.Name)
+
+			// (4): vLLM must actually have started the ZMQ publisher (log signal).
+			podName := ws.Name + "-0"
+			Eventually(func() error {
+				logs, err := utils.GetPodLogs(coreClient, ws.Namespace, podName, ws.Name)
+				if err != nil {
+					return fmt.Errorf("get logs for pod %s/%s: %w", ws.Namespace, podName, err)
+				}
+				// vLLM's kv_events.py logs "Starting ZMQ publisher thread" when the
+				// publisher actually boots. Match on the phrase to stay resilient
+				// against log-format tweaks (log level / module path).
+				if !strings.Contains(logs, "Starting ZMQ publisher thread") {
+					return fmt.Errorf("pod %s/%s logs missing 'Starting ZMQ publisher thread'",
+						ws.Namespace, podName)
+				}
+				return nil
+			}, 5*time.Minute, utils.PollInterval).Should(Succeed(),
+				"MRI child workspace %s/%s pod %s vLLM logs must show KV events ZMQ publisher startup",
+				ws.Namespace, ws.Name, podName)
+		}
 	})
 }
 


### PR DESCRIPTION
## Description

Enable vLLM's KV cache events by default and expose the ZMQ endpoint port (5557) on in-cluster Services so KV-cache-aware consumers running in the same cluster (in particular the llm-d Router / EPP that KAITO's GAIE integration wires up, but also any custom llm-d Router deployment or external cache coordinator) can subscribe.

The publisher-side cost is negligible even when nothing is subscribed (one background ZMQ thread per pod + a listening TCP socket on 5557), the socket is only reachable in-cluster (`ClusterIP` only, never on `LoadBalancer`), and users can still opt out by overriding `--kv-events-config` via `--kaito-config-file`.

### What this PR does

1. **Enable KV cache events on vLLM** — The operator injects `--kv-events-config='{"enable_kv_cache_events":true}'` into the vLLM run command (in `buildVLLMInferenceCommand`) when the workspace runtime is vLLM and the user hasn't already set `--kv-events-config` themselves. This routes through vLLM's normal `--kv-events-config` CLI parser, so users can still override it via `--kaito-config-file`. Doing it operator-side means no image rebuild is needed to toggle the feature.

2. **Advertise the ZMQ port on the vLLM pod and Service** — Add port 5557 (`kv-events`) as a container port on vLLM inference pods and expose it as a Service port so in-cluster subscribers can connect.

3. **Don't publish the ZMQ port externally** — The KV events ZMQ stream is unauthenticated / unencrypted. The Service port is only added when the Service type is `ClusterIP`; if the workspace opts into a LoadBalancer Service (`kaito.sh/enablelb: "True"`), the `kv-events` port is intentionally not added. Users who genuinely need external access should create their own Service + NetworkPolicy.

### What events are actually published

vLLM emits a single `KVEventBatch` message stream over ZMQ (defined in [`vllm/distributed/kv_events.py`](https://github.com/vllm-project/vllm/blob/main/vllm/distributed/kv_events.py)). Each batch contains one or more of the following per-block lifecycle events:

| Event | When emitted | Notable payload |
|-------|-------------|-----------------|
| `BlockStored` | A KV cache block becomes resident (prefill fills it, or a decode step allocates a new block). One event per contiguous run of newly-populated blocks. | `block_hashes[]`, `parent_block_hash`, `token_ids[]`, `block_size`, `medium` (`GPU`/`CPU`/`STORAGE`), `lora_name`, `extra_keys[]` (multimodal ids, `cache_salt`, prompt embedding hashes — required for prefix-aware routing) |
| `BlockRemoved` | A block is evicted (LRU pressure, request finish, admin flush). | `block_hashes[]`, `medium`, `group_idx` |
| `AllBlocksCleared` | Engine-level cache reset (e.g. reload/reset endpoint). | (no payload) |

Every batch carries a top-level `ts` (timestamp) and, in data-parallel deployments, a `data_parallel_rank` so consumers can attribute events to the correct DP rank. Consumers see them as `msgspec`-encoded, tagged union messages over ZMQ PUB/SUB (topic prefix optional). vLLM also opens an optional ROUTER replay endpoint so subscribers can request missed batches by starting sequence number — that endpoint is not exposed by this PR.

### What llm-d Router / EPP config is needed to actually consume them

Just wiring the vLLM producer up is not enough — the llm-d Router (formerly llm-d-inference-scheduler) EPP has to be configured with a plugin that subscribes to `tcp://<pod>:5557` and turns those events into routing signals. Concretely, the EPP's `EndpointPickerConfig` needs to enable a **KV-events-consuming producer** and a **prefix-cache scorer** that references it. The canonical setup (from the upstream [architecture doc](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/docs/architecture.md#configuration) and the [`precise-prefix-cache-producer` plugin README](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/pkg/epp/framework/plugins/requestcontrol/dataproducer/preciseprefixcache/README.md)) looks like:

```yaml
apiVersion: llm-d.ai/v1alpha1
kind: EndpointPickerConfig
plugins:
- type: precise-prefix-cache-producer            # ← this plugin owns the ZMQ subscriber lifecycle
  parameters:
    tokenProcessorConfig:
      blockSize: 16
    indexerConfig:
      kvBlockIndexConfig:
        maxPrefixBlocksToMatch: 256
    kvEventsConfig:                              # ← controls the ZMQ subscriber pool
      engineType: vllm                           # default; set to "sglang" for SGLang
- type: prefix-cache-scorer
  parameters:
    prefixMatchInfoProducerName: precise-prefix-cache-producer   # ← must reference the producer above
- type: decode-filter
- type: max-score-picker
- type: single-profile-handler
schedulingProfiles:
- name: default
  plugins:
  - pluginRef: decode-filter
  - pluginRef: max-score-picker
  - pluginRef: prefix-cache-scorer
    weight: 50
```

Key points:

- **`precise-prefix-cache-producer`** is the plugin that actually spawns a per-pod ZMQ SUB and ingests `BlockStored` / `BlockRemoved` / `AllBlocksCleared`. Its `EndpointExtractor` hook manages the subscriber lifecycle on pod add/delete against the `InferencePool`.
- The default `approx-prefix-cache-producer` (which is what the EPP auto-injects when nothing is configured) is heuristic-only and does **not** consume KV events. You have to explicitly configure `precise-prefix-cache-producer` (or another KV-events-consuming producer) for the KV events KAITO is now emitting to be used.
- **`prefix-cache-scorer`** must set `prefixMatchInfoProducerName` to the producer's name; without it the scorer falls back to the approx producer and the KV events are effectively ignored.
- The producer requires a `TokenizedPrompt` on each request, which is provided upstream by the default `token-producer` — no extra config needed for that.
- Config is passed to the EPP as `--config-file <path>` or `--config-text '<inline yaml>'`.
- The `EndpointPickerConfig` API (`apiVersion: llm-d.ai/v1alpha1`) and the `precise-prefix-cache-producer` / `prefix-cache-scorer` plugins are provided by the **llm-d-inference-scheduler EPP**, not upstream `gateway-api-inference-extension`. Upstream GAIE only ships the lightweight EPP (`lwepp`) which does not consume KV events. If you're bringing your own EPP, make sure it's the llm-d one (or another KV-events-aware fork).
- Cross-engine caveat (from the producer README): vLLM emits `extra_keys` (including `cache_salt`) in its KV events, so salted requests are routed precisely. SGLang currently does not emit `extra_keys`, so salted requests fall back to precise-cache misses until SGLang catches up.

On the KAITO side, the InferenceSet-managed `InferencePool` and the KAITO GAIE integration already point the Router at the `InferencePool` fronting the vLLM workspace pods, so once the EPP config above is applied the subscribers connect to the `kv-events` port this PR is exposing. Consumers deployed independently of the KAITO MRI controller can connect the same way — the producer side is on for every vLLM workspace, not gated on any feature flag.

### Changes

| File | Change |
|------|--------|
| `pkg/utils/consts/consts.go` | Add `PortKVCacheEvents = 5557` constant |
| `pkg/model/interface.go` | In `buildVLLMInferenceCommand`, inject `--kv-events-config='{"enable_kv_cache_events":true}'` when not already set by the user |
| `pkg/workspace/inference/preset_inferences.go` | Name the existing HTTP container port `http`; add a separate `kv-events` container port (5557) for vLLM workspaces |
| `pkg/workspace/manifests/manifests.go` | In `GenerateServiceManifest`, add the `kv-events` Service port for vLLM workspaces when the Service type is `ClusterIP` (LoadBalancer excluded to avoid publishing the unauth ZMQ stream) |

Unit tests added / updated:

- `pkg/model/interface_test.go`
  - `TestGetInferenceCommandVLLMKVCacheEventsDefault` — asserts default injection and that a user override wins.
- `pkg/workspace/manifests/manifests_test.go`
  - `TestGenerateServiceManifest_KVEventsPort` — vLLM/ClusterIP exposes the port; vLLM/LoadBalancer does not; non-vLLM/ClusterIP does not.
- `pkg/workspace/inference/preset_inferences_test.go`
  - `TestGeneratePresetInference` — asserts `expectedParams["kv-events-config"]` in the generated vLLM command.

### Why (feature value)

KV cache events provide observability into vLLM's KV cache lifecycle (`BlockStored`, `BlockRemoved`, `AllBlocksCleared`), which powers:
- KV-cache-aware routing / prefix affinity in the llm-d Router (`precise-prefix-cache-producer` + `prefix-cache-scorer`)
- Monitoring cache utilization and eviction patterns
- External cache management and coordination

The events are published via ZMQ as part of vLLM's [KVEventsConfig](https://docs.vllm.ai/en/stable/api/vllm/config/kv_events/). Only `enable_kv_cache_events` needs to be explicitly set — all other parameters (`publisher`, `endpoint`, `hwm`, etc.) use sensible defaults.

### Testing

- [x] `go test ./pkg/model/... ./pkg/workspace/manifests/... ./pkg/workspace/inference/...` passes locally
- [x] Verified `--kv-events-config` is present in the generated vLLM command for vLLM workspaces and absent for HuggingFace-transformers workspaces
- [x] Verified the ClusterIP Service exposes the `kv-events` port for vLLM workspaces and does not expose it for LoadBalancer Services or non-vLLM runtimes
- [x] End-to-end verified on a running phi-4 workspace: pod has `containerPort/kv-events=5557`, Service has `kv-events` port, vLLM log shows `Starting ZMQ publisher thread`, live ZMQ SUB receives `BlockStored`/`BlockRemoved` events — see [demo/llm/kv-events.md](https://github.com/andyzhangx/demo/blob/master/llm/kv-events.md) for the full walkthrough and consumer-side analysis (GAIE + llm-d).
