### PR TITLE
feat: populate model dtype in model_catalog.yaml and use it in memory estimation

### DIFF
--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -189,6 +189,16 @@ var (
 			// source: https://docs.vllm.ai/en/v0.17.1/api/vllm/model_executor/models/mistral_large_3/
 			Architectures: []string{"MistralLarge3ForCausalLM"},
 			PipelineTag:   "text-generation",
+			// source: https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512/blob/main/consolidated-00001-of-00272.safetensors
+			DType: "bfloat16",
+		},
+		"openai/gpt-oss-20b": {
+			// source: https://huggingface.co/openai/gpt-oss-20b/blob/main/model-00000-of-00002.safetensors
+			DType: "bfloat16",
+		},
+		"openai/gpt-oss-120b": {
+			// source: https://huggingface.co/openai/gpt-oss-120b/blob/main/model-00000-of-00014.safetensors
+			DType: "bfloat16",
 		},
 	}
 )
@@ -419,6 +429,19 @@ func getInt(config map[string]interface{}, keys []string, defaultVal int) int {
 		}
 	}
 	return defaultVal
+}
+
+// getString looks up the first matching key in config and returns its string value,
+// or "" if none of the keys are present.
+func getString(config map[string]interface{}, keys []string) string {
+	for _, key := range keys {
+		if val, ok := config[key]; ok {
+			if s, ok := val.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	return ""
 }
 
 func (g *Generator) ParseModelMetadata() {

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -449,6 +449,13 @@ func (g *Generator) ParseModelMetadata() {
 
 	g.Param.Metadata.ModelTokenLimit = maxPos
 
+	// Parse dtype from config (torch_dtype or dtype key) if not already set
+	if g.Param.Metadata.DType == "" {
+		if dt := getString(g.ModelConfig, configKeyMap["dtype"]); dt != "" {
+			g.Param.Metadata.DType = dt
+		}
+	}
+
 	g.Param.Metadata.Architectures = []string{}
 	if arch, ok := g.ModelConfig["architectures"].([]interface{}); ok {
 		for _, a := range arch {
@@ -527,6 +534,19 @@ func (g *Generator) calculateStorageSize() string {
 	return fmt.Sprintf("%dGi", req)
 }
 
+// dtypeBytesMap maps dtype strings to their size in bytes.
+// Used to compute KV cache memory from element counts.
+var dtypeBytesMap = map[string]int{
+	"float32":  4,
+	"float16":  2,
+	"bfloat16": 2,
+	"fp8":      1,
+	"float8":   1,
+	"int8":     1,
+}
+
+const defaultBytesPerElement = 2 // fp16
+
 func (g *Generator) calculateKVCacheTokenSize() (int, string) {
 	config := g.ModelConfig
 
@@ -572,7 +592,12 @@ func (g *Generator) calculateKVCacheTokenSize() (int, string) {
 	}
 
 	totalElements := elementsPerToken * hiddenLayers
-	tokenSize := totalElements * 2 // fp16
+
+	bytesPerElement := defaultBytesPerElement
+	if b, ok := dtypeBytesMap[g.Param.Metadata.DType]; ok {
+		bytesPerElement = b
+	}
+	tokenSize := totalElements * bytesPerElement
 
 	return tokenSize, attnType
 }
@@ -655,6 +680,7 @@ func (g *Generator) loadFromCatalog() bool {
 
 	// Populate fields that FetchModelMetadata would have set
 	g.Param.Metadata.ModelFileSize = entry.ModelFileSize
+	g.Param.Metadata.DType = entry.DType
 	g.Param.VLLM.ModelRunParams = make(map[string]string)
 
 	if entry.LoadFormat != "" {

--- a/presets/workspace/generator/generator_test.go
+++ b/presets/workspace/generator/generator_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/yaml.v2"
 
 	"github.com/kaito-project/kaito/pkg/model"
 )
@@ -703,4 +704,99 @@ func TestSelectWeightFiles(t *testing.T) {
 			assert.Equal(t, tc.expectedPaths, paths)
 		})
 	}
+}
+
+func TestGetString(t *testing.T) {
+	config := map[string]interface{}{
+		"torch_dtype": "bfloat16",
+		"other_key":   "value",
+		"empty_key":   "",
+		"non_string":  42,
+	}
+
+	// First matching key wins
+	assert.Equal(t, "bfloat16", getString(config, []string{"torch_dtype", "dtype"}))
+	// Falls back to second key
+	assert.Equal(t, "value", getString(config, []string{"missing", "other_key"}))
+	// No match returns empty string
+	assert.Equal(t, "", getString(config, []string{"no_such_key"}))
+	// Skips empty string values
+	assert.Equal(t, "", getString(config, []string{"empty_key"}))
+	// Skips non-string values
+	assert.Equal(t, "", getString(config, []string{"non_string"}))
+}
+
+func TestCalculateKVCacheTokenSizeWithDType(t *testing.T) {
+	// Base GQA config: 32 layers, 32 attn heads, 8 kv heads, hidden=4096
+	// headDim = 4096/32 = 128
+	// elementsPerToken = 2 * 8 * 128 = 2048
+	// totalElements = 2048 * 32 = 65536
+	baseConfig := map[string]interface{}{
+		"hidden_size":         4096,
+		"num_hidden_layers":   32,
+		"num_attention_heads": 32,
+		"num_key_value_heads": 8,
+	}
+
+	cases := []struct {
+		name             string
+		dtype            string
+		expectedBPT      int
+		expectedAttnType string
+	}{
+		{"bfloat16 uses 2 bytes", "bfloat16", 65536 * 2, "GQA"},
+		{"float16 uses 2 bytes", "float16", 65536 * 2, "GQA"},
+		{"float32 uses 4 bytes", "float32", 65536 * 4, "GQA"},
+		{"fp8 uses 1 byte", "fp8", 65536 * 1, "GQA"},
+		{"int8 uses 1 byte", "int8", 65536 * 1, "GQA"},
+		{"unknown dtype defaults to 2 bytes", "weird_type", 65536 * 2, "GQA"},
+		{"empty dtype defaults to 2 bytes", "", 65536 * 2, "GQA"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gen := NewGenerator("test/model", "")
+			gen.ModelConfig = baseConfig
+			gen.Param.Metadata.DType = tc.dtype
+
+			bpt, attnType := gen.calculateKVCacheTokenSize()
+			assert.Equal(t, tc.expectedBPT, bpt)
+			assert.Equal(t, tc.expectedAttnType, attnType)
+		})
+	}
+}
+
+func TestDTypeBytesMapCompleteness(t *testing.T) {
+	// Ensure all dtypes used in model_catalog.yaml are present in dtypeBytesMap
+	catalogData, err := os.ReadFile("../models/model_catalog.yaml")
+	assert.NoError(t, err)
+
+	var catalog ModelCatalog
+	err = yaml.Unmarshal(catalogData, &catalog)
+	assert.NoError(t, err)
+
+	for _, m := range catalog.Models {
+		if m.DType == "" {
+			continue
+		}
+		_, ok := dtypeBytesMap[m.DType]
+		assert.True(t, ok, "dtype %q (from model %s) not found in dtypeBytesMap", m.DType, m.Name)
+	}
+}
+
+func TestLoadFromCatalogDType(t *testing.T) {
+	catalogData, err := os.ReadFile("../models/model_catalog.yaml")
+	assert.NoError(t, err)
+
+	// Pick a model known to have dtype: bfloat16 in the catalog
+	gen := NewGenerator("microsoft/phi-4", "")
+	gen.CatalogData = catalogData
+	found := gen.loadFromCatalog()
+	assert.True(t, found)
+
+	gen.ParseModelMetadata()
+	gen.FinalizeParams()
+
+	// DType should be populated from the catalog entry
+	assert.Equal(t, "bfloat16", gen.Param.Metadata.DType, "loadFromCatalog should propagate DType to Param.Metadata.DType")
 }

--- a/presets/workspace/generator/model_catalog.go
+++ b/presets/workspace/generator/model_catalog.go
@@ -38,6 +38,7 @@ type CatalogEntry struct {
 	NumHiddenLayers   int      `yaml:"numHiddenLayers"`
 	NumAttentionHeads int      `yaml:"numAttentionHeads"`
 	NumKeyValueHeads  int      `yaml:"numKeyValueHeads"`
+	DType             string   `yaml:"dtype,omitempty"`
 	LoadFormat        string   `yaml:"loadFormat,omitempty"`
 	ConfigFormat      string   `yaml:"configFormat,omitempty"`
 	TokenizerMode     string   `yaml:"tokenizerMode,omitempty"`
@@ -59,6 +60,7 @@ var configKeyMap = map[string][]string{
 	"numHiddenLayers":   {"num_hidden_layers", "n_layer", "n_layers"},
 	"numAttentionHeads": {"num_attention_heads", "n_head", "n_heads"},
 	"numKeyValueHeads":  {"num_key_value_heads", "n_head_kv", "n_kv_heads"},
+	"dtype":             {"torch_dtype", "dtype"},
 }
 
 // optionalKeyMap holds catalog fields that are only stored when present and > 0.
@@ -155,6 +157,7 @@ func FetchCatalogEntry(repo, token string) (*CatalogEntry, error) {
 	entry.HeadDim = getInt(config, optionalKeyMap["headDim"], 0)
 	entry.KVLoraRank = getInt(config, optionalKeyMap["kvLoraRank"], 0)
 	entry.QKRopeHeadDim = getInt(config, optionalKeyMap["qkRopeHeadDim"], 0)
+	entry.DType = getString(config, configKeyMap["dtype"])
 
 	if entry.HeadDim > 0 && entry.NumAttentionHeads > 0 && entry.HiddenSize > 0 {
 		if entry.HeadDim == entry.HiddenSize/entry.NumAttentionHeads {
@@ -204,6 +207,9 @@ func FetchCatalogEntry(repo, token string) (*CatalogEntry, error) {
 		}
 		if ovr.PipelineTag != "" {
 			entry.PipelineTag = ovr.PipelineTag
+		}
+		if ovr.DType != "" {
+			entry.DType = ovr.DType
 		}
 	}
 

--- a/presets/workspace/generator/update_model_catalog/main.go
+++ b/presets/workspace/generator/update_model_catalog/main.go
@@ -103,7 +103,7 @@ func catalogFields(e *generator.CatalogEntry) map[string]string {
 		"numHiddenLayers":   fmt.Sprintf("%d", e.NumHiddenLayers),
 		"numAttentionHeads": fmt.Sprintf("%d", e.NumAttentionHeads),
 		"numKeyValueHeads":  fmt.Sprintf("%d", e.NumKeyValueHeads),
-		"dtype":             fmt.Sprintf("%s", e.DType),
+		"dtype":             e.DType,
 	}
 	if e.Description != "" {
 		m["description"] = e.Description

--- a/presets/workspace/generator/update_model_catalog/main.go
+++ b/presets/workspace/generator/update_model_catalog/main.go
@@ -103,6 +103,7 @@ func catalogFields(e *generator.CatalogEntry) map[string]string {
 		"numHiddenLayers":   fmt.Sprintf("%d", e.NumHiddenLayers),
 		"numAttentionHeads": fmt.Sprintf("%d", e.NumAttentionHeads),
 		"numKeyValueHeads":  fmt.Sprintf("%d", e.NumKeyValueHeads),
+		"dtype":             fmt.Sprintf("%s", e.DType),
 	}
 	if e.Description != "" {
 		m["description"] = e.Description

--- a/presets/workspace/models/model_catalog.yaml
+++ b/presets/workspace/models/model_catalog.yaml
@@ -11,6 +11,7 @@ models:
   numHiddenLayers: 40
   numAttentionHeads: 40
   numKeyValueHeads: 10
+  dtype: bfloat16
 - name: microsoft/Phi-4-mini-instruct
   description: https://huggingface.co/microsoft/Phi-4-mini-instruct
   license: mit
@@ -23,6 +24,7 @@ models:
   numHiddenLayers: 32
   numAttentionHeads: 24
   numKeyValueHeads: 8
+  dtype: bfloat16
 - name: deepseek-ai/DeepSeek-R1-Distill-Llama-8B
   description: https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Llama-8B
   license: mit
@@ -35,6 +37,7 @@ models:
   numHiddenLayers: 32
   numAttentionHeads: 32
   numKeyValueHeads: 8
+  dtype: bfloat16
 - name: deepseek-ai/DeepSeek-R1-Distill-Qwen-14B
   description: https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B
   license: mit
@@ -47,6 +50,7 @@ models:
   numHiddenLayers: 48
   numAttentionHeads: 40
   numKeyValueHeads: 8
+  dtype: bfloat16
 - name: microsoft/Phi-3-mini-4k-instruct
   description: https://huggingface.co/microsoft/Phi-3-mini-4k-instruct
   license: mit
@@ -59,6 +63,7 @@ models:
   numHiddenLayers: 32
   numAttentionHeads: 32
   numKeyValueHeads: 32
+  dtype: bfloat16
 - name: microsoft/Phi-3-mini-128k-instruct
   description: https://huggingface.co/microsoft/Phi-3-mini-128k-instruct
   license: mit
@@ -71,6 +76,7 @@ models:
   numHiddenLayers: 32
   numAttentionHeads: 32
   numKeyValueHeads: 32
+  dtype: bfloat16
 - name: microsoft/Phi-3-medium-4k-instruct
   description: https://huggingface.co/microsoft/Phi-3-medium-4k-instruct
   license: mit
@@ -83,6 +89,7 @@ models:
   numHiddenLayers: 40
   numAttentionHeads: 40
   numKeyValueHeads: 10
+  dtype: bfloat16
 - name: microsoft/Phi-3-medium-128k-instruct
   description: https://huggingface.co/microsoft/Phi-3-medium-128k-instruct
   license: mit
@@ -95,6 +102,7 @@ models:
   numHiddenLayers: 40
   numAttentionHeads: 40
   numKeyValueHeads: 10
+  dtype: bfloat16
 - name: microsoft/Phi-3.5-mini-instruct
   description: https://huggingface.co/microsoft/Phi-3.5-mini-instruct
   license: mit
@@ -107,6 +115,7 @@ models:
   numHiddenLayers: 32
   numAttentionHeads: 32
   numKeyValueHeads: 32
+  dtype: bfloat16
 - name: Qwen/Qwen2.5-Coder-7B-Instruct
   description: https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct
   license: apache-2.0
@@ -121,6 +130,7 @@ models:
   numHiddenLayers: 28
   numAttentionHeads: 28
   numKeyValueHeads: 4
+  dtype: bfloat16
 - name: Qwen/Qwen2.5-Coder-32B-Instruct
   description: https://huggingface.co/Qwen/Qwen2.5-Coder-32B-Instruct
   license: apache-2.0
@@ -135,6 +145,7 @@ models:
   numHiddenLayers: 64
   numAttentionHeads: 40
   numKeyValueHeads: 8
+  dtype: bfloat16
 - name: openai/gpt-oss-20b
   description: https://huggingface.co/openai/gpt-oss-20b
   license: apache-2.0
@@ -147,6 +158,7 @@ models:
   numHiddenLayers: 24
   numAttentionHeads: 64
   numKeyValueHeads: 8
+  dtype: bfloat16
   headDim: 64
 - name: openai/gpt-oss-120b
   description: https://huggingface.co/openai/gpt-oss-120b
@@ -160,6 +172,7 @@ models:
   numHiddenLayers: 36
   numAttentionHeads: 64
   numKeyValueHeads: 8
+  dtype: bfloat16
   headDim: 64
 - name: meta-llama/Llama-3.1-8B-Instruct
   description: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
@@ -175,6 +188,7 @@ models:
   numHiddenLayers: 32
   numAttentionHeads: 32
   numKeyValueHeads: 8
+  dtype: bfloat16
 - name: meta-llama/Llama-3.3-70B-Instruct
   description: https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct
   license: llama3.3
@@ -189,6 +203,7 @@ models:
   numHiddenLayers: 80
   numAttentionHeads: 64
   numKeyValueHeads: 8
+  dtype: bfloat16
 - name: mistralai/Mistral-7B-v0.3
   description: https://huggingface.co/mistralai/Mistral-7B-v0.3
   license: apache-2.0
@@ -200,6 +215,7 @@ models:
   numHiddenLayers: 32
   numAttentionHeads: 32
   numKeyValueHeads: 8
+  dtype: bfloat16
   loadFormat: mistral
   configFormat: mistral
   tokenizerMode: mistral
@@ -216,6 +232,7 @@ models:
   numHiddenLayers: 32
   numAttentionHeads: 32
   numKeyValueHeads: 8
+  dtype: bfloat16
   loadFormat: mistral
   configFormat: mistral
   tokenizerMode: mistral
@@ -232,6 +249,7 @@ models:
   numHiddenLayers: 26
   numAttentionHeads: 32
   numKeyValueHeads: 8
+  dtype: bfloat16
   loadFormat: mistral
   configFormat: mistral
   tokenizerMode: mistral
@@ -249,6 +267,7 @@ models:
   numHiddenLayers: 34
   numAttentionHeads: 32
   numKeyValueHeads: 8
+  dtype: bfloat16
   loadFormat: mistral
   configFormat: mistral
   tokenizerMode: mistral
@@ -265,6 +284,7 @@ models:
   numHiddenLayers: 40
   numAttentionHeads: 32
   numKeyValueHeads: 8
+  dtype: bfloat16
   loadFormat: mistral
   configFormat: mistral
   tokenizerMode: mistral
@@ -283,6 +303,7 @@ models:
   numHiddenLayers: 34
   numAttentionHeads: 8
   numKeyValueHeads: 4
+  dtype: bfloat16
   headDim: 256
 - name: google/gemma-3-27b-it
   description: https://huggingface.co/google/gemma-3-27b-it
@@ -298,6 +319,8 @@ models:
   numHiddenLayers: 62
   numAttentionHeads: 32
   numKeyValueHeads: 16
+  dtype: bfloat16
+  headDim: 128
 - name: deepseek-ai/DeepSeek-R1-0528
   description: https://huggingface.co/deepseek-ai/DeepSeek-R1-0528
   license: mit
@@ -310,6 +333,7 @@ models:
   numHiddenLayers: 61
   numAttentionHeads: 128
   numKeyValueHeads: 128
+  dtype: bfloat16
   kvLoraRank: 512
   qkRopeHeadDim: 64
 - name: deepseek-ai/DeepSeek-V3-0324
@@ -324,6 +348,7 @@ models:
   numHiddenLayers: 61
   numAttentionHeads: 128
   numKeyValueHeads: 128
+  dtype: bfloat16
   kvLoraRank: 512
   qkRopeHeadDim: 64
 - name: mistralai/Mistral-Large-3-675B-Instruct-2512
@@ -340,6 +365,7 @@ models:
   numHiddenLayers: 61
   numAttentionHeads: 128
   numKeyValueHeads: 128
+  dtype: bfloat16
   loadFormat: mistral
   configFormat: mistral
   tokenizerMode: mistral


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
This PR populates model's dtype from HuggingFace to model_catalog.yaml, and updates Kaito's KV cache memory estimation to take dtype into account (currently hardcodes 2 bytes per element).

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: