### PR TITLE
fix: return tuple instead of None in _fetch_default_model_info

### DIFF
--- a/presets/ragengine/inference/inference.py
+++ b/presets/ragengine/inference/inference.py
@@ -403,7 +403,7 @@ class Inference(CustomLLM):
             logger.error(
                 f'Error fetching models from {models_url}: {e}. "model" parameter will not be included with inference call.'
             )
-            return None
+            return None, None
 
     def _get_default_model_info(self) -> (str, int):
         """

--- a/presets/ragengine/tests/inference/conftest.py
+++ b/presets/ragengine/tests/inference/conftest.py
@@ -1,0 +1,25 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"  # Force CPU-only execution for testing
+os.environ["OMP_NUM_THREADS"] = (
+    "1"  # Force single-threaded for testing to prevent segfault while loading embedding model
+)
+os.environ["MKL_NUM_THREADS"] = "1"  # Force MKL to use a single thread
+# Set LLM_INFERENCE_URL before importing ragengine modules
+os.environ["LLM_INFERENCE_URL"] = "http://localhost:5000/v1/chat/completions"

--- a/presets/ragengine/tests/inference/test_inference.py
+++ b/presets/ragengine/tests/inference/test_inference.py
@@ -1,0 +1,77 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import pytest
+
+from ragengine.inference.inference import Inference
+
+
+class MockResponse:
+    def __init__(self, json_payload, status_code=200):
+        self.json_payload = json_payload
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_payload
+
+    def raise_for_status(self):
+        if self.status_code == 200:
+            return True
+        raise Exception("Mock error")
+
+
+# _fetch_default_model_info tests
+
+def test_fetch_default_model_info_returns_tuple_on_error():
+    """Should return (None, None) tuple when models endpoint is unreachable."""
+    inference = Inference()
+    with mock.patch(
+        "ragengine.inference.inference.requests.get",
+        side_effect=Exception("connection refused"),
+    ):
+        result = inference._fetch_default_model_info()
+        expected = (None, None)
+        assert isinstance(result, tuple), f"Expected tuple, got {type(result)}"
+        assert result == expected
+
+
+def test_fetch_default_model_info_returns_tuple_on_empty_models():
+    """Should return (None, None) when models endpoint returns empty data."""
+    response = MockResponse(json_payload={"data": []})
+    inference = Inference()
+    with mock.patch(
+        "ragengine.inference.inference.requests.get",
+        return_value=response,
+    ):
+        result = inference._fetch_default_model_info()
+        expected = (None, None)
+        assert isinstance(result, tuple)
+        assert result == expected
+
+
+def test_fetch_default_model_info_returns_model_info_on_success():
+    """Should return (model_id, max_len) when models endpoint returns data."""
+    response = MockResponse(
+        json_payload={"data": [{"id": "test-model", "max_model_len": 4096}]}
+    )
+    inference = Inference()
+    with mock.patch(
+        "ragengine.inference.inference.requests.get",
+        return_value=response,
+    ):
+        result = inference._fetch_default_model_info()
+        expected = ("test-model", 4096)
+        assert isinstance(result, tuple)
+        assert result == expected


### PR DESCRIPTION
**Reason for Change**:
The except block returns `None` but the caller does tuple unpacking, causing a TypeError when the models endpoint is unreachable.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:

**Notes for Reviewers**: