### PR TITLE
chore: bump k8s version from 1.32.9 to 1.33.8

### DIFF
--- a/.github/actions/e2e-base-setup/action.yaml
+++ b/.github/actions/e2e-base-setup/action.yaml
@@ -26,7 +26,7 @@ inputs:
   k8s_version:
     description: "Kubernetes version"
     required: false
-    default: "1.32.9"
+    default: "1.33.8"
   build_kaito_base_image:
     description: "Whether to build kaito base image"
     required: false

--- a/.github/workflows/e2e-workflow.yaml
+++ b/.github/workflows/e2e-workflow.yaml
@@ -23,7 +23,7 @@ on:
         default: "swedencentral"
       k8s_version:
         type: string
-        default: "1.32.9"
+        default: "1.33.8"
       pull_request_number:
         type: string
       ginkgo_label:

--- a/.github/workflows/ragengine-e2e-workflow.yaml
+++ b/.github/workflows/ragengine-e2e-workflow.yaml
@@ -23,7 +23,7 @@ on:
         default: "swedencentral"
       k8s_version:
         type: string
-        default: "1.32.9"
+        default: "1.33.8"
 
 jobs:
   e2e-tests:

--- a/.github/workflows/workspace-azurelinux-e2e.yaml
+++ b/.github/workflows/workspace-azurelinux-e2e.yaml
@@ -26,7 +26,7 @@ on:
       k8s_version:
         description: "AKS Kubernetes version"
         required: false
-        default: "1.32.9"
+        default: "1.33.8"
         type: string
 
 permissions:


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
Version 1.32.9 is only available in LTS.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: