### PR TITLE
chore: bump Go to 1.25.9 to fix CVE-2026-32280

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kaito-project/kaito
 
-go 1.25
+go 1.25.9
 
 require (
 	github.com/Azure/karpenter-provider-azure v1.6.3


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it
Bumps Go from 1.25 to 1.25.9 in `go.mod` and Dockerfiles to resolve **CVE-2026-32280** (unexpected work during chain building in `crypto/x509`).

### Changes
- `go.mod`: `go 1.25` → `go 1.25.9`
- `docker/workspace/Dockerfile`: golang:1.25 → golang:1.25.9
- `docker/ragengine/Dockerfile`: golang:1.25 → golang:1.25.9

## How has this been tested?
CI should pass with the updated Go version.