### PR TITLE
feat: add --node-provisioner startup parameter

### DIFF
--- a/charts/kaito/workspace/README.md
+++ b/charts/kaito/workspace/README.md
@@ -13,32 +13,48 @@ helm install workspace ./charts/kaito/workspace  \
 
 ## Values
 
-| Key                                      | Type   | Default                                 | Description                                                   |
-|------------------------------------------|--------|-----------------------------------------|---------------------------------------------------------------|
-| affinity                                 | object | `{}`                                    |                                                               |
-| image.pullPolicy                         | string | `"IfNotPresent"`                        |                                                               |
-| image.repository                         | string | `mcr.microsoft.com/aks/kaito/workspace` |                                                               |
-| image.tag                                | string | `"0.3.0"`                               |                                                               |
-| imagePullSecrets                         | list   | `[]`                                    |                                                               |
-| nodeSelector                             | object | `{}`                                    |                                                               |
-| podAnnotations                           | object | `{}`                                    |                                                               |
-| podSecurityContext.runAsNonRoot          | bool   | `true`                                  |                                                               |
-| presetRegistryName                       | string | `"mcr.microsoft.com/aks/kaito"`         |                                                               |
-| replicaCount                             | int    | `1`                                     |                                                               |
-| resources.limits.cpu                     | string | `"500m"`                                |                                                               |
-| resources.limits.memory                  | string | `"128Mi"`                               |                                                               |
-| resources.requests.cpu                   | string | `"10m"`                                 |                                                               |
-| resources.requests.memory                | string | `"64Mi"`                                |                                                               |
-| securityContext.allowPrivilegeEscalation | bool   | `false`                                 |                                                               |
-| securityContext.capabilities.drop[0]     | string | `"ALL"`                                 |                                                               |
-| defaultNodeImageFamily                   | string | `""`                                    | Default NodeClaim image-family annotation value. Supported values: `azurelinux`, `ubuntu`. Empty means `ubuntu`. Unsupported values cause workspace controller startup failure. |
-| tolerations                              | list   | `[]`                                    |                                                               |
-| webhook.port                             | int    | `9443`                                  |                                                               |
-| cloudProviderName                        | string | `"azure"`                               | Karpenter cloud provider name. Values can be "azure" or "aws" |
-| nvidiaDevicePlugin.enabled               | bool   | `true`                                  | Enable deployment of NVIDIA device plugin DaemonSet. Set to false if your cluster already has the NVIDIA device plugin installed (e.g., via GPU Operator). |
-| featureGates.disableNodeAutoProvisioning | bool   | `false`                                 | When `true`, disables Node Auto-Provisioning (NAP) and installs the `gpu-feature-discovery` subchart as a standalone replacement. Leave `false` (default) if using NAP. |
-| gpu-feature-discovery.nfd.enabled        | bool   | `true`                                  | Enable Node Feature Discovery (NFD) deployment within the GFD subchart. Set to `false` if NFD is already installed (e.g., via the NVIDIA GPU Operator) to avoid CRD conflicts. Only applies when the GFD subchart is active (`featureGates.disableNodeAutoProvisioning=true`). |
-| gpu-feature-discovery.gfd.enabled        | bool   | `true`                                  | Enable GPU Feature Discovery (GFD) within the GFD subchart. Set to `false` if GFD is already installed (e.g., via the NVIDIA GPU Operator). Only applies when the GFD subchart is active (`featureGates.disableNodeAutoProvisioning=true`). |
+| Key                                            | Type   | Default                                                  | Description                                                   |
+|------------------------------------------------|--------|----------------------------------------------------------|---------------------------------------------------------------|
+| affinity                                       | object | `{}`                                                     | Pod affinity rules.                                           |
+| image.pullPolicy                               | string | `"IfNotPresent"`                                         | Allowed values: `Always`, `IfNotPresent`, `Never`.            |
+| image.repository                               | string | `mcr.microsoft.com/aks/kaito/workspace`                  | Controller image repository.                                  |
+| image.tag                                      | string | `"0.10.0"`                                               | Controller image tag.                                         |
+| imagePullSecrets                               | list   | `[]`                                                     | List of image pull secret references (`[{name: <secret>}]`).  |
+| nodeSelector                                   | object | `{"kubernetes.io/os": "linux"}`                          | Controller pod node selector.                                 |
+| podAnnotations                                 | object | `{}`                                                     | Extra annotations added to the controller pod.                |
+| podSecurityContext.runAsUser                   | int    | `1000`                                                   | UID the controller runs as. Must be non-zero (runAsNonRoot).  |
+| podSecurityContext.runAsGroup                  | int    | `1000`                                                   | GID the controller runs as.                                   |
+| podSecurityContext.runAsNonRoot                | bool   | `true`                                                   | Allowed values: `true`, `false`. Must stay `true` on restricted PSS clusters. |
+| podSecurityContext.seccompProfile.type         | string | `"RuntimeDefault"`                                       | Allowed values: `RuntimeDefault`, `Localhost`, `Unconfined`.  |
+| presetRegistryName                             | string | `"mcr.microsoft.com/aks/kaito"`                          | Registry used to pull preset inference/tuning images.         |
+| replicaCount                                   | int    | `1`                                                      | Controller replicas. Non-negative integer; leader election enables HA when >1. |
+| deploymentStrategy.rollingUpdate.maxUnavailable| int / string | `1`                                                | Integer or percentage string (e.g. `"50%"`) per Kubernetes rolling update semantics. |
+| resources.limits.cpu                           | string | `"500m"`                                                 | Kubernetes CPU quantity.                                      |
+| resources.limits.memory                        | string | `"128Mi"`                                                | Kubernetes memory quantity.                                   |
+| resources.requests.cpu                         | string | `"10m"`                                                  | Kubernetes CPU quantity.                                      |
+| resources.requests.memory                      | string | `"64Mi"`                                                 | Kubernetes memory quantity.                                   |
+| securityContext.allowPrivilegeEscalation       | bool   | `false`                                                  | Allowed values: `true`, `false`.                              |
+| securityContext.readOnlyRootFilesystem         | bool   | `true`                                                   | Allowed values: `true`, `false`.                              |
+| securityContext.capabilities.drop[0]           | string | `"ALL"`                                                  | Linux capability name, or the special value `ALL`.            |
+| defaultNodeImageFamily                         | string | `""`                                                     | Default NodeClaim image-family annotation. Allowed values: `""` (treated as `ubuntu`), `ubuntu`, `azurelinux`. Any other value causes controller startup failure. |
+| nodeProvisioner                                | string | `""`                                                     | Node provisioner type. Allowed values: `""` (inferred from feature gates for backward compatibility), `azure-gpu-provisioner`, `azure-karpenter`, `byo`. |
+| tolerations                                    | list   | `[]`                                                     | Controller pod tolerations.                                   |
+| webhook.port                                   | int    | `9443`                                                   | Webhook HTTPS port. Valid TCP port (1–65535); must not conflict with other container ports. |
+| logging.level                                  | string | `"error"`                                                | Knative zap logging level. Allowed values: `debug`, `info`, `warn`, `error`, `dpanic`, `panic`, `fatal`. |
+| cloudProviderName                              | string | `"azure"`                                                | Cloud provider identifier propagated as the `CLOUD_PROVIDER` env var. Allowed values: `azure`, `aws`, `arc`. |
+| clusterName                                    | string | `"kaito"`                                                | Logical Kubernetes cluster name used in controller labels/metrics. |
+| spotInstance.enabled                           | bool   | `false`                                                  | Allowed values: `true`, `false`. When `true`, adds the Azure Spot toleration so workloads can be scheduled on Spot GPU node pools. |
+| localCSIDriver.useLocalCSIDriver               | bool   | `true`                                                   | Allowed values: `true`, `false`. Enables use of the bundled local CSI driver. |
+| nvidiaDevicePlugin.enabled                     | bool   | `true`                                                   | Allowed values: `true`, `false`. Set to `false` if the cluster already has an NVIDIA device plugin (e.g., via GPU Operator). |
+| nvidiaDevicePlugin.daemonsetName               | string | `"nvidia-device-plugin-daemonset"`                       | DNS-1123 name of the generated DaemonSet.                     |
+| nvidiaDevicePlugin.image                       | string | `"mcr.microsoft.com/oss/v2/nvidia/k8s-device-plugin:v0.18.2-1"` | Full image reference for the device plugin container. |
+| nvidiaDevicePlugin.imagePullPolicy             | string | `"IfNotPresent"`                                         | Allowed values: `Always`, `IfNotPresent`, `Never`.            |
+| featureGates.vLLM                              | bool   | `true`                                                   | Allowed values: `true`, `false`. Enables the vLLM inference runtime feature gate. |
+| featureGates.disableNodeAutoProvisioning       | bool   | `false`                                                  | Allowed values: `true`, `false`. When `true`, disables Node Auto-Provisioning (NAP) and installs the `gpu-feature-discovery` subchart as a standalone replacement. |
+| featureGates.gatewayAPIInferenceExtension      | bool   | `false`                                                  | Allowed values: `true`, `false`. Enables the Gateway API Inference Extension (also gates installation of the GAIE subchart). |
+| featureGates.enableInferenceSetController      | bool   | `false`                                                  | Allowed values: `true`, `false`. Enables the InferenceSet controller and its RBAC. |
+| gpu-feature-discovery.nfd.enabled              | bool   | `true`                                                   | Allowed values: `true`, `false`. Set to `false` if NFD is already installed (e.g., via the NVIDIA GPU Operator) to avoid CRD conflicts. Only applies when the GFD subchart is active (`featureGates.disableNodeAutoProvisioning=true`). |
+| gpu-feature-discovery.gfd.enabled              | bool   | `true`                                                   | Allowed values: `true`, `false`. Set to `false` if GFD is already installed (e.g., via the NVIDIA GPU Operator). Only applies when the GFD subchart is active (`featureGates.disableNodeAutoProvisioning=true`). |
 
 ## NVIDIA GPU Operator Coexistence
 

--- a/charts/kaito/workspace/templates/deployment.yaml
+++ b/charts/kaito/workspace/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
             {{- if .Values.defaultNodeImageFamily }}
             - --default-node-image-family={{ .Values.defaultNodeImageFamily }}
             {{- end }}
+            {{- if .Values.nodeProvisioner }}
+            - --node-provisioner={{ .Values.nodeProvisioner }}
+            {{- end }}
           env:
             - name: CONFIG_LOGGING_NAME
               value: {{ include "kaito.loggingConfigMapName" . | quote }}

--- a/charts/kaito/workspace/values.yaml
+++ b/charts/kaito/workspace/values.yaml
@@ -42,6 +42,7 @@ featureGates:
   gatewayAPIInferenceExtension: false
   enableInferenceSetController: false
 defaultNodeImageFamily: ""
+nodeProvisioner: ""
 nvidiaDevicePlugin:
   enabled: true
   daemonsetName: "nvidia-device-plugin-daemonset"

--- a/cmd/workspace/main.go
+++ b/cmd/workspace/main.go
@@ -96,6 +96,7 @@ func main() {
 	var probeAddr string
 	var featureGates string
 	var defaultNodeImageFamily string
+	var nodeProvisionerType string
 	var kubeClientQPS int = 30
 	var kubeClientBurst int = 50
 	var printVersionAndExit bool
@@ -110,6 +111,7 @@ func main() {
 		"Enable webhook for controller manager. Default is true.")
 	flag.StringVar(&featureGates, "feature-gates", "vLLM=true,disableNodeAutoProvisioning=false", "Enable Kaito feature gates. Default: vLLM=true,disableNodeAutoProvisioning=false.")
 	flag.StringVar(&defaultNodeImageFamily, "default-node-image-family", "", "Default node image family annotation for generated NodeClaims. Supported values: azurelinux, ubuntu. Empty means ubuntu. Unsupported values cause startup failure.")
+	flag.StringVar(&nodeProvisionerType, "node-provisioner", "", "Node provisioner type. Supported values: azure-gpu-provisioner, azure-karpenter, byo. Default: azure-gpu-provisioner. If empty, inferred from feature gates for backward compatibility.")
 	flag.BoolVar(&printVersionAndExit, "version", false, "Print version and exit.")
 	opts := zap.Options{
 		Development: true,
@@ -125,6 +127,31 @@ func main() {
 
 	if err := featuregates.ParseAndValidateFeatureGates(featureGates); err != nil {
 		klog.ErrorS(err, "unable to set `feature-gates` flag")
+		exitWithErrorFunc()
+	}
+
+	// Resolve node provisioner type: if --node-provisioner is not explicitly set,
+	// infer from feature gates for backward compatibility.
+	if nodeProvisionerType == "" {
+		switch {
+		case featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning]:
+			nodeProvisionerType = consts.NodeProvisionerBYO
+		default:
+			nodeProvisionerType = consts.NodeProvisionerAzureGPU
+		}
+		klog.InfoS("--node-provisioner not set, inferred from feature gates", "type", nodeProvisionerType)
+	}
+
+	// Sync feature gate internal state based on --node-provisioner for downstream consumers.
+	switch nodeProvisionerType {
+	case consts.NodeProvisionerBYO:
+		featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] = true
+	case consts.NodeProvisionerAzureKarpenter:
+		featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] = false
+	case consts.NodeProvisionerAzureGPU:
+		featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] = false
+	default:
+		klog.ErrorS(fmt.Errorf("unsupported node provisioner type %q", nodeProvisionerType), "unable to set --node-provisioner")
 		exitWithErrorFunc()
 	}
 
@@ -198,7 +225,7 @@ func main() {
 
 	// Select and initialize the node provisioner based on feature gates.
 	recorder := mgr.GetEventRecorderFor("KAITO-Workspace-controller")
-	nodeProvisioner := nodeprovisionmanager.NewNodeProvisioner(kClient, directClient, recorder, defaultNodeImageFamily)
+	nodeProvisioner := nodeprovisionmanager.NewNodeProvisioner(kClient, directClient, recorder, defaultNodeImageFamily, nodeProvisionerType)
 	klog.InfoS("Node provisioner selected", "name", nodeProvisioner.Name())
 	if err := nodeProvisioner.Start(ctx); err != nil {
 		klog.ErrorS(err, "failed to start node provisioner")

--- a/pkg/featuregates/featuregates.go
+++ b/pkg/featuregates/featuregates.go
@@ -26,7 +26,6 @@ var (
 	// FeatureGates is a map that holds the feature gate names and their default values for KAITO.
 	FeatureGates = map[string]bool{
 		consts.FeatureFlagVLLM:                         true,
-		consts.FeatureFlagEnsureNodeClass:              false,
 		consts.FeatureFlagDisableNodeAutoProvisioning:  false,
 		consts.FeatureFlagGatewayAPIInferenceExtension: false,
 		consts.FeatureFlagEnableInferenceSetController: false,

--- a/pkg/featuregates/featuregates_test.go
+++ b/pkg/featuregates/featuregates_test.go
@@ -59,20 +59,6 @@ func TestParseFeatureGates(t *testing.T) {
 			expectedValue: false,
 		},
 		{
-			name:          "WithValidEnableFeatureGates-ensureNodeClass",
-			featureGates:  "ensureNodeClass=true",
-			expectedError: false,
-			targetFeature: "ensureNodeClass",
-			expectedValue: true,
-		},
-		{
-			name:          "WithValidDisableFeatureGates-ensureNodeClass",
-			featureGates:  "ensureNodeClass=false",
-			expectedError: false,
-			targetFeature: "ensureNodeClass",
-			expectedValue: false,
-		},
-		{
 			name:          "WithEnableInferenceSetController",
 			featureGates:  "enableInferenceSetController=true",
 			expectedError: false,

--- a/pkg/nodeprovision/manager/factory.go
+++ b/pkg/nodeprovision/manager/factory.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/tools/record"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/nodeprovision"
 	azurekarpenter "github.com/kaito-project/kaito/pkg/nodeprovision/azure-karpenter"
 	byoprovisioner "github.com/kaito-project/kaito/pkg/nodeprovision/byo-provisioner"
@@ -27,22 +26,23 @@ import (
 	"github.com/kaito-project/kaito/pkg/workspace/resource"
 )
 
-// NewNodeProvisioner creates and returns a NodeProvisioner based on feature gates.
+// NewNodeProvisioner creates and returns a NodeProvisioner based on the provisionerType parameter.
 //
-//   - ensureNodeClass enabled: AzureKarpenterProvisioner (uses directClient for
+//   - azure-karpenter: AzureKarpenterProvisioner (uses directClient for
 //     CRD verification and global AKSNodeClass bootstrap at Start time).
-//   - NAP disabled (BYO mode): BYOProvisioner (all provisioning ops are no-ops).
-//   - Default (NAP enabled): AzureGPUProvisioner (creates/deletes NodeClaims).
-func NewNodeProvisioner(kClient, directClient client.Client, recorder record.EventRecorder, defaultNodeImageFamily string) nodeprovision.NodeProvisioner {
-	if featuregates.FeatureGates[consts.FeatureFlagEnsureNodeClass] {
+//   - byo: BYOProvisioner (all provisioning ops are no-ops).
+//   - azure-gpu-provisioner (default): AzureGPUProvisioner (creates/deletes NodeClaims).
+func NewNodeProvisioner(kClient, directClient client.Client, recorder record.EventRecorder, defaultNodeImageFamily string, provisionerType string) nodeprovision.NodeProvisioner {
+	switch provisionerType {
+	case consts.NodeProvisionerAzureKarpenter:
 		return azurekarpenter.NewAzureKarpenterProvisioner(directClient)
-	}
-	if featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning] {
+	case consts.NodeProvisionerBYO:
 		return byoprovisioner.NewBYOProvisioner(kClient)
+	default: // consts.NodeProvisionerAzureGPU
+		expectations := utils.NewControllerExpectations()
+		ncm := resource.NewNodeClaimManager(kClient, recorder, expectations)
+		ncm.SetDefaultNodeImageFamily(defaultNodeImageFamily)
+		nm := resource.NewNodeManager(kClient)
+		return gpuprovisioner.NewAzureGPUProvisioner(ncm, nm)
 	}
-	expectations := utils.NewControllerExpectations()
-	ncm := resource.NewNodeClaimManager(kClient, recorder, expectations)
-	ncm.SetDefaultNodeImageFamily(defaultNodeImageFamily)
-	nm := resource.NewNodeManager(kClient)
-	return gpuprovisioner.NewAzureGPUProvisioner(ncm, nm)
 }

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -43,10 +43,14 @@ const (
 
 	// Feature flags
 	FeatureFlagVLLM                         = "vLLM"
-	FeatureFlagEnsureNodeClass              = "ensureNodeClass"
 	FeatureFlagDisableNodeAutoProvisioning  = "disableNodeAutoProvisioning"
 	FeatureFlagGatewayAPIInferenceExtension = "gatewayAPIInferenceExtension"
 	FeatureFlagEnableInferenceSetController = "enableInferenceSetController"
+
+	// Node provisioner types
+	NodeProvisionerAzureGPU       = "azure-gpu-provisioner"
+	NodeProvisionerAzureKarpenter = "azure-karpenter"
+	NodeProvisionerBYO            = "byo"
 
 	// Nodeclaim related consts
 	KaitoNodePoolName             = "kaito"

--- a/pkg/utils/nodeclass/nodeclass.go
+++ b/pkg/utils/nodeclass/nodeclass.go
@@ -21,7 +21,6 @@ import (
 	azurev1beta1 "github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
 	awsv1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	"github.com/samber/lo"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
@@ -29,21 +28,6 @@ import (
 
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
-
-// GenerateAKSNodeClassManifest generates a default AKSNodeClass object.
-func GenerateAKSNodeClassManifest(ctx context.Context) *azurev1beta1.AKSNodeClass {
-	return &azurev1beta1.AKSNodeClass{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: consts.NodeClassName,
-			Annotations: map[string]string{
-				"kubernetes.io/description": "General purpose AKSNodeClass for running Ubuntu 22.04 nodes",
-			},
-		},
-		Spec: azurev1beta1.AKSNodeClassSpec{
-			ImageFamily: lo.ToPtr("Ubuntu2204"),
-		},
-	}
-}
 
 // GenerateEC2NodeClassManifest generates a default EC2NodeClass object.
 func GenerateEC2NodeClassManifest(ctx context.Context) *awsv1.EC2NodeClass {
@@ -75,21 +59,6 @@ func GenerateEC2NodeClassManifest(ctx context.Context) *awsv1.EC2NodeClass {
 			},
 		},
 	}
-}
-
-// VerifyAKSNodeClassCRD checks if the AKSNodeClass CRD is installed in the cluster.
-// Returns an error if the CRD does not exist (i.e., Azure Karpenter is not installed).
-func VerifyAKSNodeClassCRD(ctx context.Context, c client.Client) error {
-	crd := &apiextensionsv1.CustomResourceDefinition{}
-	crdName := "aksnodeclasses.karpenter.azure.com"
-	if err := c.Get(ctx, client.ObjectKey{Name: crdName}, crd); err != nil {
-		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("AKSNodeClass CRD (%s) not found: Azure Karpenter must be installed before enabling ensureNodeClass feature gate", crdName)
-		}
-		return fmt.Errorf("failed to check AKSNodeClass CRD existence: %w", err)
-	}
-	klog.InfoS("AKSNodeClass CRD verified", "crd", crdName)
-	return nil
 }
 
 // ensureAKSNodeClassExists checks if an AKSNodeClass exists and creates it if not.

--- a/pkg/utils/nodeclass/nodeclass_test.go
+++ b/pkg/utils/nodeclass/nodeclass_test.go
@@ -22,7 +22,6 @@ import (
 	awsv1 "github.com/aws/karpenter-provider-aws/pkg/apis/v1"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
-	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -30,17 +29,6 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/test"
 )
-
-func TestGenerateAKSNodeClassManifest(t *testing.T) {
-	t.Run("Should generate a valid AKSNodeClass object", func(t *testing.T) {
-		nodeClass := GenerateAKSNodeClassManifest(context.Background())
-
-		assert.NotNil(t, nodeClass)
-		assert.Equal(t, consts.NodeClassName, nodeClass.Name)
-		assert.Equal(t, "General purpose AKSNodeClass for running Ubuntu 22.04 nodes", nodeClass.Annotations["kubernetes.io/description"])
-		assert.Equal(t, "Ubuntu2204", *nodeClass.Spec.ImageFamily)
-	})
-}
 
 func TestGenerateEC2NodeClassManifest(t *testing.T) {
 	t.Run("Should generate a valid EC2NodeClass object", func(t *testing.T) {
@@ -55,67 +43,6 @@ func TestGenerateEC2NodeClassManifest(t *testing.T) {
 		assert.Equal(t, "test-cluster", nodeClass.Spec.SubnetSelectorTerms[0].Tags["karpenter.sh/discovery"])
 		assert.Equal(t, "test-cluster", nodeClass.Spec.SecurityGroupSelectorTerms[0].Tags["karpenter.sh/discovery"])
 	})
-}
-
-func TestVerifyAKSNodeClassCRD(t *testing.T) {
-	tests := []struct {
-		name       string
-		setupMocks func(*test.MockClient)
-		expectErr  bool
-		errMsg     string
-	}{
-		{
-			name: "CRD exists",
-			setupMocks: func(m *test.MockClient) {
-				crd := &apiextensionsv1.CustomResourceDefinition{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: "aksnodeclasses.karpenter.azure.com",
-					},
-				}
-				m.CreateOrUpdateObjectInMap(crd)
-				m.On("Get", mock.Anything, mock.Anything, mock.IsType(&apiextensionsv1.CustomResourceDefinition{}), mock.Anything).
-					Return(nil)
-			},
-			expectErr: false,
-		},
-		{
-			name: "CRD not found",
-			setupMocks: func(m *test.MockClient) {
-				m.On("Get", mock.Anything, mock.Anything, mock.IsType(&apiextensionsv1.CustomResourceDefinition{}), mock.Anything).
-					Return(apierrors.NewNotFound(schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"}, "aksnodeclasses.karpenter.azure.com"))
-			},
-			expectErr: true,
-			errMsg:    "AKSNodeClass CRD",
-		},
-		{
-			name: "API error",
-			setupMocks: func(m *test.MockClient) {
-				m.On("Get", mock.Anything, mock.Anything, mock.IsType(&apiextensionsv1.CustomResourceDefinition{}), mock.Anything).
-					Return(errors.New("connection refused"))
-			},
-			expectErr: true,
-			errMsg:    "failed to check AKSNodeClass CRD existence",
-		},
-	}
-
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			mockClient := test.NewClient()
-			tc.setupMocks(mockClient)
-
-			err := VerifyAKSNodeClassCRD(context.Background(), mockClient)
-
-			if tc.expectErr {
-				assert.Error(t, err)
-				if tc.errMsg != "" {
-					assert.Contains(t, err.Error(), tc.errMsg)
-				}
-			} else {
-				assert.NoError(t, err)
-			}
-			mockClient.AssertExpectations(t)
-		})
-	}
 }
 
 func TestEnsureGlobalAKSNodeClasses(t *testing.T) {


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
1. add --node-provisioner startup parameter for workspace component, and legacy featuregate will be used when this parameter unset.
2. removed feature gate: FeatureFlagEnsureNodeClass
3. removed some other unused functions in nodeclass.go file.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: