### PR TITLE
feat: Migrate default EPP from GWIE to llm-d inference scheduler

### DIFF
--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -85,8 +85,14 @@ const (
 	// MUST KEEP IN SYNC with the version in go.mod.
 	InferencePoolChartVersion = "v1.3.1"
 
-	// GatewayAPIInferenceExtensionImageRepository is the image repository for the Gateway API Inference Extension components.
-	GatewayAPIInferenceExtensionImageRepository = "mcr.microsoft.com/oss/v2/gateway-api-inference-extension"
+	// EPP (Endpoint Picker) image configuration.
+	// The InferencePool chart composes the image as: {hub}/{name}:{tag}
+	// Using llm-d inference scheduler which consolidates the GWIE EPP implementation
+	// with advanced scheduling plugins (KV cache-aware routing, P/D disaggregation, etc.)
+	// See: https://github.com/llm-d/llm-d-inference-scheduler
+	EPPImageHub  = "ghcr.io/llm-d"
+	EPPImageName = "llm-d-inference-scheduler"
+	EPPImageTag  = "v0.7.1"
 
 	// ConditionReady is the condition type for a ready condition.
 	ConditionReady = "Ready"

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -90,7 +90,7 @@ const (
 	// Using llm-d inference scheduler which consolidates the GWIE EPP implementation
 	// with advanced scheduling plugins (KV cache-aware routing, P/D disaggregation, etc.)
 	// See: https://github.com/llm-d/llm-d-inference-scheduler
-	EPPImageHub  = "ghcr.io/llm-d"
+	EPPImageHub  = "mcr.microsoft.com/oss/v2/llm-d"
 	EPPImageName = "llm-d-inference-scheduler"
 	EPPImageTag  = "v0.7.1"
 

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -371,7 +371,9 @@ func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1alpha1.InferenceSe
 		consts.WorkspaceCreatedByInferenceSetLabel: inferenceSetObj.Name,
 	}
 
-	// Endpoint Picker from Gateway API Inference Extension expects to pick an endpoint that can serve traffic.
+	// The EPP (Endpoint Picker Plugin) from Gateway API Inference Extension picks an endpoint that can serve traffic.
+	// KAITO overrides the default GWIE EPP image with the llm-d inference scheduler, which provides
+	// advanced scheduling plugins (KV cache-aware routing, P/D disaggregation, pluggable filters/scorers).
 	// In a multi-node inference environment, this means we need to select the leader pod (with pod index 0)
 	// since only the leader pod is capable of serving traffic.
 	matchLabels[appsv1.PodIndexLabel] = "0"

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -371,7 +371,7 @@ func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1alpha1.InferenceSe
 		consts.WorkspaceCreatedByInferenceSetLabel: inferenceSetObj.Name,
 	}
 
-	// The EPP (Endpoint Picker Plugin) from Gateway API Inference Extension picks an endpoint that can serve traffic.
+	// The Endpoint Picker (EPP) from Gateway API Inference Extension picks an endpoint that can serve traffic.
 	// KAITO overrides the default GWIE EPP image with the llm-d inference scheduler, which provides
 	// advanced scheduling plugins (KV cache-aware routing, P/D disaggregation, pluggable filters/scorers).
 	// In a multi-node inference environment, this means we need to select the leader pod (with pod index 0)

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -380,8 +380,9 @@ func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1alpha1.InferenceSe
 	helmValues := map[string]any{
 		"inferenceExtension": map[string]any{
 			"image": map[string]string{
-				"hub":        consts.GatewayAPIInferenceExtensionImageRepository,
-				"tag":        consts.InferencePoolChartVersion,
+				"hub":        consts.EPPImageHub,
+				"name":       consts.EPPImageName,
+				"tag":        consts.EPPImageTag,
 				"pullPolicy": string(corev1.PullIfNotPresent),
 			},
 		},

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -67,8 +67,9 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 			expected: map[string]any{
 				"inferenceExtension": map[string]any{
 					"image": map[string]any{
-						"hub":        consts.GatewayAPIInferenceExtensionImageRepository,
-						"tag":        consts.InferencePoolChartVersion,
+						"hub":        consts.EPPImageHub,
+						"name":       consts.EPPImageName,
+						"tag":        consts.EPPImageTag,
 						"pullPolicy": string(corev1.PullIfNotPresent),
 					},
 				},

--- a/website/docs/gateway-api-inference-extension.md
+++ b/website/docs/gateway-api-inference-extension.md
@@ -46,10 +46,10 @@ When the feature gate is enabled, [Flux](https://fluxcd.io/) will be installed i
 When you create an InferenceSet, the KAITO InferenceSet controller will:
 
 1) Create or update two Flux resources in the InferenceSet namespace:
-	 - [OCIRepository](https://fluxcd.io/flux/components/source/ocirepositories/): points to the upstream GWIE inferencepool Helm chart
-		 - URL: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
-		 - Tag/Version: https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/latest
-	 - [HelmRelease](https://fluxcd.io/flux/components/helm/helmreleases/): references the OCIRepository and applies values to deploy the InferencePool and EPP. The EPP image is overridden to use the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler) (`mcr.microsoft.com/oss/v2/llm-d/llm-d-inference-scheduler`) instead of the default GWIE EPP.
+   - [OCIRepository](https://fluxcd.io/flux/components/source/ocirepositories/): points to the upstream GWIE inferencepool Helm chart
+     - URL: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
+     - Tag/Version: https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/latest
+   - [HelmRelease](https://fluxcd.io/flux/components/helm/helmreleases/): references the OCIRepository and applies values to deploy the InferencePool and EPP. The EPP image is overridden to use the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler) (`mcr.microsoft.com/oss/v2/llm-d/llm-d-inference-scheduler:v0.7.1`) instead of the default GWIE EPP. This tag is pinned by KAITO and may be updated or made configurable in future releases.
 2) Wait for Flux resources to become Ready
 
 You can inspect these resources with kubectl in the InferenceSet namespace. Updates to the InferenceSet will reconcile these resources.

--- a/website/docs/gateway-api-inference-extension.md
+++ b/website/docs/gateway-api-inference-extension.md
@@ -50,7 +50,7 @@ When you create an InferenceSet, the KAITO InferenceSet controller will:
 	 - [OCIRepository](https://fluxcd.io/flux/components/source/ocirepositories/): points to the upstream GWIE inferencepool Helm chart
 		 - URL: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
 		 - Tag/Version: https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/latest
-	 - [HelmRelease](https://fluxcd.io/flux/components/helm/helmreleases/): references the OCIRepository and applies values to deploy the InferencePool and EPP. The EPP image is overridden to use the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler) (`ghcr.io/llm-d/llm-d-inference-scheduler`) instead of the default GWIE EPP.
+	 - [HelmRelease](https://fluxcd.io/flux/components/helm/helmreleases/): references the OCIRepository and applies values to deploy the InferencePool and EPP. The EPP image is overridden to use the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler) (`mcr.microsoft.com/oss/v2/llm-d/llm-d-inference-scheduler`) instead of the default GWIE EPP.
 3) Wait for Flux resources to become Ready
 
 You can inspect these resources with kubectl in the InferenceSet namespace. Updates to the InferenceSet will reconcile these resources.

--- a/website/docs/gateway-api-inference-extension.md
+++ b/website/docs/gateway-api-inference-extension.md
@@ -2,14 +2,14 @@
 title: Gateway API Inference Extension
 ---
 
-KAITO integrates with [Gateway API Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/) (GWIE) to provide model-aware routing and optimal endpoint selection for inference. This page covers what it is, prerequisites, how to enable it in KAITO, how it's wired, and a quickstart.
+KAITO integrates with [Gateway API Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/) (GWIE) and [llm-d](https://github.com/llm-d/llm-d-inference-scheduler) to provide model-aware routing and optimal endpoint selection for inference. This page covers what it is, prerequisites, how to enable it in KAITO, how it's wired, and a quickstart.
 
 ## What is it
 
 Gateway API Inference Extension extends [Gateway API](https://gateway-api.sigs.k8s.io/) with inference-focused backends and behaviors. It adds:
 
 - [InferencePool](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/) CRD to represent model-serving backends
-- A reference [Endpoint Picker](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/pkg/epp) (EPP) that uses inference server metrics and policies to pick the best backend
+- An [Endpoint Picker](https://github.com/llm-d/llm-d-inference-scheduler) (EPP) that uses inference server metrics and policies to pick the best backend. KAITO uses the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler) as the EPP, which consolidates the GWIE EPP implementation with advanced scheduling plugins including KV cache-aware routing, prefill/decode (P/D) disaggregation, and pluggable filters/scorers.
 - Optional [Body-Based Routing](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/pkg/bbr) (BBR) that extracts model names from OpenAI-style requests and injects a header for routing purposes
 
 KAITO uses GWIE to route requests for models to the right Workspace pods, improving latency and GPU utilization.
@@ -45,12 +45,13 @@ When the feature gate is enabled, [Flux](https://fluxcd.io/) will be installed i
 
 When you create an InferenceSet, the KAITO InferenceSet controller will:
 
-1) Create or update two Flux resources in the InferenceSet namespace:
-   - [OCIRepository](https://fluxcd.io/flux/components/source/ocirepositories/): points to the upstream GWIE inferencepool Helm chart
-     - URL: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
-     - Tag/Version: https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/latest
-   - [HelmRelease](https://fluxcd.io/flux/components/helm/helmreleases/): references the OCIRepository and applies values to deploy EPP and related resources
-2) Wait for Flux resources to become Ready
+1) Dry-run the inference workload to determine whether it's a Deployment or StatefulSet (important for how endpoints are selected)
+2) Create or update two Flux resources in the InferenceSet namespace:
+	 - [OCIRepository](https://fluxcd.io/flux/components/source/ocirepositories/): points to the upstream GWIE inferencepool Helm chart
+		 - URL: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
+		 - Tag/Version: https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/latest
+	 - [HelmRelease](https://fluxcd.io/flux/components/helm/helmreleases/): references the OCIRepository and applies values to deploy the InferencePool and EPP. The EPP image is overridden to use the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler) (`ghcr.io/llm-d/llm-d-inference-scheduler`) instead of the default GWIE EPP.
+3) Wait for Flux resources to become Ready
 
 You can inspect these resources with kubectl in the InferenceSet namespace. Updates to the InferenceSet will reconcile these resources.
 
@@ -111,7 +112,7 @@ NAME                       AGE
 phi-4-mini-inferencepool   69s
 ```
 
-Verify that the Endpoint Picker Pod is running in the InferenceSet namespace:
+Verify that the Endpoint Picker (EPP) Pod is running with the llm-d inference scheduler image in the InferenceSet namespace:
 
 ```bash
 kubectl get pod -l inferencepool=phi-4-mini-inferencepool-epp

--- a/website/docs/gateway-api-inference-extension.md
+++ b/website/docs/gateway-api-inference-extension.md
@@ -9,7 +9,7 @@ KAITO integrates with [Gateway API Inference Extension](https://gateway-api-infe
 Gateway API Inference Extension extends [Gateway API](https://gateway-api.sigs.k8s.io/) with inference-focused backends and behaviors. It adds:
 
 - [InferencePool](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/) CRD to represent model-serving backends
-- An [Endpoint Picker](https://github.com/llm-d/llm-d-inference-scheduler) (EPP) that uses inference server metrics and policies to pick the best backend. KAITO uses the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler) as the EPP, which consolidates the GWIE EPP implementation with advanced scheduling plugins including KV cache-aware routing, prefill/decode (P/D) disaggregation, and pluggable filters/scorers.
+- A reference Endpoint Picker Plugin (EPP) that uses inference server metrics and policies to pick the best backend. In KAITO, the EPP image is overridden to use the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler), which builds on the GWIE EPP with advanced scheduling plugins including KV cache-aware routing, prefill/decode (P/D) disaggregation, and pluggable filters/scorers.
 - Optional [Body-Based Routing](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/pkg/bbr) (BBR) that extracts model names from OpenAI-style requests and injects a header for routing purposes
 
 KAITO uses GWIE to route requests for models to the right Workspace pods, improving latency and GPU utilization.
@@ -111,13 +111,20 @@ NAME                       AGE
 phi-4-mini-inferencepool   69s
 ```
 
-Verify that the Endpoint Picker (EPP) Pod is running with the llm-d inference scheduler image in the InferenceSet namespace:
+Verify that the Endpoint Picker (EPP) Pod is running in the InferenceSet namespace:
 
 ```bash
 kubectl get pod -l inferencepool=phi-4-mini-inferencepool-epp
 
 NAME                                           READY   STATUS    RESTARTS   AGE
 phi-4-mini-inferencepool-epp-b74f8994b-s9kkt   1/1     Running   0          87s
+```
+
+Confirm the EPP is using the llm-d inference scheduler image:
+
+```bash
+kubectl get pod -l inferencepool=phi-4-mini-inferencepool-epp -o jsonpath='{.items[0].spec.containers[0].image}'
+# Expected: mcr.microsoft.com/oss/v2/llm-d/llm-d-inference-scheduler:v0.7.1
 ```
 
 ### 3. Deploy DestinationRule and HTTPRoute

--- a/website/docs/gateway-api-inference-extension.md
+++ b/website/docs/gateway-api-inference-extension.md
@@ -45,13 +45,12 @@ When the feature gate is enabled, [Flux](https://fluxcd.io/) will be installed i
 
 When you create an InferenceSet, the KAITO InferenceSet controller will:
 
-1) Dry-run the inference workload to determine whether it's a Deployment or StatefulSet (important for how endpoints are selected)
-2) Create or update two Flux resources in the InferenceSet namespace:
+1) Create or update two Flux resources in the InferenceSet namespace:
 	 - [OCIRepository](https://fluxcd.io/flux/components/source/ocirepositories/): points to the upstream GWIE inferencepool Helm chart
 		 - URL: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
 		 - Tag/Version: https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/latest
 	 - [HelmRelease](https://fluxcd.io/flux/components/helm/helmreleases/): references the OCIRepository and applies values to deploy the InferencePool and EPP. The EPP image is overridden to use the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler) (`mcr.microsoft.com/oss/v2/llm-d/llm-d-inference-scheduler`) instead of the default GWIE EPP.
-3) Wait for Flux resources to become Ready
+2) Wait for Flux resources to become Ready
 
 You can inspect these resources with kubectl in the InferenceSet namespace. Updates to the InferenceSet will reconcile these resources.
 


### PR DESCRIPTION
Replace the default Endpoint Picker (EPP) image from the upstream Gateway API Inference Extension EPP to llm-d-inference-scheduler (`mcr.microsoft.com/oss/v2/llm-d/llm-d-inference-scheduler:v0.7.1`).

The **InferencePool chart remains** from GWIE (oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool), **only the EPP container image is overridden** to use llm-d. This follows the GIE to llm-d migration plan where EPP implementation and plugins are consolidated into llm-d-inference-scheduler.

llm-d extends the GWIE EPP with advanced scheduling plugins including KV cache-aware routing, P/D disaggregation, and pluggable filters/scorers.

Changes:
- Replace GatewayAPIInferenceExtensionImageRepository with EPPImageHub, EPPImageName, EPPImageTag consts to properly set hub/name/tag for the InferencePool helm chart image override
- Update HelmRelease values to pass all three image fields
- Update tests accordingly
- Update gateway-api-inference-extension.md docs to reflect llm-d EPP

Ref: https://github.com/llm-d/llm-d-inference-scheduler

**Reason for Change**:
Migrate default EPP from GWIE to llm-d inference scheduler for advanced scheduling capabilities (KV cache-aware routing, P/D disaggregation). Uses MCR-hosted image for production reliability.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).