### PR TITLE
feat: support deployment name as served-mode-name for inferenceset

### DIFF
--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/kaito-project/kaito/pkg/sku"
 	"github.com/kaito-project/kaito/pkg/utils"
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 type Model interface {
@@ -331,7 +332,13 @@ func (p *PresetParam) buildHuggingfaceInferenceCommand() []string {
 }
 
 func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
-	if p.VLLM.ModelName != "" {
+	// If the Workspace was created by an InferenceSet, expose the InferenceSet
+	// name as the served model name so all replicas behind the InferenceSet
+	// share a single, stable model identifier in the OpenAI-compatible API.
+	// Standalone Workspaces keep the model's default served name.
+	if isName, ok := rc.WorkspaceMetadata.Labels[consts.WorkspaceCreatedByInferenceSetLabel]; ok && isName != "" {
+		p.VLLM.ModelRunParams["served-model-name"] = isName
+	} else if p.VLLM.ModelName != "" {
 		p.VLLM.ModelRunParams["served-model-name"] = p.VLLM.ModelName
 	}
 	if rc.MaxModelLen > 0 {

--- a/pkg/model/interface_test.go
+++ b/pkg/model/interface_test.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kaito-project/kaito/pkg/sku"
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func TestPresetParamDeepCopy(t *testing.T) {
@@ -207,6 +208,73 @@ func TestGetInferenceCommandVLLMSingleNode(t *testing.T) {
 	require.Len(t, cmd, 3)
 	assert.Contains(t, cmd[2], "vllm serve")
 	assert.Contains(t, cmd[2], "tensor-parallel-size=2")
+}
+
+func TestGetInferenceCommandVLLMServedModelName(t *testing.T) {
+	tests := []struct {
+		name              string
+		vllmModelName     string
+		workspaceLabels   map[string]string
+		expectedServed    string
+		notExpectedServed string
+	}{
+		{
+			name:           "standalone workspace uses VLLM.ModelName",
+			vllmModelName:  "default-model",
+			expectedServed: "served-model-name=default-model",
+		},
+		{
+			name:          "InferenceSet workspace uses InferenceSet name",
+			vllmModelName: "default-model",
+			workspaceLabels: map[string]string{
+				consts.WorkspaceCreatedByInferenceSetLabel: "my-inferenceset",
+			},
+			expectedServed:    "served-model-name=my-inferenceset",
+			notExpectedServed: "served-model-name=default-model",
+		},
+		{
+			name: "InferenceSet workspace overrides even when VLLM.ModelName is empty",
+			workspaceLabels: map[string]string{
+				consts.WorkspaceCreatedByInferenceSetLabel: "my-inferenceset",
+			},
+			expectedServed: "served-model-name=my-inferenceset",
+		},
+		{
+			name:          "InferenceSet label with empty value falls back to VLLM.ModelName",
+			vllmModelName: "default-model",
+			workspaceLabels: map[string]string{
+				consts.WorkspaceCreatedByInferenceSetLabel: "",
+			},
+			expectedServed: "served-model-name=default-model",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &PresetParam{
+				RuntimeParam: RuntimeParam{
+					VLLM: VLLMParam{
+						BaseCommand:    "vllm serve",
+						ModelName:      tt.vllmModelName,
+						ModelRunParams: map[string]string{},
+					},
+				},
+			}
+			rc := RuntimeContext{
+				RuntimeName:          RuntimeNameVLLM,
+				SKUNumGPUs:           1,
+				NumNodes:             1,
+				DistributedInference: false,
+				WorkspaceMetadata:    metav1.ObjectMeta{Name: "ws", Namespace: "default", Labels: tt.workspaceLabels},
+			}
+			cmd := p.GetInferenceCommand(rc)
+			require.Len(t, cmd, 3)
+			assert.Contains(t, cmd[2], tt.expectedServed)
+			if tt.notExpectedServed != "" {
+				assert.NotContains(t, cmd[2], tt.notExpectedServed)
+			}
+		})
+	}
 }
 
 func TestGetInferenceCommandVLLMMultiNode(t *testing.T) {


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

support deployment name(InferenceSet.Name) as served-mode-name for inferenceset

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Fixes #2001 

**Notes for Reviewers**: