### PR TITLE
docs: add design proposal for migrating EPP to llm-d inference scheduler

### DIFF
--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -131,54 +131,111 @@ All three default scorers work out of the box with KAITO's vLLM inference server
 
 The EPP scrapes metrics from the InferencePool's `targetPorts` (port 5000, the same port as KAITO's vLLM API endpoint). KAITO's vLLM exposes the `/metrics` endpoint on port 5000 with all required Prometheus metrics.
 
-### Advanced llm-d Plugins
+### Advanced: Custom EPP Plugin Configuration
 
-Users can access llm-d-specific plugins by providing custom `pluginsCustomConfig` in the InferencePool Helm values:
+For advanced plugins like `precise-prefix-cache-scorer` or P/D disaggregation, users provide a custom `EndpointPickerConfig` via a **ConfigMap reference** in the InferenceSet spec. This keeps the InferenceSet clean — the plugin configuration lives in a separate ConfigMap.
 
-#### Precise Prefix Cache Scorer
+#### API Changes
+
+Add an optional `eppPluginsConfigRef` field to InferenceSetSpec:
+
+```go
+type InferenceSetSpec struct {
+    // ...existing fields...
+
+    // EPPPluginsConfigRef references a ConfigMap containing custom EPP plugins configuration.
+    // The ConfigMap must contain a key "config.yaml" with the EndpointPickerConfig content.
+    // If not specified, the default llm-d plugins (queue-scorer, kv-cache-utilization-scorer,
+    // prefix-cache-scorer) are used.
+    // +optional
+    EPPPluginsConfigRef *corev1.LocalObjectReference `json:"eppPluginsConfigRef,omitempty"`
+}
+```
+
+#### User Experience
+
+```yaml
+apiVersion: kaito.sh/v1alpha1
+kind: InferenceSet
+metadata:
+  name: phi-4-mini
+spec:
+  eppPluginsConfigRef:
+    name: phi-4-mini-epp-plugins   # references a ConfigMap in the same namespace
+  # ...other fields unchanged...
+```
+
+#### Controller Behavior
+
+When `eppPluginsConfigRef` is set:
+
+1. Controller reads the referenced ConfigMap's `config.yaml` key
+2. Injects the content into the InferencePool HelmRelease values:
+   ```yaml
+   inferenceExtension:
+     pluginsConfigFile: "custom-plugins.yaml"
+     pluginsCustomConfig:
+       custom-plugins.yaml: <content from ConfigMap>
+   ```
+3. Flux reconciles the HelmRelease → EPP deployment picks up the custom config
+4. Controller watches the referenced ConfigMap for changes and triggers re-reconciliation
+
+#### Example: Precise Prefix Cache Scorer
 
 Token-level KV cache matching using KV events from the routing sidecar:
 
 ```yaml
-inferenceExtension:
-  pluginsCustomConfig:
-    custom-plugins.yaml: |-
-      apiVersion: inference.networking.x-k8s.io/v1alpha1
-      kind: EndpointPickerConfig
-      plugins:
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: phi-4-mini-epp-plugins
+data:
+  config.yaml: |
+    apiVersion: inference.networking.x-k8s.io/v1alpha1
+    kind: EndpointPickerConfig
+    plugins:
+      - type: single-profile-handler
+      - type: decode-filter
       - type: precise-prefix-cache-scorer
         parameters:
+          tokenProcessorConfig:
+            blockSize: 64                 # must match vLLM block size
+            hashSeed: "42"                # must match vLLM PYTHONHASHSEED env var
           indexerConfig:
-            tokenProcessorConfig:
-              blockSize: 5
             kvBlockIndexConfig:
-              maxPrefixBlocksToMatch: 256
-      - type: decode-filter
+              enableMetrics: true
+      - type: kv-cache-utilization-scorer
+      - type: queue-scorer
       - type: max-score-picker
-      - type: single-profile-handler
-      schedulingProfiles:
+    schedulingProfiles:
       - name: default
         plugins:
-        - pluginRef: decode-filter
-        - pluginRef: max-score-picker
-        - pluginRef: precise-prefix-cache-scorer
-          weight: 50
-  pluginsConfigFile: "custom-plugins.yaml"
+          - pluginRef: decode-filter
+          - pluginRef: precise-prefix-cache-scorer
+            weight: 2.0
+          - pluginRef: kv-cache-utilization-scorer
+            weight: 1.0
+          - pluginRef: queue-scorer
+            weight: 1.0
+          - pluginRef: max-score-picker
 ```
 
-#### Prefill/Decode (P/D) Disaggregation
+> **Note**: `precise-prefix-cache-scorer` requires the `llm-d-routing-sidecar` to provide KV events via UDS socket. The sidecar must be deployed alongside vLLM pods.
 
-Separate prefill and decode phases to different pods for better GPU utilization:
+#### Example: Prefill/Decode (P/D) Disaggregation
 
 ```yaml
-inferenceExtension:
-  pluginsCustomConfig:
-    custom-plugins.yaml: |-
-      apiVersion: inference.networking.x-k8s.io/v1alpha1
-      kind: EndpointPickerConfig
-      featureGates:
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: pd-disagg-epp-plugins
+data:
+  config.yaml: |
+    apiVersion: inference.networking.x-k8s.io/v1alpha1
+    kind: EndpointPickerConfig
+    featureGates:
       - prepareDataPlugins
-      plugins:
+    plugins:
       - type: prefix-based-pd-decider
         parameters:
           nonCachedTokens: 4
@@ -198,17 +255,16 @@ inferenceExtension:
             inference-role: decode
       - type: precise-prefix-cache-scorer
       - type: max-score-picker
-      schedulingProfiles:
+    schedulingProfiles:
       - name: prefill
         plugins:
-        - pluginRef: prefill-filter
-        - pluginRef: precise-prefix-cache-scorer
-          weight: 50
+          - pluginRef: prefill-filter
+          - pluginRef: precise-prefix-cache-scorer
+            weight: 50
       - name: decode
         plugins:
-        - pluginRef: decode-filter
-        - pluginRef: max-score-picker
-  pluginsConfigFile: "custom-plugins.yaml"
+          - pluginRef: decode-filter
+          - pluginRef: max-score-picker
 ```
 
 > **Note**: P/D disaggregation requires prefill and decode pods deployed separately with appropriate labels (`inference-role: prefill` / `inference-role: decode`).
@@ -218,9 +274,9 @@ inferenceExtension:
 | Feature | Extra Config Needed? | Notes |
 |---------|---------------------|-------|
 | Basic inference routing (queue/kv-cache/prefix-cache) | ❌ No | Default plugins work out of the box |
-| Precise prefix cache matching | ✅ Yes | Custom `pluginsCustomConfig` |
-| P/D disaggregated scheduling | ✅ Yes | Custom config + separate prefill/decode pods |
-| Label-based pod filtering | ✅ Yes | Custom `pluginsCustomConfig` |
+| Precise prefix cache matching | ✅ Yes | ConfigMap with `eppPluginsConfigRef` |
+| P/D disaggregated scheduling | ✅ Yes | ConfigMap + separate prefill/decode pods |
+| Label-based pod filtering | ✅ Yes | ConfigMap with `eppPluginsConfigRef` |
 | BBR multi-model routing | ❌ No | Independent component, unchanged |
 
 ### Request Flow

--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -1,0 +1,283 @@
+---
+title: Migrate Default EPP to llm-d Inference Scheduler
+authors:
+  - "@andyzhangx"
+reviewers:
+  - "@Fei-Guo"
+  - "@rambohe-ch"
+  - "@zhuangqh"
+creation-date: 2026-04-21
+last-updated: 2026-04-21
+status: provisional
+see-also:
+  - "docs/proposals/20250918-introduce_inferenceset_autoscaling.md"
+---
+
+# Migrate Default EPP to llm-d Inference Scheduler
+
+## Summary
+
+This proposal migrates KAITO's default Endpoint Picker (EPP) from the upstream [Gateway API Inference Extension (GWIE)](https://github.com/kubernetes-sigs/gateway-api-inference-extension) EPP to the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler). The llm-d inference scheduler consolidates the GWIE EPP with advanced scheduling plugins — including KV cache-aware routing, prefix cache matching, and prefill/decode disaggregation — under a single project, per the [GIE to llm-d migration plan](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2430).
+
+This change only replaces the EPP container image in the InferencePool Helm release. The InferencePool chart, CRDs, and all other KAITO components remain unchanged. There is no breaking change for existing users.
+
+## Motivation
+
+The GWIE project is migrating its EPP implementation and plugin ecosystem to `llm-d-inference-scheduler` ([tracking issue](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2430)). The key motivations are:
+
+1. **Upstream migration**: The GWIE EPP codebase and plugins are moving to `llm-d-inference-scheduler` to accelerate development and avoid confusion about where to develop new plugins.
+2. **Advanced scheduling plugins**: llm-d extends the GWIE EPP with plugins not available in the upstream GWIE EPP:
+   - **Precise prefix cache scorer**: Token-level KV cache matching via KV events (vs. hash-based estimation)
+   - **Prefill/Decode (P/D) disaggregation**: Separate prefill and decode phases to different pods for better GPU utilization
+   - **Label-based pod filtering**: Route requests to pods matching specific labels (e.g., GPU type, inference role)
+3. **Full backward compatibility**: llm-d uses the same `EndpointPickerConfig` API and is a drop-in replacement for the GWIE EPP. The default `default-plugins.yaml` ConfigMap created by the InferencePool chart works without modification.
+
+### Goals
+
+- Replace the default EPP image from `gateway-api-inference-extension` to `llm-d-inference-scheduler`
+- Maintain full backward compatibility — no changes required for existing InferenceSet users
+- Enable access to llm-d-specific advanced scheduling plugins via custom configuration
+
+### Non-Goals/Future Work
+
+- Changing the InferencePool Helm chart source (remains from GWIE `oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool`)
+- Migrating BBR (Body-Based Routing) — BBR is an independent component unaffected by this change
+- Implementing llm-d routing sidecar integration for KV event-based precise prefix cache scoring
+- Automatic configuration of advanced llm-d plugins (users configure via Helm values)
+
+## Proposal
+
+### Architecture
+
+The InferencePool Helm chart remains from GWIE. Only the EPP container image is overridden to use llm-d:
+
+```
+┌─────────────────────────────────────────────────────┐
+│                   KAITO Controller                   │
+│  (InferenceSet controller creates Flux resources)    │
+└──────────────────────┬──────────────────────────────┘
+                       │
+          ┌────────────┴────────────┐
+          ▼                         ▼
+┌──────────────────┐    ┌──────────────────────────┐
+│  OCIRepository    │    │     HelmRelease           │
+│  (GWIE chart)     │    │  (EPP image override      │
+│                   │    │   to llm-d)               │
+│  oci://registry.  │    │                           │
+│  k8s.io/gateway-  │    │  image:                   │
+│  api-inference-   │    │    hub: mcr.microsoft.com  │
+│  extension/charts │    │         /oss/v2/llm-d     │
+│  /inferencepool   │    │    name: llm-d-inference   │
+│                   │    │          -scheduler        │
+│  Tag: latest      │    │    tag: v0.7.1             │
+└──────────────────┘    └──────────────────────────┘
+```
+
+### EPP Image Change
+
+Replace the single EPP image constant with hub/name/tag to match the InferencePool chart's image composition (`{hub}/{name}:{tag}`):
+
+| Field | Before | After |
+|-------|--------|-------|
+| Hub | `mcr.microsoft.com/oss/v2/gateway-api-inference-extension` | `mcr.microsoft.com/oss/v2/llm-d` |
+| Name | (embedded in hub) | `llm-d-inference-scheduler` |
+| Tag | (embedded in hub) | `v0.7.1` |
+
+### Default Behavior (Zero Config)
+
+After the migration, **no additional configuration is needed** for basic usage. The InferencePool chart creates a `default-plugins.yaml` ConfigMap with three default scorers:
+
+```yaml
+apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+- type: queue-scorer
+- type: kv-cache-utilization-scorer
+- type: prefix-cache-scorer
+schedulingProfiles:
+- name: default
+  plugins:
+  - pluginRef: queue-scorer
+    weight: 2
+  - pluginRef: kv-cache-utilization-scorer
+    weight: 2
+  - pluginRef: prefix-cache-scorer
+    weight: 3
+```
+
+The llm-d EPP binary is fully compatible with this config format (same `EndpointPickerConfig` API).
+
+### Default Plugin Metrics Compatibility
+
+All three default scorers work out of the box with KAITO's vLLM inference server:
+
+| Plugin | Required Metric | vLLM Metric Name | Available on Port 5000 |
+|--------|----------------|-------------------|----------------------|
+| `queue-scorer` | Request queue depth | `vllm:num_requests_waiting` + `vllm:num_requests_running` | ✅ Yes |
+| `kv-cache-utilization-scorer` | KV cache usage | `vllm:kv_cache_usage_perc` | ✅ Yes |
+| `prefix-cache-scorer` | None (EPP-internal hash) | N/A | ✅ N/A |
+
+The EPP scrapes metrics from the InferencePool's `targetPorts` (port 5000, the same port as KAITO's vLLM API endpoint). KAITO's vLLM exposes the `/metrics` endpoint on port 5000 with all required Prometheus metrics.
+
+### Advanced llm-d Plugins
+
+Users can access llm-d-specific plugins by providing custom `pluginsCustomConfig` in the InferencePool Helm values:
+
+#### Precise Prefix Cache Scorer
+
+Token-level KV cache matching using KV events from the routing sidecar:
+
+```yaml
+inferenceExtension:
+  pluginsCustomConfig:
+    custom-plugins.yaml: |-
+      apiVersion: inference.networking.x-k8s.io/v1alpha1
+      kind: EndpointPickerConfig
+      plugins:
+      - type: precise-prefix-cache-scorer
+        parameters:
+          indexerConfig:
+            tokenProcessorConfig:
+              blockSize: 5
+            kvBlockIndexConfig:
+              maxPrefixBlocksToMatch: 256
+      - type: decode-filter
+      - type: max-score-picker
+      - type: single-profile-handler
+      schedulingProfiles:
+      - name: default
+        plugins:
+        - pluginRef: decode-filter
+        - pluginRef: max-score-picker
+        - pluginRef: precise-prefix-cache-scorer
+          weight: 50
+  pluginsConfigFile: "custom-plugins.yaml"
+```
+
+#### Prefill/Decode (P/D) Disaggregation
+
+Separate prefill and decode phases to different pods for better GPU utilization:
+
+```yaml
+inferenceExtension:
+  pluginsCustomConfig:
+    custom-plugins.yaml: |-
+      apiVersion: inference.networking.x-k8s.io/v1alpha1
+      kind: EndpointPickerConfig
+      featureGates:
+      - prepareDataPlugins
+      plugins:
+      - type: prefix-based-pd-decider
+        parameters:
+          nonCachedTokens: 4
+      - type: disagg-profile-handler
+        parameters:
+          deciders:
+            prefill: prefix-based-pd-decider
+      - type: by-label-selector
+        name: prefill-filter
+        parameters:
+          matchLabels:
+            inference-role: prefill
+      - type: by-label-selector
+        name: decode-filter
+        parameters:
+          matchLabels:
+            inference-role: decode
+      - type: precise-prefix-cache-scorer
+      - type: max-score-picker
+      schedulingProfiles:
+      - name: prefill
+        plugins:
+        - pluginRef: prefill-filter
+        - pluginRef: precise-prefix-cache-scorer
+          weight: 50
+      - name: decode
+        plugins:
+        - pluginRef: decode-filter
+        - pluginRef: max-score-picker
+  pluginsConfigFile: "custom-plugins.yaml"
+```
+
+> **Note**: P/D disaggregation requires prefill and decode pods deployed separately with appropriate labels (`inference-role: prefill` / `inference-role: decode`).
+
+### Feature Matrix
+
+| Feature | Extra Config Needed? | Notes |
+|---------|---------------------|-------|
+| Basic inference routing (queue/kv-cache/prefix-cache) | ❌ No | Default plugins work out of the box |
+| Precise prefix cache matching | ✅ Yes | Custom `pluginsCustomConfig` |
+| P/D disaggregated scheduling | ✅ Yes | Custom config + separate prefill/decode pods |
+| Label-based pod filtering | ✅ Yes | Custom `pluginsCustomConfig` |
+| BBR multi-model routing | ❌ No | Independent component, unchanged |
+
+### Request Flow
+
+#### Single Model
+
+```
+Client Request → Gateway → HTTPRoute → DestinationRule → EPP (llm-d) → Best Pod
+```
+
+- **HTTPRoute**: Routes request to the correct InferencePool
+- **DestinationRule**: TLS policy for Gateway → EPP connection (skip self-signed cert verification)
+- **EPP (llm-d)**: Selects optimal pod based on queue depth, KV cache utilization, and prefix cache scoring
+
+#### Multi-Model (with BBR)
+
+```
+Client Request → Gateway → BBR (body→header) → HTTPRoute (header match) → EPP → Best Pod
+```
+
+BBR extracts the model name from the request body and injects the `X-Gateway-Model-Name` header. HTTPRoute then routes to the correct InferencePool based on the header value.
+
+BBR is **completely unaffected** by this EPP migration — it is an independent component with its own Helm chart.
+
+### Why DestinationRule Is Needed
+
+EPP runs with `--secure-serving=true` by default, generating a self-signed TLS certificate. Istio's sidecar proxy doesn't trust self-signed certs, so without the DestinationRule, the Gateway → EPP ext-proc connection fails with TLS errors. One DestinationRule is needed per InferencePool/EPP service:
+
+```yaml
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: <inferencepool-name>-epp
+spec:
+  host: <inferencepool-name>-epp
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      insecureSkipVerify: true
+```
+
+## Implementation Strategy
+
+### Step 1: EPP Image Migration (This Proposal)
+
+- Replace EPP image constants in `pkg/utils/consts/consts.go`
+- Update `GenerateInferencePoolHelmRelease` to pass `hub`/`name`/`tag` image fields
+- Update tests and documentation
+- **PR**: [kaito-project/kaito#1975](https://github.com/kaito-project/kaito/pull/1975)
+
+### Step 2: MCR Image Publishing
+
+- Publish `llm-d-inference-scheduler` to MCR (`mcr.microsoft.com/oss/v2/llm-d/llm-d-inference-scheduler`)
+- Publish `llm-d-routing-sidecar` to MCR (`mcr.microsoft.com/oss/v2/llm-d/llm-d-routing-sidecar`)
+- **PR**: [Azure/dalec-build-defs#6817](https://github.com/Azure/dalec-build-defs/pull/6817)
+
+### Step 3: Advanced Plugin Documentation (Future)
+
+- Document how to configure llm-d-specific plugins (precise prefix cache, P/D disaggregation)
+- Add E2E tests for advanced plugin configurations
+
+## References
+
+- [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler)
+- [GIE to llm-d migration plan](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2430)
+- [KAITO GWIE documentation](https://kaito-project.github.io/kaito/docs/gateway-api-inference-extension)
+- [llm-d architecture docs](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/docs/architecture.md)
+- [Migration guide (detailed)](https://github.com/andyzhangx/demo/blob/master/llm/kaito-llm-d/README.md)
+
+## Implementation History
+
+- 2026-04-21: Open proposal PR

--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -75,24 +75,46 @@ The InferencePool Helm chart remains from GWIE. Only the EPP container image is 
 
 ### Default Behavior (Zero Config)
 
-After the migration, **no additional configuration is needed** for basic usage. The InferencePool chart creates a `default-plugins.yaml` ConfigMap with three default scorers:
+After the migration, **no additional configuration is needed** for basic usage. The InferencePool chart creates a `default-plugins.yaml` ConfigMap with three default scorers, e.g.
+
+```bash
+# kubectl get configmap phi-4-mini-inferencepool-epp -o yaml
+```
 
 ```yaml
-apiVersion: inference.networking.x-k8s.io/v1alpha1
-kind: EndpointPickerConfig
-plugins:
-- type: queue-scorer
-- type: kv-cache-utilization-scorer
-- type: prefix-cache-scorer
-schedulingProfiles:
-- name: default
-  plugins:
-  - pluginRef: queue-scorer
-    weight: 2
-  - pluginRef: kv-cache-utilization-scorer
-    weight: 2
-  - pluginRef: prefix-cache-scorer
-    weight: 3
+apiVersion: v1
+data:
+  default-plugins.yaml: |
+    apiVersion: inference.networking.x-k8s.io/v1alpha1
+    kind: EndpointPickerConfig
+    plugins:
+    - type: queue-scorer
+    - type: kv-cache-utilization-scorer
+    - type: prefix-cache-scorer
+    schedulingProfiles:
+    - name: default
+      plugins:
+      - pluginRef: queue-scorer
+        weight: 2
+      - pluginRef: kv-cache-utilization-scorer
+        weight: 2
+      - pluginRef: prefix-cache-scorer
+        weight: 3
+kind: ConfigMap
+metadata:
+  annotations:
+    meta.helm.sh/release-name: phi-4-mini-inferencepool
+    meta.helm.sh/release-namespace: default
+  creationTimestamp: "2026-04-20T02:49:11Z"
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    helm.toolkit.fluxcd.io/name: phi-4-mini-inferencepool
+    helm.toolkit.fluxcd.io/namespace: default
+  name: phi-4-mini-inferencepool-epp
+  namespace: default
+  resourceVersion: "140558777"
+  uid: 4b5ff03a-5d6b-4262-bed0-c004e8137913
+```
 ```
 
 The llm-d EPP binary is fully compatible with this config format (same `EndpointPickerConfig` API).

--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -169,7 +169,6 @@ When `eppPluginsConfig` is set:
        custom-plugins.yaml: <content from ConfigMap>
    ```
 3. Flux reconciles the HelmRelease → EPP deployment picks up the custom config
-4. Controller watches the referenced ConfigMap for changes and triggers re-reconciliation
 
 #### Configuration Update Behavior
 

--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -17,7 +17,7 @@ see-also:
 
 ## Summary
 
-This proposal migrates KAITO's default Endpoint Picker (EPP) from the upstream [Gateway API Inference Extension (GWIE)](https://github.com/kubernetes-sigs/gateway-api-inference-extension) EPP to the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler). The llm-d inference scheduler consolidates the GWIE EPP with advanced scheduling plugins — including KV cache-aware routing, prefix cache matching, and prefill/decode disaggregation — under a single project, per the [GIE to llm-d migration plan](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2430).
+This proposal migrates KAITO's default Endpoint Picker (EPP) from the upstream [Gateway API Inference Extension (GWIE)](https://github.com/kubernetes-sigs/gateway-api-inference-extension) EPP to the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler). The llm-d inference scheduler consolidates the GWIE EPP with advanced scheduling plugins — including KV cache-aware routing, prefix cache matching, and prefill/decode disaggregation — under a single project, per the [GWIE to llm-d migration plan](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2430).
 
 This change only replaces the EPP container image in the InferencePool Helm release. The InferencePool chart, CRDs, and all other KAITO components remain unchanged. There is no breaking change for existing users.
 
@@ -225,13 +225,16 @@ BBR is **completely unaffected** by this EPP migration — it is an independent 
 
 ### Why DestinationRule Is Needed
 
-EPP runs with `--secure-serving=true` by default, generating a self-signed TLS certificate. Istio's sidecar proxy doesn't trust self-signed certs, so without the DestinationRule, the Gateway → EPP ext-proc connection fails with TLS errors. One DestinationRule is needed per InferencePool/EPP service:
+EPP runs with `--secure-serving=true` by default, generating a self-signed TLS certificate. Istio's sidecar proxy doesn't trust self-signed certs, so without the DestinationRule, the Gateway → EPP ext-proc connection fails with TLS errors. One DestinationRule is needed per InferencePool/EPP service.
+
+> **Namespace note:** The DestinationRule must be created in the **same namespace** as the EPP service (i.e., the InferenceSet namespace). In Istio, DestinationRules are namespace-scoped and only visible to clients in the same namespace by default. Since KAITO deploys the Gateway/Envoy and EPP in the same namespace, this works out of the box. If a custom deployment places the Gateway in a different namespace, the DestinationRule must either be created in the Gateway's namespace or exported via `exportTo: ["*"]`.
 
 ```yaml
 apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   name: <inferencepool-name>-epp
+  namespace: <inferenceset-namespace>  # Must be in the same namespace as the EPP service
 spec:
   host: <inferencepool-name>-epp
   trafficPolicy:
@@ -262,7 +265,7 @@ spec:
 ## References
 
 - [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler)
-- [GIE to llm-d migration plan](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2430)
+- [GWIE to llm-d migration plan](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2430)
 - [KAITO GWIE documentation](https://kaito-project.github.io/kaito/docs/gateway-api-inference-extension)
 - [llm-d architecture docs](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/docs/architecture.md)
 - [Migration guide (detailed)](https://github.com/llm-d/llm-d/blob/main/docs/getting-started.md)

--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -43,7 +43,7 @@ The GWIE project is migrating its EPP implementation and plugin ecosystem to `ll
 - Changing the InferencePool Helm chart source (remains from GWIE `oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool`)
 - Migrating BBR (Body-Based Routing) — BBR is an independent component unaffected by this change
 - Implementing llm-d routing sidecar integration for KV event-based precise prefix cache scoring
-- Automatic configuration of advanced llm-d plugins (users configure via Helm values)
+- Automatic configuration of advanced llm-d plugins (users configure via `eppPluginsConfigRef` ConfigMap)
 
 ## Proposal
 

--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -65,10 +65,10 @@ The InferencePool Helm chart remains from GWIE. Only the EPP container image is 
 │                   │    │   to llm-d)               │
 │  oci://registry.  │    │                           │
 │  k8s.io/gateway-  │    │  image:                   │
-│  api-inference-   │    │    hub: mcr.microsoft.com  │
-│  extension/charts │    │         /oss/v2/llm-d     │
-│  /inferencepool   │    │    name: llm-d-inference   │
-│                   │    │          -scheduler        │
+│  api-inference-   │    │    hub: mcr.microsoft.    │
+│  extension/charts │    │      com/oss/v2/llm-d     │
+│  /inferencepool   │    │    name: llm-d-inference  │
+│                   │    │      -scheduler            │
 │  Tag: v1.3.1      │    │    tag: v0.7.1             │
 └──────────────────┘    └──────────────────────────┘
 ```
@@ -114,7 +114,6 @@ metadata:
   namespace: default
   resourceVersion: "140558777"
   uid: 4b5ff03a-5d6b-4262-bed0-c004e8137913
-```
 ```
 
 The llm-d EPP binary is fully compatible with this config format (same `EndpointPickerConfig` API).

--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -127,9 +127,9 @@ The EPP scrapes metrics from the InferencePool's `targetPorts` (port 5000, the s
 
 For advanced plugins like `precise-prefix-cache-scorer` or P/D disaggregation, users provide a custom `EndpointPickerConfig` via a **ConfigMap reference** in the InferenceSet spec. This keeps the InferenceSet clean — the plugin configuration lives in a separate ConfigMap.
 
-#### API Changes
+#### Proposed API Changes
 
-Add an optional `eppPluginsConfig` field to InferenceSetSpec:
+Add an optional `eppPluginsConfig` field to InferenceSetSpec (to be implemented in a follow-up PR):
 
 ```go
 type InferenceSetSpec struct {
@@ -324,7 +324,7 @@ BBR is **completely unaffected** by this EPP migration — it is an independent 
 
 EPP runs with `--secure-serving=true` by default, generating a self-signed TLS certificate. Istio's sidecar proxy doesn't trust self-signed certs, so without the DestinationRule, the Gateway → EPP ext-proc connection fails with TLS errors. One DestinationRule is needed per InferencePool/EPP service.
 
-> **Namespace note:** The DestinationRule must be created in the **same namespace** as the EPP service (i.e., the InferenceSet namespace). In Istio, DestinationRules are namespace-scoped and only visible to clients in the same namespace by default. Since KAITO deploys the Gateway/Envoy and EPP in the same namespace, this works out of the box. If a custom deployment places the Gateway in a different namespace, the DestinationRule must either be created in the Gateway's namespace or exported via `exportTo: ["*"]`.
+> **Namespace note:** The DestinationRule must be created in the **same namespace** as the EPP service (i.e., the InferenceSet namespace). In Istio, DestinationRules are namespace-scoped and only visible to clients in the same namespace by default. In the recommended quickstart deployment, the Gateway/Envoy and EPP are in the same namespace, so this works out of the box. If a custom deployment places the Gateway in a different namespace, the DestinationRule must either be created in the Gateway's namespace or exported via `exportTo: ["*"]`.
 
 ```yaml
 apiVersion: networking.istio.io/v1

--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -73,16 +73,6 @@ The InferencePool Helm chart remains from GWIE. Only the EPP container image is 
 └──────────────────┘    └──────────────────────────┘
 ```
 
-### EPP Image Change
-
-Replace the single EPP image constant with hub/name/tag to match the InferencePool chart's image composition (`{hub}/{name}:{tag}`):
-
-| Field | Before | After |
-|-------|--------|-------|
-| Hub | `mcr.microsoft.com/oss/v2/gateway-api-inference-extension` | `mcr.microsoft.com/oss/v2/llm-d` |
-| Name | (embedded in hub) | `llm-d-inference-scheduler` |
-| Tag | (embedded in hub) | `v0.7.1` |
-
 ### Default Behavior (Zero Config)
 
 After the migration, **no additional configuration is needed** for basic usage. The InferencePool chart creates a `default-plugins.yaml` ConfigMap with three default scorers:
@@ -254,9 +244,8 @@ spec:
 
 ### Step 1: EPP Image Migration (This Proposal)
 
-- Replace EPP image constants in `pkg/utils/consts/consts.go`
-- Update `GenerateInferencePoolHelmRelease` to pass `hub`/`name`/`tag` image fields
-- Update tests and documentation
+- Replace the default EPP image to use llm-d inference scheduler
+- Update documentation
 - **PR**: [kaito-project/kaito#1975](https://github.com/kaito-project/kaito/pull/1975)
 
 ### Step 2: MCR Image Publishing

--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -129,18 +129,18 @@ For advanced plugins like `precise-prefix-cache-scorer` or P/D disaggregation, u
 
 #### API Changes
 
-Add an optional `eppPluginsConfigRef` field to InferenceSetSpec:
+Add an optional `eppPluginsConfig` field to InferenceSetSpec:
 
 ```go
 type InferenceSetSpec struct {
     // ...existing fields...
 
-    // EPPPluginsConfigRef references a ConfigMap containing custom EPP plugins configuration.
+    // EPPPluginsConfig is the name of a ConfigMap containing custom EPP plugins configuration.
     // The ConfigMap must contain a key "config.yaml" with the EndpointPickerConfig content.
     // If not specified, the default llm-d plugins (queue-scorer, kv-cache-utilization-scorer,
     // prefix-cache-scorer) are used.
     // +optional
-    EPPPluginsConfigRef *corev1.LocalObjectReference `json:"eppPluginsConfigRef,omitempty"`
+    EPPPluginsConfig string `json:"eppPluginsConfig,omitempty"`
 }
 ```
 
@@ -152,14 +152,13 @@ kind: InferenceSet
 metadata:
   name: phi-4-mini
 spec:
-  eppPluginsConfigRef:
-    name: phi-4-mini-epp-plugins   # references a ConfigMap in the same namespace
+  eppPluginsConfig: phi-4-mini-epp-plugins   # ConfigMap name in the same namespace
   # ...other fields unchanged...
 ```
 
 #### Controller Behavior
 
-When `eppPluginsConfigRef` is set:
+When `eppPluginsConfig` is set:
 
 1. Controller reads the referenced ConfigMap's `config.yaml` key
 2. Injects the content into the InferencePool HelmRelease values:
@@ -174,7 +173,7 @@ When `eppPluginsConfigRef` is set:
 
 #### Configuration Update Behavior
 
-The llm-d EPP (v0.7.1) loads the plugin configuration **once at startup** via `--configFile` and does not support hot-reload. When the `eppPluginsConfigRef` ConfigMap is updated, the EPP pod must be restarted to pick up the new configuration.
+The llm-d EPP (v0.7.1) loads the plugin configuration **once at startup** via `--configFile` and does not support hot-reload. When the `eppPluginsConfig` ConfigMap is updated, the EPP pod must be restarted to pick up the new configuration.
 
 KAITO handles this automatically:
 
@@ -302,9 +301,9 @@ data:
 | Feature | Extra Config Needed? | Notes |
 |---------|---------------------|-------|
 | Basic inference routing (queue/kv-cache/prefix-cache) | ❌ No | Default plugins work out of the box |
-| Precise prefix cache matching | ✅ Yes | ConfigMap with `eppPluginsConfigRef` |
+| Precise prefix cache matching | ✅ Yes | ConfigMap with `eppPluginsConfig` |
 | P/D disaggregated scheduling | ✅ Yes | ConfigMap + separate prefill/decode pods |
-| Label-based pod filtering | ✅ Yes | ConfigMap with `eppPluginsConfigRef` |
+| Label-based pod filtering | ✅ Yes | ConfigMap with `eppPluginsConfig` |
 | BBR multi-model routing | ❌ No | Independent component, unchanged |
 
 ### Request Flow

--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -10,7 +10,7 @@ creation-date: 2026-04-21
 last-updated: 2026-04-21
 status: provisional
 see-also:
-  - "docs/proposals/20250918-introduce_inferenceset_autoscaling.md"
+  - "/docs/proposals/20250918-introduce_inferenceset_autoscaling.md"
 ---
 
 # Migrate Default EPP to llm-d Inference Scheduler
@@ -69,7 +69,7 @@ The InferencePool Helm chart remains from GWIE. Only the EPP container image is 
 │  extension/charts │    │         /oss/v2/llm-d     │
 │  /inferencepool   │    │    name: llm-d-inference   │
 │                   │    │          -scheduler        │
-│  Tag: latest      │    │    tag: v0.7.1             │
+│  Tag: v1.3.1      │    │    tag: v0.7.1             │
 └──────────────────┘    └──────────────────────────┘
 ```
 
@@ -265,7 +265,7 @@ spec:
 - [GIE to llm-d migration plan](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2430)
 - [KAITO GWIE documentation](https://kaito-project.github.io/kaito/docs/gateway-api-inference-extension)
 - [llm-d architecture docs](https://github.com/llm-d/llm-d-inference-scheduler/blob/main/docs/architecture.md)
-- [Migration guide (detailed)](https://github.com/andyzhangx/demo/blob/master/llm/kaito-llm-d/README.md)
+- [Migration guide (detailed)](https://github.com/llm-d/llm-d/blob/main/docs/getting-started.md)
 
 ## Implementation History
 

--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -172,6 +172,42 @@ When `eppPluginsConfigRef` is set:
 3. Flux reconciles the HelmRelease → EPP deployment picks up the custom config
 4. Controller watches the referenced ConfigMap for changes and triggers re-reconciliation
 
+#### Configuration Update Behavior
+
+The llm-d EPP (v0.7.1) loads the plugin configuration **once at startup** via `--configFile` and does not support hot-reload. When the `eppPluginsConfigRef` ConfigMap is updated, the EPP pod must be restarted to pick up the new configuration.
+
+KAITO handles this automatically:
+
+1. The InferenceSet controller watches the referenced ConfigMap for changes
+2. On change, the controller computes a SHA-256 checksum of the ConfigMap's `config.yaml` content and updates the HelmRelease values with a checksum annotation on the EPP Deployment pod template:
+   ```yaml
+   podAnnotations:
+     checksum/epp-plugins-config: <sha256 of config.yaml>
+   ```
+3. Flux reconciles the HelmRelease → the annotation change triggers a rolling restart of the EPP Deployment
+4. The new EPP pod starts with the updated configuration
+
+This makes ConfigMap updates transparent to the user — they only need to update the ConfigMap, and KAITO handles the restart automatically.
+
+> **Note**: If llm-d adds hot-reload support in a future version, KAITO can remove the checksum annotation mechanism. The ConfigMap volume mount would be sufficient since Kubernetes automatically propagates ConfigMap updates to mounted volumes (with the kubelet sync delay, typically ~60s).
+
+#### Validation
+
+Validation is performed at two levels:
+
+1. **KAITO controller-level (structural validation)**:
+   - Validates that the referenced ConfigMap exists
+   - Validates that the ConfigMap contains the required `config.yaml` key
+   - If validation fails, the controller sets a `ConfigInvalid` condition on the InferenceSet and does **not** proceed with the HelmRelease update
+   - The controller does **not** validate plugin names, types, or parameters — this avoids tight coupling with the llm-d plugin ecosystem
+
+2. **EPP-level (semantic validation)**:
+   - The llm-d EPP validates the full `EndpointPickerConfig` schema on load, including plugin types, parameters, and scheduling profile references ([configloader.go](https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/main/pkg/epp/config/loader/configloader.go))
+   - If the configuration is invalid (unknown plugin type, missing required parameter, invalid profile reference), the EPP fails to start and the pod enters `CrashLoopBackOff`
+   - Users can diagnose configuration errors via `kubectl logs` on the EPP pod
+
+This separation ensures KAITO remains loosely coupled with llm-d — new plugins can be added upstream without requiring KAITO code changes.
+
 #### Example: Precise Prefix Cache Scorer
 
 Token-level KV cache matching using KV events from the routing sidecar:

--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -173,22 +173,15 @@ When `eppPluginsConfig` is set:
 
 #### Configuration Update Behavior
 
-The llm-d EPP (v0.7.1) loads the plugin configuration **once at startup** via `--configFile` and does not support hot-reload. When the `eppPluginsConfig` ConfigMap is updated, the EPP pod must be restarted to pick up the new configuration.
+The llm-d EPP (v0.7.1) loads the plugin configuration **once at startup** via `--configFile` and does not support hot-reload.
 
-KAITO handles this automatically:
+The controller only tracks changes to the `eppPluginsConfig` field value (i.e., the ConfigMap name). When the name changes, the controller updates the HelmRelease values with the new ConfigMap reference, and Flux reconciles the EPP Deployment accordingly.
 
-1. The InferenceSet controller watches the referenced ConfigMap for changes
-2. On change, the controller computes a SHA-256 checksum of the ConfigMap's `config.yaml` content and updates the HelmRelease values with a checksum annotation on the EPP Deployment pod template:
-   ```yaml
-   podAnnotations:
-     checksum/epp-plugins-config: <sha256 of config.yaml>
-   ```
-3. Flux reconciles the HelmRelease → the annotation change triggers a rolling restart of the EPP Deployment
-4. The new EPP pod starts with the updated configuration
+If users need to update the ConfigMap content without changing the name, they can either:
+1. Create a new ConfigMap with a different name and update `eppPluginsConfig` to reference it, or
+2. Manually restart the EPP pod after updating the ConfigMap content (`kubectl rollout restart`)
 
-This makes ConfigMap updates transparent to the user — they only need to update the ConfigMap, and KAITO handles the restart automatically.
-
-> **Note**: If llm-d adds hot-reload support in a future version, KAITO can remove the checksum annotation mechanism. The ConfigMap volume mount would be sufficient since Kubernetes automatically propagates ConfigMap updates to mounted volumes (with the kubelet sync delay, typically ~60s).
+This approach keeps the controller simple — no ConfigMap watches, no checksum annotations — and is consistent with how most Kubernetes operators handle referenced config (e.g., Istio, Argo CD).
 
 #### Validation
 

--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -43,7 +43,6 @@ The GWIE project is migrating its EPP implementation and plugin ecosystem to `ll
 - Changing the InferencePool Helm chart source (remains from GWIE `oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool`)
 - Migrating BBR (Body-Based Routing) — BBR is an independent component unaffected by this change
 - Implementing llm-d routing sidecar integration for KV event-based precise prefix cache scoring
-- Automatic configuration of advanced llm-d plugins (users configure via `eppPluginsConfigRef` ConfigMap)
 
 ## Proposal
 

--- a/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
+++ b/docs/proposals/20260421-migrate-epp-to-llm-d-inference-scheduler.md
@@ -59,18 +59,18 @@ The InferencePool Helm chart remains from GWIE. Only the EPP container image is 
                        │
           ┌────────────┴────────────┐
           ▼                         ▼
-┌──────────────────┐    ┌──────────────────────────┐
-│  OCIRepository    │    │     HelmRelease           │
-│  (GWIE chart)     │    │  (EPP image override      │
-│                   │    │   to llm-d)               │
-│  oci://registry.  │    │                           │
-│  k8s.io/gateway-  │    │  image:                   │
-│  api-inference-   │    │    hub: mcr.microsoft.    │
-│  extension/charts │    │      com/oss/v2/llm-d     │
-│  /inferencepool   │    │    name: llm-d-inference  │
-│                   │    │      -scheduler            │
-│  Tag: v1.3.1      │    │    tag: v0.7.1             │
-└──────────────────┘    └──────────────────────────┘
+┌──────────────────┐    ┌────────────────────────────────┐
+│  OCIRepository    │    │     HelmRelease                 │
+│  (GWIE chart)     │    │  (EPP image override to llm-d)  │
+│                   │    │                                  │
+│  oci://registry.  │    │  image:                          │
+│  k8s.io/gateway-  │    │    hub: mcr.microsoft.com/      │
+│  api-inference-   │    │         oss/v2/llm-d             │
+│  extension/charts │    │    name: llm-d-inference-        │
+│  /inferencepool   │    │          scheduler               │
+│                   │    │    tag: v0.7.1                    │
+│  Tag: v1.3.1      │    │                                  │
+└──────────────────┘    └────────────────────────────────┘
 ```
 
 ### Default Behavior (Zero Config)
@@ -83,37 +83,31 @@ After the migration, **no additional configuration is needed** for basic usage. 
 
 ```yaml
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: phi-4-mini-inferencepool-epp
+  namespace: default
+  labels:
+    app.kubernetes.io/managed-by: Helm
+    helm.toolkit.fluxcd.io/name: phi-4-mini-inferencepool
+    helm.toolkit.fluxcd.io/namespace: default
 data:
   default-plugins.yaml: |
     apiVersion: inference.networking.x-k8s.io/v1alpha1
     kind: EndpointPickerConfig
     plugins:
-    - type: queue-scorer
-    - type: kv-cache-utilization-scorer
-    - type: prefix-cache-scorer
+      - type: queue-scorer
+      - type: kv-cache-utilization-scorer
+      - type: prefix-cache-scorer
     schedulingProfiles:
-    - name: default
-      plugins:
-      - pluginRef: queue-scorer
-        weight: 2
-      - pluginRef: kv-cache-utilization-scorer
-        weight: 2
-      - pluginRef: prefix-cache-scorer
-        weight: 3
-kind: ConfigMap
-metadata:
-  annotations:
-    meta.helm.sh/release-name: phi-4-mini-inferencepool
-    meta.helm.sh/release-namespace: default
-  creationTimestamp: "2026-04-20T02:49:11Z"
-  labels:
-    app.kubernetes.io/managed-by: Helm
-    helm.toolkit.fluxcd.io/name: phi-4-mini-inferencepool
-    helm.toolkit.fluxcd.io/namespace: default
-  name: phi-4-mini-inferencepool-epp
-  namespace: default
-  resourceVersion: "140558777"
-  uid: 4b5ff03a-5d6b-4262-bed0-c004e8137913
+      - name: default
+        plugins:
+          - pluginRef: queue-scorer
+            weight: 2
+          - pluginRef: kv-cache-utilization-scorer
+            weight: 2
+          - pluginRef: prefix-cache-scorer
+            weight: 3
 ```
 
 The llm-d EPP binary is fully compatible with this config format (same `EndpointPickerConfig` API).


### PR DESCRIPTION
## What type of PR is this?
/kind documentation

## What this PR does / why we need it:

Adds a design proposal for migrating KAITO's default Endpoint Picker (EPP) from the upstream Gateway API Inference Extension (GWIE) EPP to the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler).

**I have added optional EPPPluginsConfig in InferenceSetSpec for "Advanced: Custom EPP Plugin Configuration", this is the only API change during migration. And by default, we don't even need to set this EPPPluginsConfig , this is for better scheduling with advanced features.**

### Key points:
- **Drop-in replacement**: llm-d uses the same `EndpointPickerConfig` API — no breaking changes
- **Zero config**: Default plugins (queue-scorer, kv-cache-utilization-scorer, prefix-cache-scorer) work out of the box with KAITO's vLLM metrics
- **Advanced plugins**: Enables access to llm-d-specific plugins (precise prefix cache, P/D disaggregation, label-based filtering)
- **Upstream alignment**: Follows the [GIE to llm-d migration plan](https://github.com/kubernetes-sigs/gateway-api-inference-extension/issues/2430)

### Related PRs:
- Implementation: #1975
- MCR image build: [Azure/dalec-build-defs#6817](https://github.com/Azure/dalec-build-defs/pull/6817)

## Which issue(s) this PR fixes:
N/A (design proposal)

## Special notes for your reviewer:
This is a design-only proposal with no code changes.
