### PR TITLE
refactor: decouple base image build from supported_models.yaml

### DIFF
--- a/.github/actions/e2e-base-setup/action.yaml
+++ b/.github/actions/e2e-base-setup/action.yaml
@@ -196,19 +196,15 @@ runs:
         # non-existent images from remote registry, leading to test failures.
         python3 .github/determine_missing_preset_images.py | jq -c '.[]' | while read -r model; do
           export MODEL_NAME=$(echo "$model" | jq -r '.name')
+          export MODEL_VERSION_URL=$(echo "$model" | jq -r '.version')
 
-          # Push preset model weights as OCI artifact to ACR using ORAS
-          if [ "$MODEL_NAME" != "base" ]; then
-            export MODEL_VERSION_URL=$(echo "$model" | jq -r '.version')
-
-            # Use shared script to build and push OCI artifact
-            docker/presets/models/tfs/build_oci_artifact.sh \
-              "$MODEL_VERSION_URL" \
-              "kaito-$MODEL_NAME" \
-              "${{ env.REGISTRY }}" \
-              "${{ env.VERSION }}" \
-              "$HF_TOKEN"
-          fi
+          # Use shared script to build and push OCI artifact
+          docker/presets/models/tfs/build_oci_artifact.sh \
+            "$MODEL_VERSION_URL" \
+            "kaito-$MODEL_NAME" \
+            "${{ env.REGISTRY }}" \
+            "${{ env.VERSION }}" \
+            "$HF_TOKEN"
 
           # Override image properties in supported_models.yaml for testing purposes.
           # The updated supported_models.yaml will be read by the Workspace controller via
@@ -268,6 +264,10 @@ runs:
       if: ${{ inputs.skip_helm_install == 'false' }}
       shell: bash
       run: |
+        if [ "${{ inputs.build_kaito_base_image }}" == "true" ]; then
+          export PRESET_BASE_REGISTRY_NAME="${{ env.REGISTRY }}"
+          export PRESET_BASE_IMAGE_TAG="${{ env.VERSION }}"
+        fi
         make az-patch-install-helm
         kubectl wait --for=condition=available deploy "kaito-workspace" -n kaito-workspace --timeout=300s
       env:

--- a/.github/workflows/e2e-workflow.yaml
+++ b/.github/workflows/e2e-workflow.yaml
@@ -30,6 +30,10 @@ on:
         type: string
         required: false
         default: ""
+      build_kaito_base_image:
+        type: boolean
+        description: "Whether to build the kaito base image (detected from path changes)"
+        default: false
 
 jobs:
   e2e-tests:
@@ -75,9 +79,7 @@ jobs:
 
       - name: Set BUILD_KAITO_BASE_IMAGE
         run: |
-          # Check if we are missing the kaito-base image. If we are, we should run full e2e tests. Otherwise, run fast e2e tests.
-          BUILD_KAITO_BASE_IMAGE=$(python3 .github/determine_missing_preset_images.py | jq -r '.[] | select(.name == "base") | length > 0')
-          echo "BUILD_KAITO_BASE_IMAGE=${BUILD_KAITO_BASE_IMAGE}" >> $GITHUB_ENV
+          echo "BUILD_KAITO_BASE_IMAGE=${{ inputs.build_kaito_base_image }}" >> $GITHUB_ENV
 
       - name: Run e2e-base-setup composite action
         id: base-setup

--- a/.github/workflows/preset-image-build-1ES.yaml
+++ b/.github/workflows/preset-image-build-1ES.yaml
@@ -1,4 +1,4 @@
-name: Build and Push Preset Models 1ES
+name: Build and Push Preset Images
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -8,9 +8,23 @@ on:
   push:
     branches:
       - main
+      - 'release-*'
     paths:
-      - presets/workspace/models/supported_models.yaml
+      - 'presets/workspace/models/supported_models.yaml'
+      - 'presets/workspace/inference/**'
+      - 'presets/workspace/dependencies/**'
+      - 'presets/workspace/tuning/**'
+      - 'docker/presets/models/tfs/Dockerfile'
   workflow_dispatch:
+    inputs:
+      build_base_image:
+        description: 'Build the base image'
+        type: boolean
+        default: false
+      base_image_tag:
+        description: 'Base image tag (required when build_base_image is true, e.g. v0.9.0)'
+        type: string
+        required: false
 
 env:
     GO_VERSION: "1.25"
@@ -23,7 +37,139 @@ permissions:
   packages: write
 
 jobs:
+  # -------------------------------------------------------------------
+  # Detect which builds are needed based on changed files
+  # -------------------------------------------------------------------
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      build_base_image: ${{ steps.check.outputs.build_base_image }}
+      base_image_tag: ${{ steps.check.outputs.base_image_tag }}
+      build_models: ${{ steps.check.outputs.build_models }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Detect changes
+        id: check
+        run: |
+          # workflow_dispatch: use inputs directly
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "build_base_image=${{ inputs.build_base_image }}" >> $GITHUB_OUTPUT
+            echo "base_image_tag=${{ inputs.base_image_tag }}" >> $GITHUB_OUTPUT
+            # workflow_dispatch without build_base_image means build models
+            if [ "${{ inputs.build_base_image }}" != "true" ]; then
+              echo "build_models=true" >> $GITHUB_OUTPUT
+            else
+              echo "build_models=false" >> $GITHUB_OUTPUT
+            fi
+            exit 0
+          fi
+
+          # push event: check changed files
+          CHANGED_FILES=$(git diff --name-only ${{ github.event.before }}..${{ github.sha }})
+
+          BUILD_BASE=false
+          BUILD_MODELS=false
+
+          if echo "$CHANGED_FILES" | grep -qE '^(presets/workspace/(inference|dependencies|tuning)/|docker/presets/models/tfs/Dockerfile)'; then
+            BUILD_BASE=true
+          fi
+          if echo "$CHANGED_FILES" | grep -qF 'presets/workspace/models/supported_models.yaml'; then
+            BUILD_MODELS=true
+          fi
+
+          echo "build_base_image=$BUILD_BASE" >> $GITHUB_OUTPUT
+          echo "build_models=$BUILD_MODELS" >> $GITHUB_OUTPUT
+
+          # Determine base image tag
+          if [ "$BUILD_BASE" == "true" ]; then
+            if [[ "${{ github.ref }}" == "refs/heads/main" ]]; then
+              echo "base_image_tag=latest" >> $GITHUB_OUTPUT
+            elif [[ "${{ github.ref }}" == refs/heads/release-* ]]; then
+              MINOR_VERSION=$(echo "${{ github.ref_name }}" | sed 's/release-//')
+              LATEST_TAG=$(git tag --list "v${MINOR_VERSION}.*" --sort=-v:refname | head -1)
+              if [ -n "$LATEST_TAG" ]; then
+                echo "base_image_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
+              else
+                echo "base_image_tag=v${MINOR_VERSION}.0" >> $GITHUB_OUTPUT
+              fi
+            fi
+          fi
+
+          echo "build_base_image=$BUILD_BASE build_models=$BUILD_MODELS"
+
+  # -------------------------------------------------------------------
+  # Build the workspace base image (kaito-base)
+  # -------------------------------------------------------------------
+  build-base-image:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.build_base_image == 'true'
+    runs-on: ubuntu-latest
+    environment: preset-env
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
+
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Print image tag
+        run: echo "Base image tag will be ${{ needs.detect-changes.outputs.base_image_tag }}"
+
+      - name: Free disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc
+          sudo apt-get clean
+          df -h
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to ACR
+        run: |
+          echo "${{ secrets.PROD_1ES_ACR_PASSWORD }}" | docker login "${{ secrets.PROD_1ES_ACR_USERNAME }}.azurecr.io" \
+            -u "${{ secrets.PROD_1ES_ACR_USERNAME }}" --password-stdin
+
+      - name: Set up Docker Buildx
+        run: |
+          if ! docker buildx inspect img-builder &>/dev/null; then
+            docker buildx create --name=img-builder --driver=docker-container --use --bootstrap \
+              --driver-opt image=mcr.microsoft.com/oss/v2/moby/buildkit:v0.20.2
+          else
+            docker buildx use img-builder
+          fi
+
+      - name: Build and push
+        run: |
+          TAG="${{ needs.detect-changes.outputs.base_image_tag }}"
+          docker buildx build \
+            --builder img-builder \
+            --build-arg VERSION=$TAG \
+            --build-arg MODEL_TYPE=text-generation \
+            -t ghcr.io/kaito-project/kaito/kaito-base:$TAG \
+            -t ${{ secrets.PROD_1ES_ACR_USERNAME }}.azurecr.io/unlisted/aks/kaito/kaito-base:$TAG \
+            -o type=image,push=true,compression=zstd \
+            -f ./docker/presets/models/tfs/Dockerfile .
+
+  # -------------------------------------------------------------------
+  # Determine which preset model images need building
+  # -------------------------------------------------------------------
   determine-models:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.build_models == 'true'
     runs-on: ubuntu-latest
     environment: preset-env
     outputs:

--- a/.github/workflows/workspace-e2e.yaml
+++ b/.github/workflows/workspace-e2e.yaml
@@ -16,7 +16,34 @@ permissions:
   contents: read # This is required for actions/checkout
 
 jobs:
+  detect-base-image-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      build_base_image: ${{ steps.check.outputs.build_base_image }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Check for workspace base image changes
+        id: check
+        run: |
+          CHANGED=$(git diff --name-only ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} -- \
+            'presets/workspace/inference/' \
+            'presets/workspace/dependencies/' \
+            'presets/workspace/tuning/' \
+            'docker/presets/models/tfs/Dockerfile' | head -1)
+          if [ -n "$CHANGED" ]; then
+            echo "build_base_image=true" >> $GITHUB_OUTPUT
+            echo "Workspace base image related files changed, will rebuild."
+          else
+            echo "build_base_image=false" >> $GITHUB_OUTPUT
+            echo "No workspace base image related files changed."
+          fi
+
   run-e2e:
+    needs: detect-base-image-changes
     strategy:
       fail-fast: false
       matrix:
@@ -30,3 +57,4 @@ jobs:
       pull_request_number: ${{ github.event.pull_request.number }}
       git_sha: ${{ github.event.pull_request.head.sha }}
       node_provisioner: ${{ matrix.node-provisioner }}
+      build_kaito_base_image: ${{ needs.detect-base-image-changes.outputs.build_base_image == 'true' }}

--- a/Makefile
+++ b/Makefile
@@ -434,6 +434,12 @@ az-patch-install-helm: ## Install KAITO workspace Helm chart and set Azure clien
 	yq -i '(.image.repository)                                              = "$(REGISTRY)/workspace"'                    ./charts/kaito/workspace/values.yaml
 	yq -i '(.image.tag)                                                     = "$(IMG_TAG)"'                               ./charts/kaito/workspace/values.yaml
 	yq -i '(.clusterName)                                                   = "$(AZURE_CLUSTER_NAME)"'                    ./charts/kaito/workspace/values.yaml
+ifdef PRESET_BASE_REGISTRY_NAME
+	yq -i '(.presetBaseRegistryName)                                        = "$(PRESET_BASE_REGISTRY_NAME)"'             ./charts/kaito/workspace/values.yaml
+endif
+ifdef PRESET_BASE_IMAGE_TAG
+	yq -i '(.presetBaseImageTag)                                            = "$(PRESET_BASE_IMAGE_TAG)"'                 ./charts/kaito/workspace/values.yaml
+endif
 
 	helm install kaito-workspace ./charts/kaito/workspace --namespace $(KAITO_NAMESPACE) --create-namespace $(HELM_INSTALL_EXTRA_ARGS)
 

--- a/charts/kaito/workspace/templates/deployment.yaml
+++ b/charts/kaito/workspace/templates/deployment.yaml
@@ -55,6 +55,12 @@ spec:
                   fieldPath: metadata.namespace
             - name: PRESET_REGISTRY_NAME
               value: {{ .Values.presetRegistryName | quote }}
+            - name: PRESET_BASE_REGISTRY_NAME
+              value: {{ .Values.presetBaseRegistryName | quote }}
+            - name: PRESET_BASE_IMAGE_NAME
+              value: {{ .Values.presetBaseImageName | quote }}
+            - name: PRESET_BASE_IMAGE_TAG
+              value: {{ .Values.presetBaseImageTag | quote }}
             - name: CLOUD_PROVIDER
               value: {{ .Values.cloudProviderName | quote }}
             - name: CLUSTER_NAME

--- a/charts/kaito/workspace/templates/supported-models-configmap.yaml
+++ b/charts/kaito/workspace/templates/supported-models-configmap.yaml
@@ -8,10 +8,6 @@ metadata:
 data:
   SupportedModels: |
     models:
-      - name: base
-        type: text-generation
-        runtime: tfs
-        tag: 0.2.8
       - name: llama-3.1-8b-instruct
         type: text-generation
         version: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/commit/0e9e39f249a16976918f6564b8830bc894c89659

--- a/charts/kaito/workspace/values.yaml
+++ b/charts/kaito/workspace/values.yaml
@@ -62,6 +62,9 @@ webhook:
 logging:
   level: "error"
 presetRegistryName: mcr.microsoft.com/aks/kaito
+presetBaseRegistryName: "mcr.microsoft.com/aks/kaito"
+presetBaseImageName: "kaito-base"
+presetBaseImageTag: "0.2.8"
 resources:
   limits:
     cpu: 500m

--- a/docs/preset-image-building-process.md
+++ b/docs/preset-image-building-process.md
@@ -2,91 +2,115 @@
 
 This document describes how KAITO handles container image building for AI models in different scenarios.
 
-## Source of Truth: supported_models.yaml
+## Image Types
 
-The file [`presets/workspace/models/supported_models.yaml`](../presets/workspace/models/supported_models.yaml) is the single source of truth for KAITO presets. Each entry describes a preset combining:
-- name: preset identifier (e.g., phi-3-mini-4k-instruct)
-- runtime: inference runtime to use (e.g., tfs, vllm)
-- version: source of model weights (e.g., HuggingFace URL/commit)
-- tag: preset image tag to publish
-- downloadAtRuntime: whether weights are fetched at runtime (no image build needed)
+KAITO builds two types of preset images, managed independently:
 
-We use this file to detect changes that impact image builds:
-- New preset introduction: a new entry appears in the list
-- Tag bump: an existing preset’s `tag` value changes
+### 1. Base Image (`kaito-base`)
 
-These are collectively referred to as "affected" presets.
+The workspace base image contains the inference runtime (vLLM, transformers), tuning tools, and dependencies — but **no model weights**. It is built from `docker/presets/models/tfs/Dockerfile`.
 
-## Build Process
+The base image is **not** tracked in `supported_models.yaml`. Instead, its registry, name, and tag are passed to the workspace controller via environment variables set in the Helm chart:
 
-KAITO uses a multi-stage approach for building and distributing container images containing model weights and inference runtimes. The process differs between Pull Request validation and production releases to optimize resource usage and ensure quality.
+| Environment Variable | Default | Description |
+|---|---|---|
+| `PRESET_BASE_REGISTRY_NAME` | `mcr.microsoft.com/aks/kaito` | Registry for the base image |
+| `PRESET_BASE_IMAGE_NAME` | `kaito-base` | Image name |
+| `PRESET_BASE_IMAGE_TAG` | `0.2.8` | Image tag |
+
+Source files that affect the base image:
+- `presets/workspace/inference/**`
+- `presets/workspace/dependencies/**`
+- `presets/workspace/tuning/**`
+- `docker/presets/models/tfs/Dockerfile`
+
+### 2. Model Preset Images
+
+Each model preset packages model weights as an OCI artifact. These are tracked in [`presets/workspace/models/supported_models.yaml`](../presets/workspace/models/supported_models.yaml), which is the source of truth for model presets. Each entry describes:
+- `name`: preset identifier (e.g., `phi-3-mini-4k-instruct`)
+- `runtime`: inference runtime (e.g., `tfs`)
+- `version`: source of model weights (e.g., HuggingFace URL/commit)
+- `tag`: preset image tag to publish
+- `downloadAtRuntime`: whether weights are fetched at runtime (no image build needed)
+
+## Build Pipeline (Post-Merge)
+
+Both image types are built by a single unified workflow (`preset-image-build-1ES.yaml`). The workflow detects which files changed and conditionally runs the appropriate build jobs.
 
 ```mermaid
 graph TD
-  %% PR validation flow
-  A[PR Created/Updated] --> B[Set temp REGISTRY + VERSION]
-  B --> C{build_kaito_base_image?}
-  C -->|Yes| C1[Build + push base image]
-  C -->|No| D[Skip base image]
-  C1 --> E[Override base in supported_models.yaml]
-  D --> E
-  E --> F[Run determine_missing_preset_images.py]
-  F --> G{Missing presets?}
-  G -->|Yes| H[Build + push each missing preset]
-  H --> I[Override preset registry/tag in supported_models.yaml]
-  G -->|No| J[No preset builds]
-  I --> K[Run tests]
-  J --> K
+  A[Push to main / release-*] --> B[detect-changes job]
+  B --> C{Base image files changed?}
+  B --> D{supported_models.yaml changed?}
 
-  %% Official release flow
-  K --> L[PR Merged to Main]
-  L --> M[Set official REGISTRY + VERSION]
-  M --> N[Run determine_missing_preset_images.py]
-  N --> O{Any missing tags?}
-  O -->|Yes| P[Build missing images]
-  O -->|No| Q[No build needed]
-  P --> R[Push to Official Release Registry]
-  R --> S[Images available for users]
+  C -->|Yes| E[build-base-image]
+  E --> E1[Determine tag: main→latest, release-*→vX.Y.Z]
+  E1 --> E2[Build multi-arch image linux/amd64+arm64]
+  E2 --> E3[Push to GHCR + ACR]
+
+  D -->|Yes| F[determine-models]
+  F --> G[Run determine_missing_preset_images.py]
+  G --> H{Missing model images?}
+  H -->|Yes| I[build-models matrix on 1ES pool]
+  I --> I1[Build OCI artifacts]
+  I1 --> I2[Push to ACR + GHCR]
+  H -->|No| J[No build needed]
+
+  C -->|No| K[Skip base build]
+  D -->|No| L[Skip model builds]
 ```
 
-## Pull Request (PR) Workflow
+### Base Image Tag Strategy
 
-### Purpose
-- Validate inference runtime and model weights integration for changed presets
-- Test the preset image build process without affecting the official release registry
+| Branch | Tag |
+|---|---|
+| `main` | `latest` |
+| `release-X.Y` | Latest git tag matching `vX.Y.*` (e.g., `v0.9.0`) |
+| `workflow_dispatch` | User-provided tag |
 
-### Process
-1. **Trigger**: When a PR is opened or updated with changes to model configurations
-2. **Set PR-scoped variables**: Derive a temporary `REGISTRY` and `VERSION` from workflow context
-3. **Target Registry**: Temporary/testing registry (separate from the official release registry)
-4. **Optional base image build**: If `build_kaito_base_image == true`, build and push the base image, then override its `registry` and `tag` in `supported_models.yaml` for testing
-5. **Build Strategy for presets**:
-  - Run `determine_missing_preset_images.py` to list missing preset images for this PR context
-  - For each listed preset, build and push to the temporary registry
-  - Override each preset’s `registry` and `tag` in `supported_models.yaml` to point to the temporary values
-6. **Consume overrides**: CI installs the chart/components using the PR `REGISTRY` and `VERSION` so tests exercise the freshly built images
-7. **Cleanup**: Temporary images may be cleaned up after PR validation
+### Model Image Tag Checking Logic
 
-## Official Release Workflow (Post-Merge)
+Uses `determine_missing_preset_images.py` to avoid redundant builds:
 
-### Purpose
-- Build and publish official release images to the official container registry
-- Ensure efficient resource utilization by avoiding redundant builds
-
-### Process
-1. **Trigger**: When changes are merged to the main branch
-2. **Target Registry**: Official release registry (configurable via environment variables)
-3. **Build Strategy**: **Smart Tag Checking**
-  - Use `determine_missing_preset_images.py` to check existing tags in the registry
-  - **Only build images when their tags are missing** from the registry
-  - Skip models marked with `downloadAtRuntime: true`
-  - Skip models where the exact tag already exists
-
-### Tag Checking Logic
 ```python
 # For each model in supported_models.yaml:
 # 1. Check if model.downloadAtRuntime == true -> Skip
-# 2. Query the official registry for existing tags: <REGISTRY_PREFIX>kaito-{model.name}
+# 2. Query the official registry for existing tags via crane ls
 # 3. If model.tag exists in registry -> Skip build
 # 4. If model.tag missing -> Add to build matrix
 ```
+
+## Pull Request (PR) E2E Workflow
+
+### Purpose
+- Validate that code changes work with the correct base image and model presets
+- Build the base image only when its source files are modified in the PR
+- Build missing model preset images for testing
+
+### Process
+
+```mermaid
+graph TD
+  A[PR Created/Updated] --> B[detect-base-image-changes]
+  B --> C{Base image source files changed?}
+  C -->|Yes| D["build_kaito_base_image = true"]
+  C -->|No| E["build_kaito_base_image = false"]
+  D --> F[e2e-workflow]
+  E --> F
+  F --> G["Build + push base image to temp ACR (if needed)"]
+  F --> H[Build missing preset images to temp ACR]
+  G --> I[Override base image via Helm values]
+  H --> J[Override model registry/tag in supported_models.yaml]
+  I --> K[Deploy KAITO + run e2e tests]
+  J --> K
+```
+
+1. **Trigger**: PR opened/updated (paths-ignore: docs, examples, etc.)
+2. **Detect base image changes**: `workspace-e2e.yaml` uses `git diff` to check if files under `presets/workspace/inference/`, `dependencies/`, `tuning/`, or the Dockerfile changed
+3. **Pass to e2e workflow**: `build_kaito_base_image` boolean input is passed to `e2e-workflow.yaml`
+4. **Base image handling in e2e**:
+   - If `build_kaito_base_image == true`: build and push the base image to the temporary per-PR ACR, then override Helm values (`presetBaseRegistryName`, `presetBaseImageTag`) so the controller uses the freshly built image
+   - If `build_kaito_base_image == false`: use the default base image from the public registry
+5. **Model preset handling**: `determine_missing_preset_images.py` builds any missing model images to the temporary ACR, and overrides `registry`/`tag` in `supported_models.yaml` before building the workspace controller image
+6. **Full vs Fast e2e**: When the base image is rebuilt (or it's a release), the full e2e test suite runs. Otherwise, only `FastCheck` labeled tests run
+7. **Cleanup**: Temporary Azure resource groups (including ACR) are deleted after tests complete

--- a/hack/generate_vllm_arch_list.sh
+++ b/hack/generate_vllm_arch_list.sh
@@ -32,23 +32,14 @@ OUTPUT_FILE="${ROOT_DIR}/presets/workspace/models/vllm_model_arch_list.txt"
 BASE_REGISTRY="mcr.microsoft.com/aks/kaito/kaito-base"
 
 # ---------------------------------------------------------------------------
-# 1. Read the base image tag from supported_models.yaml
+# 1. Determine the base image tag
 # ---------------------------------------------------------------------------
-if ! command -v yq &>/dev/null; then
-    echo "ERROR: 'yq' is required but not found in PATH" >&2
-    exit 1
-fi
-
 if ! command -v docker &>/dev/null; then
     echo "ERROR: 'docker' is required but not found in PATH" >&2
     exit 1
 fi
 
-BASE_TAG=$(yq '.models[] | select(.name == "base") | .tag' "${SUPPORTED_MODELS_YAML}")
-if [[ -z "${BASE_TAG}" ]]; then
-    echo "ERROR: could not find 'base' model tag in ${SUPPORTED_MODELS_YAML}" >&2
-    exit 1
-fi
+BASE_TAG="${PRESET_BASE_IMAGE_TAG:-0.2.8}"
 
 IMAGE="${BASE_REGISTRY}:${BASE_TAG}"
 echo "Using base image: ${IMAGE}"

--- a/pkg/utils/common_preset.go
+++ b/pkg/utils/common_preset.go
@@ -230,3 +230,11 @@ func GetPresetImageName(registry, name, tag string) string {
 	}
 	return fmt.Sprintf("%s/kaito-%s:%s", registry, name, tag)
 }
+
+func GetEnvWithDefault(key, defaultValue string) string {
+	value := os.Getenv(key)
+	if value == "" {
+		return defaultValue
+	}
+	return value
+}

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -39,7 +39,6 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/generator"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/workspace/manifests"
-	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
 
 const (
@@ -367,8 +366,10 @@ func buildBenchmarkStartupProbe(timeout time.Duration, wObj *v1beta1.Workspace, 
 }
 
 func GetBaseImageName() string {
-	presetObj := metadata.MustGet("base")
-	return utils.GetPresetImageName(presetObj.Registry, presetObj.Name, presetObj.Tag)
+	registryName := utils.GetEnvWithDefault("PRESET_BASE_REGISTRY_NAME", "mcr.microsoft.com/aks/kaito")
+	imageName := utils.GetEnvWithDefault("PRESET_BASE_IMAGE_NAME", "kaito-base")
+	imageTag := utils.GetEnvWithDefault("PRESET_BASE_IMAGE_TAG", "0.2.8")
+	return fmt.Sprintf("%s/%s:%s", registryName, imageName, imageTag)
 }
 
 func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*generator.WorkspaceGeneratorContext, *corev1.PodSpec) error {

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -39,15 +39,16 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/test"
 	workspaceutil "github.com/kaito-project/kaito/pkg/utils/workspace"
 	"github.com/kaito-project/kaito/pkg/workspace/estimator/nodesestimator"
-	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
 
 var ValidStrength string = "0.5"
 
 func TestGeneratePresetInference(t *testing.T) {
 	test.RegisterTestModel()
-	baseImage := metadata.MustGet("base")
-	baseImageName := fmt.Sprintf("test-registry/kaito-base:%s", baseImage.Tag)
+	t.Setenv("PRESET_BASE_REGISTRY_NAME", "test-registry")
+	t.Setenv("PRESET_BASE_IMAGE_NAME", "kaito-base")
+	t.Setenv("PRESET_BASE_IMAGE_TAG", "0.2.8")
+	baseImageName := "test-registry/kaito-base:0.2.8"
 	testcases := map[string]struct {
 		workspace          *v1beta1.Workspace
 		nodeCount          int

--- a/pkg/workspace/tuning/preset_tuning.go
+++ b/pkg/workspace/tuning/preset_tuning.go
@@ -35,7 +35,6 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/workspace/image"
 	"github.com/kaito-project/kaito/pkg/workspace/manifests"
-	metadata "github.com/kaito-project/kaito/presets/workspace/models"
 )
 
 const (
@@ -83,8 +82,10 @@ func defaultTolerations() []corev1.Toleration {
 }
 
 func GetTuningImageInfo() string {
-	presetObj := metadata.MustGet("base")
-	return utils.GetPresetImageName(presetObj.Registry, presetObj.Name, presetObj.Tag)
+	registryName := utils.GetEnvWithDefault("PRESET_BASE_REGISTRY_NAME", "mcr.microsoft.com/aks/kaito")
+	imageName := utils.GetEnvWithDefault("PRESET_BASE_IMAGE_NAME", "kaito-base")
+	imageTag := utils.GetEnvWithDefault("PRESET_BASE_IMAGE_TAG", "0.2.8")
+	return fmt.Sprintf("%s/%s:%s", registryName, imageName, imageTag)
 }
 
 // PrepareOutputDir ensures the output directory is within the base directory.

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -1,32 +1,4 @@
 models:
-  # base image with no model weights
-  - name: base
-    type: text-generation
-    runtime: tfs
-    tag: 0.2.8
-    # Tag history:
-    # 0.2.8 - update benchmark_entrypoint.py to poll kv cache size for concurrency calculation and pin venv transformer to 5.3.0
-    # 0.2.7 - bump vllm to 0.17.1
-    # 0.2.6 - update benchmark_entrypoint.py: re-emit config before result, add max_concurrency output
-    # 0.2.5 - remove uv after installation to fix CVEs in uv package
-    # 0.2.4 - fix CVEs in kaito-base image
-    # 0.2.3 - add benchmark exec startup probe support
-    # 0.2.2 - bump vllm to 0.14.1
-    # 0.2.1 - fix adapter loading logs
-    # 0.2.0 - switch transformers runtime to OpenAI-compatible serve engine (transformers[serving])
-    # 0.1.2 - fix unknown severity vulnerability in kaito-base image
-    # 0.1.1 - bump ray to 2.52.1
-    # 0.1.0 - bump vLLM to 0.12.0. remove the support for vllm v0
-    # 0.0.9 - bump pip to 25.3
-    # 0.0.8 - Fix multi-node-health-check issue
-    # 0.0.7 - bump lmcache to 0.3.5
-    # 0.0.6 - bump vLLM to 0.10.1.1, transformers to 4.55.2, torch to 2.7.1, lmcache to 0.3.3, ray to 2.48.0, accelerate to 1.3.0
-    # 0.0.5 - update chat-template for new models
-    # 0.0.4 - bump vLLM to 0.9.0.
-    # 0.0.3 - add dependencies to support vLLM multi-node distributed inference
-    # 0.0.2 - bump vLLM to 0.8.5. Tool chat template added.
-    # 0.0.1 - Initial Release
-
   # Llama
   - name: llama-3.1-8b-instruct
     type: text-generation


### PR DESCRIPTION
Remove the 'base' entry from supported_models.yaml and pass base image registry/name/tag via environment variables (PRESET_BASE_REGISTRY_NAME, PRESET_BASE_IMAGE_NAME, PRESET_BASE_IMAGE_TAG) through the Helm chart, following the same pattern as the RAG engine preset image.

Merge base image and model preset build into a single unified workflow (preset-image-build-1ES.yaml) that conditionally triggers based on changed file paths. Base image builds only when inference/dependencies/ tuning code or Dockerfile changes; model builds only when supported_models.yaml changes. Tag strategy: main→latest, release→vX.Y.Z.

Update PR e2e workflow to detect base image source changes via git diff and pass build_kaito_base_image flag, avoiding unnecessary rebuilds.

**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: