### PR TITLE
fix: use explicit delete+insert in update_documents to prevent stale FAISS entries

### DIFF
--- a/presets/ragengine/vector_store/base.py
+++ b/presets/ragengine/vector_store/base.py
@@ -615,21 +615,34 @@ class BaseVectorStore(ABC):
                 not_found_docs.append(document)
 
         try:
-            if self.use_rwlock:
-                async with self.rwlock.writer_lock:
-                    refreshed_docs = self.index_map[index_name].refresh_ref_docs(
-                        llama_docs
-                    )
-            else:
-                refreshed_docs = self.index_map[index_name].refresh_ref_docs(llama_docs)
-
             updated_docs = []
             unchanged_docs = []
-            for doc, was_updated in zip(found_docs, refreshed_docs):
-                if was_updated:
+            index = self.index_map[index_name]
+
+            for doc, llama_doc in zip(found_docs, llama_docs):
+                existing_hash = index.docstore.get_document_hash(llama_doc.id_)
+                if existing_hash is not None and existing_hash != llama_doc.hash:
+                    # Document content changed: delete old doc+nodes then re-insert.
+                    # Using explicit delete_ref_doc + insert instead of
+                    # refresh_ref_docs to ensure the vector store (e.g. FAISS)
+                    # properly removes stale node embeddings before inserting
+                    # new ones. refresh_ref_docs can leave orphaned entries in
+                    # vector stores that do not support true in-place deletion.
+                    if self.use_rwlock:
+                        async with self.rwlock.writer_lock:
+                            index.delete_ref_doc(
+                                llama_doc.id_, delete_from_docstore=True
+                            )
+                            index.insert(llama_doc)
+                    else:
+                        index.delete_ref_doc(
+                            llama_doc.id_, delete_from_docstore=True
+                        )
+                        index.insert(llama_doc)
                     updated_docs.append(doc)
                 else:
                     unchanged_docs.append(doc)
+
             return {
                 "updated_documents": updated_docs,
                 "unchanged_documents": unchanged_docs,


### PR DESCRIPTION
## Problem

The `RAGEngine Unit Tests` workflow has been failing on **all branches** (including `main`) with 2 test failures:

```
FAILED presets/ragengine/tests/api/test_main.py::test_document_update_success - assert 500 == 200
FAILED presets/ragengine/tests/vector_store/test_faiss_store.py::TestFaissVectorStore::test_update_document - fastapi.exceptions.HTTPException: 500: Chat completion failed: 'cacbefe7-731a-4371-b6f4-c7e9aef14770'
```

## Root Cause

`BaseVectorStore.update_documents()` uses `refresh_ref_docs()` to update changed documents. Internally, `refresh_ref_docs()` calls `update_ref_doc()` which does `delete_ref_doc()` + `insert()`. However, for **FAISS** (which does not support true in-place vector deletion), stale node embeddings can remain in the vector index after the delete+insert cycle.

When `chat_completion()` is called after an update, the chat engine's retriever performs a similarity search on the FAISS index and returns these **stale nodes** whose `ref_doc_id` no longer exists in the docstore → **KeyError** on the UUID → HTTP 500.

## Fix

Replace `refresh_ref_docs()` with explicit `delete_ref_doc(delete_from_docstore=True)` + `insert()` calls, iterating over each document individually. This ensures:

1. Old nodes are fully removed from **both** the docstore and the vector store
2. New nodes with fresh embeddings are properly inserted
3. No orphaned node references remain in the FAISS index

This approach is consistent with how `QdrantVectorStoreHandler.update_documents()` already handles updates (explicit delete + re-insert).

## Changes

- `presets/ragengine/vector_store/base.py`: Replace `refresh_ref_docs()` with per-document `delete_ref_doc()` + `insert()` in `update_documents()`

## Testing

Fixes the following tests that have been failing on all branches:
- `test_document_update_success` (`presets/ragengine/tests/api/test_main.py`)
- `TestFaissVectorStore::test_update_document` (`presets/ragengine/tests/vector_store/test_faiss_store.py`)

Recent CI failures showing this is a pre-existing issue on main:
- https://github.com/kaito-project/kaito/actions/runs/23697566796 (main branch)
- https://github.com/kaito-project/kaito/actions/runs/23622860143 (main branch)
- https://github.com/kaito-project/kaito/actions/runs/23726089137 (PR #1890)
