### PR TITLE
fix: use GetTuningParameters instead of GetInferenceParameters for tuning

### DIFF
--- a/pkg/workspace/tuning/preset_tuning.go
+++ b/pkg/workspace/tuning/preset_tuning.go
@@ -213,7 +213,7 @@ func GenerateBasicTuningPodSpec(skuNumGPUs int) func(*generator.WorkspaceGenerat
 		})
 
 		// tuning commands
-		tuningParam := ctx.Model.GetInferenceParameters().DeepCopy()
+		tuningParam := ctx.Model.GetTuningParameters().DeepCopy()
 		commands := tuningParam.GetTuningCommand(pkgmodel.RuntimeContext{
 			SKUNumGPUs: skuNumGPUs,
 		})

--- a/pkg/workspace/tuning/preset_tuning_test.go
+++ b/pkg/workspace/tuning/preset_tuning_test.go
@@ -661,3 +661,80 @@ func (m *mockModel) SupportDistributedInference() bool {
 func (m *mockModel) SupportTuning() bool {
 	return true
 }
+
+// mockModelDistinctParams returns different PresetParam values for inference vs tuning,
+// allowing tests to verify the correct method is called.
+type mockModelDistinctParams struct{}
+
+func (m *mockModelDistinctParams) GetInferenceParameters() *pkgmodel.PresetParam {
+	return &pkgmodel.PresetParam{
+		GPUCountRequirement: "1",
+		RuntimeParam: pkgmodel.RuntimeParam{
+			Transformers: pkgmodel.HuggingfaceTransformersParam{
+				BaseCommand: "inference-command-should-not-appear",
+			},
+		},
+	}
+}
+
+func (m *mockModelDistinctParams) GetTuningParameters() *pkgmodel.PresetParam {
+	return &pkgmodel.PresetParam{
+		GPUCountRequirement: "1",
+		RuntimeParam: pkgmodel.RuntimeParam{
+			Transformers: pkgmodel.HuggingfaceTransformersParam{
+				BaseCommand: "tuning-base-command",
+			},
+		},
+	}
+}
+
+func (m *mockModelDistinctParams) SupportDistributedInference() bool {
+	return false
+}
+
+func (m *mockModelDistinctParams) SupportTuning() bool {
+	return true
+}
+
+func TestGenerateBasicTuningPodSpec_UsesTuningParams(t *testing.T) {
+	workspace := &kaitov1beta1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-workspace",
+			Namespace: "default",
+		},
+		Resource: kaitov1beta1.ResourceSpec{
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"accelerator": "nvidia-gpu",
+				},
+			},
+		},
+		Tuning: &kaitov1beta1.TuningSpec{
+			Preset: &kaitov1beta1.PresetSpec{
+				PresetMeta: kaitov1beta1.PresetMeta{
+					Name: "test-model",
+				},
+			},
+		},
+	}
+
+	gctx := &generator.WorkspaceGeneratorContext{
+		Ctx:       context.Background(),
+		Workspace: workspace,
+		Model:     &mockModelDistinctParams{},
+	}
+
+	podSpec := &corev1.PodSpec{}
+
+	modifier := GenerateBasicTuningPodSpec(1)
+	err := modifier(gctx, podSpec)
+	assert.NoError(t, err)
+
+	// The container command should use tuning parameters, not inference parameters
+	assert.NotEmpty(t, podSpec.Containers, "expected at least one container")
+	cmd := strings.Join(podSpec.Containers[0].Command, " ")
+	assert.Contains(t, cmd, "tuning-base-command",
+		"expected tuning command to use GetTuningParameters().BaseCommand")
+	assert.NotContains(t, cmd, "inference-command-should-not-appear",
+		"tuning command must not use GetInferenceParameters().BaseCommand")
+}


### PR DESCRIPTION
**Reason for Change**:
`GenerateBasicTuningPodSpec` calls `GetInferenceParameters()` but passes the result to `GetTuningCommand()`.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:

**Notes for Reviewers**: