### PR TITLE
[WIP] fix: disable EPP secure-serving to let Gateway provider handle TLS

### DIFF
--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -388,7 +388,7 @@ func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1alpha1.InferenceSe
 				"pullPolicy": string(corev1.PullIfNotPresent),
 			},
 			// Disable EPP's built-in self-signed TLS so that the Gateway provider
-			// (Istio / Envoy Gateway) handles mTLS natively.  This removes the
+			// (Istio / Envoy Gateway) handles mTLS natively. This removes the
 			// need for an Istio DestinationRule to bypass certificate verification.
 			// Requires upstream GWIE chart fix: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2871
 			"flags": map[string]any{

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -20,6 +20,7 @@ import (
 	"path"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	kustomize "github.com/fluxcd/pkg/apis/kustomize"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
@@ -387,13 +388,6 @@ func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1alpha1.InferenceSe
 				"tag":        consts.EPPImageTag,
 				"pullPolicy": string(corev1.PullIfNotPresent),
 			},
-			// Disable EPP's built-in self-signed TLS so that the Gateway provider
-			// (Istio / Envoy Gateway) handles mTLS natively. This removes the
-			// need for an Istio DestinationRule to bypass certificate verification.
-			// Requires upstream GWIE chart fix: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2871
-			"flags": map[string]any{
-				"secure-serving": false,
-			},
 		},
 		"inferencePool": map[string]any{
 			"targetPorts": []map[string]any{{
@@ -427,6 +421,25 @@ func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1alpha1.InferenceSe
 			Values: &apiextensionsv1.JSON{
 				Raw: rawHelmValues,
 			},
+			// Disable EPP's built-in self-signed TLS so that the Gateway provider
+			// (Istio / Envoy Gateway) handles mTLS natively. This removes the
+			// need for an Istio DestinationRule to bypass certificate verification.
+			// We use a Flux postRenderer instead of chart flags because the current
+			// GWIE chart (v1.3.1) renders boolean flags as separate args
+			// (--key "value"), which Go pflag misinterprets for bool flags.
+			// See: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2871
+			PostRenderers: []helmv2.PostRenderer{{
+				Kustomize: &helmv2.Kustomize{
+					Patches: []kustomize.Patch{{
+						Target: &kustomize.Selector{
+							Kind: "Deployment",
+						},
+						Patch: `- op: add
+  path: /spec/template/spec/containers/0/args/-
+  value: --secure-serving=false`,
+					}},
+				},
+			}},
 		},
 	}, nil
 }

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -387,10 +387,11 @@ func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1alpha1.InferenceSe
 				"tag":        consts.EPPImageTag,
 				"pullPolicy": string(corev1.PullIfNotPresent),
 			},
+			// Disable EPP's built-in self-signed TLS so that the Gateway provider
+			// (Istio / Envoy Gateway) handles mTLS natively.  This removes the
+			// need for an Istio DestinationRule to bypass certificate verification.
+			// Requires upstream GWIE chart fix: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2871
 			"flags": map[string]any{
-				// Disable EPP's built-in self-signed TLS so that the Gateway provider
-				// (Istio / Envoy Gateway) handles mTLS natively.  This removes the
-				// need for an Istio DestinationRule to bypass certificate verification.
 				"secure-serving": false,
 			},
 		},

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -387,6 +387,12 @@ func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1alpha1.InferenceSe
 				"tag":        consts.EPPImageTag,
 				"pullPolicy": string(corev1.PullIfNotPresent),
 			},
+			"flags": map[string]any{
+				// Disable EPP's built-in self-signed TLS so that the Gateway provider
+				// (Istio / Envoy Gateway) handles mTLS natively.  This removes the
+				// need for an Istio DestinationRule to bypass certificate verification.
+				"secure-serving": false,
+			},
 		},
 		"inferencePool": map[string]any{
 			"targetPorts": []map[string]any{{

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -72,6 +72,9 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 						"tag":        consts.EPPImageTag,
 						"pullPolicy": string(corev1.PullIfNotPresent),
 					},
+					"flags": map[string]any{
+						"secure-serving": false,
+					},
 				},
 				"inferencePool": map[string]any{
 					"targetPorts": []any{

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -72,9 +72,6 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 						"tag":        consts.EPPImageTag,
 						"pullPolicy": string(corev1.PullIfNotPresent),
 					},
-					"flags": map[string]any{
-						"secure-serving": false,
-					},
 				},
 				"inferencePool": map[string]any{
 					"targetPorts": []any{
@@ -113,6 +110,14 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 			vals := map[string]any{}
 			assert.NoError(t, json.Unmarshal(helmRelease.Spec.Values.Raw, &vals))
 			assert.Equal(t, tc.expected, vals)
+
+			// Verify postRenderers inject --secure-serving=false
+			assert.Len(t, helmRelease.Spec.PostRenderers, 1)
+			assert.NotNil(t, helmRelease.Spec.PostRenderers[0].Kustomize)
+			assert.Len(t, helmRelease.Spec.PostRenderers[0].Kustomize.Patches, 1)
+			patch := helmRelease.Spec.PostRenderers[0].Kustomize.Patches[0]
+			assert.Equal(t, "Deployment", patch.Target.Kind)
+			assert.Contains(t, patch.Patch, "--secure-serving=false")
 		})
 	}
 }

--- a/website/docs/gateway-api-inference-extension.md
+++ b/website/docs/gateway-api-inference-extension.md
@@ -127,13 +127,7 @@ kubectl get pod -l inferencepool=phi-4-mini-inferencepool-epp -o jsonpath='{.ite
 # Expected: mcr.microsoft.com/oss/v2/llm-d/llm-d-inference-scheduler:v0.7.1
 ```
 
-### 3. Deploy DestinationRule and HTTPRoute
-
-Apply an Istio DestinationRule. Since EPP runs with `--secure-serving=true` by default using a self-signed certificate, and Istio doesn't trust self-signed certificates, this DestinationRule bypasses TLS verification as a temporary workaround:
-
-```bash
-kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/gateway-api-inference-extension/destinationrule-phi-4-mini-instruct.yaml
-```
+### 3. Deploy HTTPRoute
 
 Create the HTTPRoute that targets the InferenceSet's InferencePool (via `.spec.endpointPickerRef`) and defines the routing matchers used by the Gateway:
 
@@ -291,11 +285,10 @@ kubectl run -it --rm --restart=Never curl --image=curlimages/curl -- curl -X POS
 
 ### 4. [Optional] Deploy BBR
 
-Deploy a second KAITO InferenceSet and DestinationRule with a different model to demonstrate multi-model routing. This step uses [`mistral-7b-instruct`](https://github.com/kaito-project/kaito/blob/main/examples/inference/kaito_inferenceset_mistral_7b-instruct.yaml) as an example:
+Deploy a second KAITO InferenceSet with a different model to demonstrate multi-model routing. This step uses [`mistral-7b-instruct`](https://github.com/kaito-project/kaito/blob/main/examples/inference/kaito_inferenceset_mistral_7b-instruct.yaml) as an example:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/inference/kaito_inferenceset_mistral_7b-instruct.yaml
-kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/gateway-api-inference-extension/destinationrule-mistral-7b-instruct.yaml
 ```
 
 Install the Body-Based Routing (BBR) Helm chart. BBR automatically extracts model names from OpenAI-style API requests and injects an `X-Gateway-Model-Name` header to the inference request, enabling model routing without modifying client code:


### PR DESCRIPTION
## What type of PR is this?
/kind improvement

## What this PR does / why we need it
The GWIE InferencePool EPP defaults to `--secure-serving=true`, which creates a self-signed TLS certificate. When deployed behind a Gateway provider (Istio, Envoy Gateway), this self-signed cert causes TLS verification failures, requiring an Istio `DestinationRule` workaround to bypass certificate verification.

This PR sets `secure-serving=false` in the HelmRelease values generated by the InferenceSet controller, so EPP runs plain-text gRPC and the Gateway provider handles encryption natively (e.g., Istio mTLS).

### Benefits
- **Eliminates the need for `DestinationRule` resources** — no more TLS bypass workarounds
- **Simplifies deployment topology** — fewer Istio-specific resources to manage
- **Follows best practice** — let the service mesh handle mTLS instead of application-level self-signed certs

### How it works
The InferencePool Helm chart supports a `flags` field in values that gets rendered as CLI arguments to the EPP container. By setting:

```yaml
inferenceExtension:
  flags:
    secure-serving: false
```

The EPP container starts with `--secure-serving=false`, serving plain-text gRPC on port 9002. The Gateway provider (Istio/Envoy Gateway) handles all TLS/mTLS between Gateway and EPP.

### Before (current behavior)
```
Client → Gateway → ext-proc → EPP (self-signed TLS) → DestinationRule needed to bypass cert verification
```

### After (this PR)
```
Client → Gateway → ext-proc → EPP (plain gRPC) → Gateway provider handles mTLS natively
```

## Dependencies
⚠️ **This PR depends on an upstream GWIE Helm chart fix**: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2871

The current GWIE chart renders boolean flags as separate args (`--key "value"`), which causes Go pflag to misinterpret `--secure-serving false` as `--secure-serving` (=true) + positional arg "false". The upstream fix changes the template to use `--key=value` format.

## Which issue(s) this PR fixes
Related to the GWIE quickstart guide simplification — removes the need for DestinationRule in https://kaito-project.github.io/kaito/docs/gateway-api-inference-extension/

## Special notes for your reviewer
- Only 2 files changed: `manifests.go` and `manifests_test.go`
- The `flags` field is a standard feature of the upstream InferencePool Helm chart
- This is safe because KAITO already requires a Gateway provider (Istio or Envoy Gateway) as a prerequisite
- Upstream chart fix PR: https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2871
