### PR TITLE
proposal: add RAGEngine guardrails UX/API direction

### DIFF
--- a/docs/proposals/20260416-ragengine-guardrails-ux-api.md
+++ b/docs/proposals/20260416-ragengine-guardrails-ux-api.md
@@ -1,0 +1,121 @@
+---
+title: RAGEngine Guardrails UX and API
+authors:
+  - "@xiaoqi-7"
+reviewers:
+  - "@Fei-Guo"
+creation-date: 2026-04-16
+last-updated: 2026-04-16
+status: provisional
+see-also:
+  - "/docs/proposals/20250715-inference-aware-routing-layer.md"
+---
+
+## Summary
+
+This proposal defines the intended user-facing model for RAGEngine output guardrails.
+The goal is to keep the CRD surface minimal while allowing guardrail policy to evolve as
+we add more scanners and runtime capabilities.
+
+The proposed user model is:
+
+```yaml
+spec:
+  guardrails:
+    enabled: true
+```
+
+Detailed guardrail behavior is stored in a ConfigMap as YAML rather than modeled as
+scanner-specific fields in the `RAGEngine` CRD.
+
+## Goals
+
+- Define a small, stable UX entry point for enabling RAGEngine guardrails.
+- Keep detailed guardrail policy outside the CRD in a ConfigMap-backed YAML document.
+- Allow scanner additions and policy evolution without repeated CRD changes.
+
+## Non-Goals
+
+- Implement the full runtime behavior in this PR.
+- Expose scanner-specific configuration in the CRD.
+- Finalize streaming, auditing, or error-handling semantics in this document.
+
+## Proposed UX and API Shape
+
+### Minimal CRD Entry Point
+
+The intended user-facing switch is a minimal `guardrails.enabled` field in the
+`RAGEngine` spec.
+
+```yaml
+apiVersion: kaito.sh/v1beta1
+kind: RAGEngine
+metadata:
+  name: ragengine-with-guardrails
+spec:
+  guardrails:
+    enabled: true
+```
+
+At this stage, the proposal does not add scanner-specific CRD fields such as `action`,
+`scanners`, `patterns`, or `blockMessage`.
+
+### ConfigMap-Based YAML Policy
+
+Detailed policy is defined in YAML and delivered through a ConfigMap.
+
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ragengine-guardrails-policy
+data:
+  guardrails.yaml: |
+    action: redact
+    blockMessage: The model output was blocked by output guardrails.
+    scanners:
+      - type: regex
+        patterns:
+          - 'https?://\\S+'
+      - type: ban_substrings
+        substrings:
+          - secret
+```
+
+The exact YAML schema can evolve, but the design principle is fixed: detailed policy lives
+in ConfigMap YAML, not in the CRD.
+
+### Default ConfigMap Support
+
+Follow-up implementation may provide a default ConfigMap and default mount path so that
+guardrail policy can be enabled without introducing a broad CRD surface in the same step.
+
+## Deferred Scope
+
+This proposal defines the UX shape only. The following items are deferred to follow-up
+implementation PRs:
+
+- runtime error-handling semantics
+- YAML policy loading implementation
+- default ConfigMap wiring
+- scanner registry and additional scanners
+- audit event model
+- streaming scanning behavior
+
+## Follow-Up Implementation Plan
+
+This proposal is intended to support the following implementation sequence:
+
+1. Land the initial non-streaming output guardrails hook.
+2. Define explicit error-handling semantics.
+3. Introduce a runtime YAML policy loader.
+4. Add default ConfigMap support.
+5. Refactor scanner construction into a registry/factory structure.
+6. Add more scanners in small batches.
+7. Add audit foundations.
+8. Add minimal streaming scanning support.
+9. Polish graceful UX and operational behavior.
+
+The CRD exposure for `guardrails.enabled` can be added later if we decide the final user
+experience should include an explicit RAGEngine spec toggle rather than relying only on
+ConfigMap-based policy.

--- a/website/docs/proposals.md
+++ b/website/docs/proposals.md
@@ -2,15 +2,15 @@
 title: Proposals
 ---
 
-This section contains proposals for adding new models to KAITO. Each proposal describes the process of evaluating and integrating new OSS models into the KAITO ecosystem.
+This section contains proposals for significant KAITO features and model integrations. Some proposals describe how new OSS models are evaluated and integrated, while others define broader platform or API changes.
 
 ## Proposal Template
 
-Before creating a new model proposal, please use the following template: [Model Proposal Template](https://github.com/kaito-project/kaito/blob/main/docs/proposals/YYYYMMDD-model-template.md)
+Before creating a new proposal, use the appropriate template in [docs/proposals](https://github.com/kaito-project/kaito/tree/main/docs/proposals).
 
 ## Current Proposals
 
-Below are the current model proposals in various stages of integration:
+Below are the current proposals in various stages of integration:
 
 ### Provisional Status
 - [Llama 3.3 70B Instruct](https://github.com/kaito-project/kaito/blob/main/docs/proposals/20250529-llama-3.3-70b-instruct.md) - Meta's multilingual instruction-tuned 70B model
@@ -18,6 +18,7 @@ Below are the current model proposals in various stages of integration:
 - [Phi-4 Instruct](https://github.com/kaito-project/kaito/blob/main/docs/proposals/20241212-phi4-instruct.md) - Microsoft's latest Phi-4 instruction-tuned model
 - [Distributed Inference](https://github.com/kaito-project/kaito/blob/main/docs/proposals/20250325-distributed-inference.md) - Support for distributed inference across multiple GPUs
 - [Model as OCI Artifacts](https://github.com/kaito-project/kaito/blob/main/docs/proposals/20250609-model-as-oci-artifacts.md) - Packaging models as OCI artifacts
+- [RAGEngine Guardrails UX and API](https://github.com/kaito-project/kaito/blob/main/docs/proposals/20260416-ragengine-guardrails-ux-api.md) - Minimal enable switch plus ConfigMap-based YAML policy for RAGEngine guardrails
 
 ### Integrated Status
 - [Mistral Instruct](https://github.com/kaito-project/kaito/blob/main/docs/proposals/20240205-mistral-instruct.md) - Mistral AI's instruction-tuned model


### PR DESCRIPTION
## Summary

This PR defines the intended UX/API direction for RAGEngine output guardrails.

The proposed user model is:

- `spec.guardrails.enabled` as the minimal user-facing switch
- detailed guardrail policy stored in ConfigMap YAML
- no scanner-specific CRD expansion in this stage

## Included

- add a proposal for the RAGEngine guardrails UX/API shape
- define the minimal `guardrails.enabled` entry point
- define ConfigMap-based YAML policy as the direction for detailed guardrail configuration
- document deferred scope for follow-up implementation PRs
- add the proposal to the proposals index

## Not included

- runtime implementation
- scanner-specific CRD fields
- error-handling implementation
- streaming scanning
- audit implementation
- default ConfigMap wiring

## Follow-up

This proposal is intended to guide the next implementation PRs for:

1. error handling semantics
2. YAML policy loader
3. default ConfigMap support
4. scanner registry foundation
5. additional scanners
6. audit foundation
7. streaming scanning
8. graceful UX polish
9. ops hardening