### PR TITLE
feat: inject NixlConnector kv-transfer-config for P/D disaggregated inference

### DIFF
--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -12,9 +12,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-
 env:
   KIND_VERSION: "0.31.0"
   KUBECTL_VERSION: "1.33.0"
@@ -86,7 +83,7 @@ jobs:
           # Install via Helm
           # CSI Local Node cannot be configured to not deploy and it crashes on kind on github runners for unknown reasons
           # so we need to filter it out its components
-          helm template kaito-workspace ./charts/kaito/workspace --namespace ${{ env.KAITO_NAMESPACE }} --set featureGates.disableNodeAutoProvisioning="true" --set featureGates.enableInferenceSetController="true" --set featureGates.gatewayAPIInferenceExtension="true" --include-crds --debug --wait | awk '
+          helm template kaito-workspace ./charts/kaito/workspace --namespace ${{ env.KAITO_NAMESPACE }} --set featureGates.disableNodeAutoProvisioning="true" --set featureGates.enableInferenceSetController="true" --include-crds --debug --wait | awk '
             BEGIN { RS="---\n"; ORS="---\n"; csi=0 }
             /kind: ServiceAccount/ && /name: csi-local-node/ { csi=1 }
             /kind: StorageClass/ && /name: kaito-local-nvme-disk/ { csi=1 }
@@ -95,7 +92,7 @@ jobs:
             /kind: DaemonSet/ && /name: csi-local-node/ { csi=1 }
             !csi { print }
             { csi=0 }
-          ' | kubectl apply --namespace ${{ env.KAITO_NAMESPACE }} -f -
+          ' | kubectl apply -f -
 
           # Wait for controller to be ready
           kubectl wait --for=condition=available --timeout=300s deployment/kaito-workspace -n ${{ env.KAITO_NAMESPACE }}
@@ -150,7 +147,6 @@ jobs:
             labelSelector:
               matchLabels:
                 apps: aikit-test
-                kaito.sh/inference-role: decode
             replicas: 1
             template:
               inference:
@@ -174,216 +170,6 @@ jobs:
         run: |
           echo "Waiting for inferenceset to be ready..."
           kubectl wait --for='jsonpath={.status.readyReplicas}=1' inferenceset/inferenceset-aikit-test --timeout 300s
-
-      - name: Validate GWIE infrastructure
-        run: |
-          # Note: GWIE resource chain (OCIRepository → HelmRelease → InferencePool → EPP)
-          # is only created for vLLM preset-based InferenceSet workloads.
-          # AIKit uses custom template inference, so GWIE resources won't be created.
-          # Here we validate that the GWIE infrastructure is correctly deployed.
-
-          echo "=== Checking Flux CRDs are installed ==="
-          kubectl get crd ocirepositories.source.toolkit.fluxcd.io
-          echo "✓ Flux OCIRepository CRD installed"
-          kubectl get crd helmreleases.helm.toolkit.fluxcd.io
-          echo "✓ Flux HelmRelease CRD installed"
-
-          echo "=== Checking GWIE CRDs are installed ==="
-          kubectl get crd inferencepools.inference.networking.k8s.io
-          echo "✓ InferencePool CRD installed"
-          kubectl get crd inferenceobjectives.inference.networking.x-k8s.io
-          echo "✓ InferenceObjective CRD installed"
-
-          echo "=== Checking Flux controllers are running ==="
-          # Flux helm-controller and source-controller are deployed as part of the flux2 subchart
-          kubectl get deployments -n ${{ env.KAITO_NAMESPACE }} -o wide
-          for controller in helm-controller source-controller; do
-            if kubectl get deployment $controller -n ${{ env.KAITO_NAMESPACE }} >/dev/null 2>&1; then
-              kubectl wait --for=condition=available --timeout=120s deployment/$controller -n ${{ env.KAITO_NAMESPACE }}
-              echo "✓ $controller is available"
-            else
-              echo "✗ $controller deployment not found"
-              exit 1
-            fi
-          done
-
-          echo "=== Checking controller feature gates ==="
-          CONTROLLER_ARGS=$(kubectl get deployment kaito-workspace -n ${{ env.KAITO_NAMESPACE }} -o jsonpath='{.spec.template.spec.containers[0].args}')
-          echo "Controller args: $CONTROLLER_ARGS"
-          if echo "$CONTROLLER_ARGS" | grep -q "gatewayAPIInferenceExtension=true"; then
-            echo "✓ gatewayAPIInferenceExtension feature gate enabled"
-          else
-            echo "✗ gatewayAPIInferenceExtension feature gate not found"
-            exit 1
-          fi
-          if echo "$CONTROLLER_ARGS" | grep -q "enableInferenceSetController=true"; then
-            echo "✓ enableInferenceSetController feature gate enabled"
-          else
-            echo "✗ enableInferenceSetController feature gate not found"
-            exit 1
-          fi
-
-          echo "=== Verifying GWIE not created for non-preset InferenceSet (expected) ==="
-          POOL_NAME="inferenceset-aikit-test-inferencepool"
-          if kubectl get ocirepository $POOL_NAME 2>/dev/null; then
-            echo "✗ Unexpected: GWIE resources found for custom template InferenceSet"
-            exit 1
-          else
-            echo "✓ Confirmed: GWIE resources not created for AIKit custom template (only vLLM preset supported)"
-          fi
-
-      - name: Create preset InferenceSet for GWIE resource chain test
-        run: |
-          # Strategy: Pre-create a dummy Workspace with the correct label so the
-          # InferenceSet controller finds it during reconciliation and proceeds to
-          # ensureGatewayAPIInferenceExtension(). We can't let the controller create
-          # the Workspace itself because the Workspace webhook calls the HuggingFace
-          # API for preset validation, which fails on CI without a token.
-          #
-          # 1. Create dummy Workspace first (with matching label, custom template to avoid HF API)
-          # 2. Create InferenceSet with preset (triggers GWIE code path)
-          # 3. Controller sees workspace count >= 1, skips creation, proceeds to GWIE
-
-          # Create a dummy Workspace with the controller's label so it counts as
-          # an existing workspace. Use custom template (no preset) to avoid webhook
-          # calling HuggingFace API.
-          cat << 'EOF' > dummy-workspace.yaml
-          apiVersion: kaito.sh/v1beta1
-          kind: Workspace
-          metadata:
-            name: inferenceset-preset-gwie-test-dummy
-            labels:
-              inferenceset.kaito.sh/created-by: inferenceset-preset-gwie-test
-              apps: gwie-preset-test
-          resource:
-            labelSelector:
-              matchLabels:
-                apps: gwie-preset-test
-          inference:
-            template:
-              spec:
-                containers:
-                  - name: dummy
-                    image: registry.k8s.io/pause:3.10
-          EOF
-          kubectl apply -f dummy-workspace.yaml
-
-          # Now create the preset InferenceSet
-          cat << 'EOF' > preset-inferenceset.yaml
-          apiVersion: kaito.sh/v1alpha1
-          kind: InferenceSet
-          metadata:
-            name: inferenceset-preset-gwie-test
-          spec:
-            labelSelector:
-              matchLabels:
-                apps: gwie-preset-test
-            replicas: 1
-            template:
-              resource:
-                instanceType: ""
-              inference:
-                preset:
-                  name: phi-4-mini-instruct
-          EOF
-          kubectl apply -f preset-inferenceset.yaml
-
-          # Add ownerReference to the dummy workspace for proper garbage collection.
-          # Note: the controller finds workspaces by the inferenceset.kaito.sh/created-by label,
-          # not by ownerReferences. The ownerRef ensures K8s GC cleans up the workspace.
-          IS_UID=$(kubectl get inferenceset inferenceset-preset-gwie-test -o jsonpath='{.metadata.uid}')
-          kubectl patch workspace inferenceset-preset-gwie-test-dummy --type=merge -p "{
-            \"metadata\": {
-              \"ownerReferences\": [{
-                \"apiVersion\": \"kaito.sh/v1alpha1\",
-                \"kind\": \"InferenceSet\",
-                \"name\": \"inferenceset-preset-gwie-test\",
-                \"uid\": \"$IS_UID\",
-                \"controller\": true,
-                \"blockOwnerDeletion\": true
-              }]
-            }
-          }"
-
-          echo "✓ Created dummy Workspace + preset InferenceSet for GWIE test"
-
-      - name: Wait for GWIE resource chain to be created
-        run: |
-          POOL_NAME="inferenceset-preset-gwie-test-inferencepool"
-
-          # The dummy Workspace is already created. Wait for the InferenceSet controller
-          # to reconcile and create GWIE resources (OCIRepository, HelmRelease).
-
-          # Wait for OCIRepository to be created (indicates GWIE reconciliation ran)
-          echo "Waiting for GWIE OCIRepository to be created..."
-          OCI_FOUND=false
-          for i in $(seq 1 60); do
-            if kubectl get ocirepository "$POOL_NAME" 2>/dev/null; then
-              echo "✓ OCIRepository $POOL_NAME created"
-              OCI_FOUND=true
-              break
-            fi
-            echo "  Attempt $i/60: waiting for OCIRepository..."
-            sleep 5
-          done
-          if [ "$OCI_FOUND" != "true" ]; then
-            echo "✗ Timed out waiting for OCIRepository $POOL_NAME (300s)"
-            exit 1
-          fi
-
-          # Wait for HelmRelease to be created
-          echo "Waiting for GWIE HelmRelease to be created..."
-          HR_FOUND=false
-          for i in $(seq 1 60); do
-            if kubectl get helmrelease "$POOL_NAME" 2>/dev/null; then
-              echo "✓ HelmRelease $POOL_NAME created"
-              HR_FOUND=true
-              break
-            fi
-            echo "  Attempt $i/60: waiting for HelmRelease..."
-            sleep 5
-          done
-          if [ "$HR_FOUND" != "true" ]; then
-            echo "✗ Timed out waiting for HelmRelease $POOL_NAME (300s)"
-            exit 1
-          fi
-
-      - name: Validate GWIE resource chain for preset InferenceSet
-        run: |
-          POOL_NAME="inferenceset-preset-gwie-test-inferencepool"
-
-          echo "=== Validating OCIRepository ==="
-          if ! kubectl get ocirepository "$POOL_NAME" -o yaml; then
-            echo "✗ OCIRepository $POOL_NAME not found"
-            exit 1
-          fi
-          echo "✓ OCIRepository exists"
-
-          echo "=== Validating HelmRelease ==="
-          if ! kubectl get helmrelease "$POOL_NAME" -o yaml; then
-            echo "✗ HelmRelease $POOL_NAME not found"
-            exit 1
-          fi
-          echo "✓ HelmRelease exists"
-
-          # Validate HelmRelease references the correct OCIRepository
-          CHART_REF=$(kubectl get helmrelease "$POOL_NAME" -o jsonpath='{.spec.chartRef.name}')
-          if [ "$CHART_REF" != "$POOL_NAME" ]; then
-            echo "✗ HelmRelease chartRef.name is '$CHART_REF', expected '$POOL_NAME'"
-            exit 1
-          fi
-          echo "✓ HelmRelease references correct OCIRepository"
-
-          # Validate HelmRelease has correct owner reference
-          OWNER=$(kubectl get helmrelease "$POOL_NAME" -o json | jq -r '.metadata.ownerReferences[] | select(.kind=="InferenceSet") | .kind')
-          if [ "$OWNER" != "InferenceSet" ]; then
-            echo "✗ HelmRelease owner is '$OWNER', expected 'InferenceSet'"
-            exit 1
-          fi
-          echo "✓ HelmRelease has correct InferenceSet owner reference"
-
-          echo "=== GWIE resource chain validation passed ==="
-          echo "✓ Full GWIE resource chain created for vLLM preset InferenceSet"
 
       - name: Validate response content
         run: |
@@ -479,27 +265,3 @@ jobs:
 
           echo "=== Node information ==="
           kubectl describe nodes
-
-          echo "=== GWIE: OCIRepository ==="
-          kubectl get ocirepository -A -o yaml || true
-
-          echo "=== GWIE: HelmRelease ==="
-          kubectl get helmrelease -A -o yaml || true
-
-          echo "=== GWIE: InferencePool ==="
-          kubectl get inferencepool -A -o yaml || true
-
-          echo "=== GWIE: EPP Deployment ==="
-          kubectl get deployment -l app=inferenceset-aikit-test-inferencepool-epp -o yaml || true
-
-          echo "=== GWIE: EPP Pod Logs ==="
-          kubectl logs -l app=inferenceset-aikit-test-inferencepool-epp --tail=50 || true
-
-          echo "=== Preset GWIE Test: InferenceSet Status ==="
-          kubectl get inferenceset inferenceset-preset-gwie-test -o yaml || true
-
-          echo "=== Preset GWIE Test: Child Workspaces ==="
-          kubectl get workspace -l inferenceset.kaito.sh/created-by=inferenceset-preset-gwie-test -o yaml || true
-
-          echo "=== Preset GWIE Test: Node Labels ==="
-          kubectl get nodes --show-labels || true

--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -12,6 +12,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   KIND_VERSION: "0.31.0"
   KUBECTL_VERSION: "1.33.0"
@@ -83,7 +86,7 @@ jobs:
           # Install via Helm
           # CSI Local Node cannot be configured to not deploy and it crashes on kind on github runners for unknown reasons
           # so we need to filter it out its components
-          helm template kaito-workspace ./charts/kaito/workspace --namespace ${{ env.KAITO_NAMESPACE }} --set featureGates.disableNodeAutoProvisioning="true" --set featureGates.enableInferenceSetController="true" --include-crds --debug --wait | awk '
+          helm template kaito-workspace ./charts/kaito/workspace --namespace ${{ env.KAITO_NAMESPACE }} --set featureGates.disableNodeAutoProvisioning="true" --set featureGates.enableInferenceSetController="true" --set featureGates.gatewayAPIInferenceExtension="true" --include-crds --debug --wait | awk '
             BEGIN { RS="---\n"; ORS="---\n"; csi=0 }
             /kind: ServiceAccount/ && /name: csi-local-node/ { csi=1 }
             /kind: StorageClass/ && /name: kaito-local-nvme-disk/ { csi=1 }
@@ -92,7 +95,7 @@ jobs:
             /kind: DaemonSet/ && /name: csi-local-node/ { csi=1 }
             !csi { print }
             { csi=0 }
-          ' | kubectl apply -f -
+          ' | kubectl apply --namespace ${{ env.KAITO_NAMESPACE }} -f -
 
           # Wait for controller to be ready
           kubectl wait --for=condition=available --timeout=300s deployment/kaito-workspace -n ${{ env.KAITO_NAMESPACE }}
@@ -170,6 +173,216 @@ jobs:
         run: |
           echo "Waiting for inferenceset to be ready..."
           kubectl wait --for='jsonpath={.status.readyReplicas}=1' inferenceset/inferenceset-aikit-test --timeout 300s
+
+      - name: Validate GWIE infrastructure
+        run: |
+          # Note: GWIE resource chain (OCIRepository → HelmRelease → InferencePool → EPP)
+          # is only created for vLLM preset-based InferenceSet workloads.
+          # AIKit uses custom template inference, so GWIE resources won't be created.
+          # Here we validate that the GWIE infrastructure is correctly deployed.
+
+          echo "=== Checking Flux CRDs are installed ==="
+          kubectl get crd ocirepositories.source.toolkit.fluxcd.io
+          echo "✓ Flux OCIRepository CRD installed"
+          kubectl get crd helmreleases.helm.toolkit.fluxcd.io
+          echo "✓ Flux HelmRelease CRD installed"
+
+          echo "=== Checking GWIE CRDs are installed ==="
+          kubectl get crd inferencepools.inference.networking.k8s.io
+          echo "✓ InferencePool CRD installed"
+          kubectl get crd inferenceobjectives.inference.networking.x-k8s.io
+          echo "✓ InferenceObjective CRD installed"
+
+          echo "=== Checking Flux controllers are running ==="
+          # Flux helm-controller and source-controller are deployed as part of the flux2 subchart
+          kubectl get deployments -n ${{ env.KAITO_NAMESPACE }} -o wide
+          for controller in helm-controller source-controller; do
+            if kubectl get deployment $controller -n ${{ env.KAITO_NAMESPACE }} >/dev/null 2>&1; then
+              kubectl wait --for=condition=available --timeout=120s deployment/$controller -n ${{ env.KAITO_NAMESPACE }}
+              echo "✓ $controller is available"
+            else
+              echo "✗ $controller deployment not found"
+              exit 1
+            fi
+          done
+
+          echo "=== Checking controller feature gates ==="
+          CONTROLLER_ARGS=$(kubectl get deployment kaito-workspace -n ${{ env.KAITO_NAMESPACE }} -o jsonpath='{.spec.template.spec.containers[0].args}')
+          echo "Controller args: $CONTROLLER_ARGS"
+          if echo "$CONTROLLER_ARGS" | grep -q "gatewayAPIInferenceExtension=true"; then
+            echo "✓ gatewayAPIInferenceExtension feature gate enabled"
+          else
+            echo "✗ gatewayAPIInferenceExtension feature gate not found"
+            exit 1
+          fi
+          if echo "$CONTROLLER_ARGS" | grep -q "enableInferenceSetController=true"; then
+            echo "✓ enableInferenceSetController feature gate enabled"
+          else
+            echo "✗ enableInferenceSetController feature gate not found"
+            exit 1
+          fi
+
+          echo "=== Verifying GWIE not created for non-preset InferenceSet (expected) ==="
+          POOL_NAME="inferenceset-aikit-test-inferencepool"
+          if kubectl get ocirepository $POOL_NAME 2>/dev/null; then
+            echo "✗ Unexpected: GWIE resources found for custom template InferenceSet"
+            exit 1
+          else
+            echo "✓ Confirmed: GWIE resources not created for AIKit custom template (only vLLM preset supported)"
+          fi
+
+      - name: Create preset InferenceSet for GWIE resource chain test
+        run: |
+          # Strategy: Pre-create a dummy Workspace with the correct label so the
+          # InferenceSet controller finds it during reconciliation and proceeds to
+          # ensureGatewayAPIInferenceExtension(). We can't let the controller create
+          # the Workspace itself because the Workspace webhook calls the HuggingFace
+          # API for preset validation, which fails on CI without a token.
+          #
+          # 1. Create dummy Workspace first (with matching label, custom template to avoid HF API)
+          # 2. Create InferenceSet with preset (triggers GWIE code path)
+          # 3. Controller sees workspace count >= 1, skips creation, proceeds to GWIE
+
+          # Create a dummy Workspace with the controller's label so it counts as
+          # an existing workspace. Use custom template (no preset) to avoid webhook
+          # calling HuggingFace API.
+          cat << 'EOF' > dummy-workspace.yaml
+          apiVersion: kaito.sh/v1beta1
+          kind: Workspace
+          metadata:
+            name: inferenceset-preset-gwie-test-dummy
+            labels:
+              inferenceset.kaito.sh/created-by: inferenceset-preset-gwie-test
+              apps: gwie-preset-test
+          resource:
+            labelSelector:
+              matchLabels:
+                apps: gwie-preset-test
+          inference:
+            template:
+              spec:
+                containers:
+                  - name: dummy
+                    image: registry.k8s.io/pause:3.10
+          EOF
+          kubectl apply -f dummy-workspace.yaml
+
+          # Now create the preset InferenceSet
+          cat << 'EOF' > preset-inferenceset.yaml
+          apiVersion: kaito.sh/v1alpha1
+          kind: InferenceSet
+          metadata:
+            name: inferenceset-preset-gwie-test
+          spec:
+            labelSelector:
+              matchLabels:
+                apps: gwie-preset-test
+            replicas: 1
+            template:
+              resource:
+                instanceType: ""
+              inference:
+                preset:
+                  name: phi-4-mini-instruct
+          EOF
+          kubectl apply -f preset-inferenceset.yaml
+
+          # Add ownerReference to the dummy workspace for proper garbage collection.
+          # Note: the controller finds workspaces by the inferenceset.kaito.sh/created-by label,
+          # not by ownerReferences. The ownerRef ensures K8s GC cleans up the workspace.
+          IS_UID=$(kubectl get inferenceset inferenceset-preset-gwie-test -o jsonpath='{.metadata.uid}')
+          kubectl patch workspace inferenceset-preset-gwie-test-dummy --type=merge -p "{
+            \"metadata\": {
+              \"ownerReferences\": [{
+                \"apiVersion\": \"kaito.sh/v1alpha1\",
+                \"kind\": \"InferenceSet\",
+                \"name\": \"inferenceset-preset-gwie-test\",
+                \"uid\": \"$IS_UID\",
+                \"controller\": true,
+                \"blockOwnerDeletion\": true
+              }]
+            }
+          }"
+
+          echo "✓ Created dummy Workspace + preset InferenceSet for GWIE test"
+
+      - name: Wait for GWIE resource chain to be created
+        run: |
+          POOL_NAME="inferenceset-preset-gwie-test-inferencepool"
+
+          # The dummy Workspace is already created. Wait for the InferenceSet controller
+          # to reconcile and create GWIE resources (OCIRepository, HelmRelease).
+
+          # Wait for OCIRepository to be created (indicates GWIE reconciliation ran)
+          echo "Waiting for GWIE OCIRepository to be created..."
+          OCI_FOUND=false
+          for i in $(seq 1 60); do
+            if kubectl get ocirepository "$POOL_NAME" 2>/dev/null; then
+              echo "✓ OCIRepository $POOL_NAME created"
+              OCI_FOUND=true
+              break
+            fi
+            echo "  Attempt $i/60: waiting for OCIRepository..."
+            sleep 5
+          done
+          if [ "$OCI_FOUND" != "true" ]; then
+            echo "✗ Timed out waiting for OCIRepository $POOL_NAME (300s)"
+            exit 1
+          fi
+
+          # Wait for HelmRelease to be created
+          echo "Waiting for GWIE HelmRelease to be created..."
+          HR_FOUND=false
+          for i in $(seq 1 60); do
+            if kubectl get helmrelease "$POOL_NAME" 2>/dev/null; then
+              echo "✓ HelmRelease $POOL_NAME created"
+              HR_FOUND=true
+              break
+            fi
+            echo "  Attempt $i/60: waiting for HelmRelease..."
+            sleep 5
+          done
+          if [ "$HR_FOUND" != "true" ]; then
+            echo "✗ Timed out waiting for HelmRelease $POOL_NAME (300s)"
+            exit 1
+          fi
+
+      - name: Validate GWIE resource chain for preset InferenceSet
+        run: |
+          POOL_NAME="inferenceset-preset-gwie-test-inferencepool"
+
+          echo "=== Validating OCIRepository ==="
+          if ! kubectl get ocirepository "$POOL_NAME" -o yaml; then
+            echo "✗ OCIRepository $POOL_NAME not found"
+            exit 1
+          fi
+          echo "✓ OCIRepository exists"
+
+          echo "=== Validating HelmRelease ==="
+          if ! kubectl get helmrelease "$POOL_NAME" -o yaml; then
+            echo "✗ HelmRelease $POOL_NAME not found"
+            exit 1
+          fi
+          echo "✓ HelmRelease exists"
+
+          # Validate HelmRelease references the correct OCIRepository
+          CHART_REF=$(kubectl get helmrelease "$POOL_NAME" -o jsonpath='{.spec.chartRef.name}')
+          if [ "$CHART_REF" != "$POOL_NAME" ]; then
+            echo "✗ HelmRelease chartRef.name is '$CHART_REF', expected '$POOL_NAME'"
+            exit 1
+          fi
+          echo "✓ HelmRelease references correct OCIRepository"
+
+          # Validate HelmRelease has correct owner reference
+          OWNER=$(kubectl get helmrelease "$POOL_NAME" -o json | jq -r '.metadata.ownerReferences[] | select(.kind=="InferenceSet") | .kind')
+          if [ "$OWNER" != "InferenceSet" ]; then
+            echo "✗ HelmRelease owner is '$OWNER', expected 'InferenceSet'"
+            exit 1
+          fi
+          echo "✓ HelmRelease has correct InferenceSet owner reference"
+
+          echo "=== GWIE resource chain validation passed ==="
+          echo "✓ Full GWIE resource chain created for vLLM preset InferenceSet"
 
       - name: Validate response content
         run: |
@@ -265,3 +478,27 @@ jobs:
 
           echo "=== Node information ==="
           kubectl describe nodes
+
+          echo "=== GWIE: OCIRepository ==="
+          kubectl get ocirepository -A -o yaml || true
+
+          echo "=== GWIE: HelmRelease ==="
+          kubectl get helmrelease -A -o yaml || true
+
+          echo "=== GWIE: InferencePool ==="
+          kubectl get inferencepool -A -o yaml || true
+
+          echo "=== GWIE: EPP Deployment ==="
+          kubectl get deployment -l app=inferenceset-aikit-test-inferencepool-epp -o yaml || true
+
+          echo "=== GWIE: EPP Pod Logs ==="
+          kubectl logs -l app=inferenceset-aikit-test-inferencepool-epp --tail=50 || true
+
+          echo "=== Preset GWIE Test: InferenceSet Status ==="
+          kubectl get inferenceset inferenceset-preset-gwie-test -o yaml || true
+
+          echo "=== Preset GWIE Test: Child Workspaces ==="
+          kubectl get workspace -l inferenceset.kaito.sh/created-by=inferenceset-preset-gwie-test -o yaml || true
+
+          echo "=== Preset GWIE Test: Node Labels ==="
+          kubectl get nodes --show-labels || true

--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -150,6 +150,7 @@ jobs:
             labelSelector:
               matchLabels:
                 apps: aikit-test
+                kaito.sh/inference-role: decode
             replicas: 1
             template:
               inference:

--- a/api/v1alpha1/inferenceset_types.go
+++ b/api/v1alpha1/inferenceset_types.go
@@ -31,6 +31,7 @@ type InferenceSetTemplate struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
+	// +kubebuilder:validation:XPreserveUnknownFields
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// +optional
 	Resource  InferenceSetResourceSpec   `json:"resource"`

--- a/api/v1alpha1/inferenceset_types.go
+++ b/api/v1alpha1/inferenceset_types.go
@@ -31,7 +31,8 @@ type InferenceSetTemplate struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
-	// +kubebuilder:validation:XPreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// +optional
 	Resource  InferenceSetResourceSpec   `json:"resource"`

--- a/api/v1beta1/labels.go
+++ b/api/v1beta1/labels.go
@@ -66,6 +66,11 @@ const (
 	// disable it; when absent or any other value, the benchmark runs.
 	AnnotationDisableBenchmark = KAITOPrefix + "disable-benchmark"
 
+	// LabelInferenceRole indicates the inference role of a workspace in P/D disaggregated serving.
+	// Propagated from InferenceSet.Spec.Template.Metadata.Labels onto child workspaces by the InferenceSet controller.
+	// Valid values: "prefill", "decode".
+	LabelInferenceRole = KAITOPrefix + "inference-role"
+
 	// AnnotationPerformanceMode selects the vLLM performance preset.
 	// Valid values are "balanced" (default), "interactivity", and "throughput".
 	//   - "interactivity": optimizes for low per-request latency (fine-grained CUDA

--- a/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
+++ b/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
@@ -219,6 +219,7 @@ spec:
                       Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   resource:
                     properties:
                       instanceType:

--- a/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
+++ b/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
@@ -218,7 +218,6 @@ spec:
                     description: |-
                       Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                   resource:
                     properties:

--- a/config/crd/bases/kaito.sh_inferencesets.yaml
+++ b/config/crd/bases/kaito.sh_inferencesets.yaml
@@ -219,6 +219,7 @@ spec:
                       Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   resource:
                     properties:
                       instanceType:

--- a/config/crd/bases/kaito.sh_inferencesets.yaml
+++ b/config/crd/bases/kaito.sh_inferencesets.yaml
@@ -218,7 +218,6 @@ spec:
                     description: |-
                       Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                   resource:
                     properties:

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -114,7 +114,7 @@ const (
 	RoutingSidecarTag   = "v0.7.1"
 
 	// When the routing sidecar is present, vLLM moves to this internal port.
-	PortInferenceServerInternal = 5001
+	PortInferenceServerInternal = int32(5001)
 
 	// Inference role constants for P/D disaggregated serving.
 	InferenceRoleEnvName = "KAITO_INFERENCE_ROLE"

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -106,6 +106,21 @@ const (
 	EPPImageName = "llm-d-inference-scheduler"
 	EPPImageTag  = "v0.7.1"
 
+	// Routing sidecar for P/D disaggregation on decode workspaces.
+	// The sidecar takes over the public-facing port (5000) so the Service
+	// routes traffic to it. It then forwards to vLLM on the internal port (5001).
+	// See: https://github.com/llm-d/llm-d-routing-sidecar
+	RoutingSidecarImage = "mcr.microsoft.com/oss/v2/llm-d/llm-d-routing-sidecar"
+	RoutingSidecarTag   = "v0.7.1"
+
+	// When the routing sidecar is present, vLLM moves to this internal port.
+	PortInferenceServerInternal = 5001
+
+	// Inference role constants for P/D disaggregated serving.
+	InferenceRoleEnvName = "KAITO_INFERENCE_ROLE"
+	InferenceRolePrefill = "prefill"
+	InferenceRoleDecode  = "decode"
+
 	// ConditionReady is the condition type for a ready condition.
 	ConditionReady = "Ready"
 

--- a/pkg/workspace/controllers/benchmark.go
+++ b/pkg/workspace/controllers/benchmark.go
@@ -177,6 +177,7 @@ func reconcileBenchmarkResult(ctx context.Context, wObj *kaitov1beta1.Workspace)
 
 	tailLines := benchmarkLogTailLines
 	req := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container: wObj.Name,
 		TailLines: &tailLines,
 	})
 	stream, err := req.Stream(ctx)

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -862,6 +862,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 	sidecarArgs := []string{
 		fmt.Sprintf("--port=%d", consts.PortInferenceServer),
 		fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
+		"--secure-proxy=false",
 	}
 
 	if sidecarExists {

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -801,27 +801,45 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			// Insert or rewrite --port to override vLLM's default listen port.
 			// Use string replacement to handle both single-node and multi-node
 			// shell script commands (where appending at end would break the script).
-			// If --port already exists with a different value, rewrite it to the internal port.
-			internalPort := fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)
+			// Handles both "--port <n>" (space form) and "--port=<n>" (equals form).
+			internalPortSpace := fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)
+			internalPortEquals := fmt.Sprintf("--port=%d", consts.PortInferenceServerInternal)
 			if !portOverrideAdded && strings.Contains(cmd, "inference_api.py") {
-				// Check for any existing --port flag and rewrite it
-				if idx := strings.Index(cmd, "--port "); idx >= 0 {
-					// Find the end of the port number
-					portStart := idx + len("--port ")
+				rewritten := false
+				// Check for "--port=<n>" form first (e.g., from BuildCmdStr)
+				if idx := strings.Index(cmd, "--port="); idx >= 0 {
+					portStart := idx + len("--port=")
 					portEnd := portStart
 					for portEnd < len(cmd) && cmd[portEnd] >= '0' && cmd[portEnd] <= '9' {
 						portEnd++
 					}
 					if portEnd > portStart {
 						existing := cmd[idx:portEnd]
-						spec.Containers[i].Command[j] = strings.Replace(cmd, existing, internalPort, 1)
+						spec.Containers[i].Command[j] = strings.Replace(cmd, existing, internalPortEquals, 1)
+						rewritten = true
 					}
-				} else {
-					// No existing --port, insert after inference_api.py
+				}
+				// Check for "--port <n>" form (space-separated)
+				if !rewritten {
+					if idx := strings.Index(cmd, "--port "); idx >= 0 {
+						portStart := idx + len("--port ")
+						portEnd := portStart
+						for portEnd < len(cmd) && cmd[portEnd] >= '0' && cmd[portEnd] <= '9' {
+							portEnd++
+						}
+						if portEnd > portStart {
+							existing := cmd[idx:portEnd]
+							spec.Containers[i].Command[j] = strings.Replace(cmd, existing, internalPortSpace, 1)
+							rewritten = true
+						}
+					}
+				}
+				// No existing --port flag, insert after inference_api.py
+				if !rewritten {
 					spec.Containers[i].Command[j] = strings.Replace(
 						cmd,
 						"inference_api.py",
-						"inference_api.py "+internalPort,
+						"inference_api.py "+internalPortSpace,
 						1,
 					)
 				}
@@ -867,6 +885,24 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 				}
 			} else {
 				spec.Containers[i].Ports[0].ContainerPort = consts.PortInferenceServer
+			}
+			// Ensure POD_IP env is present
+			podIPFound := false
+			for j := range spec.Containers[i].Env {
+				if spec.Containers[i].Env[j].Name == "POD_IP" {
+					podIPFound = true
+					break
+				}
+			}
+			if !podIPFound {
+				spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
+					Name: "POD_IP",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "status.podIP",
+						},
+					},
+				})
 			}
 			break
 		}

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -740,7 +740,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			spec.Containers[i].Ports = portsCopy
 			for j := range spec.Containers[i].Ports {
 				if spec.Containers[i].Ports[j].ContainerPort == int32(consts.PortInferenceServer) {
-					spec.Containers[i].Ports[j].ContainerPort = int32(consts.PortInferenceServerInternal)
+					spec.Containers[i].Ports[j].ContainerPort = consts.PortInferenceServerInternal
 				}
 			}
 		}
@@ -749,7 +749,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			spec.Containers[i].ReadinessProbe = spec.Containers[i].ReadinessProbe.DeepCopy()
 			if spec.Containers[i].ReadinessProbe.HTTPGet != nil {
 				if spec.Containers[i].ReadinessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-					spec.Containers[i].ReadinessProbe.HTTPGet.Port = intstr.FromInt32(int32(consts.PortInferenceServerInternal))
+					spec.Containers[i].ReadinessProbe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
 				}
 			}
 			if spec.Containers[i].ReadinessProbe.Exec != nil {
@@ -765,7 +765,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			spec.Containers[i].LivenessProbe = spec.Containers[i].LivenessProbe.DeepCopy()
 			if spec.Containers[i].LivenessProbe.HTTPGet != nil {
 				if spec.Containers[i].LivenessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-					spec.Containers[i].LivenessProbe.HTTPGet.Port = intstr.FromInt32(int32(consts.PortInferenceServerInternal))
+					spec.Containers[i].LivenessProbe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
 				}
 			}
 			if spec.Containers[i].LivenessProbe.Exec != nil {
@@ -781,7 +781,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			spec.Containers[i].StartupProbe = spec.Containers[i].StartupProbe.DeepCopy()
 			if spec.Containers[i].StartupProbe.HTTPGet != nil {
 				if spec.Containers[i].StartupProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-					spec.Containers[i].StartupProbe.HTTPGet.Port = intstr.FromInt32(int32(consts.PortInferenceServerInternal))
+					spec.Containers[i].StartupProbe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
 				}
 			}
 			if spec.Containers[i].StartupProbe.Exec != nil {
@@ -835,8 +835,43 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 		}
 	}
 
-	// Only inject sidecar container if not already present
-	if !sidecarExists {
+	expectedBackendURL := fmt.Sprintf("http://localhost:%d", consts.PortInferenceServerInternal)
+
+	if sidecarExists {
+		// Reconcile existing sidecar to ensure its config matches expected values
+		for i := range spec.Containers {
+			if spec.Containers[i].Name != "llm-d-routing-sidecar" {
+				continue
+			}
+			// Ensure BACKEND_URL points to the internal port
+			backendFound := false
+			for j := range spec.Containers[i].Env {
+				if spec.Containers[i].Env[j].Name == "BACKEND_URL" {
+					spec.Containers[i].Env[j].Value = expectedBackendURL
+					backendFound = true
+					break
+				}
+			}
+			if !backendFound {
+				spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
+					Name:  "BACKEND_URL",
+					Value: expectedBackendURL,
+				})
+			}
+			// Ensure image is up to date
+			spec.Containers[i].Image = fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag)
+			// Ensure port is set correctly
+			if len(spec.Containers[i].Ports) == 0 {
+				spec.Containers[i].Ports = []corev1.ContainerPort{
+					{ContainerPort: consts.PortInferenceServer, Name: "sidecar", Protocol: corev1.ProtocolTCP},
+				}
+			} else {
+				spec.Containers[i].Ports[0].ContainerPort = consts.PortInferenceServer
+			}
+			break
+		}
+	} else {
+		// Inject new sidecar container
 		sidecar := corev1.Container{
 			Name:  "llm-d-routing-sidecar",
 			Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
@@ -850,7 +885,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			Env: []corev1.EnvVar{
 				{
 					Name:  "BACKEND_URL",
-					Value: fmt.Sprintf("http://localhost:%d", consts.PortInferenceServerInternal),
+					Value: expectedBackendURL,
 				},
 				{
 					Name: "POD_IP",

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -20,6 +20,16 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
@@ -30,16 +40,6 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/workspace/manifests"
 	metadata "github.com/kaito-project/kaito/presets/workspace/models"
-
-	"github.com/samber/lo"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -879,12 +879,9 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			// Ensure image is up to date
 			spec.Containers[i].Image = fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag)
 			// Ensure port is set correctly
-			if len(spec.Containers[i].Ports) == 0 {
-				spec.Containers[i].Ports = []corev1.ContainerPort{
-					{ContainerPort: consts.PortInferenceServer, Name: "sidecar", Protocol: corev1.ProtocolTCP},
-				}
-			} else {
-				spec.Containers[i].Ports[0].ContainerPort = consts.PortInferenceServer
+			// Set ports to exactly the expected single port struct for deterministic spec
+			spec.Containers[i].Ports = []corev1.ContainerPort{
+				{ContainerPort: consts.PortInferenceServer, Name: "sidecar", Protocol: corev1.ProtocolTCP},
 			}
 			// Ensure POD_IP env is present
 			podIPFound := false

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -853,7 +853,16 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 		}
 	}
 
-	expectedBackendURL := fmt.Sprintf("http://localhost:%d", consts.PortInferenceServerInternal)
+
+	// The llm-d routing sidecar uses command-line flags (not environment variables)
+	// to configure its listening port and backend vLLM port:
+	//   --port=<listen-port>       (default: 8000)
+	//   --vllm-port=<backend-port> (default: 8001)
+	// We must explicitly set these to match our port scheme (5000 / 5001).
+	sidecarArgs := []string{
+		fmt.Sprintf("--port=%d", consts.PortInferenceServer),
+		fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
+	}
 
 	if sidecarExists {
 		// Reconcile existing sidecar to ensure its config matches expected values
@@ -861,24 +870,10 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			if spec.Containers[i].Name != "llm-d-routing-sidecar" {
 				continue
 			}
-			// Ensure BACKEND_URL points to the internal port
-			backendFound := false
-			for j := range spec.Containers[i].Env {
-				if spec.Containers[i].Env[j].Name == "BACKEND_URL" {
-					spec.Containers[i].Env[j].Value = expectedBackendURL
-					backendFound = true
-					break
-				}
-			}
-			if !backendFound {
-				spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
-					Name:  "BACKEND_URL",
-					Value: expectedBackendURL,
-				})
-			}
 			// Ensure image is up to date
 			spec.Containers[i].Image = fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag)
-			// Ensure port is set correctly
+			// Ensure args include correct port flags
+			spec.Containers[i].Args = sidecarArgs
 			// Set ports to exactly the expected single port struct for deterministic spec
 			spec.Containers[i].Ports = []corev1.ContainerPort{
 				{ContainerPort: consts.PortInferenceServer, Name: "sidecar", Protocol: corev1.ProtocolTCP},
@@ -901,6 +896,14 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 					},
 				})
 			}
+			// Remove stale BACKEND_URL env if present (no longer used)
+			envs := spec.Containers[i].Env[:0]
+			for _, e := range spec.Containers[i].Env {
+				if e.Name != "BACKEND_URL" {
+					envs = append(envs, e)
+				}
+			}
+			spec.Containers[i].Env = envs
 			break
 		}
 	} else {
@@ -908,6 +911,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 		sidecar := corev1.Container{
 			Name:  "llm-d-routing-sidecar",
 			Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
+			Args:  sidecarArgs,
 			Ports: []corev1.ContainerPort{
 				{
 					ContainerPort: consts.PortInferenceServer,
@@ -916,10 +920,6 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 				},
 			},
 			Env: []corev1.EnvVar{
-				{
-					Name:  "BACKEND_URL",
-					Value: expectedBackendURL,
-				},
 				{
 					Name: "POD_IP",
 					ValueFrom: &corev1.EnvVarSource{

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -669,7 +669,7 @@ func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec
 // to the KAITO_INFERENCE_ROLE environment variable on all containers.
 // This is used by the vLLM inference_api.py to inject NixlConnector kv-transfer-config
 // for P/D disaggregated inference. The label is propagated from
-// InferenceSet.Spec.Template.Labels onto child workspaces by the InferenceSet controller.
+// InferenceSet.Spec.Template.Metadata.Labels onto child workspaces by the InferenceSet controller.
 func SetInferenceRoleEnv(ctx *generator.WorkspaceGeneratorContext, spec *corev1.PodSpec) error {
 	role, ok := ctx.Workspace.Labels[v1beta1.LabelInferenceRole]
 	if !ok || (role != consts.InferenceRolePrefill && role != consts.InferenceRoleDecode) {

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -795,8 +795,12 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 		// Update --vllm-port in container command and args
 		portOverrideAdded := false
 		for j, cmd := range spec.Containers[i].Command {
-			if strings.Contains(cmd, "--vllm-port="+oldPort) {
-				spec.Containers[i].Command[j] = strings.ReplaceAll(cmd, "--vllm-port="+oldPort, "--vllm-port="+newPort)
+			// Use a working copy so all transformations within the same
+			// command string are cumulative (avoid clobbering earlier rewrites).
+			updated := cmd
+
+			if strings.Contains(updated, "--vllm-port="+oldPort) {
+				updated = strings.ReplaceAll(updated, "--vllm-port="+oldPort, "--vllm-port="+newPort)
 			}
 			// Insert or rewrite --port to override vLLM's default listen port.
 			// Use string replacement to handle both single-node and multi-node
@@ -804,40 +808,40 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			// Handles both "--port <n>" (space form) and "--port=<n>" (equals form).
 			internalPortSpace := fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)
 			internalPortEquals := fmt.Sprintf("--port=%d", consts.PortInferenceServerInternal)
-			if !portOverrideAdded && strings.Contains(cmd, "inference_api.py") {
+			if !portOverrideAdded && strings.Contains(updated, "inference_api.py") {
 				rewritten := false
 				// Check for "--port=<n>" form first (e.g., from BuildCmdStr)
-				if idx := strings.Index(cmd, "--port="); idx >= 0 {
+				if idx := strings.Index(updated, "--port="); idx >= 0 {
 					portStart := idx + len("--port=")
 					portEnd := portStart
-					for portEnd < len(cmd) && cmd[portEnd] >= '0' && cmd[portEnd] <= '9' {
+					for portEnd < len(updated) && updated[portEnd] >= '0' && updated[portEnd] <= '9' {
 						portEnd++
 					}
 					if portEnd > portStart {
-						existing := cmd[idx:portEnd]
-						spec.Containers[i].Command[j] = strings.Replace(cmd, existing, internalPortEquals, 1)
+						existing := updated[idx:portEnd]
+						updated = strings.Replace(updated, existing, internalPortEquals, 1)
 						rewritten = true
 					}
 				}
 				// Check for "--port <n>" form (space-separated)
 				if !rewritten {
-					if idx := strings.Index(cmd, "--port "); idx >= 0 {
+					if idx := strings.Index(updated, "--port "); idx >= 0 {
 						portStart := idx + len("--port ")
 						portEnd := portStart
-						for portEnd < len(cmd) && cmd[portEnd] >= '0' && cmd[portEnd] <= '9' {
+						for portEnd < len(updated) && updated[portEnd] >= '0' && updated[portEnd] <= '9' {
 							portEnd++
 						}
 						if portEnd > portStart {
-							existing := cmd[idx:portEnd]
-							spec.Containers[i].Command[j] = strings.Replace(cmd, existing, internalPortSpace, 1)
+							existing := updated[idx:portEnd]
+							updated = strings.Replace(updated, existing, internalPortSpace, 1)
 							rewritten = true
 						}
 					}
 				}
 				// No existing --port flag, insert after inference_api.py
 				if !rewritten {
-					spec.Containers[i].Command[j] = strings.Replace(
-						cmd,
+					updated = strings.Replace(
+						updated,
 						"inference_api.py",
 						"inference_api.py "+internalPortSpace,
 						1,
@@ -845,6 +849,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 				}
 				portOverrideAdded = true
 			}
+			spec.Containers[i].Command[j] = updated
 		}
 		for j, arg := range spec.Containers[i].Args {
 			if strings.Contains(arg, "--vllm-port="+oldPort) {

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -664,3 +664,205 @@ func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec
 	spec.Volumes = append(spec.Volumes, utils.DefaultModelWeightsVolume)
 	return nil
 }
+
+// SetInferenceRoleEnv propagates the kaito.sh/inference-role label from the workspace
+// to the KAITO_INFERENCE_ROLE environment variable on all containers.
+// This is used by the vLLM inference_api.py to inject NixlConnector kv-transfer-config
+// for P/D disaggregated inference. The label is propagated from
+// InferenceSet.Spec.Template.Labels onto child workspaces by the InferenceSet controller.
+func SetInferenceRoleEnv(ctx *generator.WorkspaceGeneratorContext, spec *corev1.PodSpec) error {
+	role, ok := ctx.Workspace.Labels[v1beta1.LabelInferenceRole]
+	if !ok || (role != consts.InferenceRolePrefill && role != consts.InferenceRoleDecode) {
+		return nil
+	}
+	envVar := corev1.EnvVar{
+		Name:  consts.InferenceRoleEnvName,
+		Value: role,
+	}
+	for i := range spec.Containers {
+		// Upsert: replace existing entry if present to avoid duplicates
+		found := false
+		for j, env := range spec.Containers[i].Env {
+			if env.Name == consts.InferenceRoleEnvName {
+				spec.Containers[i].Env[j] = envVar
+				found = true
+				break
+			}
+		}
+		if !found {
+			spec.Containers[i].Env = append(spec.Containers[i].Env, envVar)
+		}
+	}
+	return nil
+}
+
+// SetRoutingSidecar adds the llm-d routing sidecar container to decode workspace pods.
+// When the workspace has the inference-role: decode label, the sidecar is injected
+// alongside the main vLLM container. The sidecar takes over the public-facing port (5000)
+// and vLLM is moved to an internal port (5001). The sidecar orchestrates P/D disaggregation
+// (contacting prefill pods if needed via x-prefiller-host-port header) and forwards to
+// the local vLLM engine on port 5001. When no header is present, it transparently proxies.
+// Prefill workspaces (inference-role: prefill) do not get the sidecar.
+func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.PodSpec) error {
+	role, ok := ctx.Workspace.Labels[v1beta1.LabelInferenceRole]
+	if !ok || role != consts.InferenceRoleDecode {
+		return nil
+	}
+
+	// Only apply to vLLM runtime — other runtimes don't support P/D disaggregation
+	runtimeName := v1beta1.GetWorkspaceRuntimeName(ctx.Workspace)
+	if runtimeName != pkgmodel.RuntimeNameVLLM {
+		return nil
+	}
+
+	// Check if sidecar already exists to avoid duplicate injection
+	sidecarExists := false
+	for _, c := range spec.Containers {
+		if c.Name == "llm-d-routing-sidecar" {
+			sidecarExists = true
+			break
+		}
+	}
+
+	// Move vLLM to internal port so the sidecar can take over the public-facing port.
+	// Update container ports, readiness/liveness probes, and vllm-port arg/command.
+	// Deep-copy mutable slices to avoid contaminating shared package-level defaults.
+	oldPort := strconv.Itoa(int(consts.PortInferenceServer))
+	newPort := strconv.Itoa(int(consts.PortInferenceServerInternal))
+	for i := range spec.Containers {
+		if spec.Containers[i].Name == "llm-d-routing-sidecar" {
+			continue
+		}
+		// Deep-copy ports to avoid mutating shared defaults
+		if len(spec.Containers[i].Ports) > 0 {
+			portsCopy := make([]corev1.ContainerPort, len(spec.Containers[i].Ports))
+			copy(portsCopy, spec.Containers[i].Ports)
+			spec.Containers[i].Ports = portsCopy
+			for j := range spec.Containers[i].Ports {
+				if spec.Containers[i].Ports[j].ContainerPort == int32(consts.PortInferenceServer) {
+					spec.Containers[i].Ports[j].ContainerPort = int32(consts.PortInferenceServerInternal)
+				}
+			}
+		}
+		// Update readiness probe port (HTTPGet or Exec)
+		if spec.Containers[i].ReadinessProbe != nil {
+			spec.Containers[i].ReadinessProbe = spec.Containers[i].ReadinessProbe.DeepCopy()
+			if spec.Containers[i].ReadinessProbe.HTTPGet != nil {
+				if spec.Containers[i].ReadinessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+					spec.Containers[i].ReadinessProbe.HTTPGet.Port = intstr.FromInt32(int32(consts.PortInferenceServerInternal))
+				}
+			}
+			if spec.Containers[i].ReadinessProbe.Exec != nil {
+				for j, cmd := range spec.Containers[i].ReadinessProbe.Exec.Command {
+					if strings.Contains(cmd, "--vllm-port="+oldPort) {
+						spec.Containers[i].ReadinessProbe.Exec.Command[j] = strings.ReplaceAll(cmd, "--vllm-port="+oldPort, "--vllm-port="+newPort)
+					}
+				}
+			}
+		}
+		// Update liveness probe port (HTTPGet or Exec)
+		if spec.Containers[i].LivenessProbe != nil {
+			spec.Containers[i].LivenessProbe = spec.Containers[i].LivenessProbe.DeepCopy()
+			if spec.Containers[i].LivenessProbe.HTTPGet != nil {
+				if spec.Containers[i].LivenessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+					spec.Containers[i].LivenessProbe.HTTPGet.Port = intstr.FromInt32(int32(consts.PortInferenceServerInternal))
+				}
+			}
+			if spec.Containers[i].LivenessProbe.Exec != nil {
+				for j, cmd := range spec.Containers[i].LivenessProbe.Exec.Command {
+					if strings.Contains(cmd, "--vllm-port="+oldPort) {
+						spec.Containers[i].LivenessProbe.Exec.Command[j] = strings.ReplaceAll(cmd, "--vllm-port="+oldPort, "--vllm-port="+newPort)
+					}
+				}
+			}
+		}
+		// Update startup probe port (HTTPGet or Exec)
+		if spec.Containers[i].StartupProbe != nil {
+			spec.Containers[i].StartupProbe = spec.Containers[i].StartupProbe.DeepCopy()
+			if spec.Containers[i].StartupProbe.HTTPGet != nil {
+				if spec.Containers[i].StartupProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+					spec.Containers[i].StartupProbe.HTTPGet.Port = intstr.FromInt32(int32(consts.PortInferenceServerInternal))
+				}
+			}
+			if spec.Containers[i].StartupProbe.Exec != nil {
+				for j, cmd := range spec.Containers[i].StartupProbe.Exec.Command {
+					if strings.Contains(cmd, "--vllm-port="+oldPort) {
+						spec.Containers[i].StartupProbe.Exec.Command[j] = strings.ReplaceAll(cmd, "--vllm-port="+oldPort, "--vllm-port="+newPort)
+					}
+				}
+			}
+		}
+		// Update --vllm-port in container command and args
+		portOverrideAdded := false
+		for j, cmd := range spec.Containers[i].Command {
+			if strings.Contains(cmd, "--vllm-port="+oldPort) {
+				spec.Containers[i].Command[j] = strings.ReplaceAll(cmd, "--vllm-port="+oldPort, "--vllm-port="+newPort)
+			}
+			// Insert or rewrite --port to override vLLM's default listen port.
+			// Use string replacement to handle both single-node and multi-node
+			// shell script commands (where appending at end would break the script).
+			// If --port already exists with a different value, rewrite it to the internal port.
+			internalPort := fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)
+			if !portOverrideAdded && strings.Contains(cmd, "inference_api.py") {
+				// Check for any existing --port flag and rewrite it
+				if idx := strings.Index(cmd, "--port "); idx >= 0 {
+					// Find the end of the port number
+					portStart := idx + len("--port ")
+					portEnd := portStart
+					for portEnd < len(cmd) && cmd[portEnd] >= '0' && cmd[portEnd] <= '9' {
+						portEnd++
+					}
+					if portEnd > portStart {
+						existing := cmd[idx:portEnd]
+						spec.Containers[i].Command[j] = strings.Replace(cmd, existing, internalPort, 1)
+					}
+				} else {
+					// No existing --port, insert after inference_api.py
+					spec.Containers[i].Command[j] = strings.Replace(
+						cmd,
+						"inference_api.py",
+						"inference_api.py "+internalPort,
+						1,
+					)
+				}
+				portOverrideAdded = true
+			}
+		}
+		for j, arg := range spec.Containers[i].Args {
+			if strings.Contains(arg, "--vllm-port="+oldPort) {
+				spec.Containers[i].Args[j] = strings.ReplaceAll(arg, "--vllm-port="+oldPort, "--vllm-port="+newPort)
+			}
+		}
+	}
+
+	// Only inject sidecar container if not already present
+	if !sidecarExists {
+		sidecar := corev1.Container{
+			Name:  "llm-d-routing-sidecar",
+			Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
+			Ports: []corev1.ContainerPort{
+				{
+					ContainerPort: consts.PortInferenceServer,
+					Name:          "sidecar",
+					Protocol:      corev1.ProtocolTCP,
+				},
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "BACKEND_URL",
+					Value: fmt.Sprintf("http://localhost:%d", consts.PortInferenceServerInternal),
+				},
+				{
+					Name: "POD_IP",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "status.podIP",
+						},
+					},
+				},
+			},
+		}
+		spec.Containers = append(spec.Containers, sidecar)
+	}
+	return nil
+}

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -20,16 +20,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/samber/lo"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
@@ -40,6 +30,16 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/workspace/manifests"
 	metadata "github.com/kaito-project/kaito/presets/workspace/models"
+
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -852,7 +852,6 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			}
 		}
 	}
-
 
 	// The llm-d routing sidecar uses command-line flags (not environment variables)
 	// to configure its listening port and backend vLLM port:

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -21,15 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/samber/lo"
-	"github.com/stretchr/testify/mock"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/sku"
@@ -41,6 +32,15 @@ import (
 	workspaceutil "github.com/kaito-project/kaito/pkg/utils/workspace"
 	"github.com/kaito-project/kaito/pkg/workspace/estimator/nodesestimator"
 	metadata "github.com/kaito-project/kaito/presets/workspace/models"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/mock"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var ValidStrength string = "0.5"

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1565,6 +1565,7 @@ func TestSetRoutingSidecar(t *testing.T) {
 				expectedArgs := []string{
 					fmt.Sprintf("--port=%d", consts.PortInferenceServer),
 					fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
+					"--secure-proxy=false",
 				}
 				if len(sidecar.Args) != len(expectedArgs) {
 					t.Errorf("expected %d args, got %d: %v", len(expectedArgs), len(sidecar.Args), sidecar.Args)

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -21,6 +21,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/mock"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/sku"
@@ -32,15 +41,6 @@ import (
 	workspaceutil "github.com/kaito-project/kaito/pkg/utils/workspace"
 	"github.com/kaito-project/kaito/pkg/workspace/estimator/nodesestimator"
 	metadata "github.com/kaito-project/kaito/presets/workspace/models"
-
-	"github.com/samber/lo"
-	"github.com/stretchr/testify/mock"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var ValidStrength string = "0.5"
@@ -1333,4 +1333,293 @@ func toParameterMap(in []string) map[string]string {
 		}
 	}
 	return ret
+}
+
+func TestSetInferenceRoleEnv(t *testing.T) {
+	tests := []struct {
+		name           string
+		labels         map[string]string
+		containers     int
+		preExistingEnv bool
+		expectEnvSet   bool
+		expectedValue  string
+	}{
+		{
+			name:         "no label - no env set",
+			labels:       map[string]string{},
+			containers:   1,
+			expectEnvSet: false,
+		},
+		{
+			name:         "invalid role - no env set",
+			labels:       map[string]string{v1beta1.LabelInferenceRole: "invalid"},
+			containers:   1,
+			expectEnvSet: false,
+		},
+		{
+			name:          "prefill role - env set on all containers",
+			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
+			containers:    2,
+			expectEnvSet:  true,
+			expectedValue: consts.InferenceRolePrefill,
+		},
+		{
+			name:          "decode role - env set on all containers",
+			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
+			containers:    1,
+			expectEnvSet:  true,
+			expectedValue: consts.InferenceRoleDecode,
+		},
+		{
+			name:           "prefill role - upsert existing env var without duplicates",
+			labels:         map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
+			containers:     1,
+			preExistingEnv: true,
+			expectEnvSet:   true,
+			expectedValue:  "prefill",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			workspace := &v1beta1.Workspace{}
+			workspace.Labels = tc.labels
+
+			spec := &corev1.PodSpec{}
+			for i := 0; i < tc.containers; i++ {
+				c := corev1.Container{
+					Name: fmt.Sprintf("container-%d", i),
+				}
+				if tc.preExistingEnv {
+					c.Env = []corev1.EnvVar{
+						{Name: consts.InferenceRoleEnvName, Value: "old-value"},
+					}
+				}
+				spec.Containers = append(spec.Containers, c)
+			}
+
+			ctx := &generator.WorkspaceGeneratorContext{
+				Workspace: workspace,
+			}
+
+			err := SetInferenceRoleEnv(ctx, spec)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for i, c := range spec.Containers {
+				count := 0
+				for _, env := range c.Env {
+					if env.Name == consts.InferenceRoleEnvName {
+						count++
+						if !tc.expectEnvSet {
+							t.Errorf("container %d: env KAITO_INFERENCE_ROLE should not be set", i)
+						} else if env.Value != tc.expectedValue {
+							t.Errorf("container %d: expected value %q, got %q", i, tc.expectedValue, env.Value)
+						}
+					}
+				}
+				if tc.expectEnvSet && count == 0 {
+					t.Errorf("container %d: expected KAITO_INFERENCE_ROLE to be set", i)
+				}
+				if count > 1 {
+					t.Errorf("container %d: found %d entries for KAITO_INFERENCE_ROLE, expected at most 1", i, count)
+				}
+			}
+		})
+	}
+}
+
+func TestSetRoutingSidecar(t *testing.T) {
+	tests := []struct {
+		name               string
+		labels             map[string]string
+		existingContainers []corev1.Container
+		multiNode          bool
+		expectSidecar      bool
+	}{
+		{
+			name:          "no label - no sidecar",
+			labels:        map[string]string{},
+			expectSidecar: false,
+		},
+		{
+			name:          "prefill role - no sidecar",
+			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
+			expectSidecar: false,
+		},
+		{
+			name:          "decode role - sidecar injected",
+			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
+			expectSidecar: true,
+		},
+		{
+			name:   "decode role - sidecar already exists - no duplicate",
+			labels: map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
+			existingContainers: []corev1.Container{
+				{Name: "llm-d-routing-sidecar", Image: "old-image"},
+			},
+			expectSidecar: true,
+		},
+		{
+			name:               "decode role - multi-node shell command",
+			labels:             map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
+			existingContainers: nil,
+			multiNode:          true,
+			expectSidecar:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Enable vLLM feature gate for runtime detection
+			originalVLLM := featuregates.FeatureGates[consts.FeatureFlagVLLM]
+			featuregates.FeatureGates[consts.FeatureFlagVLLM] = true
+			defer func() { featuregates.FeatureGates[consts.FeatureFlagVLLM] = originalVLLM }()
+
+			workspace := &v1beta1.Workspace{}
+			workspace.Labels = tc.labels
+
+			spec := &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "vllm",
+						Ports: []corev1.ContainerPort{
+							{ContainerPort: int32(consts.PortInferenceServer), Name: "http", Protocol: corev1.ProtocolTCP},
+						},
+						Command: []string{"/bin/sh", "-c", "python3 /workspace/vllm/inference_api.py --served-model-name test"},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Port: intstr.FromInt32(int32(consts.PortInferenceServer)),
+									Path: "/health",
+								},
+							},
+						},
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Port: intstr.FromInt32(int32(consts.PortInferenceServer)),
+									Path: "/health",
+								},
+							},
+						},
+					},
+				},
+			}
+			// Multi-node uses a shell if/else script wrapping inference_api.py
+			if tc.multiNode {
+				spec.Containers[0].Command = []string{"/bin/sh", "-c",
+					"if [ \"$RAY_HEAD\" = \"true\" ]; then ray start --head && python3 /workspace/vllm/inference_api.py --served-model-name test; else ray start && sleep infinity; fi"}
+			}
+			if tc.existingContainers != nil {
+				spec.Containers = append(spec.Containers, tc.existingContainers...)
+			}
+
+			ctx := &generator.WorkspaceGeneratorContext{
+				Workspace: workspace,
+			}
+
+			err := SetRoutingSidecar(ctx, spec)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			sidecarCount := 0
+			for _, c := range spec.Containers {
+				if c.Name == "llm-d-routing-sidecar" {
+					sidecarCount++
+				}
+			}
+
+			if tc.expectSidecar && sidecarCount == 0 {
+				t.Error("expected routing sidecar to be present")
+			}
+			if !tc.expectSidecar && sidecarCount > 0 {
+				t.Error("routing sidecar should not be present")
+			}
+			if sidecarCount > 1 {
+				t.Errorf("found %d sidecar containers, expected at most 1", sidecarCount)
+			}
+
+			// Verify sidecar config for decode role (newly injected case)
+			if tc.expectSidecar && tc.existingContainers == nil {
+				var sidecar *corev1.Container
+				for i, c := range spec.Containers {
+					if c.Name == "llm-d-routing-sidecar" {
+						sidecar = &spec.Containers[i]
+						break
+					}
+				}
+				if sidecar == nil {
+					t.Fatal("sidecar not found")
+				}
+				expectedImage := fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag)
+				if sidecar.Image != expectedImage {
+					t.Errorf("expected image %q, got %q", expectedImage, sidecar.Image)
+				}
+				if len(sidecar.Ports) != 1 || sidecar.Ports[0].ContainerPort != int32(consts.PortInferenceServer) {
+					t.Errorf("expected port %d, got %v", consts.PortInferenceServer, sidecar.Ports)
+				}
+				// Check BACKEND_URL env
+				foundBackend := false
+				for _, env := range sidecar.Env {
+					if env.Name == "BACKEND_URL" {
+						expectedURL := fmt.Sprintf("http://localhost:%d", consts.PortInferenceServerInternal)
+						if env.Value != expectedURL {
+							t.Errorf("expected BACKEND_URL %q, got %q", expectedURL, env.Value)
+						}
+						foundBackend = true
+					}
+				}
+				if !foundBackend {
+					t.Error("BACKEND_URL env not found on sidecar")
+				}
+			}
+
+			// Verify vLLM port/probe/command rewrites for ALL decode cases (including sidecar-exists)
+			if tc.expectSidecar {
+				for _, c := range spec.Containers {
+					if c.Name == "llm-d-routing-sidecar" {
+						continue
+					}
+					for _, p := range c.Ports {
+						if p.ContainerPort == int32(consts.PortInferenceServer) {
+							t.Errorf("vLLM container still has port %d, expected %d", consts.PortInferenceServer, consts.PortInferenceServerInternal)
+						}
+					}
+					// Verify command has --port override inserted (not appended after fi)
+					for _, cmd := range c.Command {
+						if strings.Contains(cmd, "inference_api.py") {
+							expectedPortArg := fmt.Sprintf("inference_api.py --port %d", consts.PortInferenceServerInternal)
+							if !strings.Contains(cmd, expectedPortArg) {
+								t.Errorf("expected command to contain %q, got %q", expectedPortArg, cmd)
+							}
+							// Multi-node: ensure --port is NOT after 'fi'
+							if strings.Contains(cmd, "; fi") {
+								fiIdx := strings.Index(cmd, "; fi")
+								portStr := fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)
+								portIdx := strings.Index(cmd, portStr)
+								if portIdx > fiIdx {
+									t.Errorf("--port was appended after 'fi' instead of after inference_api.py: %q", cmd)
+								}
+							}
+						}
+					}
+					// Verify readiness probe port updated
+					if c.ReadinessProbe != nil && c.ReadinessProbe.HTTPGet != nil {
+						if c.ReadinessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+							t.Errorf("readiness probe still targets port %d", consts.PortInferenceServer)
+						}
+					}
+					// Verify liveness probe port updated
+					if c.LivenessProbe != nil && c.LivenessProbe.HTTPGet != nil {
+						if c.LivenessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+							t.Errorf("liveness probe still targets port %d", consts.PortInferenceServer)
+						}
+					}
+				}
+			}
+		})
+	}
 }

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1561,19 +1561,25 @@ func TestSetRoutingSidecar(t *testing.T) {
 				if len(sidecar.Ports) != 1 || sidecar.Ports[0].ContainerPort != int32(consts.PortInferenceServer) {
 					t.Errorf("expected port %d, got %v", consts.PortInferenceServer, sidecar.Ports)
 				}
-				// Check BACKEND_URL env
-				foundBackend := false
-				for _, env := range sidecar.Env {
-					if env.Name == "BACKEND_URL" {
-						expectedURL := fmt.Sprintf("http://localhost:%d", consts.PortInferenceServerInternal)
-						if env.Value != expectedURL {
-							t.Errorf("expected BACKEND_URL %q, got %q", expectedURL, env.Value)
+				// Check sidecar args (--port and --vllm-port flags)
+				expectedArgs := []string{
+					fmt.Sprintf("--port=%d", consts.PortInferenceServer),
+					fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
+				}
+				if len(sidecar.Args) != len(expectedArgs) {
+					t.Errorf("expected %d args, got %d: %v", len(expectedArgs), len(sidecar.Args), sidecar.Args)
+				} else {
+					for i, expected := range expectedArgs {
+						if sidecar.Args[i] != expected {
+							t.Errorf("expected arg[%d] %q, got %q", i, expected, sidecar.Args[i])
 						}
-						foundBackend = true
 					}
 				}
-				if !foundBackend {
-					t.Error("BACKEND_URL env not found on sidecar")
+				// BACKEND_URL should NOT be present (sidecar uses flags, not env)
+				for _, env := range sidecar.Env {
+					if env.Name == "BACKEND_URL" {
+						t.Error("BACKEND_URL env should not be present on sidecar (uses --vllm-port flag instead)")
+					}
 				}
 			}
 

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -28,6 +28,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1542,8 +1542,8 @@ func TestSetRoutingSidecar(t *testing.T) {
 				t.Errorf("found %d sidecar containers, expected at most 1", sidecarCount)
 			}
 
-			// Verify sidecar config for decode role (newly injected case)
-			if tc.expectSidecar && tc.existingContainers == nil {
+			// Verify sidecar config for decode role (both newly injected and reconciled cases)
+			if tc.expectSidecar {
 				var sidecar *corev1.Container
 				for i, c := range spec.Containers {
 					if c.Name == "llm-d-routing-sidecar" {

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -393,8 +393,13 @@ func createGemma4InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1a
 		uniqueID := fmt.Sprint("preset-gemma4-is-", rand.Intn(1000))
 		inferenceSetObj = utils.GenerateInferenceSetManifestWithVLLM(uniqueID, namespaceName, "", replicas, "Standard_NV36ads_A10_v5",
 			&metav1.LabelSelector{
-				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma4-vllm"},
-			}, PresetGemma4_E2BInstructModel, nil, nil, "")
+				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma-vllm"},
+			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
+		// Add inference-role label to test NixlConnector kv-transfer-config injection
+		if inferenceSetObj.Spec.Template.Labels == nil {
+			inferenceSetObj.Spec.Template.Labels = make(map[string]string)
+		}
+		inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = "decode"
 		createAndValidateInferenceSet(inferenceSetObj)
 
 	})


### PR DESCRIPTION
## What this PR does / why we need it

Implements **checklist items #3, #7, and InferenceSet CRD label propagation** from the [MRI proposal](https://github.com/kaito-project/kaito/blob/main/docs/proposals/20260424-multiroleinference-pd-disaggregation.md#implementation-checklist):

- [x] **3** — Controller: inject default vLLM NixlConnector kv-transfer-config (`kv_both`) into child InferenceSet config
- [x] **7** — Workspace controller: include llm-d routing sidecar in decode StatefulSet spec when `kaito.sh/inference-role: decode` label is present
- [x] **CRD** — InferenceSet `spec.template.metadata` now accepts labels/annotations (x-kubernetes-preserve-unknown-fields)

### Label propagation: MultiRoleInference → InferenceSet → Workspace → Sidecar

The full P/D label flow works as follows:

```
MultiRoleInference controller (future PR)
  │ creates child InferenceSets with spec.template.metadata.labels:
  │   kaito.sh/inference-role: prefill   (for prefill InferenceSet)
  │   kaito.sh/inference-role: decode    (for decode InferenceSet)
  ▼
InferenceSet controller (already implemented, maps.Clone at workspace creation)
  │ propagates spec.template.metadata.labels → Workspace metadata.labels
  │ ⚠️ Previously blocked by CRD strict decoding — FIXED in this PR
  │    (added x-kubernetes-preserve-unknown-fields on template.metadata)
  ▼
Workspace controller (this PR)
  │ SetInferenceRoleEnv() reads kaito.sh/inference-role label
  │   → injects KAITO_INFERENCE_ROLE=prefill|decode env var
  │ SetRoutingSidecar() reads kaito.sh/inference-role label
  │   → decode only: injects llm-d-routing-sidecar container
  │   → moves vLLM to internal port 5001
  ▼
vLLM startup (this PR)
  │ set_nixl_kv_transfer_config_if_applicable() reads KAITO_INFERENCE_ROLE
  │   → injects NixlConnector kv-transfer-config for P/D KV cache transfer
  ▼
Runtime traffic flow (decode pod):
  Client → Service:5000 → sidecar:5000 → vLLM:5001
```

### End-to-end flow

```
InferenceSet controller
  → creates Workspace with label kaito.sh/inference-role=prefill|decode
    → Workspace controller (SetInferenceRoleEnv + SetRoutingSidecar)
      → StatefulSet pod env: KAITO_INFERENCE_ROLE=prefill|decode
      → StatefulSet pod (decode only): llm-d-routing-sidecar container on port 5000
        → inference_api.py (set_nixl_kv_transfer_config_if_applicable)
          → vLLM kv_transfer_config: NixlConnector
```

### Changes

**CRD fix — enable label propagation through InferenceSet template:**
- `api/v1alpha1/inferenceset_types.go`: Add `+kubebuilder:validation:XPreserveUnknownFields` on `InferenceSetTemplate.ObjectMeta`
- `config/crd/bases/kaito.sh_inferencesets.yaml`: Add `x-kubernetes-preserve-unknown-fields: true` on `spec.template.metadata`
- `charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml`: Same CRD fix for helm chart
- The InferenceSet controller already propagates `spec.template.metadata.labels` to workspace labels via `maps.Clone()` — this CRD fix unblocks that path by allowing the labels field to pass strict decoding

**Go side — workspace controller propagates label → env var (#3):**
- `api/v1beta1/labels.go`: Add `LabelInferenceRole = "kaito.sh/inference-role"` constant
- `pkg/workspace/inference/preset_inferences.go`: Add `SetInferenceRoleEnv()` modifier
  - Reads `kaito.sh/inference-role` label from the Workspace object
  - When value is `prefill` or `decode`, injects `KAITO_INFERENCE_ROLE` env var on all containers
  - Wired into the `podOpts` chain after `SetAdapterPuller`
- `pkg/workspace/inference/preset_inferences_test.go`: Add `TestSetInferenceRoleEnv` covering no label, invalid role, prefill/decode roles with multi-container pods

**Go side — routing sidecar injection for decode workspaces (#7):**
- `pkg/utils/consts/consts.go`: Add `RoutingSidecarImage`, `RoutingSidecarTag` (v0.7.1), `PortInferenceServerInternal` (int32(5001)) constants
- `pkg/workspace/inference/preset_inferences.go`: Add `SetRoutingSidecar()` modifier
  - Only applies to vLLM runtime (other runtimes skip)
  - Checks for `kaito.sh/inference-role: decode` label on the Workspace
  - Injects `llm-d-routing-sidecar` container with:
    - Port 5000 (takes over public-facing Service port)
    - CLI flags `--port=5000 --vllm-port=5001` (configures listening port and backend vLLM port)
    - `POD_IP` from `status.podIP` fieldRef
  - Reconciles existing sidecar — if sidecar already exists, updates image, args, ports, and removes stale BACKEND_URL env
  - Rewrites any existing `--port` flag to internal port (handles user-customized ports)
  - Patches vLLM container: moves containerPort, readiness/liveness/startup probes, and `--port` arg from 5000 → 5001
- `pkg/workspace/inference/preset_inferences_test.go`: Add `TestSetRoutingSidecar` covering no label, prefill role, decode role, sidecar reconciliation, multi-node commands, and duplicate prevention

**Python side — vLLM startup reads env var → injects NixlConnector config (#3):**
- `presets/workspace/inference/vllm/inference_api.py`: Add `set_nixl_kv_transfer_config_if_applicable()`
  - Reads `KAITO_INFERENCE_ROLE` env var
  - Injects `{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}`
  - Both prefill and decode roles use `kv_both` (each pod can send and receive KV cache)
  - Runs after `set_kv_cache_offloading_if_appliable()` and overrides LMCache auto-set config
  - **Respects user-provided `vllm.kv-transfer-config`** from inference configmap — if user explicitly set `kv-transfer-config`, that value is preserved
  - Regular (non-MRI) workspaces are unaffected (env var not present)

**Tests:**
- `presets/workspace/inference/vllm/tests/test_nixl_kv_transfer_config.py`: Unit tests covering:
  - No env var / empty / invalid role → no-op
  - prefill / decode role → inject NixlConnector config
  - Override existing LMCache auto-set config
  - Respect user-provided kv-transfer-config from inference configmap

## Which issue(s) this PR fixes
Part of MultiRoleInference P/D disaggregation implementation.

## Does this PR introduce a user-facing change?
```release-note
NONE
```

### Decode StatefulSet: before vs after sidecar injection

**Before (prefill workspace, or non-MRI workspace):**
```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: deepseek-v32-prefill-ws-0
spec:
  template:
    spec:
      containers:
        - name: deepseek-v32-prefill-ws-0
          image: mcr.microsoft.com/aks/kaito/kaito-base:latest
          ports:
            - containerPort: 5000
          env:
            - name: KAITO_INFERENCE_ROLE
              value: "prefill"
```

**After (decode workspace — `kaito.sh/inference-role: decode`):**
```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: deepseek-v32-decode-ws-0
spec:
  template:
    spec:
      containers:
        - name: deepseek-v32-decode-ws-0
          image: mcr.microsoft.com/aks/kaito/kaito-base:latest
          ports:
            - containerPort: 5001          # ← moved to internal port
          env:
            - name: KAITO_INFERENCE_ROLE
              value: "decode"

        - name: llm-d-routing-sidecar      # ← injected by SetRoutingSidecar
          image: mcr.microsoft.com/oss/v2/llm-d/llm-d-routing-sidecar:v0.7.1
          ports:
            - containerPort: 5000          # ← takes over public-facing port
              name: sidecar
          args:
            - "--port=5000"
            - "--vllm-port=5001"
            - "--secure-proxy=false"
          env:
            - name: POD_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
```

Traffic flow: `Client → Service:5000 → sidecar:5000 → vLLM:5001`

The sidecar is **only** injected for vLLM runtime workspaces with `kaito.sh/inference-role: decode` label. Prefill and regular workspaces are unchanged.


### Example: Creating an InferenceSet with decode role

To enable P/D disaggregation sidecar injection, set `kaito.sh/inference-role: decode` in `spec.template.metadata.labels`:

```yaml
apiVersion: kaito.sh/v1alpha1
kind: InferenceSet
metadata:
  name: my-decode-inferenceset
spec:
  labelSelector:
    matchLabels:
      apps: my-model
  replicas: 3
  template:
    metadata:
      labels:
        kaito.sh/inference-role: decode    # triggers sidecar injection
    resource:
      instanceType: Standard_NC24ads_A100_v4
    inference:
      preset:
        name: deepseek-ai/DeepSeek-V3.2
        presetOptions:
          modelAccessSecret: hf-token
```

The InferenceSet controller propagates `spec.template.metadata.labels` to each generated Workspace's `metadata.labels`. The Workspace controller then:
1. Reads `kaito.sh/inference-role: decode` → injects `KAITO_INFERENCE_ROLE=decode` env var
2. Injects `llm-d-routing-sidecar` container (port 5000) and moves vLLM to internal port 5001
3. vLLM startup detects `KAITO_INFERENCE_ROLE` → auto-configures NixlConnector for KV cache transfer

For prefill workspaces, use `kaito.sh/inference-role: prefill` — no sidecar is injected, only the env var and NixlConnector config.

