### PR TITLE
feat: add guardrails YAML policy loader to RAG runtime

### DIFF
--- a/presets/ragengine/config.py
+++ b/presets/ragengine/config.py
@@ -69,6 +69,28 @@ LLM_CONTEXT_WINDOW = int(
 )  # Default context window size
 # LLM_RESPONSE_FIELD = os.getenv("LLM_RESPONSE_FIELD", "result")  # Uncomment if needed in the future
 
+
+def _parse_csv_env(name: str) -> tuple[str, ...]:
+    raw_value = os.getenv(name, "")
+    return tuple(item.strip() for item in raw_value.split(",") if item.strip())
+
+
+OUTPUT_GUARDRAILS_ENABLED = (
+    os.getenv("OUTPUT_GUARDRAILS_ENABLED", "false").lower() == "true"
+)
+OUTPUT_GUARDRAILS_POLICY_PATH = os.getenv("OUTPUT_GUARDRAILS_POLICY_PATH", "")
+OUTPUT_GUARDRAILS_ACTION_ON_HIT = os.getenv(
+    "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact"
+).lower()
+OUTPUT_GUARDRAILS_REGEX_PATTERNS = _parse_csv_env("OUTPUT_GUARDRAILS_REGEX_PATTERNS")
+OUTPUT_GUARDRAILS_BANNED_SUBSTRINGS = _parse_csv_env(
+    "OUTPUT_GUARDRAILS_BANNED_SUBSTRINGS"
+)
+OUTPUT_GUARDRAILS_BLOCK_MESSAGE = os.getenv(
+    "OUTPUT_GUARDRAILS_BLOCK_MESSAGE",
+    "The model output was blocked by output guardrails.",
+)
+
 """
 =========================================================================
 """

--- a/presets/ragengine/guardrails/__init__.py
+++ b/presets/ragengine/guardrails/__init__.py
@@ -1,0 +1,3 @@
+from .output_guardrails import OutputGuardrails
+
+__all__ = ["OutputGuardrails"]

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -1,0 +1,164 @@
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import yaml
+from llm_guard import scan_output
+from llm_guard.output_scanners import BanSubstrings, Regex
+
+from ragengine import config
+from ragengine.models import ChatCompletionResponse, get_message_content
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_BLOCK_MESSAGE = "The model output was blocked by output guardrails."
+
+
+@dataclass
+class OutputGuardrails:
+    enabled: bool
+    action_on_hit: str
+    regex_patterns: list[str]
+    banned_substrings: list[str]
+    block_message: str = DEFAULT_BLOCK_MESSAGE
+
+    @classmethod
+    def from_config(cls) -> "OutputGuardrails":
+        guardrails = cls(
+            enabled=config.OUTPUT_GUARDRAILS_ENABLED,
+            action_on_hit=config.OUTPUT_GUARDRAILS_ACTION_ON_HIT,
+            regex_patterns=list(config.OUTPUT_GUARDRAILS_REGEX_PATTERNS),
+            banned_substrings=list(config.OUTPUT_GUARDRAILS_BANNED_SUBSTRINGS),
+            block_message=config.OUTPUT_GUARDRAILS_BLOCK_MESSAGE,
+        )
+        return guardrails._apply_policy_file(config.OUTPUT_GUARDRAILS_POLICY_PATH)
+
+    def _apply_policy_file(self, policy_path: str) -> "OutputGuardrails":
+        if not policy_path:
+            return self
+
+        try:
+            with open(policy_path, encoding="utf-8") as policy_file:
+                policy = yaml.safe_load(policy_file) or {}
+        except FileNotFoundError:
+            logger.warning("output_guardrails_policy_missing path=%s", policy_path)
+            return self
+        except Exception:
+            logger.exception("output_guardrails_policy_load_failed path=%s", policy_path)
+            return self
+
+        if not isinstance(policy, dict):
+            logger.warning("output_guardrails_policy_invalid path=%s", policy_path)
+            return self
+
+        regex_patterns: list[str] = []
+        banned_substrings: list[str] = []
+        for scanner in policy.get("scanners", []):
+            if not isinstance(scanner, dict):
+                continue
+
+            scanner_type = str(scanner.get("type", "")).lower()
+            if scanner_type == "regex":
+                regex_patterns.extend(_coerce_string_list(scanner.get("patterns")))
+            elif scanner_type == "ban_substrings":
+                banned_substrings.extend(_coerce_string_list(scanner.get("substrings")))
+            elif scanner_type:
+                logger.warning(
+                    "output_guardrails_policy_unknown_scanner type=%s",
+                    scanner_type,
+                )
+
+        return OutputGuardrails(
+            enabled=self.enabled,
+            action_on_hit=str(policy.get("action", self.action_on_hit)).lower(),
+            regex_patterns=regex_patterns or list(self.regex_patterns),
+            banned_substrings=banned_substrings or list(self.banned_substrings),
+            block_message=str(policy.get("blockMessage", self.block_message)),
+        )
+
+    def guard_response(
+        self,
+        response: ChatCompletionResponse,
+        request: dict[str, Any],
+    ) -> ChatCompletionResponse:
+        if not self.enabled:
+            return response
+
+        scanners = self._build_scanners()
+        if not scanners:
+            return response
+
+        try:
+            prompt = self._extract_prompt(request)
+            response_data = response.model_dump(mode="python")
+
+            for choice in response_data.get("choices", []):
+                message = choice.get("message") or {}
+                content = message.get("content")
+                if message.get("role") != "assistant" or not isinstance(content, str):
+                    continue
+
+                sanitized_output, results_valid, results_score = scan_output(
+                    scanners, prompt, content, fail_fast=False
+                )
+                triggered_scanners = {
+                    scanner_name: results_score.get(scanner_name)
+                    for scanner_name, is_valid in results_valid.items()
+                    if not is_valid
+                }
+                if not triggered_scanners:
+                    continue
+
+                if self.action_on_hit == "block":
+                    message["content"] = self.block_message
+                else:
+                    message["content"] = sanitized_output
+
+                logger.info(
+                    "output_guardrails_triggered action=%s response_id=%s scanners=%s",
+                    self.action_on_hit,
+                    response.id,
+                    triggered_scanners,
+                )
+
+            return ChatCompletionResponse(**response_data)
+        except Exception:
+            logger.exception("output_guardrails_failed")
+            return response
+
+    def _build_scanners(self) -> list[Any]:
+        scanners: list[Any] = []
+
+        if self.regex_patterns:
+            scanners.append(Regex(patterns=self.regex_patterns, redact=True))
+
+        if self.banned_substrings:
+            scanners.append(
+                BanSubstrings(
+                    substrings=self.banned_substrings,
+                    redact=self.action_on_hit == "redact",
+                )
+            )
+
+        return scanners
+
+    def _extract_prompt(self, request: dict[str, Any]) -> str:
+        messages = request.get("messages", [])
+        if not isinstance(messages, list):
+            return ""
+
+        prompt_parts = []
+        for message in messages:
+            if not isinstance(message, dict):
+                continue
+            content = get_message_content(message)
+            if content:
+                prompt_parts.append(content)
+
+        return "\n\n".join(prompt_parts)
+
+
+def _coerce_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item]

--- a/presets/ragengine/main.py
+++ b/presets/ragengine/main.py
@@ -56,6 +56,7 @@ from ragengine.config import (  # noqa: E402
     VECTOR_DB_TYPE,
     VECTOR_DB_URL,
 )
+from ragengine.guardrails import OutputGuardrails  # noqa: E402
 from ragengine.metrics.prometheus_metrics import (  # noqa: E402
     MODE_LOCAL,
     MODE_REMOTE,
@@ -160,6 +161,7 @@ else:
 
 # Initialize RAG operations
 rag_ops = VectorStoreManager(vector_store_handler)
+output_guardrails = OutputGuardrails.from_config()
 
 
 @app.get("/metrics", operation_id="get_metrics", tags=["Monitoring"])
@@ -335,6 +337,7 @@ async def chat_completions(request: dict):
             )
 
         response = await rag_ops.chat_completion(request)
+        response = output_guardrails.guard_response(response, request)
         status = STATUS_SUCCESS
         return response
     except HTTPException as http_exc:

--- a/presets/ragengine/requirements.txt
+++ b/presets/ragengine/requirements.txt
@@ -29,6 +29,8 @@ nest-asyncio==1.6.0
 httpx==0.27.0
 requests==2.32.4
 openai==1.108.1
+llm-guard==0.3.16
+PyYAML>=6.0.2
 
 tiktoken==0.11.0
 tree-sitter==0.23.2

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -1,0 +1,63 @@
+import os
+import sys
+import textwrap
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+
+from ragengine import config
+from ragengine.guardrails.output_guardrails import (
+    DEFAULT_BLOCK_MESSAGE,
+    OutputGuardrails,
+)
+
+
+def test_from_config_loads_yaml_policy(tmp_path, monkeypatch):
+    policy_path = tmp_path / "guardrails.yaml"
+    policy_path.write_text(
+        textwrap.dedent(
+            """
+            action: block
+            blockMessage: blocked-by-policy
+            scanners:
+              - type: regex
+                patterns:
+                  - https?://\\S+
+              - type: ban_substrings
+                substrings:
+                  - secret
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_REGEX_PATTERNS", tuple())
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BANNED_SUBSTRINGS", tuple())
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE)
+
+    guardrails = OutputGuardrails.from_config()
+
+    assert guardrails.enabled is True
+    assert guardrails.action_on_hit == "block"
+    assert guardrails.regex_patterns == [r"https?://\S+"]
+    assert guardrails.banned_substrings == ["secret"]
+    assert guardrails.block_message == "blocked-by-policy"
+
+
+def test_from_config_falls_back_to_env_values_when_policy_path_missing(monkeypatch):
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", "/tmp/missing-guardrails.yaml")
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_REGEX_PATTERNS", (r"secret",))
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BANNED_SUBSTRINGS", ("token",))
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE)
+
+    guardrails = OutputGuardrails.from_config()
+
+    assert guardrails.enabled is True
+    assert guardrails.action_on_hit == "redact"
+    assert guardrails.regex_patterns == [r"secret"]
+    assert guardrails.banned_substrings == ["token"]
+    assert guardrails.block_message == DEFAULT_BLOCK_MESSAGE


### PR DESCRIPTION
## Summary

This PR adds runtime support for loading output guardrails policy from a `guardrails.yaml` file in the RAG service.

The change is intentionally scoped to the runtime layer. It adds YAML-based guardrails policy loading, maps policy fields into the existing runtime guardrails model, and wires the loader into the chat completions path so the policy can take effect at runtime.

## What Changed

- Added a runtime policy path setting in the RAG configuration.
- Added YAML-based output guardrails policy loading from `guardrails.yaml`.
- Mapped YAML policy fields into the existing runtime guardrails structure.
- Wired the runtime guardrails loader into the RAG chat completions flow.
- Added focused tests for YAML-based policy loading and fallback behavior.
- Added the required Python dependencies for guardrails scanning and YAML parsing.

## Files In Scope

- `presets/ragengine/config.py`
- `presets/ragengine/guardrails/__init__.py`
- `presets/ragengine/guardrails/output_guardrails.py`
- `presets/ragengine/main.py`
- `presets/ragengine/requirements.txt`
- `presets/ragengine/tests/guardrails/test_output_guardrails.py`

## Out Of Scope

This PR does not include:

- Default ConfigMap creation or propagation.
- Controller-side ConfigMap copy logic.
- Pod volume mount wiring.
- Helm template changes.
- Broader Kubernetes integration.

Those changes will be handled separately in a follow-up PR.

## Validation

- `/home/yiqi/kaito/.venv/bin/python -m pytest presets/ragengine/tests/guardrails/test_output_guardrails.py -q --full-trace`