### PR TITLE
test: add GWIE resource chain validation to AIKit integration test

### DIFF
--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -174,69 +174,55 @@ jobs:
           echo "Waiting for inferenceset to be ready..."
           kubectl wait --for='jsonpath={.status.readyReplicas}=1' inferenceset/inferenceset-aikit-test --timeout 300s
 
-      - name: Validate GWIE resource chain
+      - name: Validate GWIE infrastructure
         run: |
-          POOL_NAME="inferenceset-aikit-test-inferencepool"
+          # Note: GWIE resource chain (OCIRepository → HelmRelease → InferencePool → EPP)
+          # is only created for vLLM preset-based InferenceSet workloads.
+          # AIKit uses custom template inference, so GWIE resources won't be created.
+          # Here we validate that the GWIE infrastructure is correctly deployed.
 
-          echo "=== Checking Flux OCIRepository ==="
-          kubectl wait --for=condition=ready ocirepository/$POOL_NAME --timeout=120s
-          echo "OCIRepository is ready"
+          echo "=== Checking Flux CRDs are installed ==="
+          kubectl get crd ocirepositories.source.toolkit.fluxcd.io
+          echo "✓ Flux OCIRepository CRD installed"
+          kubectl get crd helmreleases.helm.toolkit.fluxcd.io
+          echo "✓ Flux HelmRelease CRD installed"
 
-          echo "=== Checking Flux HelmRelease ==="
-          kubectl wait --for=condition=ready helmrelease/$POOL_NAME --timeout=180s
-          echo "HelmRelease is ready"
+          echo "=== Checking InferencePool CRD is installed ==="
+          kubectl get crd inferencepools.inference.networking.k8s.io
+          echo "✓ InferencePool CRD installed"
 
-          echo "=== Checking InferencePool ==="
-          kubectl get inferencepool $POOL_NAME -o yaml
-          echo "InferencePool created successfully"
-
-          echo "=== Checking EPP Deployment ==="
-          kubectl wait --for=condition=available --timeout=180s deployment/${POOL_NAME}-epp
-          echo "EPP Deployment is available"
-
-          echo "=== Verifying EPP container args ==="
-          EPP_ARGS=$(kubectl get deployment ${POOL_NAME}-epp -o jsonpath='{.spec.template.spec.containers[0].args}')
-          echo "EPP args: $EPP_ARGS"
-
-          # Verify critical args
-          for expected in "pool-name" "pool-namespace" "grpc-port"; do
-            if echo "$EPP_ARGS" | grep -q "$expected"; then
-              echo "✓ Found expected arg: $expected"
-            else
-              echo "✗ Missing expected arg: $expected"
-              exit 1
-            fi
-          done
-
-          echo "=== Verifying EPP pod is Running ==="
-          kubectl get pod -l app=${POOL_NAME}-epp -o wide
-          EPP_POD=$(kubectl get pod -l app=${POOL_NAME}-epp -o jsonpath='{.items[0].metadata.name}')
-          EPP_STATUS=$(kubectl get pod $EPP_POD -o jsonpath='{.status.phase}')
-          if [ "$EPP_STATUS" != "Running" ]; then
-            echo "EPP pod is not running: $EPP_STATUS"
-            kubectl describe pod $EPP_POD
+          echo "=== Checking Flux controllers are running ==="
+          kubectl get pods -n ${{ env.KAITO_NAMESPACE }} -l app.kubernetes.io/part-of=flux -o wide
+          FLUX_PODS=$(kubectl get pods -n ${{ env.KAITO_NAMESPACE }} -l app.kubernetes.io/part-of=flux --no-headers 2>/dev/null | wc -l)
+          if [ "$FLUX_PODS" -ge 1 ]; then
+            echo "✓ Flux controllers running ($FLUX_PODS pods)"
+          else
+            echo "✗ No Flux controllers found"
             exit 1
           fi
 
-          echo "=== Checking EPP health endpoint ==="
-          kubectl port-forward deployment/${POOL_NAME}-epp 9090:9090 &
-          EPP_PF_PID=$!
-          sleep 3
-          # EPP exposes metrics on :9090/metrics
-          if curl -sf http://localhost:9090/metrics > /dev/null 2>&1; then
-            echo "✓ EPP metrics endpoint is healthy"
+          echo "=== Checking controller feature gates ==="
+          CONTROLLER_ARGS=$(kubectl get deployment kaito-workspace -n ${{ env.KAITO_NAMESPACE }} -o jsonpath='{.spec.template.spec.containers[0].args}')
+          echo "Controller args: $CONTROLLER_ARGS"
+          if echo "$CONTROLLER_ARGS" | grep -q "gatewayAPIInferenceExtension=true"; then
+            echo "✓ gatewayAPIInferenceExtension feature gate enabled"
           else
-            echo "⚠ EPP metrics endpoint not reachable (may be expected if secure-serving is changing)"
+            echo "✗ gatewayAPIInferenceExtension feature gate not found"
+            exit 1
           fi
-          kill $EPP_PF_PID || true
+          if echo "$CONTROLLER_ARGS" | grep -q "enableInferenceSetController=true"; then
+            echo "✓ enableInferenceSetController feature gate enabled"
+          else
+            echo "✗ enableInferenceSetController feature gate not found"
+            exit 1
+          fi
 
-          echo "=== Verifying InferencePool selector matches inference pods ==="
-          POOL_SELECTOR=$(kubectl get inferencepool $POOL_NAME -o jsonpath='{.spec.selector}')
-          echo "InferencePool selector: $POOL_SELECTOR"
-          MATCHED_PODS=$(kubectl get pods -l kaito.sh/createdByInferenceSet=inferenceset-aikit-test --no-headers 2>/dev/null | wc -l)
-          echo "Pods matching InferencePool selector: $MATCHED_PODS"
-          if [ "$MATCHED_PODS" -lt 1 ]; then
-            echo "WARNING: No pods matched InferencePool selector"
+          echo "=== Verifying GWIE not created for non-preset InferenceSet (expected) ==="
+          POOL_NAME="inferenceset-aikit-test-inferencepool"
+          if kubectl get ocirepository $POOL_NAME 2>/dev/null; then
+            echo "⚠ Unexpected: GWIE resources found for custom template InferenceSet"
+          else
+            echo "✓ Confirmed: GWIE resources not created for AIKit custom template (only vLLM preset supported)"
           fi
 
       - name: Validate response content

--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -95,7 +95,7 @@ jobs:
             /kind: DaemonSet/ && /name: csi-local-node/ { csi=1 }
             !csi { print }
             { csi=0 }
-          ' | kubectl apply -f -
+          ' | kubectl apply --namespace ${{ env.KAITO_NAMESPACE }} -f -
 
           # Wait for controller to be ready
           kubectl wait --for=condition=available --timeout=300s deployment/kaito-workspace -n ${{ env.KAITO_NAMESPACE }}

--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -187,9 +187,11 @@ jobs:
           kubectl get crd helmreleases.helm.toolkit.fluxcd.io
           echo "✓ Flux HelmRelease CRD installed"
 
-          echo "=== Checking InferencePool CRD is installed ==="
+          echo "=== Checking GWIE CRDs are installed ==="
           kubectl get crd inferencepools.inference.networking.k8s.io
           echo "✓ InferencePool CRD installed"
+          kubectl get crd inferenceobjectives.inference.networking.x-k8s.io
+          echo "✓ InferenceObjective CRD installed"
 
           echo "=== Checking Flux controllers are running ==="
           # Flux helm-controller and source-controller are deployed as part of the flux2 subchart
@@ -223,7 +225,8 @@ jobs:
           echo "=== Verifying GWIE not created for non-preset InferenceSet (expected) ==="
           POOL_NAME="inferenceset-aikit-test-inferencepool"
           if kubectl get ocirepository $POOL_NAME 2>/dev/null; then
-            echo "⚠ Unexpected: GWIE resources found for custom template InferenceSet"
+            echo "✗ Unexpected: GWIE resources found for custom template InferenceSet"
+            exit 1
           else
             echo "✓ Confirmed: GWIE resources not created for AIKit custom template (only vLLM preset supported)"
           fi

--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -86,7 +86,7 @@ jobs:
           # Install via Helm
           # CSI Local Node cannot be configured to not deploy and it crashes on kind on github runners for unknown reasons
           # so we need to filter it out its components
-          helm template kaito-workspace ./charts/kaito/workspace --namespace ${{ env.KAITO_NAMESPACE }} --set featureGates.disableNodeAutoProvisioning="true" --set featureGates.enableInferenceSetController="true" --include-crds --debug --wait | awk '
+          helm template kaito-workspace ./charts/kaito/workspace --namespace ${{ env.KAITO_NAMESPACE }} --set featureGates.disableNodeAutoProvisioning="true" --set featureGates.enableInferenceSetController="true" --set featureGates.gatewayAPIInferenceExtension="true" --include-crds --debug --wait | awk '
             BEGIN { RS="---\n"; ORS="---\n"; csi=0 }
             /kind: ServiceAccount/ && /name: csi-local-node/ { csi=1 }
             /kind: StorageClass/ && /name: kaito-local-nvme-disk/ { csi=1 }
@@ -194,14 +194,49 @@ jobs:
           kubectl wait --for=condition=available --timeout=180s deployment/${POOL_NAME}-epp
           echo "EPP Deployment is available"
 
-          echo "=== Verifying EPP pod args ==="
+          echo "=== Verifying EPP container args ==="
           EPP_ARGS=$(kubectl get deployment ${POOL_NAME}-epp -o jsonpath='{.spec.template.spec.containers[0].args}')
           echo "EPP args: $EPP_ARGS"
-          if echo "$EPP_ARGS" | grep -q "pool-name"; then
-            echo "EPP pool-name arg found"
-          else
-            echo "ERROR: EPP missing pool-name arg"
+
+          # Verify critical args
+          for expected in "pool-name" "pool-namespace" "grpc-port"; do
+            if echo "$EPP_ARGS" | grep -q "$expected"; then
+              echo "✓ Found expected arg: $expected"
+            else
+              echo "✗ Missing expected arg: $expected"
+              exit 1
+            fi
+          done
+
+          echo "=== Verifying EPP pod is Running ==="
+          kubectl get pod -l app=${POOL_NAME}-epp -o wide
+          EPP_POD=$(kubectl get pod -l app=${POOL_NAME}-epp -o jsonpath='{.items[0].metadata.name}')
+          EPP_STATUS=$(kubectl get pod $EPP_POD -o jsonpath='{.status.phase}')
+          if [ "$EPP_STATUS" != "Running" ]; then
+            echo "EPP pod is not running: $EPP_STATUS"
+            kubectl describe pod $EPP_POD
             exit 1
+          fi
+
+          echo "=== Checking EPP health endpoint ==="
+          kubectl port-forward deployment/${POOL_NAME}-epp 9090:9090 &
+          EPP_PF_PID=$!
+          sleep 3
+          # EPP exposes metrics on :9090/metrics
+          if curl -sf http://localhost:9090/metrics > /dev/null 2>&1; then
+            echo "✓ EPP metrics endpoint is healthy"
+          else
+            echo "⚠ EPP metrics endpoint not reachable (may be expected if secure-serving is changing)"
+          fi
+          kill $EPP_PF_PID || true
+
+          echo "=== Verifying InferencePool selector matches inference pods ==="
+          POOL_SELECTOR=$(kubectl get inferencepool $POOL_NAME -o jsonpath='{.spec.selector}')
+          echo "InferencePool selector: $POOL_SELECTOR"
+          MATCHED_PODS=$(kubectl get pods -l kaito.sh/createdByInferenceSet=inferenceset-aikit-test --no-headers 2>/dev/null | wc -l)
+          echo "Pods matching InferencePool selector: $MATCHED_PODS"
+          if [ "$MATCHED_PODS" -lt 1 ]; then
+            echo "WARNING: No pods matched InferencePool selector"
           fi
 
       - name: Validate response content
@@ -300,16 +335,16 @@ jobs:
           kubectl describe nodes
 
           echo "=== GWIE: OCIRepository ==="
-          kubectl get ocirepository -A -o yaml
+          kubectl get ocirepository -A -o yaml || true
 
           echo "=== GWIE: HelmRelease ==="
-          kubectl get helmrelease -A -o yaml
+          kubectl get helmrelease -A -o yaml || true
 
           echo "=== GWIE: InferencePool ==="
-          kubectl get inferencepool -A -o yaml
+          kubectl get inferencepool -A -o yaml || true
 
           echo "=== GWIE: EPP Deployment ==="
-          kubectl get deployment -l app=inferenceset-aikit-test-inferencepool-epp -o yaml
+          kubectl get deployment -l app=inferenceset-aikit-test-inferencepool-epp -o yaml || true
 
           echo "=== GWIE: EPP Pod Logs ==="
           kubectl logs -l app=inferenceset-aikit-test-inferencepool-epp --tail=50 || true

--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -174,6 +174,36 @@ jobs:
           echo "Waiting for inferenceset to be ready..."
           kubectl wait --for='jsonpath={.status.readyReplicas}=1' inferenceset/inferenceset-aikit-test --timeout 300s
 
+      - name: Validate GWIE resource chain
+        run: |
+          POOL_NAME="inferenceset-aikit-test-inferencepool"
+
+          echo "=== Checking Flux OCIRepository ==="
+          kubectl wait --for=condition=ready ocirepository/$POOL_NAME --timeout=120s
+          echo "OCIRepository is ready"
+
+          echo "=== Checking Flux HelmRelease ==="
+          kubectl wait --for=condition=ready helmrelease/$POOL_NAME --timeout=180s
+          echo "HelmRelease is ready"
+
+          echo "=== Checking InferencePool ==="
+          kubectl get inferencepool $POOL_NAME -o yaml
+          echo "InferencePool created successfully"
+
+          echo "=== Checking EPP Deployment ==="
+          kubectl wait --for=condition=available --timeout=180s deployment/${POOL_NAME}-epp
+          echo "EPP Deployment is available"
+
+          echo "=== Verifying EPP pod args ==="
+          EPP_ARGS=$(kubectl get deployment ${POOL_NAME}-epp -o jsonpath='{.spec.template.spec.containers[0].args}')
+          echo "EPP args: $EPP_ARGS"
+          if echo "$EPP_ARGS" | grep -q "pool-name"; then
+            echo "EPP pool-name arg found"
+          else
+            echo "ERROR: EPP missing pool-name arg"
+            exit 1
+          fi
+
       - name: Validate response content
         run: |
           # Set up port forwarding to the workspace service
@@ -268,3 +298,18 @@ jobs:
 
           echo "=== Node information ==="
           kubectl describe nodes
+
+          echo "=== GWIE: OCIRepository ==="
+          kubectl get ocirepository -A -o yaml
+
+          echo "=== GWIE: HelmRelease ==="
+          kubectl get helmrelease -A -o yaml
+
+          echo "=== GWIE: InferencePool ==="
+          kubectl get inferencepool -A -o yaml
+
+          echo "=== GWIE: EPP Deployment ==="
+          kubectl get deployment -l app=inferenceset-aikit-test-inferencepool-epp -o yaml
+
+          echo "=== GWIE: EPP Pod Logs ==="
+          kubectl logs -l app=inferenceset-aikit-test-inferencepool-epp --tail=50 || true

--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -192,14 +192,17 @@ jobs:
           echo "✓ InferencePool CRD installed"
 
           echo "=== Checking Flux controllers are running ==="
-          kubectl get pods -n ${{ env.KAITO_NAMESPACE }} -l app.kubernetes.io/part-of=flux -o wide
-          FLUX_PODS=$(kubectl get pods -n ${{ env.KAITO_NAMESPACE }} -l app.kubernetes.io/part-of=flux --no-headers 2>/dev/null | wc -l)
-          if [ "$FLUX_PODS" -ge 1 ]; then
-            echo "✓ Flux controllers running ($FLUX_PODS pods)"
-          else
-            echo "✗ No Flux controllers found"
-            exit 1
-          fi
+          # Flux helm-controller and source-controller are deployed as part of the flux2 subchart
+          kubectl get deployments -n ${{ env.KAITO_NAMESPACE }} -o wide
+          for controller in helm-controller source-controller; do
+            if kubectl get deployment $controller -n ${{ env.KAITO_NAMESPACE }} >/dev/null 2>&1; then
+              kubectl wait --for=condition=available --timeout=120s deployment/$controller -n ${{ env.KAITO_NAMESPACE }}
+              echo "✓ $controller is available"
+            else
+              echo "✗ $controller deployment not found"
+              exit 1
+            fi
+          done
 
           echo "=== Checking controller feature gates ==="
           CONTROLLER_ARGS=$(kubectl get deployment kaito-workspace -n ${{ env.KAITO_NAMESPACE }} -o jsonpath='{.spec.template.spec.containers[0].args}')


### PR DESCRIPTION
## What type of PR is this?

/kind feature

## What this PR does / why we need it

The AIKit integration workflow already deploys an InferenceSet with `enableInferenceSetController=true`, but does not validate the GWIE (Gateway API Inference Extension) infrastructure. This PR adds:

1. **Enables `gatewayAPIInferenceExtension` feature gate** in the `helm template` command, so Flux subchart (CRDs + controllers) is deployed
2. **Validates GWIE infrastructure** is correctly installed:
   - Flux CRDs (OCIRepository, HelmRelease)
   - InferencePool CRD
   - Flux controllers running in KAITO namespace
   - Controller feature gates (`gatewayAPIInferenceExtension=true`, `enableInferenceSetController=true`)
3. **Adds GWIE debug info** to the always-run debug step

### Test Limitations

> **GWIE resource chain (OCIRepository → HelmRelease → InferencePool → EPP) is only created for vLLM preset-based InferenceSet workloads.** The AIKit test uses custom template inference (not preset), so the InferenceSet controller skips `ensureGatewayAPIInferenceExtension` ([code](https://github.com/kaito-project/kaito/blob/main/pkg/inferenceset/inferenceset_controller.go#L411-L412)). This means:
>
> - ✅ We **can** validate: Flux CRDs installed, Flux controllers running, InferencePool CRD present, controller feature gates correct
> - ❌ We **cannot** validate: OCIRepository/HelmRelease creation, InferencePool resource, EPP Deployment/pod
>
> Full GWIE resource chain e2e testing requires a vLLM preset InferenceSet, which needs GPU nodes not available in the kind-based CI environment.

## Which issue(s) this PR fixes

None — this is a test coverage gap.

## Special notes for your reviewer

No new infrastructure needed — Flux and InferencePool CRDs are already bundled as Helm chart dependencies. The only workflow change is enabling `featureGates.gatewayAPIInferenceExtension=true` to deploy them.