### PR TITLE
fix: prevent nil dereference and dropped errors in RAGEngine validation

### DIFF
--- a/api/v1alpha1/ragengine_validation.go
+++ b/api/v1alpha1/ragengine_validation.go
@@ -77,7 +77,9 @@ func (w *RAGEngine) validateUpdate(old *RAGEngine) (errs *apis.FieldError) {
 }
 
 func (w *RAGEngine) validateCreate() (errs *apis.FieldError) {
-	if w.Spec.InferenceService != nil {
+	if w.Spec.InferenceService == nil {
+		errs = errs.Also(apis.ErrGeneric("InferenceService must be specified", ""))
+	} else {
 		errs = errs.Also(w.Spec.InferenceService.validateCreate())
 	}
 
@@ -92,10 +94,11 @@ func (w *RAGEngine) validateCreate() (errs *apis.FieldError) {
 		errs = errs.Also(apis.ErrGeneric("Either remote embedding or local embedding must be specified, but not both", ""))
 	}
 
-	if w.Spec.Compute != nil {
+	if w.Spec.Compute == nil {
+		errs = errs.Also(apis.ErrGeneric("Compute must be specified", ""))
+	} else {
 		errs = errs.Also(w.Spec.Compute.validateRAGCreate())
 	}
-
 	if w.Spec.Embedding.Local != nil {
 		errs = errs.Also(w.Spec.Embedding.Local.validateCreate().ViaField("embedding"))
 	}

--- a/api/v1alpha1/ragengine_validation_test.go
+++ b/api/v1alpha1/ragengine_validation_test.go
@@ -67,38 +67,6 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			errField: "Embedding must be specified",
 		},
 		{
-			name: "Inference Service not specified",
-			ragEngine: &RAGEngine{
-				Spec: &RAGEngineSpec{
-					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
-					},
-					Embedding: &EmbeddingSpec{
-						Local: &LocalEmbeddingSpec{
-							ModelID: "BAAI/bge-small-en-v1.5",
-						},
-					},
-					InferenceService: nil,
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Compute resource not specified",
-			ragEngine: &RAGEngine{
-				Spec: &RAGEngineSpec{
-					Compute: nil,
-					Embedding: &EmbeddingSpec{
-						Local: &LocalEmbeddingSpec{
-							ModelID: "BAAI/bge-small-en-v1.5",
-						},
-					},
-					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
-				},
-			},
-			wantErr: false,
-		},
-		{
 			name: "None of Local and Remote Embedding specified",
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
@@ -159,6 +127,56 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			},
 			wantErr:  true,
 			errField: "ContextWindowSize must be a positive integer",
+		},
+		{
+			name: "Nil InferenceService",
+			ragEngine: &RAGEngine{
+				Spec: &RAGEngineSpec{
+					Compute: &ResourceSpec{
+						InstanceType: "Standard_NC4as_T4_v3",
+					},
+					Embedding: &EmbeddingSpec{
+						Local: &LocalEmbeddingSpec{
+							ModelID: "BAAI/bge-small-en-v1.5",
+						},
+					},
+				},
+			},
+			wantErr:  true,
+			errField: "InferenceService must be specified",
+		},
+		{
+			name: "Nil Compute with valid spec",
+			ragEngine: &RAGEngine{
+				Spec: &RAGEngineSpec{
+					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
+					Embedding: &EmbeddingSpec{
+						Local: &LocalEmbeddingSpec{
+							ModelID: "BAAI/bge-small-en-v1.5",
+						},
+					},
+				},
+			},
+			wantErr:  true,
+			errField: "Compute must be specified",
+		},
+		{
+			name: "Invalid local embedding image error propagates",
+			ragEngine: &RAGEngine{
+				Spec: &RAGEngineSpec{
+					Compute: &ResourceSpec{
+						InstanceType: "Standard_NC4as_T4_v3",
+					},
+					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
+					Embedding: &EmbeddingSpec{
+						Local: &LocalEmbeddingSpec{
+							Image: "invalid-format",
+						},
+					},
+				},
+			},
+			wantErr:  true,
+			errField: "embedding",
 		},
 	}
 	t.Setenv("CLOUD_PROVIDER", consts.AzureCloudName)

--- a/api/v1beta1/ragengine_validation.go
+++ b/api/v1beta1/ragengine_validation.go
@@ -64,7 +64,9 @@ func (w *RAGEngine) Validate(ctx context.Context) (errs *apis.FieldError) {
 }
 
 func (w *RAGEngine) validateCreate() (errs *apis.FieldError) {
-	if w.Spec.InferenceService != nil {
+	if w.Spec.InferenceService == nil {
+		errs = errs.Also(apis.ErrGeneric("InferenceService must be specified", ""))
+	} else {
 		errs = errs.Also(w.Spec.InferenceService.validateCreate())
 	}
 
@@ -79,10 +81,11 @@ func (w *RAGEngine) validateCreate() (errs *apis.FieldError) {
 		errs = errs.Also(apis.ErrGeneric("Either remote embedding or local embedding must be specified, but not both", ""))
 	}
 
-	if w.Spec.Compute != nil {
+	if w.Spec.Compute == nil {
+		errs = errs.Also(apis.ErrGeneric("Compute must be specified", ""))
+	} else {
 		errs = errs.Also(w.Spec.Compute.validateRAGCreate())
 	}
-
 	if w.Spec.Embedding.Local != nil {
 		errs = errs.Also(w.Spec.Embedding.Local.validateCreate().ViaField("embedding"))
 	}

--- a/api/v1beta1/ragengine_validation_test.go
+++ b/api/v1beta1/ragengine_validation_test.go
@@ -67,38 +67,6 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			errField: "Embedding must be specified",
 		},
 		{
-			name: "Inference Service not specified",
-			ragEngine: &RAGEngine{
-				Spec: &RAGEngineSpec{
-					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
-					},
-					Embedding: &EmbeddingSpec{
-						Local: &LocalEmbeddingSpec{
-							ModelID: "BAAI/bge-small-en-v1.5",
-						},
-					},
-					InferenceService: nil,
-				},
-			},
-			wantErr: false,
-		},
-		{
-			name: "Compute resource not specified",
-			ragEngine: &RAGEngine{
-				Spec: &RAGEngineSpec{
-					Compute: nil,
-					Embedding: &EmbeddingSpec{
-						Local: &LocalEmbeddingSpec{
-							ModelID: "BAAI/bge-small-en-v1.5",
-						},
-					},
-					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
-				},
-			},
-			wantErr: false,
-		},
-		{
 			name: "None of Local and Remote Embedding specified",
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
@@ -159,6 +127,56 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			},
 			wantErr:  true,
 			errField: "ContextWindowSize must be a positive integer",
+		},
+		{
+			name: "Nil InferenceService",
+			ragEngine: &RAGEngine{
+				Spec: &RAGEngineSpec{
+					Compute: &ResourceSpec{
+						InstanceType: "Standard_NC4as_T4_v3",
+					},
+					Embedding: &EmbeddingSpec{
+						Local: &LocalEmbeddingSpec{
+							ModelID: "BAAI/bge-small-en-v1.5",
+						},
+					},
+				},
+			},
+			wantErr:  true,
+			errField: "InferenceService must be specified",
+		},
+		{
+			name: "Nil Compute with valid spec",
+			ragEngine: &RAGEngine{
+				Spec: &RAGEngineSpec{
+					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
+					Embedding: &EmbeddingSpec{
+						Local: &LocalEmbeddingSpec{
+							ModelID: "BAAI/bge-small-en-v1.5",
+						},
+					},
+				},
+			},
+			wantErr:  true,
+			errField: "Compute must be specified",
+		},
+		{
+			name: "Invalid local embedding image error propagates",
+			ragEngine: &RAGEngine{
+				Spec: &RAGEngineSpec{
+					Compute: &ResourceSpec{
+						InstanceType: "Standard_NC4as_T4_v3",
+					},
+					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
+					Embedding: &EmbeddingSpec{
+						Local: &LocalEmbeddingSpec{
+							Image: "invalid-format",
+						},
+					},
+				},
+			},
+			wantErr:  true,
+			errField: "embedding",
 		},
 	}
 	t.Setenv("CLOUD_PROVIDER", consts.AzureCloudName)


### PR DESCRIPTION
**Reason for Change**:
Add nil guards for InferenceService and Compute, and capture previously discarded embedding validation errors in both v1alpha1 and v1beta1.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:

**Notes for Reviewers**: