### PR TITLE
fix: support non-streaming /v1/chat/completions in text-generation server

### DIFF
--- a/presets/workspace/inference/text-generation/inference_api.py
+++ b/presets/workspace/inference/text-generation/inference_api.py
@@ -339,13 +339,142 @@ def _resolve_model_name(body: dict) -> dict:
     return body
 
 
+def _maybe_return_json_response(output: Any) -> JSONResponse | None:
+    """Pass through upstream non-streaming responses when available."""
+    if isinstance(output, JSONResponse):
+        return output
+    if isinstance(output, dict):
+        return JSONResponse(output)
+    if hasattr(output, "model_dump"):
+        return JSONResponse(output.model_dump(exclude_none=True))
+    if hasattr(output, "dict"):
+        return JSONResponse(output.dict(exclude_none=True))
+    return None
+
+
+def _iter_sse_payloads(output: Any):
+    """Yield JSON payloads from the transformers SSE generator."""
+    for raw_chunk in output:
+        if raw_chunk is None:
+            continue
+        if isinstance(raw_chunk, bytes):
+            raw_chunk = raw_chunk.decode()
+
+        for line in str(raw_chunk).splitlines():
+            if not line.startswith("data:"):
+                continue
+
+            payload = line.removeprefix("data:").strip()
+            if payload == "" or payload == "[DONE]":
+                continue
+
+            try:
+                yield json.loads(payload)
+            except json.JSONDecodeError as exc:
+                raise ValueError(f"invalid SSE payload from transformers serve: {payload}") from exc
+
+
+def _merge_tool_call_delta(
+    tool_calls_by_index: dict[int, dict[str, Any]], tool_call_delta: dict[str, Any]
+):
+    """Merge streaming tool-call deltas into a final OpenAI message payload."""
+    index = tool_call_delta.get("index", 0)
+    tool_call = tool_calls_by_index.setdefault(
+        index,
+        {
+            "index": index,
+            "type": "function",
+            "function": {"name": "", "arguments": ""},
+        },
+    )
+
+    if tool_call_delta.get("id"):
+        tool_call["id"] = tool_call_delta["id"]
+    if tool_call_delta.get("type"):
+        tool_call["type"] = tool_call_delta["type"]
+
+    function_delta = tool_call_delta.get("function") or {}
+    if function_delta.get("name"):
+        tool_call["function"]["name"] = function_delta["name"]
+    if function_delta.get("arguments"):
+        tool_call["function"]["arguments"] += function_delta["arguments"]
+
+
+def _collect_chat_completion_response(output: Any, requested_model: str) -> dict[str, Any]:
+    """Aggregate SSE chat-completion chunks into a single JSON response."""
+    response = {
+        "id": None,
+        "object": "chat.completion",
+        "created": int(datetime.datetime.now().timestamp()),
+        "model": requested_model,
+    }
+    role = "assistant"
+    content_parts: list[str] = []
+    finish_reason = None
+    tool_calls_by_index: dict[int, dict[str, Any]] = {}
+
+    for payload in _iter_sse_payloads(output):
+        if response["id"] is None and payload.get("id") is not None:
+            response["id"] = payload["id"]
+        if payload.get("created") is not None:
+            response["created"] = payload["created"]
+        if payload.get("usage") is not None:
+            response["usage"] = payload["usage"]
+
+        for choice in payload.get("choices", []):
+            delta = choice.get("delta") or {}
+            if delta.get("role"):
+                role = delta["role"]
+            if delta.get("content"):
+                content_parts.append(delta["content"])
+            for tool_call_delta in delta.get("tool_calls") or []:
+                _merge_tool_call_delta(tool_calls_by_index, tool_call_delta)
+            if choice.get("finish_reason") is not None:
+                finish_reason = choice["finish_reason"]
+
+    if response["id"] is None:
+        raise ValueError("no chat completion data received from transformers serve")
+
+    message: dict[str, Any] = {"role": role}
+    content = "".join(content_parts)
+    if tool_calls_by_index:
+        ordered_tool_calls = []
+        for index in sorted(tool_calls_by_index):
+            tool_call = dict(tool_calls_by_index[index])
+            tool_call.pop("index", None)
+            ordered_tool_calls.append(tool_call)
+        message["content"] = content or None
+        message["tool_calls"] = ordered_tool_calls
+    else:
+        message["content"] = content
+
+    response["choices"] = [
+        {
+            "index": 0,
+            "message": message,
+            "finish_reason": finish_reason or ("tool_calls" if tool_calls_by_index else "stop"),
+        }
+    ]
+    return response
+
+
 @app.post("/v1/chat/completions")
 def chat_completion(body: dict):
-    """OpenAI-compatible chat completions endpoint (SSE streamed)."""
+    """OpenAI-compatible chat completions endpoint."""
+    requested_model = body.get("model", _served_model_name)
     body = _resolve_model_name(body)
     serve_command.validate_chat_completion_request(request=body)
     output = serve_command.generate_chat_completion(body)
-    return StreamingResponse(output, media_type="text/event-stream")
+    if body.get("stream", True):
+        if isinstance(output, StreamingResponse):
+            return output
+        return StreamingResponse(output, media_type="text/event-stream")
+
+    upstream_response = _maybe_return_json_response(output)
+    if upstream_response is not None:
+        return upstream_response
+
+    return JSONResponse(_collect_chat_completion_response(output, requested_model))
 
 
 @app.post("/v1/responses")

--- a/presets/workspace/inference/text-generation/tests/test_inference_api.py
+++ b/presets/workspace/inference/text-generation/tests/test_inference_api.py
@@ -70,17 +70,31 @@ def configured_app(request):
     sys.argv = original_argv
 
 
-def _make_sse_chunk(role="assistant", content="Hello", finish_reason=None):
+def _make_sse_chunk(
+    role="assistant",
+    content="Hello",
+    finish_reason=None,
+    model="HuggingFaceTB/SmolLM2-135M-Instruct",
+    tool_calls=None,
+):
     """Build a single SSE chunk string matching the transformers serve format."""
+    delta = {}
+    if role is not None:
+        delta["role"] = role
+    if content is not None:
+        delta["content"] = content
+    if tool_calls is not None:
+        delta["tool_calls"] = tool_calls
+
     chunk = {
         "id": f"chatcmpl-{uuid.uuid4().hex[:8]}",
         "object": "chat.completion.chunk",
         "created": 1700000000,
-        "model": "HuggingFaceTB/SmolLM2-135M-Instruct",
+        "model": model,
         "choices": [
             {
                 "index": 0,
-                "delta": {"role": role, "content": content},
+                "delta": delta,
                 "finish_reason": finish_reason,
             }
         ],
@@ -166,6 +180,130 @@ def test_chat_completions_multi_turn(configured_app):
                 content_pieces.append(delta["content"])
 
     assert len(content_pieces) > 0, "Expected generated content in the response"
+
+
+def test_chat_completions_stream_false_returns_json(configured_app):
+    """POST /v1/chat/completions returns a single JSON response when stream=false."""
+    fake_sse = iter(
+        [
+            _make_sse_chunk(content="Hi"),
+            _make_sse_chunk(role=None, content=" there", finish_reason="stop"),
+        ]
+    )
+
+    client = TestClient(configured_app)
+    request_data = {
+        "model": configured_app.test_config["model_path"],
+        "messages": [{"role": "user", "content": "Say hello in two words."}],
+        "max_tokens": 10,
+        "temperature": 0.0,
+        "stream": False,
+    }
+    with (
+        patch("inference_api.serve_command.validate_chat_completion_request"),
+        patch(
+            "inference_api.serve_command.generate_chat_completion",
+            return_value=fake_sse,
+        ),
+    ):
+        response = client.post("/v1/chat/completions", json=request_data)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["object"] == "chat.completion"
+    assert data["model"] == configured_app.test_config["model_path"]
+    assert data["choices"][0]["message"] == {
+        "role": "assistant",
+        "content": "Hi there",
+    }
+    assert data["choices"][0]["finish_reason"] == "stop"
+
+
+def test_chat_completions_stream_false_aggregates_tool_calls(configured_app):
+    """POST /v1/chat/completions preserves streamed tool-call deltas when stream=false."""
+    fake_sse = iter(
+        [
+            _make_sse_chunk(content=None),
+            _make_sse_chunk(
+                role=None,
+                content=None,
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {"name": "get_weather"},
+                    }
+                ],
+            ),
+            _make_sse_chunk(
+                role=None,
+                content=None,
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "type": "function",
+                        "function": {"arguments": '{"city":"'},
+                    }
+                ],
+            ),
+            _make_sse_chunk(
+                role=None,
+                content=None,
+                finish_reason="tool_calls",
+                tool_calls=[
+                    {
+                        "index": 0,
+                        "type": "function",
+                        "function": {"arguments": 'Paris"}'},
+                    }
+                ],
+            ),
+        ]
+    )
+
+    client = TestClient(configured_app)
+    request_data = {
+        "model": configured_app.test_config["model_path"],
+        "messages": [{"role": "user", "content": "What's the weather in Paris?"}],
+        "stream": False,
+        "tools": [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "description": "Get the weather for a city.",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            }
+        ],
+    }
+    with (
+        patch("inference_api.serve_command.validate_chat_completion_request"),
+        patch(
+            "inference_api.serve_command.generate_chat_completion",
+            return_value=fake_sse,
+        ),
+    ):
+        response = client.post("/v1/chat/completions", json=request_data)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["choices"][0]["finish_reason"] == "tool_calls"
+    assert data["choices"][0]["message"]["content"] is None
+    assert data["choices"][0]["message"]["tool_calls"] == [
+        {
+            "id": "call_123",
+            "type": "function",
+            "function": {
+                "name": "get_weather",
+                "arguments": '{"city":"Paris"}',
+            },
+        }
+    ]
 
 
 # ---------------------------------------------------------------------------
@@ -376,3 +514,39 @@ def test_served_model_name_in_chat_completions(local_model_app):
     ):
         response = client.post("/v1/chat/completions", json=request_data)
     assert response.status_code == 200
+
+
+def test_served_model_name_in_non_stream_chat_completions(local_model_app):
+    """POST /v1/chat/completions keeps the served model name when stream=false."""
+    fake_sse = iter(
+        [
+            _make_sse_chunk(content="Hi", model=local_model_app.test_config["model_path"]),
+            _make_sse_chunk(
+                role=None,
+                content=" there",
+                finish_reason="stop",
+                model=local_model_app.test_config["model_path"],
+            ),
+        ]
+    )
+
+    client = TestClient(local_model_app)
+    request_data = {
+        "model": "smollm2",
+        "messages": [{"role": "user", "content": "Hi"}],
+        "max_tokens": 5,
+        "stream": False,
+    }
+    with (
+        patch("inference_api.serve_command.validate_chat_completion_request"),
+        patch(
+            "inference_api.serve_command.generate_chat_completion",
+            return_value=fake_sse,
+        ),
+    ):
+        response = client.post("/v1/chat/completions", json=request_data)
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["model"] == "smollm2"
+    assert data["choices"][0]["message"]["content"] == "Hi there"


### PR DESCRIPTION
**Reason for Change**:
The text-generation wrapper always returned SSE for `/v1/chat/completions`, even when clients sent `"stream": false`.

This change keeps streaming behavior unchanged and aggregates streamed chat-completion chunks into a single OpenAI-compatible JSON response for non-streaming requests. It also preserves streamed tool-call deltas and the served-model alias in the final response.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
Fixes #1885

**Notes for Reviewers**:
1. This stays on the current `transformers` 4.x integration path instead of attempting a broader 5.x migration; the wrapper now handles `stream=false` locally and also passes through upstream JSON responses if they become available later.
2. Tests cover plain non-streaming responses, streamed tool-call delta aggregation, and served-model alias preservation.
