### PR TITLE
refactor: unify output guardrails scanner configuration

### DIFF
--- a/presets/ragengine/config.py
+++ b/presets/ragengine/config.py
@@ -70,11 +70,6 @@ LLM_CONTEXT_WINDOW = int(
 # LLM_RESPONSE_FIELD = os.getenv("LLM_RESPONSE_FIELD", "result")  # Uncomment if needed in the future
 
 
-def _parse_csv_env(name: str) -> tuple[str, ...]:
-    raw_value = os.getenv(name, "")
-    return tuple(item.strip() for item in raw_value.split(",") if item.strip())
-
-
 OUTPUT_GUARDRAILS_ENABLED = (
     os.getenv("OUTPUT_GUARDRAILS_ENABLED", "false").lower() == "true"
 )
@@ -82,10 +77,6 @@ OUTPUT_GUARDRAILS_POLICY_PATH = os.getenv("OUTPUT_GUARDRAILS_POLICY_PATH", "")
 OUTPUT_GUARDRAILS_ACTION_ON_HIT = os.getenv(
     "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact"
 ).lower()
-OUTPUT_GUARDRAILS_REGEX_PATTERNS = _parse_csv_env("OUTPUT_GUARDRAILS_REGEX_PATTERNS")
-OUTPUT_GUARDRAILS_BANNED_SUBSTRINGS = _parse_csv_env(
-    "OUTPUT_GUARDRAILS_BANNED_SUBSTRINGS"
-)
 OUTPUT_GUARDRAILS_BLOCK_MESSAGE = os.getenv(
     "OUTPUT_GUARDRAILS_BLOCK_MESSAGE",
     "The model output was blocked by output guardrails.",

--- a/presets/ragengine/config.py
+++ b/presets/ragengine/config.py
@@ -74,13 +74,6 @@ OUTPUT_GUARDRAILS_ENABLED = (
     os.getenv("OUTPUT_GUARDRAILS_ENABLED", "false").lower() == "true"
 )
 OUTPUT_GUARDRAILS_POLICY_PATH = os.getenv("OUTPUT_GUARDRAILS_POLICY_PATH", "")
-OUTPUT_GUARDRAILS_ACTION_ON_HIT = os.getenv(
-    "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact"
-).lower()
-OUTPUT_GUARDRAILS_BLOCK_MESSAGE = os.getenv(
-    "OUTPUT_GUARDRAILS_BLOCK_MESSAGE",
-    "The model output was blocked by output guardrails.",
-)
 
 """
 =========================================================================

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -195,13 +195,6 @@ def _normalize_policy_scanner_configs(
 
     return scanner_configs
 
-
-def _coerce_policy_scanner_configs(
-    value: Any, policy_path: str
-) -> list[NormalizedScannerConfig]:
-    return _normalize_policy_scanner_configs(value, policy_path)
-
-
 def _build_scanner(
     scanner_config: NormalizedScannerConfig,
     action_on_hit: str,

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BLOCK_MESSAGE = "The model output was blocked by output guardrails."
 
-ScannerConfig = dict[str, Any]
+NormalizedScannerConfig = dict[str, Any]
 
 SUPPORTED_POLICY_SCANNERS = {
     "ban_substrings": "BanSubstrings",
@@ -41,7 +41,7 @@ class OutputGuardrails:
     enabled: bool
     action_on_hit: str
     block_message: str = DEFAULT_BLOCK_MESSAGE
-    scanner_configs: list[ScannerConfig] = field(default_factory=list)
+    scanner_configs: list[NormalizedScannerConfig] = field(default_factory=list)
 
     @classmethod
     def from_config(cls) -> "OutputGuardrails":
@@ -74,7 +74,7 @@ class OutputGuardrails:
 
         scanner_configs = list(self.scanner_configs)
         if "scanners" in policy:
-            scanner_configs = _coerce_policy_scanner_configs(
+            scanner_configs = _normalize_policy_scanner_configs(
                 policy.get("scanners"),
                 policy_path,
             )
@@ -169,16 +169,16 @@ def _coerce_string_list(value: Any) -> list[str]:
     return [item for item in value if isinstance(item, str) and item]
 
 
-def _coerce_policy_scanner_configs(
+def _normalize_policy_scanner_configs(
     value: Any, policy_path: str
-) -> list[ScannerConfig]:
+) -> list[NormalizedScannerConfig]:
     if value is None:
         return []
     if not isinstance(value, list):
         logger.warning("output_guardrails_policy_invalid_scanners path=%s", policy_path)
         return []
 
-    scanner_configs: list[ScannerConfig] = []
+    scanner_configs: list[NormalizedScannerConfig] = []
     for scanner in value:
         if not isinstance(scanner, dict):
             continue
@@ -196,18 +196,31 @@ def _coerce_policy_scanner_configs(
     return scanner_configs
 
 
-def _build_scanner(scanner_config: ScannerConfig, action_on_hit: str) -> Any | None:
+def _coerce_policy_scanner_configs(
+    value: Any, policy_path: str
+) -> list[NormalizedScannerConfig]:
+    return _normalize_policy_scanner_configs(value, policy_path)
+
+
+def _build_scanner(
+    scanner_config: NormalizedScannerConfig,
+    action_on_hit: str,
+) -> Any | None:
     scanner_type = str(scanner_config.get("type", "")).lower()
     scanner_class = _resolve_scanner_class(scanner_type)
     if scanner_class is None:
         return None
 
-    kwargs = _build_scanner_kwargs(scanner_class, scanner_config, action_on_hit)
-    if kwargs is None:
+    constructor_args = _build_scanner_constructor_args(
+        scanner_class,
+        scanner_config,
+        action_on_hit,
+    )
+    if constructor_args is None:
         return None
 
     try:
-        return scanner_class(**kwargs)
+        return scanner_class(**constructor_args)
     except Exception:
         logger.exception(
             "output_guardrails_policy_scanner_build_failed type=%s",
@@ -216,34 +229,36 @@ def _build_scanner(scanner_config: ScannerConfig, action_on_hit: str) -> Any | N
         return None
 
 
-def _build_scanner_kwargs(
+def _build_scanner_constructor_args(
     scanner_class: type[Any],
-    scanner_config: ScannerConfig,
+    scanner_config: NormalizedScannerConfig,
     action_on_hit: str,
 ) -> dict[str, Any] | None:
+    # Translate one normalized policy scanner config into constructor arguments
+    # for the concrete llm_guard scanner class.
     signature = inspect.signature(scanner_class)
-    kwargs: dict[str, Any] = {}
+    constructor_args: dict[str, Any] = {}
     scanner_type = str(scanner_config.get("type", "")).lower()
-    config_values = {
+    scanner_options = {
         key: value for key, value in scanner_config.items() if key != "type"
     }
 
     for name, parameter in signature.parameters.items():
-        if not _is_supported_scanner_parameter(parameter):
+        if not _is_scanner_constructor_parameter(parameter):
             continue
 
-        value_found, value = _resolve_scanner_argument(
+        value_found, value = _resolve_scanner_parameter_value(
             name,
             scanner_type,
             scanner_config,
-            config_values,
+            scanner_options,
             action_on_hit,
         )
         if value_found:
-            kwargs[name] = value
+            constructor_args[name] = value
             continue
 
-        if _is_required_scanner_parameter(parameter):
+        if _is_required_constructor_parameter(parameter):
             logger.warning(
                 "output_guardrails_policy_invalid_scanner_config type=%s missing=%s",
                 scanner_type,
@@ -251,7 +266,7 @@ def _build_scanner_kwargs(
             )
             return None
 
-    return kwargs
+    return constructor_args
 
 
 def _resolve_scanner_class(scanner_type: str) -> type[Any] | None:
@@ -270,11 +285,11 @@ def _resolve_scanner_class(scanner_type: str) -> type[Any] | None:
     return scanner_class
 
 
-def _resolve_scanner_argument(
+def _resolve_scanner_parameter_value(
     name: str,
     scanner_type: str,
-    scanner_config: ScannerConfig,
-    config_values: dict[str, Any],
+    scanner_config: NormalizedScannerConfig,
+    scanner_options: dict[str, Any],
     action_on_hit: str,
 ) -> tuple[bool, Any]:
     if name == "redact":
@@ -286,20 +301,20 @@ def _resolve_scanner_argument(
     if name == "substrings" and scanner_type == "ban_substrings":
         return True, _coerce_string_list(scanner_config.get("substrings"))
 
-    if name in config_values:
-        return True, config_values[name]
+    if name in scanner_options:
+        return True, scanner_options[name]
 
     return False, None
 
 
-def _is_supported_scanner_parameter(parameter: inspect.Parameter) -> bool:
+def _is_scanner_constructor_parameter(parameter: inspect.Parameter) -> bool:
     return parameter.kind in (
         inspect.Parameter.POSITIONAL_OR_KEYWORD,
         inspect.Parameter.KEYWORD_ONLY,
     )
 
 
-def _is_required_scanner_parameter(parameter: inspect.Parameter) -> bool:
+def _is_required_constructor_parameter(parameter: inspect.Parameter) -> bool:
     return parameter.default is inspect.Signature.empty
 
 

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -16,114 +16,20 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-import llm_guard.output_scanners as llm_guard_output_scanners
 import yaml
 from llm_guard import scan_output
-from llm_guard.input_scanners.ban_substrings import (
-    MatchType as BanSubstringsMatchType,
-)
-from llm_guard.input_scanners.regex import MatchType as RegexMatchType
 
 from ragengine import config
+from ragengine.guardrails.scanner_schemas import (
+    SCANNER_REGISTRY,
+    ParsedScannerConfig,
+)
 from ragengine.models import ChatCompletionResponse, get_message_content
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_BLOCK_MESSAGE = "The model output was blocked by output guardrails."
 DEFAULT_ACTION_ON_HIT = "redact"
-
-
-# ===============================
-# Scanner config schemas
-#
-# Each schema describes the YAML shape AND knows how to build the
-# corresponding llm_guard scanner. To add a new scanner:
-#   1. Define a dataclass with from_dict() and build()
-#   2. Register it in SCANNER_REGISTRY below
-#
-# TODO: Once this scanner config surface stabilizes, move schema
-# validation to the admission webhook so that invalid policies are
-# rejected at apply-time instead of being silently skipped at runtime.
-#
-# TODO: Many llm_guard scanners (e.g. Toxicity, Bias, Language) do not
-# support redaction; pairing them with action=redact would be a no-op.
-# When adding such scanners, declare a per-schema `supports_redact` flag
-# and reject the (action=redact + non-redact scanner) combination here
-# in the schema layer, instead of trying to fix it at runtime.
-# ===============================
-
-
-@dataclass
-class BanSubstringsConfig:
-    substrings: list[str]
-    match_type: str = "word"
-    case_sensitive: bool = False
-    contains_all: bool = False
-
-    @classmethod
-    def from_dict(cls, raw: dict) -> "BanSubstringsConfig":
-        substrings = _coerce_string_list(raw.get("substrings"))
-        if not substrings:
-            raise ValueError(
-                "ban_substrings requires 'substrings' to be a non-empty list of strings"
-            )
-        return cls(
-            substrings=substrings,
-            match_type=str(raw.get("match_type", "word")).lower(),
-            case_sensitive=bool(raw.get("case_sensitive", False)),
-            contains_all=bool(raw.get("contains_all", False)),
-        )
-
-    def build(self, action_on_hit: str) -> Any:
-        return llm_guard_output_scanners.BanSubstrings(
-            substrings=list(self.substrings),
-            match_type=BanSubstringsMatchType[self.match_type.upper()],
-            case_sensitive=self.case_sensitive,
-            contains_all=self.contains_all,
-            redact=(action_on_hit == "redact"),
-        )
-
-
-@dataclass
-class RegexConfig:
-    patterns: list[str]
-    is_blocked: bool = True
-    match_type: str = "search"
-
-    @classmethod
-    def from_dict(cls, raw: dict) -> "RegexConfig":
-        patterns = _coerce_string_list(raw.get("patterns"))
-        if not patterns:
-            raise ValueError(
-                "regex requires 'patterns' to be a non-empty list of strings"
-            )
-        return cls(
-            patterns=patterns,
-            is_blocked=bool(raw.get("is_blocked", True)),
-            match_type=str(raw.get("match_type", "search")).lower(),
-        )
-
-    def build(self, action_on_hit: str) -> Any:
-        return llm_guard_output_scanners.Regex(
-            patterns=list(self.patterns),
-            is_blocked=self.is_blocked,
-            match_type=RegexMatchType[self.match_type.upper()],
-            redact=(action_on_hit == "redact"),
-        )
-
-
-SCANNER_REGISTRY: dict[str, type] = {
-    "ban_substrings": BanSubstringsConfig,
-    "regex": RegexConfig,
-}
-
-
-@dataclass
-class ParsedScannerConfig:
-    """A scanner config that has already passed schema validation."""
-
-    type: str
-    config: Any
 
 
 @dataclass
@@ -250,12 +156,6 @@ class OutputGuardrails:
                 prompt_parts.append(content)
 
         return "\n\n".join(prompt_parts)
-
-
-def _coerce_string_list(value: Any) -> list[str]:
-    if not isinstance(value, list):
-        return []
-    return [item for item in value if isinstance(item, str) and item]
 
 
 def _parse_policy_scanner_configs(

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -41,9 +41,7 @@ class OutputGuardrails:
 
     @classmethod
     def from_config(cls) -> "OutputGuardrails":
-        # When the feature flag is off, skip policy I/O entirely: there is no
-        # need to open / parse / validate the YAML file, and a malformed
-        # policy must not surface warnings while guardrails are disabled.
+        # Skip policy I/O when disabled so a malformed policy stays silent.
         if not config.OUTPUT_GUARDRAILS_ENABLED:
             return cls(enabled=False)
 
@@ -52,6 +50,9 @@ class OutputGuardrails:
 
     def _apply_policy_file(self, policy_path: str) -> "OutputGuardrails":
         if not policy_path:
+            # No policy configured: returns self with empty scanner_configs.
+            # Combined with enabled=True this is effectively fail-open.
+            # TODO(next-PR): ship a default policy or refuse to start.
             return self
 
         try:

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -11,7 +11,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import inspect
 import logging
 import re
 from dataclasses import dataclass, field
@@ -20,6 +19,10 @@ from typing import Any
 import llm_guard.output_scanners as llm_guard_output_scanners
 import yaml
 from llm_guard import scan_output
+from llm_guard.input_scanners.ban_substrings import (
+    MatchType as BanSubstringsMatchType,
+)
+from llm_guard.input_scanners.regex import MatchType as RegexMatchType
 
 from ragengine import config
 from ragengine.models import ChatCompletionResponse, get_message_content
@@ -27,22 +30,94 @@ from ragengine.models import ChatCompletionResponse, get_message_content
 logger = logging.getLogger(__name__)
 
 DEFAULT_BLOCK_MESSAGE = "The model output was blocked by output guardrails."
+DEFAULT_ACTION_ON_HIT = "redact"
 
-NormalizedScannerConfig = dict[str, Any]
 
-SUPPORTED_POLICY_SCANNERS = {
-    "ban_substrings": "BanSubstrings",
-    "regex": "Regex",
+# ===============================
+# Scanner config schemas
+#
+# Each schema describes the YAML shape AND knows how to build the
+# corresponding llm_guard scanner. To add a new scanner:
+#   1. Define a dataclass with from_dict() and build()
+#   2. Register it in SCANNER_REGISTRY below
+# ===============================
+
+
+@dataclass
+class BanSubstringsConfig:
+    substrings: list[str]
+    match_type: str = "word"
+    case_sensitive: bool = False
+    contains_all: bool = False
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "BanSubstringsConfig":
+        substrings = _coerce_string_list(raw.get("substrings"))
+        if not substrings:
+            raise ValueError("ban_substrings requires non-empty 'substrings'")
+        return cls(
+            substrings=substrings,
+            match_type=str(raw.get("match_type", "word")).lower(),
+            case_sensitive=bool(raw.get("case_sensitive", False)),
+            contains_all=bool(raw.get("contains_all", False)),
+        )
+
+    def build(self, action_on_hit: str) -> Any:
+        return llm_guard_output_scanners.BanSubstrings(
+            substrings=list(self.substrings),
+            match_type=BanSubstringsMatchType[self.match_type.upper()],
+            case_sensitive=self.case_sensitive,
+            contains_all=self.contains_all,
+            redact=(action_on_hit == "redact"),
+        )
+
+
+@dataclass
+class RegexConfig:
+    patterns: list[str]
+    is_blocked: bool = True
+    match_type: str = "search"
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "RegexConfig":
+        patterns = _coerce_string_list(raw.get("patterns"))
+        if not patterns:
+            raise ValueError("regex requires non-empty 'patterns'")
+        return cls(
+            patterns=patterns,
+            is_blocked=bool(raw.get("is_blocked", True)),
+            match_type=str(raw.get("match_type", "search")).lower(),
+        )
+
+    def build(self, action_on_hit: str) -> Any:
+        return llm_guard_output_scanners.Regex(
+            patterns=list(self.patterns),
+            is_blocked=self.is_blocked,
+            match_type=RegexMatchType[self.match_type.upper()],
+            redact=(action_on_hit == "redact"),
+        )
+
+
+SCANNER_REGISTRY: dict[str, type] = {
+    "ban_substrings": BanSubstringsConfig,
+    "regex": RegexConfig,
 }
 
-DEFAULT_ACTION_ON_HIT = "redact"
+
+@dataclass
+class ParsedScannerConfig:
+    """A scanner config that has already passed schema validation."""
+
+    type: str
+    config: Any
+
 
 @dataclass
 class OutputGuardrails:
     enabled: bool
     action_on_hit: str = DEFAULT_ACTION_ON_HIT
     block_message: str = DEFAULT_BLOCK_MESSAGE
-    scanner_configs: list[NormalizedScannerConfig] = field(default_factory=list)
+    scanner_configs: list[ParsedScannerConfig] = field(default_factory=list)
 
     @classmethod
     def from_config(cls) -> "OutputGuardrails":
@@ -71,7 +146,7 @@ class OutputGuardrails:
 
         scanner_configs = list(self.scanner_configs)
         if "scanners" in policy:
-            scanner_configs = _normalize_policy_scanner_configs(
+            scanner_configs = _parse_policy_scanner_configs(
                 policy.get("scanners"),
                 policy_path,
             )
@@ -137,11 +212,14 @@ class OutputGuardrails:
 
     def _build_scanners(self) -> list[Any]:
         scanners: list[Any] = []
-        for scanner_config in self.scanner_configs:
-            scanner = _build_scanner(scanner_config, self.action_on_hit)
-            if scanner is not None:
-                scanners.append(scanner)
-
+        for parsed in self.scanner_configs:
+            try:
+                scanners.append(parsed.config.build(self.action_on_hit))
+            except Exception:
+                logger.exception(
+                    "output_guardrails_policy_scanner_build_failed type=%s",
+                    parsed.type,
+                )
         return scanners
 
     def _extract_prompt(self, request: dict[str, Any]) -> str:
@@ -166,146 +244,49 @@ def _coerce_string_list(value: Any) -> list[str]:
     return [item for item in value if isinstance(item, str) and item]
 
 
-def _normalize_policy_scanner_configs(
+def _parse_policy_scanner_configs(
     value: Any, policy_path: str
-) -> list[NormalizedScannerConfig]:
+) -> list[ParsedScannerConfig]:
     if value is None:
         return []
     if not isinstance(value, list):
         logger.warning("output_guardrails_policy_invalid_scanners path=%s", policy_path)
         return []
 
-    scanner_configs: list[NormalizedScannerConfig] = []
-    for scanner in value:
-        if not isinstance(scanner, dict):
+    parsed_configs: list[ParsedScannerConfig] = []
+    for raw in value:
+        if not isinstance(raw, dict):
             continue
-        scanner_type = _normalize_scanner_key(str(scanner.get("type", "")).strip())
+
+        scanner_type = _normalize_scanner_key(str(raw.get("type", "")).strip())
         if not scanner_type:
             continue
 
-        normalized_config = {"type": scanner_type}
-        for key, item in scanner.items():
-            if key == "type":
-                continue
-            normalized_config[_normalize_scanner_key(str(key))] = item
-        scanner_configs.append(normalized_config)
-
-    return scanner_configs
-
-def _build_scanner(
-    scanner_config: NormalizedScannerConfig,
-    action_on_hit: str,
-) -> Any | None:
-    scanner_type = str(scanner_config.get("type", "")).lower()
-    scanner_class = _resolve_scanner_class(scanner_type)
-    if scanner_class is None:
-        return None
-
-    constructor_args = _build_scanner_constructor_args(
-        scanner_class,
-        scanner_config,
-        action_on_hit,
-    )
-    if constructor_args is None:
-        return None
-
-    try:
-        return scanner_class(**constructor_args)
-    except Exception:
-        logger.exception(
-            "output_guardrails_policy_scanner_build_failed type=%s",
-            scanner_type,
-        )
-        return None
-
-
-def _build_scanner_constructor_args(
-    scanner_class: type[Any],
-    scanner_config: NormalizedScannerConfig,
-    action_on_hit: str,
-) -> dict[str, Any] | None:
-    # Translate one normalized policy scanner config into constructor arguments
-    # for the concrete llm_guard scanner class.
-    signature = inspect.signature(scanner_class)
-    constructor_args: dict[str, Any] = {}
-    scanner_type = str(scanner_config.get("type", "")).lower()
-    scanner_options = {
-        key: value for key, value in scanner_config.items() if key != "type"
-    }
-
-    for name, parameter in signature.parameters.items():
-        if not _is_scanner_constructor_parameter(parameter):
-            continue
-
-        value_found, value = _resolve_scanner_parameter_value(
-            name,
-            scanner_type,
-            scanner_config,
-            scanner_options,
-            action_on_hit,
-        )
-        if value_found:
-            constructor_args[name] = value
-            continue
-
-        if _is_required_constructor_parameter(parameter):
+        schema_cls = SCANNER_REGISTRY.get(scanner_type)
+        if schema_cls is None:
             logger.warning(
-                "output_guardrails_policy_invalid_scanner_config type=%s missing=%s",
-                scanner_type,
-                name,
+                "output_guardrails_policy_unknown_scanner type=%s", scanner_type
             )
-            return None
+            continue
 
-    return constructor_args
+        normalized_raw = {
+            _normalize_scanner_key(str(key)): item
+            for key, item in raw.items()
+            if key != "type"
+        }
+        try:
+            cfg = schema_cls.from_dict(normalized_raw)
+        except (TypeError, ValueError) as e:
+            logger.warning(
+                "output_guardrails_policy_invalid_scanner_config type=%s error=%s",
+                scanner_type,
+                e,
+            )
+            continue
 
+        parsed_configs.append(ParsedScannerConfig(type=scanner_type, config=cfg))
 
-def _resolve_scanner_class(scanner_type: str) -> type[Any] | None:
-    class_name = SUPPORTED_POLICY_SCANNERS.get(scanner_type)
-    if not class_name:
-        logger.warning("output_guardrails_policy_unknown_scanner type=%s", scanner_type)
-        return None
-
-    scanner_class = getattr(llm_guard_output_scanners, class_name, None)
-    if scanner_class is None:
-        logger.warning(
-            "output_guardrails_policy_unavailable_scanner type=%s", scanner_type
-        )
-        return None
-
-    return scanner_class
-
-
-def _resolve_scanner_parameter_value(
-    name: str,
-    scanner_type: str,
-    scanner_config: NormalizedScannerConfig,
-    scanner_options: dict[str, Any],
-    action_on_hit: str,
-) -> tuple[bool, Any]:
-    if name == "redact":
-        return True, action_on_hit == "redact"
-
-    if name == "patterns" and scanner_type == "regex":
-        return True, _coerce_string_list(scanner_config.get("patterns"))
-
-    if name == "substrings" and scanner_type == "ban_substrings":
-        return True, _coerce_string_list(scanner_config.get("substrings"))
-
-    if name in scanner_options:
-        return True, scanner_options[name]
-
-    return False, None
-
-
-def _is_scanner_constructor_parameter(parameter: inspect.Parameter) -> bool:
-    return parameter.kind in (
-        inspect.Parameter.POSITIONAL_OR_KEYWORD,
-        inspect.Parameter.KEYWORD_ONLY,
-    )
-
-
-def _is_required_constructor_parameter(parameter: inspect.Parameter) -> bool:
-    return parameter.default is inspect.Signature.empty
+    return parsed_configs
 
 
 def _normalize_scanner_key(value: str) -> str:

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -100,7 +100,9 @@ class OutputGuardrails:
         return OutputGuardrails(
             enabled=self.enabled,
             action_on_hit=_normalize_action(policy.get("action"), self.action_on_hit),
-            block_message=_coerce_string(policy.get("blockMessage"), self.block_message),
+            block_message=_coerce_string(
+                policy.get("blockMessage"), self.block_message
+            ),
             scanner_configs=scanner_configs,
         )
 
@@ -185,7 +187,9 @@ def _coerce_string_list(value: Any) -> list[str]:
     return [item for item in value if isinstance(item, str) and item]
 
 
-def _coerce_policy_scanner_configs(value: Any, policy_path: str) -> list[dict[str, Any]]:
+def _coerce_policy_scanner_configs(
+    value: Any, policy_path: str
+) -> list[dict[str, Any]]:
     if value is None:
         return []
     if not isinstance(value, list):
@@ -219,7 +223,9 @@ def _build_scanner(scanner_config: dict[str, Any], action_on_hit: str) -> Any | 
 
     scanner_class = getattr(llm_guard_output_scanners, class_name, None)
     if scanner_class is None:
-        logger.warning("output_guardrails_policy_unavailable_scanner type=%s", scanner_type)
+        logger.warning(
+            "output_guardrails_policy_unavailable_scanner type=%s", scanner_type
+        )
         return None
 
     kwargs = _build_scanner_kwargs(scanner_class, scanner_config, action_on_hit)
@@ -243,7 +249,9 @@ def _build_scanner_kwargs(
 ) -> dict[str, Any] | None:
     signature = inspect.signature(scanner_class)
     kwargs: dict[str, Any] = {}
-    config_values = {key: value for key, value in scanner_config.items() if key != "type"}
+    config_values = {
+        key: value for key, value in scanner_config.items() if key != "type"
+    }
 
     for name, parameter in signature.parameters.items():
         if parameter.kind not in (

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_BLOCK_MESSAGE = "The model output was blocked by output guardrails."
 DEFAULT_ACTION_ON_HIT = "redact"
 
+
 @dataclass
 class OutputGuardrails:
     enabled: bool

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -20,6 +20,7 @@ from typing import Any
 import llm_guard.output_scanners as llm_guard_output_scanners
 import yaml
 from llm_guard import scan_output
+
 from ragengine import config
 from ragengine.models import ChatCompletionResponse, get_message_content
 

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -58,7 +58,10 @@ class BanSubstringsConfig:
     def from_dict(cls, raw: dict) -> "BanSubstringsConfig":
         substrings = _coerce_string_list(raw.get("substrings"))
         if not substrings:
-            raise ValueError("ban_substrings requires non-empty 'substrings'")
+            raise ValueError(
+                "ban_substrings scanner requires 'substrings' to be a "
+                "non-empty list of strings"
+            )
         return cls(
             substrings=substrings,
             match_type=str(raw.get("match_type", "word")).lower(),
@@ -86,7 +89,9 @@ class RegexConfig:
     def from_dict(cls, raw: dict) -> "RegexConfig":
         patterns = _coerce_string_list(raw.get("patterns"))
         if not patterns:
-            raise ValueError("regex requires non-empty 'patterns'")
+            raise ValueError(
+                "regex scanner requires 'patterns' to be a non-empty list of strings"
+            )
         return cls(
             patterns=patterns,
             is_blocked=bool(raw.get("is_blocked", True)),

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -35,21 +35,18 @@ SUPPORTED_POLICY_SCANNERS = {
     "regex": "Regex",
 }
 
+DEFAULT_ACTION_ON_HIT = "redact"
 
 @dataclass
 class OutputGuardrails:
     enabled: bool
-    action_on_hit: str
+    action_on_hit: str = DEFAULT_ACTION_ON_HIT
     block_message: str = DEFAULT_BLOCK_MESSAGE
     scanner_configs: list[NormalizedScannerConfig] = field(default_factory=list)
 
     @classmethod
     def from_config(cls) -> "OutputGuardrails":
-        guardrails = cls(
-            enabled=config.OUTPUT_GUARDRAILS_ENABLED,
-            action_on_hit=config.OUTPUT_GUARDRAILS_ACTION_ON_HIT,
-            block_message=config.OUTPUT_GUARDRAILS_BLOCK_MESSAGE,
-        )
+        guardrails = cls(enabled=config.OUTPUT_GUARDRAILS_ENABLED)
         return guardrails._apply_policy_file(config.OUTPUT_GUARDRAILS_POLICY_PATH)
 
     def _apply_policy_file(self, policy_path: str) -> "OutputGuardrails":

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -18,7 +18,6 @@ from typing import Any
 import yaml
 from llm_guard import scan_output
 from llm_guard.output_scanners import BanSubstrings, Regex
-
 from ragengine import config
 from ragengine.models import ChatCompletionResponse, get_message_content
 

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -59,8 +59,7 @@ class BanSubstringsConfig:
         substrings = _coerce_string_list(raw.get("substrings"))
         if not substrings:
             raise ValueError(
-                "ban_substrings scanner requires 'substrings' to be a "
-                "non-empty list of strings"
+                "ban_substrings requires 'substrings' to be a non-empty list of strings"
             )
         return cls(
             substrings=substrings,
@@ -90,7 +89,7 @@ class RegexConfig:
         patterns = _coerce_string_list(raw.get("patterns"))
         if not patterns:
             raise ValueError(
-                "regex scanner requires 'patterns' to be a non-empty list of strings"
+                "regex requires 'patterns' to be a non-empty list of strings"
             )
         return cls(
             patterns=patterns,

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -29,28 +29,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_BLOCK_MESSAGE = "The model output was blocked by output guardrails."
 
 SUPPORTED_POLICY_SCANNERS = {
-    "ban_code": "BanCode",
-    "ban_competitors": "BanCompetitors",
     "ban_substrings": "BanSubstrings",
-    "ban_topics": "BanTopics",
-    "bias": "Bias",
-    "code": "Code",
-    "factual_consistency": "FactualConsistency",
-    "gibberish": "Gibberish",
-    "json": "JSON",
-    "language": "Language",
-    "language_same": "LanguageSame",
-    "malicious_urls": "MaliciousURLs",
-    "no_refusal": "NoRefusal",
-    "no_refusal_light": "NoRefusalLight",
-    "reading_time": "ReadingTime",
     "regex": "Regex",
-    "relevance": "Relevance",
-    "secret_detection": "Sensitive",
-    "sensitive": "Sensitive",
-    "sentiment": "Sentiment",
-    "toxicity": "Toxicity",
-    "url_reachability": "URLReachability",
 }
 
 
@@ -260,10 +240,6 @@ def _build_scanner_kwargs(
         ):
             continue
 
-        if name in config_values:
-            kwargs[name] = config_values[name]
-            continue
-
         if name == "redact":
             kwargs[name] = action_on_hit == "redact"
             continue
@@ -274,6 +250,10 @@ def _build_scanner_kwargs(
 
         if name == "substrings" and scanner_config.get("type") == "ban_substrings":
             kwargs[name] = _coerce_string_list(scanner_config.get("substrings"))
+            continue
+
+        if name in config_values:
+            kwargs[name] = config_values[name]
             continue
 
         if parameter.default is inspect.Signature.empty:

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -11,13 +11,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import logging
-from dataclasses import dataclass
+import re
+from dataclasses import dataclass, field
 from typing import Any
 
+import llm_guard.output_scanners as llm_guard_output_scanners
 import yaml
 from llm_guard import scan_output
-from llm_guard.output_scanners import BanSubstrings, Regex
 from ragengine import config
 from ragengine.models import ChatCompletionResponse, get_message_content
 
@@ -25,22 +27,44 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BLOCK_MESSAGE = "The model output was blocked by output guardrails."
 
+SUPPORTED_POLICY_SCANNERS = {
+    "ban_code": "BanCode",
+    "ban_competitors": "BanCompetitors",
+    "ban_substrings": "BanSubstrings",
+    "ban_topics": "BanTopics",
+    "bias": "Bias",
+    "code": "Code",
+    "factual_consistency": "FactualConsistency",
+    "gibberish": "Gibberish",
+    "json": "JSON",
+    "language": "Language",
+    "language_same": "LanguageSame",
+    "malicious_urls": "MaliciousURLs",
+    "no_refusal": "NoRefusal",
+    "no_refusal_light": "NoRefusalLight",
+    "reading_time": "ReadingTime",
+    "regex": "Regex",
+    "relevance": "Relevance",
+    "secret_detection": "Sensitive",
+    "sensitive": "Sensitive",
+    "sentiment": "Sentiment",
+    "toxicity": "Toxicity",
+    "url_reachability": "URLReachability",
+}
+
 
 @dataclass
 class OutputGuardrails:
     enabled: bool
     action_on_hit: str
-    regex_patterns: list[str]
-    banned_substrings: list[str]
     block_message: str = DEFAULT_BLOCK_MESSAGE
+    scanner_configs: list[dict[str, Any]] = field(default_factory=list)
 
     @classmethod
     def from_config(cls) -> "OutputGuardrails":
         guardrails = cls(
             enabled=config.OUTPUT_GUARDRAILS_ENABLED,
             action_on_hit=config.OUTPUT_GUARDRAILS_ACTION_ON_HIT,
-            regex_patterns=list(config.OUTPUT_GUARDRAILS_REGEX_PATTERNS),
-            banned_substrings=list(config.OUTPUT_GUARDRAILS_BANNED_SUBSTRINGS),
             block_message=config.OUTPUT_GUARDRAILS_BLOCK_MESSAGE,
         )
         return guardrails._apply_policy_file(config.OUTPUT_GUARDRAILS_POLICY_PATH)
@@ -65,43 +89,18 @@ class OutputGuardrails:
             logger.warning("output_guardrails_policy_invalid path=%s", policy_path)
             return self
 
-        regex_patterns = list(self.regex_patterns)
-        banned_substrings = list(self.banned_substrings)
+        scanner_configs = list(self.scanner_configs)
         if "scanners" in policy:
-            regex_patterns = []
-            banned_substrings = []
-            scanners = policy.get("scanners") or []
-            if not isinstance(scanners, list):
-                logger.warning(
-                    "output_guardrails_policy_invalid_scanners path=%s", policy_path
-                )
-                scanners = []
-
-            for scanner in scanners:
-                if not isinstance(scanner, dict):
-                    continue
-
-                scanner_type = str(scanner.get("type", "")).lower()
-                if scanner_type == "regex":
-                    regex_patterns.extend(_coerce_string_list(scanner.get("patterns")))
-                elif scanner_type == "ban_substrings":
-                    banned_substrings.extend(
-                        _coerce_string_list(scanner.get("substrings"))
-                    )
-                elif scanner_type:
-                    logger.warning(
-                        "output_guardrails_policy_unknown_scanner type=%s",
-                        scanner_type,
-                    )
+            scanner_configs = _coerce_policy_scanner_configs(
+                policy.get("scanners"),
+                policy_path,
+            )
 
         return OutputGuardrails(
             enabled=self.enabled,
             action_on_hit=_normalize_action(policy.get("action"), self.action_on_hit),
-            regex_patterns=regex_patterns,
-            banned_substrings=banned_substrings,
-            block_message=_coerce_string(
-                policy.get("blockMessage"), self.block_message
-            ),
+            block_message=_coerce_string(policy.get("blockMessage"), self.block_message),
+            scanner_configs=scanner_configs,
         )
 
     def guard_response(
@@ -156,17 +155,10 @@ class OutputGuardrails:
 
     def _build_scanners(self) -> list[Any]:
         scanners: list[Any] = []
-
-        if self.regex_patterns:
-            scanners.append(Regex(patterns=self.regex_patterns, redact=True))
-
-        if self.banned_substrings:
-            scanners.append(
-                BanSubstrings(
-                    substrings=self.banned_substrings,
-                    redact=self.action_on_hit == "redact",
-                )
-            )
+        for scanner_config in self.scanner_configs:
+            scanner = _build_scanner(scanner_config, self.action_on_hit)
+            if scanner is not None:
+                scanners.append(scanner)
 
         return scanners
 
@@ -190,6 +182,105 @@ def _coerce_string_list(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
     return [item for item in value if isinstance(item, str) and item]
+
+
+def _coerce_policy_scanner_configs(value: Any, policy_path: str) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        logger.warning("output_guardrails_policy_invalid_scanners path=%s", policy_path)
+        return []
+
+    scanner_configs: list[dict[str, Any]] = []
+    for scanner in value:
+        if not isinstance(scanner, dict):
+            continue
+        scanner_type = _normalize_scanner_key(str(scanner.get("type", "")).strip())
+        if not scanner_type:
+            continue
+
+        normalized_config = {"type": scanner_type}
+        for key, item in scanner.items():
+            if key == "type":
+                continue
+            normalized_config[_normalize_scanner_key(str(key))] = item
+        scanner_configs.append(normalized_config)
+
+    return scanner_configs
+
+
+def _build_scanner(scanner_config: dict[str, Any], action_on_hit: str) -> Any | None:
+    scanner_type = str(scanner_config.get("type", "")).lower()
+    class_name = SUPPORTED_POLICY_SCANNERS.get(scanner_type)
+    if not class_name:
+        logger.warning("output_guardrails_policy_unknown_scanner type=%s", scanner_type)
+        return None
+
+    scanner_class = getattr(llm_guard_output_scanners, class_name, None)
+    if scanner_class is None:
+        logger.warning("output_guardrails_policy_unavailable_scanner type=%s", scanner_type)
+        return None
+
+    kwargs = _build_scanner_kwargs(scanner_class, scanner_config, action_on_hit)
+    if kwargs is None:
+        return None
+
+    try:
+        return scanner_class(**kwargs)
+    except Exception:
+        logger.exception(
+            "output_guardrails_policy_scanner_build_failed type=%s",
+            scanner_type,
+        )
+        return None
+
+
+def _build_scanner_kwargs(
+    scanner_class: type[Any],
+    scanner_config: dict[str, Any],
+    action_on_hit: str,
+) -> dict[str, Any] | None:
+    signature = inspect.signature(scanner_class)
+    kwargs: dict[str, Any] = {}
+    config_values = {key: value for key, value in scanner_config.items() if key != "type"}
+
+    for name, parameter in signature.parameters.items():
+        if parameter.kind not in (
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            inspect.Parameter.KEYWORD_ONLY,
+        ):
+            continue
+
+        if name in config_values:
+            kwargs[name] = config_values[name]
+            continue
+
+        if name == "redact":
+            kwargs[name] = action_on_hit == "redact"
+            continue
+
+        if name == "patterns" and scanner_config.get("type") == "regex":
+            kwargs[name] = _coerce_string_list(scanner_config.get("patterns"))
+            continue
+
+        if name == "substrings" and scanner_config.get("type") == "ban_substrings":
+            kwargs[name] = _coerce_string_list(scanner_config.get("substrings"))
+            continue
+
+        if parameter.default is inspect.Signature.empty:
+            logger.warning(
+                "output_guardrails_policy_invalid_scanner_config type=%s missing=%s",
+                scanner_config.get("type"),
+                name,
+            )
+            return None
+
+    return kwargs
+
+
+def _normalize_scanner_key(value: str) -> str:
+    value = value.replace("-", "_")
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", value).lower()
 
 
 def _coerce_string(value: Any, fallback: str) -> str:

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -44,6 +44,12 @@ DEFAULT_ACTION_ON_HIT = "redact"
 # TODO: Once this scanner config surface stabilizes, move schema
 # validation to the admission webhook so that invalid policies are
 # rejected at apply-time instead of being silently skipped at runtime.
+#
+# TODO: Many llm_guard scanners (e.g. Toxicity, Bias, Language) do not
+# support redaction; pairing them with action=redact would be a no-op.
+# When adding such scanners, declare a per-schema `supports_redact` flag
+# and reject the (action=redact + non-redact scanner) combination here
+# in the schema layer, instead of trying to fix it at runtime.
 # ===============================
 
 

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -41,7 +41,13 @@ class OutputGuardrails:
 
     @classmethod
     def from_config(cls) -> "OutputGuardrails":
-        guardrails = cls(enabled=config.OUTPUT_GUARDRAILS_ENABLED)
+        # When the feature flag is off, skip policy I/O entirely: there is no
+        # need to open / parse / validate the YAML file, and a malformed
+        # policy must not surface warnings while guardrails are disabled.
+        if not config.OUTPUT_GUARDRAILS_ENABLED:
+            return cls(enabled=False)
+
+        guardrails = cls(enabled=True)
         return guardrails._apply_policy_file(config.OUTPUT_GUARDRAILS_POLICY_PATH)
 
     def _apply_policy_file(self, policy_path: str) -> "OutputGuardrails":

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -31,7 +31,6 @@ logger = logging.getLogger(__name__)
 DEFAULT_BLOCK_MESSAGE = "The model output was blocked by output guardrails."
 DEFAULT_ACTION_ON_HIT = "redact"
 
-
 @dataclass
 class OutputGuardrails:
     enabled: bool

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -40,6 +40,10 @@ DEFAULT_ACTION_ON_HIT = "redact"
 # corresponding llm_guard scanner. To add a new scanner:
 #   1. Define a dataclass with from_dict() and build()
 #   2. Register it in SCANNER_REGISTRY below
+#
+# TODO: Once this scanner config surface stabilizes, move schema
+# validation to the admission webhook so that invalid policies are
+# rejected at apply-time instead of being silently skipped at runtime.
 # ===============================
 
 

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -28,6 +28,8 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BLOCK_MESSAGE = "The model output was blocked by output guardrails."
 
+ScannerConfig = dict[str, Any]
+
 SUPPORTED_POLICY_SCANNERS = {
     "ban_substrings": "BanSubstrings",
     "regex": "Regex",
@@ -39,7 +41,7 @@ class OutputGuardrails:
     enabled: bool
     action_on_hit: str
     block_message: str = DEFAULT_BLOCK_MESSAGE
-    scanner_configs: list[dict[str, Any]] = field(default_factory=list)
+    scanner_configs: list[ScannerConfig] = field(default_factory=list)
 
     @classmethod
     def from_config(cls) -> "OutputGuardrails":
@@ -169,14 +171,14 @@ def _coerce_string_list(value: Any) -> list[str]:
 
 def _coerce_policy_scanner_configs(
     value: Any, policy_path: str
-) -> list[dict[str, Any]]:
+) -> list[ScannerConfig]:
     if value is None:
         return []
     if not isinstance(value, list):
         logger.warning("output_guardrails_policy_invalid_scanners path=%s", policy_path)
         return []
 
-    scanner_configs: list[dict[str, Any]] = []
+    scanner_configs: list[ScannerConfig] = []
     for scanner in value:
         if not isinstance(scanner, dict):
             continue
@@ -194,18 +196,10 @@ def _coerce_policy_scanner_configs(
     return scanner_configs
 
 
-def _build_scanner(scanner_config: dict[str, Any], action_on_hit: str) -> Any | None:
+def _build_scanner(scanner_config: ScannerConfig, action_on_hit: str) -> Any | None:
     scanner_type = str(scanner_config.get("type", "")).lower()
-    class_name = SUPPORTED_POLICY_SCANNERS.get(scanner_type)
-    if not class_name:
-        logger.warning("output_guardrails_policy_unknown_scanner type=%s", scanner_type)
-        return None
-
-    scanner_class = getattr(llm_guard_output_scanners, class_name, None)
+    scanner_class = _resolve_scanner_class(scanner_type)
     if scanner_class is None:
-        logger.warning(
-            "output_guardrails_policy_unavailable_scanner type=%s", scanner_type
-        )
         return None
 
     kwargs = _build_scanner_kwargs(scanner_class, scanner_config, action_on_hit)
@@ -224,47 +218,89 @@ def _build_scanner(scanner_config: dict[str, Any], action_on_hit: str) -> Any | 
 
 def _build_scanner_kwargs(
     scanner_class: type[Any],
-    scanner_config: dict[str, Any],
+    scanner_config: ScannerConfig,
     action_on_hit: str,
 ) -> dict[str, Any] | None:
     signature = inspect.signature(scanner_class)
     kwargs: dict[str, Any] = {}
+    scanner_type = str(scanner_config.get("type", "")).lower()
     config_values = {
         key: value for key, value in scanner_config.items() if key != "type"
     }
 
     for name, parameter in signature.parameters.items():
-        if parameter.kind not in (
-            inspect.Parameter.POSITIONAL_OR_KEYWORD,
-            inspect.Parameter.KEYWORD_ONLY,
-        ):
+        if not _is_supported_scanner_parameter(parameter):
             continue
 
-        if name == "redact":
-            kwargs[name] = action_on_hit == "redact"
+        value_found, value = _resolve_scanner_argument(
+            name,
+            scanner_type,
+            scanner_config,
+            config_values,
+            action_on_hit,
+        )
+        if value_found:
+            kwargs[name] = value
             continue
 
-        if name == "patterns" and scanner_config.get("type") == "regex":
-            kwargs[name] = _coerce_string_list(scanner_config.get("patterns"))
-            continue
-
-        if name == "substrings" and scanner_config.get("type") == "ban_substrings":
-            kwargs[name] = _coerce_string_list(scanner_config.get("substrings"))
-            continue
-
-        if name in config_values:
-            kwargs[name] = config_values[name]
-            continue
-
-        if parameter.default is inspect.Signature.empty:
+        if _is_required_scanner_parameter(parameter):
             logger.warning(
                 "output_guardrails_policy_invalid_scanner_config type=%s missing=%s",
-                scanner_config.get("type"),
+                scanner_type,
                 name,
             )
             return None
 
     return kwargs
+
+
+def _resolve_scanner_class(scanner_type: str) -> type[Any] | None:
+    class_name = SUPPORTED_POLICY_SCANNERS.get(scanner_type)
+    if not class_name:
+        logger.warning("output_guardrails_policy_unknown_scanner type=%s", scanner_type)
+        return None
+
+    scanner_class = getattr(llm_guard_output_scanners, class_name, None)
+    if scanner_class is None:
+        logger.warning(
+            "output_guardrails_policy_unavailable_scanner type=%s", scanner_type
+        )
+        return None
+
+    return scanner_class
+
+
+def _resolve_scanner_argument(
+    name: str,
+    scanner_type: str,
+    scanner_config: ScannerConfig,
+    config_values: dict[str, Any],
+    action_on_hit: str,
+) -> tuple[bool, Any]:
+    if name == "redact":
+        return True, action_on_hit == "redact"
+
+    if name == "patterns" and scanner_type == "regex":
+        return True, _coerce_string_list(scanner_config.get("patterns"))
+
+    if name == "substrings" and scanner_type == "ban_substrings":
+        return True, _coerce_string_list(scanner_config.get("substrings"))
+
+    if name in config_values:
+        return True, config_values[name]
+
+    return False, None
+
+
+def _is_supported_scanner_parameter(parameter: inspect.Parameter) -> bool:
+    return parameter.kind in (
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    )
+
+
+def _is_required_scanner_parameter(parameter: inspect.Parameter) -> bool:
+    return parameter.default is inspect.Signature.empty
 
 
 def _normalize_scanner_key(value: str) -> str:

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -29,6 +29,7 @@ and reject the (action=redact + non-redact scanner) combination at parse
 time, instead of trying to fix it at runtime.
 """
 
+import re
 from dataclasses import dataclass
 from typing import Any
 
@@ -37,6 +38,12 @@ from llm_guard.input_scanners.ban_substrings import (
     MatchType as BanSubstringsMatchType,
 )
 from llm_guard.input_scanners.regex import MatchType as RegexMatchType
+
+# Allowed match_type values, mirrored from llm_guard's enum *values* (not names).
+# Keeping these here lets us reject invalid policies at parse time instead of
+# letting the error surface only when the scanner is built.
+_BAN_SUBSTRINGS_MATCH_TYPES = frozenset(m.value for m in BanSubstringsMatchType)
+_REGEX_MATCH_TYPES = frozenset(m.value for m in RegexMatchType)
 
 
 @dataclass
@@ -53,9 +60,15 @@ class BanSubstringsConfig:
             raise ValueError(
                 "ban_substrings requires 'substrings' to be a non-empty list of strings"
             )
+        match_type = str(raw.get("match_type", "word")).lower()
+        if match_type not in _BAN_SUBSTRINGS_MATCH_TYPES:
+            raise ValueError(
+                f"ban_substrings 'match_type' must be one of "
+                f"{sorted(_BAN_SUBSTRINGS_MATCH_TYPES)}, got {match_type!r}"
+            )
         return cls(
             substrings=substrings,
-            match_type=str(raw.get("match_type", "word")).lower(),
+            match_type=match_type,
             case_sensitive=bool(raw.get("case_sensitive", False)),
             contains_all=bool(raw.get("contains_all", False)),
         )
@@ -63,7 +76,7 @@ class BanSubstringsConfig:
     def build(self, action_on_hit: str) -> Any:
         return llm_guard_output_scanners.BanSubstrings(
             substrings=list(self.substrings),
-            match_type=BanSubstringsMatchType[self.match_type.upper()],
+            match_type=BanSubstringsMatchType(self.match_type),
             case_sensitive=self.case_sensitive,
             contains_all=self.contains_all,
             redact=(action_on_hit == "redact"),
@@ -83,17 +96,30 @@ class RegexConfig:
             raise ValueError(
                 "regex requires 'patterns' to be a non-empty list of strings"
             )
+        for pattern in patterns:
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                raise ValueError(
+                    f"regex pattern {pattern!r} is not a valid regular expression: {exc}"
+                ) from exc
+        match_type = str(raw.get("match_type", "search")).lower()
+        if match_type not in _REGEX_MATCH_TYPES:
+            raise ValueError(
+                f"regex 'match_type' must be one of "
+                f"{sorted(_REGEX_MATCH_TYPES)}, got {match_type!r}"
+            )
         return cls(
             patterns=patterns,
             is_blocked=bool(raw.get("is_blocked", True)),
-            match_type=str(raw.get("match_type", "search")).lower(),
+            match_type=match_type,
         )
 
     def build(self, action_on_hit: str) -> Any:
         return llm_guard_output_scanners.Regex(
             patterns=list(self.patterns),
             is_blocked=self.is_blocked,
-            match_type=RegexMatchType[self.match_type.upper()],
+            match_type=RegexMatchType(self.match_type),
             redact=(action_on_hit == "redact"),
         )
 

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -1,0 +1,118 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Scanner config schemas for output guardrails.
+
+Each schema describes the YAML shape of one llm_guard scanner AND knows how
+to build the corresponding scanner instance. To add a new scanner:
+  1. Define a dataclass with `from_dict()` and `build()`
+  2. Register it in SCANNER_REGISTRY below
+
+TODO: Once this scanner config surface stabilizes, move schema validation
+to the admission webhook so that invalid policies are rejected at
+apply-time instead of being silently skipped at runtime.
+
+TODO: Many llm_guard scanners (e.g. Toxicity, Bias, Language) do not
+support redaction; pairing them with action=redact would be a no-op.
+When adding such scanners, declare a per-schema `supports_redact` flag
+and reject the (action=redact + non-redact scanner) combination at parse
+time, instead of trying to fix it at runtime.
+"""
+
+from dataclasses import dataclass
+from typing import Any
+
+import llm_guard.output_scanners as llm_guard_output_scanners
+from llm_guard.input_scanners.ban_substrings import (
+    MatchType as BanSubstringsMatchType,
+)
+from llm_guard.input_scanners.regex import MatchType as RegexMatchType
+
+
+@dataclass
+class BanSubstringsConfig:
+    substrings: list[str]
+    match_type: str = "word"
+    case_sensitive: bool = False
+    contains_all: bool = False
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "BanSubstringsConfig":
+        substrings = _coerce_string_list(raw.get("substrings"))
+        if not substrings:
+            raise ValueError(
+                "ban_substrings requires 'substrings' to be a non-empty list of strings"
+            )
+        return cls(
+            substrings=substrings,
+            match_type=str(raw.get("match_type", "word")).lower(),
+            case_sensitive=bool(raw.get("case_sensitive", False)),
+            contains_all=bool(raw.get("contains_all", False)),
+        )
+
+    def build(self, action_on_hit: str) -> Any:
+        return llm_guard_output_scanners.BanSubstrings(
+            substrings=list(self.substrings),
+            match_type=BanSubstringsMatchType[self.match_type.upper()],
+            case_sensitive=self.case_sensitive,
+            contains_all=self.contains_all,
+            redact=(action_on_hit == "redact"),
+        )
+
+
+@dataclass
+class RegexConfig:
+    patterns: list[str]
+    is_blocked: bool = True
+    match_type: str = "search"
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "RegexConfig":
+        patterns = _coerce_string_list(raw.get("patterns"))
+        if not patterns:
+            raise ValueError(
+                "regex requires 'patterns' to be a non-empty list of strings"
+            )
+        return cls(
+            patterns=patterns,
+            is_blocked=bool(raw.get("is_blocked", True)),
+            match_type=str(raw.get("match_type", "search")).lower(),
+        )
+
+    def build(self, action_on_hit: str) -> Any:
+        return llm_guard_output_scanners.Regex(
+            patterns=list(self.patterns),
+            is_blocked=self.is_blocked,
+            match_type=RegexMatchType[self.match_type.upper()],
+            redact=(action_on_hit == "redact"),
+        )
+
+
+SCANNER_REGISTRY: dict[str, type] = {
+    "ban_substrings": BanSubstringsConfig,
+    "regex": RegexConfig,
+}
+
+
+@dataclass
+class ParsedScannerConfig:
+    """A scanner config that has already passed schema validation."""
+
+    type: str
+    config: Any
+
+
+def _coerce_string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str) and item]

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -18,9 +18,10 @@ to build the corresponding scanner instance. To add a new scanner:
   1. Define a dataclass with `from_dict()` and `build()`
   2. Register it in SCANNER_REGISTRY below
 
-TODO: Once this scanner config surface stabilizes, move schema validation
-to the admission webhook so that invalid policies are rejected at
-apply-time instead of being silently skipped at runtime.
+NOTE: Validation here is the runtime safety net for cases the
+admission webhook cannot cover (failurePolicy=Ignore, pre-existing
+CRs, ConfigMap-mounted policies, version skew). Bad configs are
+logged and skipped so the rest of the chain still runs.
 
 TODO: Many llm_guard scanners (e.g. Toxicity, Bias, Language) do not
 support redaction; pairing them with action=redact would be a no-op.
@@ -69,8 +70,12 @@ class BanSubstringsConfig:
         return cls(
             substrings=substrings,
             match_type=match_type,
-            case_sensitive=bool(raw.get("case_sensitive", False)),
-            contains_all=bool(raw.get("contains_all", False)),
+            case_sensitive=_coerce_bool(
+                raw.get("case_sensitive"), False, field="case_sensitive"
+            ),
+            contains_all=_coerce_bool(
+                raw.get("contains_all"), False, field="contains_all"
+            ),
         )
 
     def build(self, action_on_hit: str) -> Any:
@@ -111,7 +116,7 @@ class RegexConfig:
             )
         return cls(
             patterns=patterns,
-            is_blocked=bool(raw.get("is_blocked", True)),
+            is_blocked=_coerce_bool(raw.get("is_blocked"), True, field="is_blocked"),
             match_type=match_type,
         )
 
@@ -142,3 +147,13 @@ def _coerce_string_list(value: Any) -> list[str]:
     if not isinstance(value, list):
         return []
     return [item for item in value if isinstance(item, str) and item]
+
+
+def _coerce_bool(value: Any, fallback: bool, *, field: str) -> bool:
+    # bool("false") is True, so we reject non-bool inputs explicitly instead of
+    # silently inverting user intent. YAML native true/false parses to Python bool.
+    if value is None:
+        return fallback
+    if isinstance(value, bool):
+        return value
+    raise ValueError(f"{field!r} must be a boolean (true/false), got {value!r}")

--- a/presets/ragengine/tests/api/test_chat_completions.py
+++ b/presets/ragengine/tests/api/test_chat_completions.py
@@ -21,6 +21,7 @@ import pytest
 import respx
 
 from ragengine.guardrails import OutputGuardrails
+from ragengine.guardrails.output_guardrails import ParsedScannerConfig, RegexConfig
 
 
 @pytest.fixture(autouse=True)
@@ -300,7 +301,12 @@ async def test_chat_completions_output_guardrails_redact(
         OutputGuardrails(
             enabled=True,
             action_on_hit="redact",
-            scanner_configs=[{"type": "regex", "patterns": [r"https?://\S+"]}],
+            scanner_configs=[
+                ParsedScannerConfig(
+                    type="regex",
+                    config=RegexConfig(patterns=[r"https?://\S+"]),
+                ),
+            ],
         ),
     )
 
@@ -356,7 +362,12 @@ async def test_chat_completions_output_guardrails_block(
             enabled=True,
             action_on_hit="block",
             block_message="blocked-by-policy",
-            scanner_configs=[{"type": "regex", "patterns": [r"https?://\S+"]}],
+            scanner_configs=[
+                ParsedScannerConfig(
+                    type="regex",
+                    config=RegexConfig(patterns=[r"https?://\S+"]),
+                ),
+            ],
         ),
     )
 

--- a/presets/ragengine/tests/api/test_chat_completions.py
+++ b/presets/ragengine/tests/api/test_chat_completions.py
@@ -21,7 +21,7 @@ import pytest
 import respx
 
 from ragengine.guardrails import OutputGuardrails
-from ragengine.guardrails.output_guardrails import ParsedScannerConfig, RegexConfig
+from ragengine.guardrails.scanner_schemas import ParsedScannerConfig, RegexConfig
 
 
 @pytest.fixture(autouse=True)

--- a/presets/ragengine/tests/api/test_chat_completions.py
+++ b/presets/ragengine/tests/api/test_chat_completions.py
@@ -425,12 +425,6 @@ async def test_chat_completions_output_guardrails_policy_file(
     monkeypatch.setattr(
         ragengine.config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path)
     )
-    monkeypatch.setattr(ragengine.config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(
-        ragengine.config,
-        "OUTPUT_GUARDRAILS_BLOCK_MESSAGE",
-        "env-block-message",
-    )
     monkeypatch.setattr(
         ragengine.main,
         "output_guardrails",

--- a/presets/ragengine/tests/api/test_chat_completions.py
+++ b/presets/ragengine/tests/api/test_chat_completions.py
@@ -300,8 +300,7 @@ async def test_chat_completions_output_guardrails_redact(
         OutputGuardrails(
             enabled=True,
             action_on_hit="redact",
-            regex_patterns=[r"https?://\S+"],
-            banned_substrings=[],
+            scanner_configs=[{"type": "regex", "patterns": [r"https?://\S+"]}],
         ),
     )
 
@@ -356,9 +355,8 @@ async def test_chat_completions_output_guardrails_block(
         OutputGuardrails(
             enabled=True,
             action_on_hit="block",
-            regex_patterns=[r"https?://\S+"],
-            banned_substrings=[],
             block_message="blocked-by-policy",
+            scanner_configs=[{"type": "regex", "patterns": [r"https?://\S+"]}],
         ),
     )
 
@@ -428,12 +426,6 @@ async def test_chat_completions_output_guardrails_policy_file(
         ragengine.config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path)
     )
     monkeypatch.setattr(ragengine.config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(
-        ragengine.config, "OUTPUT_GUARDRAILS_REGEX_PATTERNS", (r"secret",)
-    )
-    monkeypatch.setattr(
-        ragengine.config, "OUTPUT_GUARDRAILS_BANNED_SUBSTRINGS", tuple()
-    )
     monkeypatch.setattr(
         ragengine.config,
         "OUTPUT_GUARDRAILS_BLOCK_MESSAGE",

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -318,4 +318,3 @@ def test_build_scanners_supports_normalized_ban_substrings_type(monkeypatch):
     assert isinstance(scanners[0], FakeBanSubstrings)
     assert scanners[0].substrings == ["secret"]
     assert scanners[0].redact is True
-

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -20,7 +20,10 @@ import ragengine.guardrails.output_guardrails as output_guardrails_module
 from ragengine import config
 from ragengine.guardrails.output_guardrails import (
     DEFAULT_BLOCK_MESSAGE,
+    BanSubstringsConfig,
     OutputGuardrails,
+    ParsedScannerConfig,
+    RegexConfig,
 )
 
 
@@ -52,8 +55,14 @@ def test_from_config_loads_yaml_policy(tmp_path, monkeypatch):
     assert guardrails.action_on_hit == "block"
     assert guardrails.block_message == "blocked-by-policy"
     assert guardrails.scanner_configs == [
-        {"type": "regex", "patterns": [r"https?://\S+"]},
-        {"type": "ban_substrings", "substrings": ["secret"]},
+        ParsedScannerConfig(
+            type="regex",
+            config=RegexConfig(patterns=[r"https?://\S+"]),
+        ),
+        ParsedScannerConfig(
+            type="ban_substrings",
+            config=BanSubstringsConfig(substrings=["secret"]),
+        ),
     ]
 
 
@@ -93,7 +102,10 @@ def test_from_config_replaces_scanners_with_policy_values(tmp_path, monkeypatch)
 
     assert guardrails.action_on_hit == "block"
     assert guardrails.scanner_configs == [
-        {"type": "ban_substrings", "substrings": ["yaml-only"]},
+        ParsedScannerConfig(
+            type="ban_substrings",
+            config=BanSubstringsConfig(substrings=["yaml-only"]),
+        ),
     ]
 
 
@@ -119,7 +131,10 @@ def test_from_config_invalid_action_falls_back_to_env_value(tmp_path, monkeypatc
 
     assert guardrails.action_on_hit == "redact"
     assert guardrails.scanner_configs == [
-        {"type": "regex", "patterns": [r"https?://\S+"]},
+        ParsedScannerConfig(
+            type="regex",
+            config=RegexConfig(patterns=[r"https?://\S+"]),
+        ),
     ]
 
 
@@ -151,13 +166,25 @@ def test_from_config_skips_invalid_scanners_and_filters_non_string_values(
     tmp_path, monkeypatch
 ):
     class FakeRegex:
-        def __init__(self, patterns, redact=False):
+        def __init__(self, patterns, is_blocked=True, match_type=None, redact=False):
             self.patterns = patterns
+            self.is_blocked = is_blocked
+            self.match_type = match_type
             self.redact = redact
 
     class FakeBanSubstrings:
-        def __init__(self, substrings, redact=False):
+        def __init__(
+            self,
+            substrings,
+            match_type=None,
+            case_sensitive=False,
+            contains_all=False,
+            redact=False,
+        ):
             self.substrings = substrings
+            self.match_type = match_type
+            self.case_sensitive = case_sensitive
+            self.contains_all = contains_all
             self.redact = redact
 
     policy_path = tmp_path / "guardrails.yaml"
@@ -199,8 +226,14 @@ def test_from_config_skips_invalid_scanners_and_filters_non_string_values(
     guardrails = OutputGuardrails.from_config()
 
     assert guardrails.scanner_configs == [
-        {"type": "regex", "patterns": [r"https?://\S+", "", 123]},
-        {"type": "ban_substrings", "substrings": ["secret", None, ""]},
+        ParsedScannerConfig(
+            type="regex",
+            config=RegexConfig(patterns=[r"https?://\S+"]),
+        ),
+        ParsedScannerConfig(
+            type="ban_substrings",
+            config=BanSubstringsConfig(substrings=["secret"]),
+        ),
     ]
 
     scanners = guardrails._build_scanners()
@@ -212,59 +245,36 @@ def test_from_config_skips_invalid_scanners_and_filters_non_string_values(
     assert scanners[1].redact is True
 
 
-def test_build_scanners_skips_unknown_and_missing_required_scanners(monkeypatch):
-    class FakeRequiredScanner:
-        def __init__(self, required_value):
-            self.required_value = required_value
-
-    class FakeOkScanner:
-        def __init__(self, redact=False):
-            self.redact = redact
-
-    monkeypatch.setitem(
-        output_guardrails_module.SUPPORTED_POLICY_SCANNERS,
-        "fake_required",
-        "FakeRequiredScanner",
-    )
-    monkeypatch.setitem(
-        output_guardrails_module.SUPPORTED_POLICY_SCANNERS,
-        "fake_ok",
-        "FakeOkScanner",
-    )
-    monkeypatch.setattr(
-        output_guardrails_module.llm_guard_output_scanners,
-        "FakeRequiredScanner",
-        FakeRequiredScanner,
-        raising=False,
-    )
-    monkeypatch.setattr(
-        output_guardrails_module.llm_guard_output_scanners,
-        "FakeOkScanner",
-        FakeOkScanner,
-        raising=False,
-    )
-
-    guardrails = OutputGuardrails(
-        enabled=True,
-        action_on_hit="redact",
-        scanner_configs=[
+def test_parse_policy_scanner_configs_skips_unknown_and_invalid_schema():
+    parsed = output_guardrails_module._parse_policy_scanner_configs(
+        [
             {"type": "unknown_scanner"},
-            {"type": "fake_required"},
-            {"type": "fake_ok"},
+            {"type": "regex"},  # missing required 'patterns'
+            {"type": "ban_substrings"},  # missing required 'substrings'
+            {"type": "regex", "patterns": ["a"]},
         ],
+        "guardrails.yaml",
     )
 
-    scanners = guardrails._build_scanners()
-
-    assert len(scanners) == 1
-    assert isinstance(scanners[0], FakeOkScanner)
-    assert scanners[0].redact is True
+    assert parsed == [
+        ParsedScannerConfig(type="regex", config=RegexConfig(patterns=["a"])),
+    ]
 
 
 def test_build_scanners_supports_normalized_ban_substrings_type(monkeypatch):
     class FakeBanSubstrings:
-        def __init__(self, substrings, redact=False):
+        def __init__(
+            self,
+            substrings,
+            match_type=None,
+            case_sensitive=False,
+            contains_all=False,
+            redact=False,
+        ):
             self.substrings = substrings
+            self.match_type = match_type
+            self.case_sensitive = case_sensitive
+            self.contains_all = contains_all
             self.redact = redact
 
     monkeypatch.setattr(
@@ -274,7 +284,7 @@ def test_build_scanners_supports_normalized_ban_substrings_type(monkeypatch):
         raising=False,
     )
 
-    scanner_configs = output_guardrails_module._normalize_policy_scanner_configs(
+    parsed = output_guardrails_module._parse_policy_scanner_configs(
         [{"type": "ban-substrings", "substrings": ["secret"]}],
         "guardrails.yaml",
     )
@@ -282,13 +292,16 @@ def test_build_scanners_supports_normalized_ban_substrings_type(monkeypatch):
     guardrails = OutputGuardrails(
         enabled=True,
         action_on_hit="redact",
-        scanner_configs=scanner_configs,
+        scanner_configs=parsed,
     )
 
     scanners = guardrails._build_scanners()
 
-    assert guardrails.scanner_configs == [
-        {"type": "ban_substrings", "substrings": ["secret"]},
+    assert parsed == [
+        ParsedScannerConfig(
+            type="ban_substrings",
+            config=BanSubstringsConfig(substrings=["secret"]),
+        ),
     ]
     assert len(scanners) == 1
     assert isinstance(scanners[0], FakeBanSubstrings)

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -430,6 +430,23 @@ def test_parse_policy_scanner_configs_skips_uncompilable_regex_pattern():
     assert parsed == [_regex_cfg(patterns=[r"\d+"])]
 
 
+def test_parse_policy_scanner_configs_rejects_non_bool_flags():
+    parsed = output_guardrails_module._parse_policy_scanner_configs(
+        [
+            # String "false" is truthy in Python; must be rejected, not silently
+            # treated as True.
+            {"type": "ban_substrings", "substrings": ["a"], "case_sensitive": "false"},
+            {"type": "ban_substrings", "substrings": ["a"], "contains_all": 1},
+            {"type": "regex", "patterns": ["a"], "is_blocked": "no"},
+            # Native YAML booleans (already parsed to Python bool) are accepted.
+            {"type": "ban_substrings", "substrings": ["a"], "case_sensitive": True},
+        ],
+        "guardrails.yaml",
+    )
+
+    assert parsed == [_ban_subs_cfg(substrings=["a"], case_sensitive=True)]
+
+
 # ---------------------------------------------------------------------------
 # _build_scanners
 # ---------------------------------------------------------------------------

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -17,11 +17,14 @@ import textwrap
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
 
 import ragengine.guardrails.output_guardrails as output_guardrails_module
+import ragengine.guardrails.scanner_schemas as scanner_schemas_module
 from ragengine import config
 from ragengine.guardrails.output_guardrails import (
     DEFAULT_BLOCK_MESSAGE,
-    BanSubstringsConfig,
     OutputGuardrails,
+)
+from ragengine.guardrails.scanner_schemas import (
+    BanSubstringsConfig,
     ParsedScannerConfig,
     RegexConfig,
 )
@@ -211,13 +214,13 @@ def test_from_config_skips_invalid_scanners_and_filters_non_string_values(
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
     monkeypatch.setattr(
-        output_guardrails_module.llm_guard_output_scanners,
+        scanner_schemas_module.llm_guard_output_scanners,
         "Regex",
         FakeRegex,
         raising=False,
     )
     monkeypatch.setattr(
-        output_guardrails_module.llm_guard_output_scanners,
+        scanner_schemas_module.llm_guard_output_scanners,
         "BanSubstrings",
         FakeBanSubstrings,
         raising=False,
@@ -278,7 +281,7 @@ def test_build_scanners_supports_normalized_ban_substrings_type(monkeypatch):
             self.redact = redact
 
     monkeypatch.setattr(
-        output_guardrails_module.llm_guard_output_scanners,
+        scanner_schemas_module.llm_guard_output_scanners,
         "BanSubstrings",
         FakeBanSubstrings,
         raising=False,

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -10,9 +10,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import builtins
 import os
 import sys
 import textwrap
+import time
+
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
 
@@ -28,29 +32,151 @@ from ragengine.guardrails.scanner_schemas import (
     ParsedScannerConfig,
     RegexConfig,
 )
+from ragengine.models import ChatCompletionResponse
+
+
+# ---------------------------------------------------------------------------
+# Test helpers / fixtures
+# ---------------------------------------------------------------------------
+
+
+def _write_policy(tmp_path, monkeypatch, yaml_content: str, *, enabled: bool = True):
+    """Write a guardrails YAML policy and point env vars at it."""
+    policy_path = tmp_path / "guardrails.yaml"
+    policy_path.write_text(textwrap.dedent(yaml_content).strip(), encoding="utf-8")
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", enabled)
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
+    return policy_path
+
+
+def _regex_cfg(patterns=("a",), **kw) -> ParsedScannerConfig:
+    return ParsedScannerConfig(
+        type="regex",
+        config=RegexConfig(patterns=list(patterns), **kw),
+    )
+
+
+def _ban_subs_cfg(substrings=("secret",), **kw) -> ParsedScannerConfig:
+    return ParsedScannerConfig(
+        type="ban_substrings",
+        config=BanSubstringsConfig(substrings=list(substrings), **kw),
+    )
+
+
+def _make_response(content: str = "hello") -> ChatCompletionResponse:
+    return ChatCompletionResponse(
+        id="chatcmpl-test",
+        object="chat.completion",
+        created=int(time.time()),
+        model="mock-model",
+        choices=[
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }
+        ],
+    )
+
+
+def _make_tool_call_response() -> ChatCompletionResponse:
+    """Assistant response carrying tool_calls but no string content."""
+    return ChatCompletionResponse(
+        id="chatcmpl-test",
+        object="chat.completion",
+        created=int(time.time()),
+        model="mock-model",
+        choices=[
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "type": "function",
+                            "function": {"name": "f", "arguments": "{}"},
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+    )
+
+
+def _patch_scan_output(monkeypatch, fn):
+    monkeypatch.setattr(output_guardrails_module, "scan_output", fn)
+
+
+@pytest.fixture
+def fake_llm_guard_scanners(monkeypatch):
+    """Replace llm_guard's Regex / BanSubstrings with simple recording stubs.
+
+    Returns ``(FakeRegex, FakeBanSubstrings)`` so individual tests can assert on
+    isinstance / captured kwargs.
+    """
+
+    class FakeRegex:
+        def __init__(self, patterns, *, is_blocked=True, match_type=None, redact=False):
+            self.patterns = patterns
+            self.is_blocked = is_blocked
+            self.match_type = match_type
+            self.redact = redact
+
+    class FakeBanSubstrings:
+        def __init__(
+            self,
+            substrings,
+            *,
+            match_type=None,
+            case_sensitive=False,
+            contains_all=False,
+            redact=False,
+        ):
+            self.substrings = substrings
+            self.match_type = match_type
+            self.case_sensitive = case_sensitive
+            self.contains_all = contains_all
+            self.redact = redact
+
+    monkeypatch.setattr(
+        scanner_schemas_module.llm_guard_output_scanners,
+        "Regex",
+        FakeRegex,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scanner_schemas_module.llm_guard_output_scanners,
+        "BanSubstrings",
+        FakeBanSubstrings,
+        raising=False,
+    )
+    return FakeRegex, FakeBanSubstrings
+
+
+# ---------------------------------------------------------------------------
+# Policy loading via from_config
+# ---------------------------------------------------------------------------
 
 
 def test_from_config_loads_yaml_policy(tmp_path, monkeypatch):
-    policy_path = tmp_path / "guardrails.yaml"
-    policy_path.write_text(
-        textwrap.dedent(
-            """
-            action: block
-            blockMessage: blocked-by-policy
-            scanners:
-              - type: regex
-                patterns:
-                  - https?://\\S+
-              - type: ban_substrings
-                substrings:
-                  - secret
-            """
-        ).strip(),
-        encoding="utf-8",
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: block
+        blockMessage: blocked-by-policy
+        scanners:
+          - type: regex
+            patterns:
+              - https?://\\S+
+          - type: ban_substrings
+            substrings:
+              - secret
+        """,
     )
-
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
 
     guardrails = OutputGuardrails.from_config()
 
@@ -58,14 +184,8 @@ def test_from_config_loads_yaml_policy(tmp_path, monkeypatch):
     assert guardrails.action_on_hit == "block"
     assert guardrails.block_message == "blocked-by-policy"
     assert guardrails.scanner_configs == [
-        ParsedScannerConfig(
-            type="regex",
-            config=RegexConfig(patterns=[r"https?://\S+"]),
-        ),
-        ParsedScannerConfig(
-            type="ban_substrings",
-            config=BanSubstringsConfig(substrings=["secret"]),
-        ),
+        _regex_cfg(patterns=[r"https?://\S+"]),
+        _ban_subs_cfg(substrings=["secret"]),
     ]
 
 
@@ -84,80 +204,55 @@ def test_from_config_keeps_empty_scanners_when_policy_path_missing(monkeypatch):
 
 
 def test_from_config_replaces_scanners_with_policy_values(tmp_path, monkeypatch):
-    policy_path = tmp_path / "guardrails.yaml"
-    policy_path.write_text(
-        textwrap.dedent(
-            """
-            action: block
-            scanners:
-              - type: ban_substrings
-                substrings:
-                  - yaml-only
-            """
-        ).strip(),
-        encoding="utf-8",
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: block
+        scanners:
+          - type: ban_substrings
+            substrings:
+              - yaml-only
+        """,
     )
-
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
 
     guardrails = OutputGuardrails.from_config()
 
     assert guardrails.action_on_hit == "block"
-    assert guardrails.scanner_configs == [
-        ParsedScannerConfig(
-            type="ban_substrings",
-            config=BanSubstringsConfig(substrings=["yaml-only"]),
-        ),
-    ]
+    assert guardrails.scanner_configs == [_ban_subs_cfg(substrings=["yaml-only"])]
 
 
-def test_from_config_invalid_action_falls_back_to_env_value(tmp_path, monkeypatch):
-    policy_path = tmp_path / "guardrails.yaml"
-    policy_path.write_text(
-        textwrap.dedent(
-            """
-            action: passthrough
-            scanners:
-              - type: regex
-                patterns:
-                  - https?://\\S+
-            """
-        ).strip(),
-        encoding="utf-8",
+def test_from_config_invalid_action_falls_back_to_default(tmp_path, monkeypatch):
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: passthrough
+        scanners:
+          - type: regex
+            patterns:
+              - https?://\\S+
+        """,
     )
-
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
 
     guardrails = OutputGuardrails.from_config()
 
     assert guardrails.action_on_hit == "redact"
-    assert guardrails.scanner_configs == [
-        ParsedScannerConfig(
-            type="regex",
-            config=RegexConfig(patterns=[r"https?://\S+"]),
-        ),
-    ]
+    assert guardrails.scanner_configs == [_regex_cfg(patterns=[r"https?://\S+"])]
 
 
 def test_from_config_returns_empty_scanners_when_policy_scanners_is_not_a_list(
     tmp_path, monkeypatch
 ):
-    policy_path = tmp_path / "guardrails.yaml"
-    policy_path.write_text(
-        textwrap.dedent(
-            """
-            action: block
-            scanners:
-              type: regex
-            """
-        ).strip(),
-        encoding="utf-8",
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: block
+        scanners:
+          type: regex
+        """,
     )
-
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
 
     guardrails = OutputGuardrails.from_config()
 
@@ -166,77 +261,32 @@ def test_from_config_returns_empty_scanners_when_policy_scanners_is_not_a_list(
 
 
 def test_from_config_skips_invalid_scanners_and_filters_non_string_values(
-    tmp_path, monkeypatch
+    tmp_path, monkeypatch, fake_llm_guard_scanners
 ):
-    class FakeRegex:
-        def __init__(self, patterns, is_blocked=True, match_type=None, redact=False):
-            self.patterns = patterns
-            self.is_blocked = is_blocked
-            self.match_type = match_type
-            self.redact = redact
-
-    class FakeBanSubstrings:
-        def __init__(
-            self,
-            substrings,
-            match_type=None,
-            case_sensitive=False,
-            contains_all=False,
-            redact=False,
-        ):
-            self.substrings = substrings
-            self.match_type = match_type
-            self.case_sensitive = case_sensitive
-            self.contains_all = contains_all
-            self.redact = redact
-
-    policy_path = tmp_path / "guardrails.yaml"
-    policy_path.write_text(
-        textwrap.dedent(
-            """
-            scanners:
-              - not-a-dict
-              - type: regex
-                patterns:
-                  - https?://\\S+
-                  - ""
-                  - 123
-              - type: ban-substrings
-                substrings:
-                  - secret
-                  - null
-                  - ""
-            """
-        ).strip(),
-        encoding="utf-8",
-    )
-
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
-    monkeypatch.setattr(
-        scanner_schemas_module.llm_guard_output_scanners,
-        "Regex",
-        FakeRegex,
-        raising=False,
-    )
-    monkeypatch.setattr(
-        scanner_schemas_module.llm_guard_output_scanners,
-        "BanSubstrings",
-        FakeBanSubstrings,
-        raising=False,
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        scanners:
+          - not-a-dict
+          - type: regex
+            patterns:
+              - https?://\\S+
+              - ""
+              - 123
+          - type: ban-substrings
+            substrings:
+              - secret
+              - null
+              - ""
+        """,
     )
 
     guardrails = OutputGuardrails.from_config()
 
     assert guardrails.scanner_configs == [
-        ParsedScannerConfig(
-            type="regex",
-            config=RegexConfig(patterns=[r"https?://\S+"]),
-        ),
-        ParsedScannerConfig(
-            type="ban_substrings",
-            config=BanSubstringsConfig(substrings=["secret"]),
-        ),
+        _regex_cfg(patterns=[r"https?://\S+"]),
+        _ban_subs_cfg(substrings=["secret"]),
     ]
 
     scanners = guardrails._build_scanners()
@@ -246,6 +296,74 @@ def test_from_config_skips_invalid_scanners_and_filters_non_string_values(
     assert scanners[0].redact is True
     assert scanners[1].substrings == ["secret"]
     assert scanners[1].redact is True
+
+
+def test_from_config_with_empty_policy_path_keeps_defaults(monkeypatch):
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", "")
+
+    guardrails = OutputGuardrails.from_config()
+
+    assert guardrails.enabled is True
+    assert guardrails.scanner_configs == []
+    assert guardrails.action_on_hit == "redact"
+    assert guardrails.block_message == DEFAULT_BLOCK_MESSAGE
+
+
+def test_from_config_skips_policy_io_when_disabled(tmp_path, monkeypatch):
+    """When the feature flag is off, the policy file must not be opened
+    even if the path is set (and even if the file is malformed)."""
+    policy_path = _write_policy(
+        tmp_path,
+        monkeypatch,
+        "scanners: [unclosed\n",
+        enabled=False,
+    )
+
+    open_calls: list[str] = []
+    real_open = builtins.open
+
+    def tracking_open(path, *args, **kwargs):
+        open_calls.append(str(path))
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", tracking_open)
+
+    guardrails = OutputGuardrails.from_config()
+
+    assert guardrails.enabled is False
+    assert guardrails.scanner_configs == []
+    assert str(policy_path) not in open_calls
+
+
+# ---------------------------------------------------------------------------
+# Policy file load edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_apply_policy_file_handles_yaml_parse_error(tmp_path, monkeypatch):
+    _write_policy(tmp_path, monkeypatch, "scanners: [unclosed\n")
+
+    guardrails = OutputGuardrails.from_config()
+
+    assert guardrails.enabled is True
+    assert guardrails.scanner_configs == []
+    assert guardrails.action_on_hit == "redact"
+    assert guardrails.block_message == DEFAULT_BLOCK_MESSAGE
+
+
+def test_apply_policy_file_rejects_non_dict_top_level(tmp_path, monkeypatch):
+    _write_policy(tmp_path, monkeypatch, "- just\n- a list\n")
+
+    guardrails = OutputGuardrails.from_config()
+
+    assert guardrails.enabled is True
+    assert guardrails.scanner_configs == []
+
+
+# ---------------------------------------------------------------------------
+# _parse_policy_scanner_configs edge cases
+# ---------------------------------------------------------------------------
 
 
 def test_parse_policy_scanner_configs_skips_unknown_and_invalid_schema():
@@ -259,33 +377,69 @@ def test_parse_policy_scanner_configs_skips_unknown_and_invalid_schema():
         "guardrails.yaml",
     )
 
+    assert parsed == [_regex_cfg(patterns=["a"])]
+
+
+def test_parse_policy_scanner_configs_handles_none_and_blank_type():
+    assert (
+        output_guardrails_module._parse_policy_scanner_configs(None, "guardrails.yaml")
+        == []
+    )
+
+    parsed = output_guardrails_module._parse_policy_scanner_configs(
+        [
+            {"type": ""},
+            {"type": "   "},
+            {},
+            {"type": "regex", "patterns": ["ok"]},
+        ],
+        "guardrails.yaml",
+    )
+    assert parsed == [_regex_cfg(patterns=["ok"])]
+
+
+def test_parse_policy_scanner_configs_skips_invalid_match_type():
+    parsed = output_guardrails_module._parse_policy_scanner_configs(
+        [
+            {"type": "ban_substrings", "substrings": ["a"], "match_type": "bogus"},
+            {"type": "regex", "patterns": ["a"], "match_type": "bogus"},
+            {"type": "ban_substrings", "substrings": ["a"], "match_type": "WORD"},
+            {"type": "regex", "patterns": ["a"], "match_type": "FullMatch"},
+        ],
+        "guardrails.yaml",
+    )
+
+    # Invalid match_type values are rejected at parse time; valid ones are
+    # accepted case-insensitively and stored in normalized lowercase form.
     assert parsed == [
-        ParsedScannerConfig(type="regex", config=RegexConfig(patterns=["a"])),
+        _ban_subs_cfg(substrings=["a"], match_type="word"),
+        _regex_cfg(patterns=["a"], match_type="fullmatch"),
     ]
 
 
-def test_build_scanners_supports_normalized_ban_substrings_type(monkeypatch):
-    class FakeBanSubstrings:
-        def __init__(
-            self,
-            substrings,
-            match_type=None,
-            case_sensitive=False,
-            contains_all=False,
-            redact=False,
-        ):
-            self.substrings = substrings
-            self.match_type = match_type
-            self.case_sensitive = case_sensitive
-            self.contains_all = contains_all
-            self.redact = redact
-
-    monkeypatch.setattr(
-        scanner_schemas_module.llm_guard_output_scanners,
-        "BanSubstrings",
-        FakeBanSubstrings,
-        raising=False,
+def test_parse_policy_scanner_configs_skips_uncompilable_regex_pattern():
+    parsed = output_guardrails_module._parse_policy_scanner_configs(
+        [
+            {"type": "regex", "patterns": ["[unclosed"]},
+            {"type": "regex", "patterns": ["valid", "(?P<x>"]},
+            {"type": "regex", "patterns": [r"\d+"]},
+        ],
+        "guardrails.yaml",
     )
+
+    # Any pattern in the list that fails to compile rejects the whole scanner.
+    assert parsed == [_regex_cfg(patterns=[r"\d+"])]
+
+
+# ---------------------------------------------------------------------------
+# _build_scanners
+# ---------------------------------------------------------------------------
+
+
+def test_build_scanners_supports_normalized_ban_substrings_type(
+    fake_llm_guard_scanners,
+):
+    _, FakeBanSubstrings = fake_llm_guard_scanners
 
     parsed = output_guardrails_module._parse_policy_scanner_configs(
         [{"type": "ban-substrings", "substrings": ["secret"]}],
@@ -300,13 +454,175 @@ def test_build_scanners_supports_normalized_ban_substrings_type(monkeypatch):
 
     scanners = guardrails._build_scanners()
 
-    assert parsed == [
-        ParsedScannerConfig(
-            type="ban_substrings",
-            config=BanSubstringsConfig(substrings=["secret"]),
-        ),
-    ]
+    assert parsed == [_ban_subs_cfg(substrings=["secret"])]
     assert len(scanners) == 1
     assert isinstance(scanners[0], FakeBanSubstrings)
     assert scanners[0].substrings == ["secret"]
     assert scanners[0].redact is True
+
+
+def test_build_scanners_skips_configs_whose_build_raises(monkeypatch):
+    sentinel = object()
+    call_count = {"n": 0}
+
+    def fake_regex(*args, **kwargs):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("simulated build failure")
+        return sentinel
+
+    monkeypatch.setattr(
+        scanner_schemas_module.llm_guard_output_scanners,
+        "Regex",
+        fake_regex,
+        raising=False,
+    )
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        scanner_configs=[_regex_cfg(patterns=["a"]), _regex_cfg(patterns=["b"])],
+    )
+
+    # First config raised -> skipped; second was built successfully.
+    assert guardrails._build_scanners() == [sentinel]
+
+
+def test_regex_config_build_uses_value_lookup_for_fullmatch(
+    fake_llm_guard_scanners,
+):
+    """Regression test: enum value 'fullmatch' must work end-to-end (the enum
+    NAME is FULL_MATCH, so a name-based lookup would raise KeyError)."""
+    cfg = RegexConfig.from_dict({"patterns": ["a"], "match_type": "fullmatch"})
+    scanner = cfg.build("redact")
+
+    assert scanner.match_type == scanner_schemas_module.RegexMatchType.FULL_MATCH
+
+
+# ---------------------------------------------------------------------------
+# guard_response runtime branches
+# ---------------------------------------------------------------------------
+
+
+def test_guard_response_short_circuits_when_disabled():
+    response = _make_response("anything")
+    assert (
+        OutputGuardrails(enabled=False).guard_response(response, {"messages": []})
+        is response
+    )
+
+
+def test_guard_response_short_circuits_when_no_scanners():
+    response = _make_response("anything")
+    guardrails = OutputGuardrails(enabled=True, scanner_configs=[])
+    assert guardrails.guard_response(response, {"messages": []}) is response
+
+
+def test_guard_response_skips_non_string_content(monkeypatch):
+    """When the assistant message has no string content (e.g. tool_calls only),
+    the scanner pipeline must be skipped instead of being fed a None."""
+
+    def _fail_scan(*args, **kwargs):
+        raise AssertionError("scan_output should not be invoked")
+
+    _patch_scan_output(monkeypatch, _fail_scan)
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        scanner_configs=[_regex_cfg(patterns=[r"\S+"])],
+    )
+
+    out = guardrails.guard_response(_make_tool_call_response(), {"messages": []})
+    assert out.choices[0].message.content is None
+
+
+def test_guard_response_passes_through_when_no_scanner_triggered(monkeypatch):
+    _patch_scan_output(
+        monkeypatch,
+        lambda scanners, prompt, output, fail_fast: (
+            output,
+            {"regex": True},
+            {"regex": 0.0},
+        ),
+    )
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        scanner_configs=[_regex_cfg(patterns=[r"never-matches"])],
+    )
+
+    out = guardrails.guard_response(_make_response("clean output"), {"messages": []})
+    assert out.choices[0].message.content == "clean output"
+
+
+def test_guard_response_recovers_when_scan_output_raises(monkeypatch):
+    def _boom(*args, **kwargs):
+        raise RuntimeError("scanner exploded")
+
+    _patch_scan_output(monkeypatch, _boom)
+
+    response = _make_response("clean output")
+    guardrails = OutputGuardrails(
+        enabled=True,
+        scanner_configs=[_regex_cfg(patterns=[r"\S+"])],
+    )
+
+    # Internal failure must degrade safely: return the original response object.
+    assert guardrails.guard_response(response, {"messages": []}) is response
+
+
+@pytest.mark.parametrize(
+    "action,block_message,expected_content",
+    [
+        ("redact", DEFAULT_BLOCK_MESSAGE, "REDACTED-CONTENT"),
+        ("block", "blocked!", "blocked!"),
+    ],
+)
+def test_guard_response_applies_action(
+    monkeypatch, action, block_message, expected_content
+):
+    _patch_scan_output(
+        monkeypatch,
+        lambda scanners, prompt, output, fail_fast: (
+            "REDACTED-CONTENT",
+            {"regex": False},
+            {"regex": 0.9},
+        ),
+    )
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        action_on_hit=action,
+        block_message=block_message,
+        scanner_configs=[_regex_cfg(patterns=[r"\S+"])],
+    )
+
+    out = guardrails.guard_response(_make_response("dirty"), {"messages": []})
+    assert out.choices[0].message.content == expected_content
+
+
+# ---------------------------------------------------------------------------
+# _extract_prompt defensive branches
+# ---------------------------------------------------------------------------
+
+
+def test_extract_prompt_handles_non_list_messages():
+    guardrails = OutputGuardrails(enabled=True)
+    assert guardrails._extract_prompt({"messages": "not-a-list"}) == ""
+    assert guardrails._extract_prompt({}) == ""
+
+
+def test_extract_prompt_skips_non_dict_message_entries():
+    guardrails = OutputGuardrails(enabled=True)
+    prompt = guardrails._extract_prompt(
+        {
+            "messages": [
+                "garbage",
+                None,
+                {"role": "user", "content": "hello"},
+                42,
+                {"role": "user", "content": "world"},
+            ]
+        }
+    )
+
+    assert prompt == "hello\n\nworld"

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -45,10 +45,6 @@ def test_from_config_loads_yaml_policy(tmp_path, monkeypatch):
 
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(
-        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
-    )
 
     guardrails = OutputGuardrails.from_config()
 
@@ -65,10 +61,6 @@ def test_from_config_keeps_empty_scanners_when_policy_path_missing(monkeypatch):
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(
         config, "OUTPUT_GUARDRAILS_POLICY_PATH", "/tmp/missing-guardrails.yaml"
-    )
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(
-        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
     )
 
     guardrails = OutputGuardrails.from_config()
@@ -96,10 +88,6 @@ def test_from_config_replaces_scanners_with_policy_values(tmp_path, monkeypatch)
 
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(
-        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
-    )
 
     guardrails = OutputGuardrails.from_config()
 
@@ -126,10 +114,6 @@ def test_from_config_invalid_action_falls_back_to_env_value(tmp_path, monkeypatc
 
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(
-        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
-    )
 
     guardrails = OutputGuardrails.from_config()
 
@@ -156,10 +140,6 @@ def test_from_config_returns_empty_scanners_when_policy_scanners_is_not_a_list(
 
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(
-        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
-    )
 
     guardrails = OutputGuardrails.from_config()
 
@@ -203,10 +183,6 @@ def test_from_config_skips_invalid_scanners_and_filters_non_string_values(
 
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(
-        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
-    )
     monkeypatch.setattr(
         output_guardrails_module.llm_guard_output_scanners,
         "Regex",

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -45,7 +45,9 @@ def test_from_config_loads_yaml_policy(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE)
+    monkeypatch.setattr(
+        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
+    )
 
     guardrails = OutputGuardrails.from_config()
 
@@ -64,7 +66,9 @@ def test_from_config_keeps_empty_scanners_when_policy_path_missing(monkeypatch):
         config, "OUTPUT_GUARDRAILS_POLICY_PATH", "/tmp/missing-guardrails.yaml"
     )
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE)
+    monkeypatch.setattr(
+        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
+    )
 
     guardrails = OutputGuardrails.from_config()
 
@@ -92,7 +96,9 @@ def test_from_config_replaces_scanners_with_policy_values(tmp_path, monkeypatch)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE)
+    monkeypatch.setattr(
+        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
+    )
 
     guardrails = OutputGuardrails.from_config()
 
@@ -120,7 +126,9 @@ def test_from_config_invalid_action_falls_back_to_env_value(tmp_path, monkeypatc
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE)
+    monkeypatch.setattr(
+        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
+    )
 
     guardrails = OutputGuardrails.from_config()
 

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -45,43 +45,36 @@ def test_from_config_loads_yaml_policy(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_REGEX_PATTERNS", tuple())
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BANNED_SUBSTRINGS", tuple())
-    monkeypatch.setattr(
-        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
-    )
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE)
 
     guardrails = OutputGuardrails.from_config()
 
     assert guardrails.enabled is True
     assert guardrails.action_on_hit == "block"
-    assert guardrails.regex_patterns == [r"https?://\S+"]
-    assert guardrails.banned_substrings == ["secret"]
     assert guardrails.block_message == "blocked-by-policy"
+    assert guardrails.scanner_configs == [
+        {"type": "regex", "patterns": [r"https?://\S+"]},
+        {"type": "ban_substrings", "substrings": ["secret"]},
+    ]
 
 
-def test_from_config_falls_back_to_env_values_when_policy_path_missing(monkeypatch):
+def test_from_config_keeps_empty_scanners_when_policy_path_missing(monkeypatch):
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(
         config, "OUTPUT_GUARDRAILS_POLICY_PATH", "/tmp/missing-guardrails.yaml"
     )
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_REGEX_PATTERNS", (r"secret",))
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BANNED_SUBSTRINGS", ("token",))
-    monkeypatch.setattr(
-        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
-    )
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE)
 
     guardrails = OutputGuardrails.from_config()
 
     assert guardrails.enabled is True
     assert guardrails.action_on_hit == "redact"
-    assert guardrails.regex_patterns == [r"secret"]
-    assert guardrails.banned_substrings == ["token"]
     assert guardrails.block_message == DEFAULT_BLOCK_MESSAGE
+    assert guardrails.scanner_configs == []
 
 
-def test_from_config_policy_scanners_replace_env_values(tmp_path, monkeypatch):
+def test_from_config_replaces_scanners_with_policy_values(tmp_path, monkeypatch):
     policy_path = tmp_path / "guardrails.yaml"
     policy_path.write_text(
         textwrap.dedent(
@@ -99,17 +92,14 @@ def test_from_config_policy_scanners_replace_env_values(tmp_path, monkeypatch):
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_REGEX_PATTERNS", (r"secret",))
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BANNED_SUBSTRINGS", ("token",))
-    monkeypatch.setattr(
-        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
-    )
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE)
 
     guardrails = OutputGuardrails.from_config()
 
     assert guardrails.action_on_hit == "block"
-    assert guardrails.regex_patterns == []
-    assert guardrails.banned_substrings == ["yaml-only"]
+    assert guardrails.scanner_configs == [
+        {"type": "ban_substrings", "substrings": ["yaml-only"]},
+    ]
 
 
 def test_from_config_invalid_action_falls_back_to_env_value(tmp_path, monkeypatch):
@@ -130,13 +120,11 @@ def test_from_config_invalid_action_falls_back_to_env_value(tmp_path, monkeypatc
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_REGEX_PATTERNS", tuple())
-    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BANNED_SUBSTRINGS", tuple())
-    monkeypatch.setattr(
-        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
-    )
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE)
 
     guardrails = OutputGuardrails.from_config()
 
     assert guardrails.action_on_hit == "redact"
-    assert guardrails.regex_patterns == [r"https?://\S+"]
+    assert guardrails.scanner_configs == [
+        {"type": "regex", "patterns": [r"https?://\S+"]},
+    ]

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -10,7 +10,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import os
 import sys
 import textwrap

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -298,7 +298,7 @@ def test_build_scanners_supports_normalized_ban_substrings_type(monkeypatch):
         raising=False,
     )
 
-    scanner_configs = output_guardrails_module._coerce_policy_scanner_configs(
+    scanner_configs = output_guardrails_module._normalize_policy_scanner_configs(
         [{"type": "ban-substrings", "substrings": ["secret"]}],
         "guardrails.yaml",
     )

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -16,6 +16,7 @@ import textwrap
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
 
+import ragengine.guardrails.output_guardrails as output_guardrails_module
 from ragengine import config
 from ragengine.guardrails.output_guardrails import (
     DEFAULT_BLOCK_MESSAGE,
@@ -136,3 +137,185 @@ def test_from_config_invalid_action_falls_back_to_env_value(tmp_path, monkeypatc
     assert guardrails.scanner_configs == [
         {"type": "regex", "patterns": [r"https?://\S+"]},
     ]
+
+
+def test_from_config_returns_empty_scanners_when_policy_scanners_is_not_a_list(
+    tmp_path, monkeypatch
+):
+    policy_path = tmp_path / "guardrails.yaml"
+    policy_path.write_text(
+        textwrap.dedent(
+            """
+            action: block
+            scanners:
+              type: regex
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
+    monkeypatch.setattr(
+        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
+    )
+
+    guardrails = OutputGuardrails.from_config()
+
+    assert guardrails.action_on_hit == "block"
+    assert guardrails.scanner_configs == []
+
+
+def test_from_config_skips_invalid_scanners_and_filters_non_string_values(
+    tmp_path, monkeypatch
+):
+    class FakeRegex:
+        def __init__(self, patterns, redact=False):
+            self.patterns = patterns
+            self.redact = redact
+
+    class FakeBanSubstrings:
+        def __init__(self, substrings, redact=False):
+            self.substrings = substrings
+            self.redact = redact
+
+    policy_path = tmp_path / "guardrails.yaml"
+    policy_path.write_text(
+        textwrap.dedent(
+            """
+            scanners:
+              - not-a-dict
+              - type: regex
+                patterns:
+                  - https?://\\S+
+                  - ""
+                  - 123
+              - type: ban-substrings
+                substrings:
+                  - secret
+                  - null
+                  - ""
+            """
+        ).strip(),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", str(policy_path))
+    monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ACTION_ON_HIT", "redact")
+    monkeypatch.setattr(
+        config, "OUTPUT_GUARDRAILS_BLOCK_MESSAGE", DEFAULT_BLOCK_MESSAGE
+    )
+    monkeypatch.setattr(
+        output_guardrails_module.llm_guard_output_scanners,
+        "Regex",
+        FakeRegex,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        output_guardrails_module.llm_guard_output_scanners,
+        "BanSubstrings",
+        FakeBanSubstrings,
+        raising=False,
+    )
+
+    guardrails = OutputGuardrails.from_config()
+
+    assert guardrails.scanner_configs == [
+        {"type": "regex", "patterns": [r"https?://\S+", "", 123]},
+        {"type": "ban_substrings", "substrings": ["secret", None, ""]},
+    ]
+
+    scanners = guardrails._build_scanners()
+
+    assert len(scanners) == 2
+    assert scanners[0].patterns == [r"https?://\S+"]
+    assert scanners[0].redact is True
+    assert scanners[1].substrings == ["secret"]
+    assert scanners[1].redact is True
+
+
+def test_build_scanners_skips_unknown_and_missing_required_scanners(monkeypatch):
+    class FakeRequiredScanner:
+        def __init__(self, required_value):
+            self.required_value = required_value
+
+    class FakeOkScanner:
+        def __init__(self, redact=False):
+            self.redact = redact
+
+    monkeypatch.setitem(
+        output_guardrails_module.SUPPORTED_POLICY_SCANNERS,
+        "fake_required",
+        "FakeRequiredScanner",
+    )
+    monkeypatch.setitem(
+        output_guardrails_module.SUPPORTED_POLICY_SCANNERS,
+        "fake_ok",
+        "FakeOkScanner",
+    )
+    monkeypatch.setattr(
+        output_guardrails_module.llm_guard_output_scanners,
+        "FakeRequiredScanner",
+        FakeRequiredScanner,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        output_guardrails_module.llm_guard_output_scanners,
+        "FakeOkScanner",
+        FakeOkScanner,
+        raising=False,
+    )
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        action_on_hit="redact",
+        scanner_configs=[
+            {"type": "unknown_scanner"},
+            {"type": "fake_required"},
+            {"type": "fake_ok"},
+        ],
+    )
+
+    scanners = guardrails._build_scanners()
+
+    assert len(scanners) == 1
+    assert isinstance(scanners[0], FakeOkScanner)
+    assert scanners[0].redact is True
+
+
+def test_build_scanners_supports_normalized_ban_substrings_type(monkeypatch):
+    class FakeBanSubstrings:
+        def __init__(self, substrings, redact=False):
+            self.substrings = substrings
+            self.redact = redact
+
+    monkeypatch.setattr(
+        output_guardrails_module.llm_guard_output_scanners,
+        "BanSubstrings",
+        FakeBanSubstrings,
+        raising=False,
+    )
+
+    scanner_configs = output_guardrails_module._coerce_policy_scanner_configs(
+        [{"type": "ban-substrings", "substrings": ["secret"]}],
+        "guardrails.yaml",
+    )
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        action_on_hit="redact",
+        scanner_configs=scanner_configs,
+    )
+
+    scanners = guardrails._build_scanners()
+
+    assert guardrails.scanner_configs == [
+        {"type": "ban_substrings", "substrings": ["secret"]},
+    ]
+    assert len(scanners) == 1
+    assert isinstance(scanners[0], FakeBanSubstrings)
+    assert scanners[0].substrings == ["secret"]
+    assert scanners[0].redact is True
+

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -34,7 +34,6 @@ from ragengine.guardrails.scanner_schemas import (
 )
 from ragengine.models import ChatCompletionResponse
 
-
 # ---------------------------------------------------------------------------
 # Test helpers / fixtures
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Refactor output-guardrails policy loading into per-scanner dataclass schemas, and reject invalid policies at parse time instead of at runtime.

### Changes

- **New `scanner_schemas.py`**: one dataclass per scanner (`BanSubstringsConfig`, `RegexConfig`) with `from_dict()` + `build()`; `SCANNER_REGISTRY` maps the YAML `type` field to its schema. Adding a scanner = write dataclass + register.
- **Validation hardening**:
  - `match_type` checked against live `llm_guard` enum values (auto-syncs with upstream).
  - Regex `patterns` pre-compiled via `re.compile()` — bad regex rejected at parse time.
  - Booleans go through `_coerce_bool`, which rejects non-bool inputs (e.g. the truthy string `"false"`).
- **Bug fix**: `RegexMatchType` was looked up by enum *name* (`MatchType[x.upper()]`) — would `KeyError` on `match_type: fullmatch` (enum name is `FULL_MATCH`). Now looked up by *value*.
- **`from_config()`** short-circuits when `OUTPUT_GUARDRAILS_ENABLED=false` — skips file I/O, no spurious warnings on disabled deployments.
- Removed duplicate `DEFAULT_BLOCK_MESSAGE` from `config.py`.

### Tests

Rewrote with shared helpers + `parametrize`. **27 tests, 100% line coverage** on `output_guardrails.py` and `scanner_schemas.py`.

### Out of scope (tracked separately)

- `fail_open` behavior — PR #1963
- Default policy / refuse-to-start when policy missing — `TODO(next-PR)` in `_apply_policy_file`
- Admission webhook for apply-time validation — `NOTE` in `scanner_schemas.py` explains why runtime validation stays even after the webhook lands