### PR TITLE
feat: add AWQ quantization support

### DIFF
--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -153,6 +153,18 @@ type Metadata struct {
 	// This field is only for best effort supported vLLM models.
 	// +optional
 	AllowRemoteFiles bool `yaml:"allowRemoteFiles,omitempty"`
+
+	// QuantMethod specifies the weight quantization method used by the model
+	// (e.g., "awq", "gptq"). Maps to quantization_config.quant_method in the
+	// model's HuggingFace config.json.
+	// +optional
+	QuantMethod string `yaml:"quantMethod,omitempty"`
+
+	// QuantBits specifies the number of bits used for weight quantization
+	// (e.g., 4 for 4-bit AWQ). Maps to quantization_config.bits in the
+	// model's HuggingFace config.json.
+	// +optional
+	QuantBits int `yaml:"quantBits,omitempty"`
 }
 
 // Validate checks if the Metadata is valid.

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -523,6 +523,14 @@ func (g *Generator) ParseModelMetadata() {
 			break
 		}
 	}
+
+	// Parse quantization config (e.g., AWQ, GPTQ) from HuggingFace config.json.
+	if qc, ok := g.ModelConfig["quantization_config"].(map[string]interface{}); ok {
+		if qm, ok := qc["quant_method"].(string); ok {
+			g.Param.Metadata.QuantMethod = qm
+		}
+		g.Param.Metadata.QuantBits = getInt(qc, []string{"bits"}, 0)
+	}
 }
 
 func (g *Generator) calculateStorageSize() string {
@@ -577,6 +585,7 @@ func (g *Generator) calculateKVCacheTokenSize() (int, string) {
 	}
 
 	totalElements := elementsPerToken * hiddenLayers
+	// TODO: honor kv-cache quantization instead of hardcoding fp16
 	tokenSize := totalElements * 2 // fp16
 
 	return tokenSize, attnType
@@ -649,6 +658,14 @@ func (g *Generator) loadFromCatalog() bool {
 	}
 	if entry.QKRopeHeadDim > 0 {
 		g.ModelConfig["qk_rope_head_dim"] = entry.QKRopeHeadDim
+	}
+
+	// Restore quantization_config so ParseModelMetadata can pick it up.
+	if entry.QuantMethod != "" {
+		g.ModelConfig["quantization_config"] = map[string]interface{}{
+			"quant_method": entry.QuantMethod,
+			"bits":         entry.QuantBits,
+		}
 	}
 
 	// Set architectures in config for ParseModelMetadata to pick up

--- a/presets/workspace/generator/generator_test.go
+++ b/presets/workspace/generator/generator_test.go
@@ -41,10 +41,10 @@ func TestGeneratePreset(t *testing.T) {
 					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "microsoft/Phi-4-mini-instruct"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
-					ModelFileSize:          "8Gi",
+					ModelFileSize:          "7.15Gi",
 					BytesPerToken:          131072,
 					ModelTokenLimit:        131072,
-					DiskStorageRequirement: "88Gi", // 8 + 80
+					DiskStorageRequirement: "87Gi", // 7.15 + 80
 				},
 				AttnType: "GQA",
 			},
@@ -68,10 +68,10 @@ func TestGeneratePreset(t *testing.T) {
 					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "tiiuae/falcon-7b-instruct"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
-					ModelFileSize:          "14Gi", // Python test expects 27Gi due to double counting (bin+safetensors). We fix this to use safetensors only.
+					ModelFileSize:          "13.44Gi", // Python test expects 27Gi due to double counting (bin+safetensors). We fix this to use safetensors only.
 					BytesPerToken:          8192,
 					ModelTokenLimit:        2048,
-					DiskStorageRequirement: "94Gi", // 14 + 80
+					DiskStorageRequirement: "93Gi", // 13.44 + 80
 				},
 				AttnType: "MQA",
 			},
@@ -95,10 +95,11 @@ func TestGeneratePreset(t *testing.T) {
 					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "mistralai/Ministral-3-8B-Instruct-2512"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
-					ModelFileSize:          "10Gi",
+					ModelFileSize:          "9.70Gi",
 					BytesPerToken:          139264,
 					ModelTokenLimit:        262144,
-					DiskStorageRequirement: "90Gi", // 10 + 80
+					DiskStorageRequirement: "89Gi", // 9.70 + 80
+					QuantMethod:            "fp8",
 				},
 				AttnType: "GQA",
 			},
@@ -122,11 +123,12 @@ func TestGeneratePreset(t *testing.T) {
 					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "mistralai/Mistral-Large-3-675B-Instruct-2512"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
-					ModelFileSize:          "635Gi",
+					ModelFileSize:          "634.70Gi",
 					BytesPerToken:          70272,
 					ModelTokenLimit:        294912,
-					DiskStorageRequirement: "715Gi", // 635 + 80
+					DiskStorageRequirement: "714Gi", // 634.70 + 80
 					ToolCallParser:         "mistral",
+					QuantMethod:            "compressed-tensors",
 				},
 				AttnType: "MLA",
 			},
@@ -150,10 +152,10 @@ func TestGeneratePreset(t *testing.T) {
 					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "Qwen/Qwen3-Coder-30B-A3B-Instruct"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
-					ModelFileSize:          "57Gi",
+					ModelFileSize:          "56.87Gi",
 					BytesPerToken:          98304,
 					ModelTokenLimit:        262144,
-					DiskStorageRequirement: "137Gi", // 57 + 80
+					DiskStorageRequirement: "136Gi", // 56.87 + 80
 					ReasoningParser:        "qwen3",
 					ToolCallParser:         "qwen3_xml",
 				},
@@ -179,10 +181,10 @@ func TestGeneratePreset(t *testing.T) {
 					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "Qwen/Qwen3-8B"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
-					ModelFileSize:          "16Gi",
+					ModelFileSize:          "15.26Gi",
 					BytesPerToken:          147456,
 					ModelTokenLimit:        40960,
-					DiskStorageRequirement: "96Gi", // 16 + 80
+					DiskStorageRequirement: "95Gi", // 15.26 + 80
 					ReasoningParser:        "qwen3",
 					ToolCallParser:         "hermes",
 				},
@@ -208,12 +210,13 @@ func TestGeneratePreset(t *testing.T) {
 					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "deepseek-ai/DeepSeek-V3.1"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
-					ModelFileSize:          "642Gi",
+					ModelFileSize:          "641.30Gi",
 					BytesPerToken:          70272,
 					ModelTokenLimit:        163840,
-					DiskStorageRequirement: "722Gi", // 642 + 80
+					DiskStorageRequirement: "721Gi", // 641.30 + 80
 					ReasoningParser:        "deepseek_v3",
 					ToolCallParser:         "deepseek_v31",
+					QuantMethod:            "fp8",
 				},
 				AttnType: "MLA",
 			},
@@ -237,12 +240,13 @@ func TestGeneratePreset(t *testing.T) {
 					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "deepseek-ai/DeepSeek-V3"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
-					ModelFileSize:          "642Gi",
+					ModelFileSize:          "641.30Gi",
 					BytesPerToken:          70272,
 					ModelTokenLimit:        163840,
-					DiskStorageRequirement: "722Gi", // 642 + 80
+					DiskStorageRequirement: "721Gi", // 641.30 + 80
 					ReasoningParser:        "deepseek_v3",
 					ToolCallParser:         "deepseek_v3",
+					QuantMethod:            "fp8",
 				},
 				AttnType: "MLA",
 			},
@@ -266,10 +270,10 @@ func TestGeneratePreset(t *testing.T) {
 					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "nvidia/Nemotron-Orchestrator-8B"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
-					ModelFileSize:          "31Gi",
+					ModelFileSize:          "30.51Gi",
 					BytesPerToken:          147456,
 					ModelTokenLimit:        40960,
-					DiskStorageRequirement: "111Gi", // 31 + 80
+					DiskStorageRequirement: "110Gi", // 30.51 + 80
 					ReasoningParser:        "qwen3",
 					ToolCallParser:         "hermes",
 				},
@@ -277,6 +281,37 @@ func TestGeneratePreset(t *testing.T) {
 			},
 			expectedVLLM: model.VLLMParam{
 				ModelName: "nemotron-orchestrator-8b",
+				ModelRunParams: map[string]string{
+					"load_format":    "auto",
+					"config_format":  "auto",
+					"tokenizer_mode": "auto",
+				},
+				DisallowLoRA: false,
+			},
+		},
+		{
+			modelRepo: "Qwen/Qwen3-8B-AWQ",
+			expectedParam: model.PresetParam{
+				Metadata: model.Metadata{
+					Name:                   "qwen3-8b-awq",
+					Architectures:          []string{"Qwen3ForCausalLM"},
+					ModelType:              "tfs",
+					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "Qwen/Qwen3-8B-AWQ"),
+					DownloadAtRuntime:      true,
+					DownloadAuthRequired:   false,
+					ModelFileSize:          "5.68Gi",
+					BytesPerToken:          147456,
+					ModelTokenLimit:        40960,
+					DiskStorageRequirement: "85Gi", // 5.68 + 80
+					ReasoningParser:        "qwen3",
+					ToolCallParser:         "hermes",
+					QuantMethod:            "awq",
+					QuantBits:              4,
+				},
+				AttnType: "GQA",
+			},
+			expectedVLLM: model.VLLMParam{
+				ModelName: "qwen3-8b-awq",
 				ModelRunParams: map[string]string{
 					"load_format":    "auto",
 					"config_format":  "auto",
@@ -305,6 +340,8 @@ func TestGeneratePreset(t *testing.T) {
 			assert.Equal(t, tc.expectedParam.Metadata.ModelTokenLimit, param.Metadata.ModelTokenLimit)
 			assert.Equal(t, tc.expectedParam.Metadata.ReasoningParser, param.Metadata.ReasoningParser)
 			assert.Equal(t, tc.expectedParam.Metadata.ToolCallParser, param.Metadata.ToolCallParser)
+			assert.Equal(t, tc.expectedParam.Metadata.QuantMethod, param.Metadata.QuantMethod)
+			assert.Equal(t, tc.expectedParam.Metadata.QuantBits, param.Metadata.QuantBits)
 
 			// Struct fields
 			assert.Equal(t, tc.expectedParam.Metadata.DiskStorageRequirement, param.Metadata.DiskStorageRequirement)
@@ -449,10 +486,10 @@ func TestLoadFromCatalog(t *testing.T) {
 					ModelType:              "tfs",
 					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "microsoft/Phi-4-mini-instruct"),
 					DownloadAtRuntime:      true,
-					ModelFileSize:          "8Gi",
+					ModelFileSize:          "7.15Gi",
 					BytesPerToken:          131072,
 					ModelTokenLimit:        131072,
-					DiskStorageRequirement: "88Gi",
+					DiskStorageRequirement: "87Gi",
 				},
 				AttnType: "GQA",
 			},
@@ -467,10 +504,10 @@ func TestLoadFromCatalog(t *testing.T) {
 					ModelType:              "tfs",
 					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "microsoft/phi-4"),
 					DownloadAtRuntime:      true,
-					ModelFileSize:          "28Gi",
+					ModelFileSize:          "27.31Gi",
 					BytesPerToken:          204800,
 					ModelTokenLimit:        16384,
-					DiskStorageRequirement: "108Gi",
+					DiskStorageRequirement: "107Gi",
 				},
 				AttnType: "GQA",
 			},
@@ -485,10 +522,10 @@ func TestLoadFromCatalog(t *testing.T) {
 					ModelType:              "tfs",
 					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "google/gemma-3-4b-it"),
 					DownloadAtRuntime:      true,
-					ModelFileSize:          "9Gi",
+					ModelFileSize:          "8.01Gi",
 					BytesPerToken:          139264,
 					ModelTokenLimit:        131072,
-					DiskStorageRequirement: "89Gi",
+					DiskStorageRequirement: "88Gi",
 					ToolCallParser:         "functiongemma",
 				},
 				AttnType: "GQA",
@@ -504,10 +541,10 @@ func TestLoadFromCatalog(t *testing.T) {
 					ModelType:              "tfs",
 					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "mistralai/Mistral-7B-v0.3"),
 					DownloadAtRuntime:      true,
-					ModelFileSize:          "14Gi",
+					ModelFileSize:          "13.50Gi",
 					BytesPerToken:          131072,
 					ModelTokenLimit:        32768,
-					DiskStorageRequirement: "94Gi",
+					DiskStorageRequirement: "93Gi",
 					ToolCallParser:         "mistral",
 				},
 				AttnType: "GQA",
@@ -523,10 +560,10 @@ func TestLoadFromCatalog(t *testing.T) {
 					ModelType:              "tfs",
 					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "mistralai/Ministral-3-8B-Instruct-2512"),
 					DownloadAtRuntime:      true,
-					ModelFileSize:          "10Gi",
+					ModelFileSize:          "9.70Gi",
 					BytesPerToken:          139264,
 					ModelTokenLimit:        262144,
-					DiskStorageRequirement: "90Gi",
+					DiskStorageRequirement: "89Gi",
 				},
 				AttnType: "GQA",
 			},

--- a/presets/workspace/generator/model_catalog.go
+++ b/presets/workspace/generator/model_catalog.go
@@ -44,6 +44,8 @@ type CatalogEntry struct {
 	HeadDim           int      `yaml:"headDim,omitempty"`
 	KVLoraRank        int      `yaml:"kvLoraRank,omitempty"`
 	QKRopeHeadDim     int      `yaml:"qkRopeHeadDim,omitempty"`
+	QuantMethod       string   `yaml:"quantMethod,omitempty"`
+	QuantBits         int      `yaml:"quantBits,omitempty"`
 }
 
 // ModelCatalog holds the list of pre-computed model entries.
@@ -160,6 +162,14 @@ func FetchCatalogEntry(repo, token string) (*CatalogEntry, error) {
 		if entry.HeadDim == entry.HiddenSize/entry.NumAttentionHeads {
 			entry.HeadDim = 0
 		}
+	}
+
+	// Extract quantization config (e.g., AWQ, GPTQ) from HuggingFace config.json.
+	if qc, ok := config["quantization_config"].(map[string]interface{}); ok {
+		if qm, ok := qc["quant_method"].(string); ok {
+			entry.QuantMethod = qm
+		}
+		entry.QuantBits = getInt(qc, []string{"bits"}, 0)
 	}
 
 	// Copy format fields from generator (only when non-default)

--- a/presets/workspace/generator/model_catalog.go
+++ b/presets/workspace/generator/model_catalog.go
@@ -95,6 +95,13 @@ func fetchModelInfo(g *Generator, repo string) (license, pipelineTag string, bas
 		if l, ok := cardData["license"].(string); ok {
 			license = l
 		}
+		// When license is "other", HuggingFace stores the actual license
+		// identifier in the license_name field.
+		if license == "other" {
+			if ln, ok := cardData["license_name"].(string); ok && ln != "" {
+				license = ln
+			}
+		}
 		if pipelineTag == "" {
 			if pt, ok := cardData["pipeline_tag"].(string); ok {
 				pipelineTag = pt

--- a/presets/workspace/generator/update_model_catalog/main.go
+++ b/presets/workspace/generator/update_model_catalog/main.go
@@ -125,6 +125,12 @@ func catalogFields(e *generator.CatalogEntry) map[string]string {
 	if e.QKRopeHeadDim > 0 {
 		m["qkRopeHeadDim"] = fmt.Sprintf("%d", e.QKRopeHeadDim)
 	}
+	if e.QuantMethod != "" {
+		m["quantMethod"] = e.QuantMethod
+	}
+	if e.QuantBits > 0 {
+		m["quantBits"] = fmt.Sprintf("%d", e.QuantBits)
+	}
 	if e.LoadFormat != "" {
 		m["loadFormat"] = e.LoadFormat
 	}

--- a/presets/workspace/models/model_catalog.yaml
+++ b/presets/workspace/models/model_catalog.yaml
@@ -148,6 +148,7 @@ models:
   numAttentionHeads: 64
   numKeyValueHeads: 8
   headDim: 64
+  quantMethod: mxfp4
 - name: openai/gpt-oss-120b
   description: https://huggingface.co/openai/gpt-oss-120b
   license: apache-2.0
@@ -161,6 +162,7 @@ models:
   numAttentionHeads: 64
   numKeyValueHeads: 8
   headDim: 64
+  quantMethod: mxfp4
 - name: meta-llama/Llama-3.1-8B-Instruct
   description: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct
   license: llama3.1
@@ -236,6 +238,7 @@ models:
   configFormat: mistral
   tokenizerMode: mistral
   headDim: 128
+  quantMethod: fp8
 - name: mistralai/Ministral-3-8B-Instruct-2512
   description: https://huggingface.co/mistralai/Ministral-3-8B-Instruct-2512
   license: apache-2.0
@@ -252,6 +255,7 @@ models:
   loadFormat: mistral
   configFormat: mistral
   tokenizerMode: mistral
+  quantMethod: fp8
 - name: mistralai/Ministral-3-14B-Instruct-2512
   description: https://huggingface.co/mistralai/Ministral-3-14B-Instruct-2512
   license: apache-2.0
@@ -269,6 +273,7 @@ models:
   configFormat: mistral
   tokenizerMode: mistral
   headDim: 128
+  quantMethod: fp8
 - name: google/gemma-3-4b-it
   description: https://huggingface.co/google/gemma-3-4b-it
   license: gemma
@@ -313,6 +318,7 @@ models:
   numKeyValueHeads: 128
   kvLoraRank: 512
   qkRopeHeadDim: 64
+  quantMethod: fp8
 - name: deepseek-ai/DeepSeek-V3-0324
   description: https://huggingface.co/deepseek-ai/DeepSeek-V3-0324
   license: mit
@@ -327,6 +333,7 @@ models:
   numKeyValueHeads: 128
   kvLoraRank: 512
   qkRopeHeadDim: 64
+  quantMethod: fp8
 - name: mistralai/Mistral-Large-3-675B-Instruct-2512
   description: https://huggingface.co/mistralai/Mistral-Large-3-675B-Instruct-2512
   license: apache-2.0
@@ -347,6 +354,7 @@ models:
   headDim: 192
   kvLoraRank: 512
   qkRopeHeadDim: 64
+  quantMethod: compressed-tensors
 - name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
   description: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
   license: other
@@ -428,3 +436,19 @@ models:
   numAttentionHeads: 40
   numKeyValueHeads: 8
   headDim: 128
+- name: Qwen/Qwen3-8B-AWQ
+  description: https://huggingface.co/Qwen/Qwen3-8B-AWQ
+  license: apache-2.0
+  pipelineTag: text-generation
+  baseModel:
+  - Qwen/Qwen3-8B
+  modelFileSize: 5.68Gi
+  architectures:
+  - Qwen3ForCausalLM
+  modelTokenLimit: 40960
+  hiddenSize: 4096
+  numHiddenLayers: 36
+  numAttentionHeads: 32
+  numKeyValueHeads: 8
+  quantMethod: awq
+  quantBits: 4

--- a/presets/workspace/models/model_catalog.yaml
+++ b/presets/workspace/models/model_catalog.yaml
@@ -357,7 +357,7 @@ models:
   quantMethod: compressed-tensors
 - name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
   description: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
-  license: other
+  license: nvidia-nemotron-open-model-license
   pipelineTag: text-generation
   modelFileSize: 230.25Gi
   architectures:
@@ -369,7 +369,7 @@ models:
   numKeyValueHeads: 2
 - name: nvidia/Nemotron-Cascade-2-30B-A3B
   description: https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B
-  license: other
+  license: nvidia-open-model-license
   pipelineTag: text-generation
   modelFileSize: 58.82Gi
   architectures:
@@ -382,7 +382,7 @@ models:
   headDim: 128
 - name: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
   description: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
-  license: other
+  license: nvidia-nemotron-open-model-license
   pipelineTag: text-generation
   modelFileSize: 58.82Gi
   architectures:
@@ -395,7 +395,7 @@ models:
   headDim: 128
 - name: nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16
   description: https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16
-  license: other
+  license: nvidia-open-model-license
   pipelineTag: image-text-to-text
   modelFileSize: 24.55Gi
   architectures:
@@ -407,7 +407,7 @@ models:
   numKeyValueHeads: 8
 - name: nvidia/NVIDIA-Nemotron-Nano-9B-v2
   description: https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2
-  license: other
+  license: nvidia-open-model-license
   pipelineTag: text-generation
   baseModel:
   - nvidia/NVIDIA-Nemotron-Nano-12B-v2-Base
@@ -423,7 +423,7 @@ models:
   headDim: 128
 - name: nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16
   description: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16
-  license: other
+  license: nvidia-nemotron-open-model-license
   pipelineTag: text-generation
   baseModel:
   - nvidia/NVIDIA-Nemotron-Nano-9B-v2

--- a/presets/workspace/models/model_catalog_mtbench_scores.md
+++ b/presets/workspace/models/model_catalog_mtbench_scores.md
@@ -41,3 +41,4 @@ All models were deployed as KAITO Workspace CRs on AKS and evaluated using the v
 | nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 | vllm | 6.89 | 6.45 | 7.20 | 6.60 | 9.95 | 5.30 | 7.05 | 6.15 | 6.40 | 2026-04-29 |
 | nvidia/Nemotron-Cascade-2-30B-A3B | vllm | 5.71 | 3.40 | 6.85 | 6.60 | 9.20 | 5.65 | 4.15 | 4.90 | 4.95 | 2026-04-29 |
 | nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16 | vllm | 6.91 | 7.35 | 7.30 | 7.05 | 9.65 | 6.35 | 7.25 | 5.40 | 4.90 | 2026-04-29 |
+| Qwen/Qwen3-8B-AWQ | vllm | 3.98 | 6.05 | 6.20 | 2.60 | 1.95 | 1.95 | 5.30 | 3.55 | 4.25 | 2026-04-29 |

--- a/presets/workspace/models/vllm_model.go
+++ b/presets/workspace/models/vllm_model.go
@@ -138,6 +138,8 @@ func (m *vLLMCompatibleModel) GetInferenceParameters() *model.PresetParam {
 		DownloadAtRuntime:    true,
 		DownloadAuthRequired: m.model.DownloadAuthRequired,
 		Architectures:        m.model.Architectures,
+		QuantMethod:          m.model.QuantMethod,
+		QuantBits:            m.model.QuantBits,
 	}
 
 	runParamsVLLM := make(map[string]string)
@@ -148,8 +150,13 @@ func (m *vLLMCompatibleModel) GetInferenceParameters() *model.PresetParam {
 	if _, ok := runParamsVLLM["trust-remote-code"]; !ok {
 		runParamsVLLM["trust-remote-code"] = ""
 	}
+
+	// For quantized models, let vLLM auto-detect the optimal dtype
+	// TODO: test if we can always set dtype to "auto"
 	if _, ok := runParamsVLLM["dtype"]; !ok {
-		if m.model.DType != "" {
+		if m.model.QuantMethod != "" {
+			runParamsVLLM["dtype"] = "auto"
+		} else if m.model.DType != "" {
 			runParamsVLLM["dtype"] = m.model.DType
 		} else {
 			runParamsVLLM["dtype"] = "bfloat16"

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -51,6 +51,7 @@ const (
 	PresetGPT_OSS_20BModel          = "gpt-oss-20b"
 	PresetGPT_OSS_120BModel         = "gpt-oss-120b"
 	PresetMinistral33BInstructModel = "mistralai/ministral-3-3b-instruct-2512"
+	PresetQwen3_8BAWQModel          = "Qwen/Qwen3-8B-AWQ"
 	WorkspaceHashAnnotation         = "workspace.kaito.io/hash"
 	// WorkspaceRevisionAnnotation represents the revision number of the workload managed by the workspace
 	WorkspaceRevisionAnnotation = "workspace.kaito.io/revision"

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -326,6 +326,29 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateChatCompletionsEndpoint(workspaceObj)
 	})
 
+	It("should create a qwen3-8b-awq workspace with AWQ quantization successfully", utils.GinkgoLabelFastCheck, func() {
+		numOfNode := 1
+		workspaceObj := createQwen3_8BAWQWorkspaceWithPresetPublicModeAndVLLM(numOfNode)
+
+		defer cleanupResources(workspaceObj)
+		time.Sleep(30 * time.Second)
+
+		validateCreateNode(workspaceObj, numOfNode)
+		validateResourceStatus(workspaceObj)
+
+		time.Sleep(30 * time.Second)
+
+		validateAssociatedService(workspaceObj)
+		validateInferenceConfig(workspaceObj)
+
+		validateInferenceResource(workspaceObj, int32(numOfNode))
+
+		validateWorkspaceReadiness(workspaceObj)
+		validateWorkspaceBenchmarkCompleted(workspaceObj)
+		validateModelsEndpoint(workspaceObj)
+		validateChatCompletionsEndpoint(workspaceObj)
+	})
+
 	It("should create a ministral-3-3b-instruct-2512 workspace with preset public mode successfully", func() {
 		numOfNode := 1
 		workspaceObj := createMinistral3_3BInstructWorkspaceWithPresetPublicModeAndVLLM(numOfNode)
@@ -504,6 +527,20 @@ func createMinistral3_3BInstructWorkspaceWithPresetPublicModeAndVLLM(numOfNode i
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "public-preset-e2e-test-ministral-3-3b-instruct-vllm"},
 			}, nil, PresetMinistral33BInstructModel, nil, nil, nil, "", "")
+
+		createAndValidateWorkspace(workspaceObj)
+	})
+	return workspaceObj
+}
+
+func createQwen3_8BAWQWorkspaceWithPresetPublicModeAndVLLM(numOfNode int) *kaitov1beta1.Workspace {
+	workspaceObj := &kaitov1beta1.Workspace{}
+	By("Creating a workspace CR with Qwen3-8B-AWQ preset public mode and vLLM", func() {
+		uniqueID := fmt.Sprint("preset-qwen3-8b-awq-", rand.Intn(1000))
+		workspaceObj = utils.GenerateInferenceWorkspaceManifestWithVLLM(uniqueID, namespaceName, "", numOfNode, "Standard_NV36ads_A10_v5",
+			&metav1.LabelSelector{
+				MatchLabels: map[string]string{"kaito-workspace": "public-preset-e2e-test-qwen3-8b-awq-vllm"},
+			}, nil, PresetQwen3_8BAWQModel, nil, nil, nil, "", "")
 
 		createAndValidateWorkspace(workspaceObj)
 	})


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
This PR added support for AWQ-quantized models in Kaito. Changes include:
- Supported parsing quantization_config in config.json in HuggingFace.
- Introduced fields quantMethod and quantBits to model catalog and onboarded Qwen/Qwen3-8B-AWQ as an example.
- Set vllm dtype parameter to 'auto' for quantized models. This is needed because in vLLM quantizations usually only support specific dtypes (e.g. only float16 is supported when quantization=awq).
- Fix model license loading for Nvidia models.

NOTE:
- We are not passing flag 'quantization' to vLLM. This is because vLLM can auto-select the optimal quantization method based on hardware and kernel availability. For example, vLLM will choose between awq_marlin (fastest), awq and awq_triton when a model's quantization_method is awq. Passing 'quantization=awq' to vLLM will enforce awq and affect inference speed.
- There is no need to update the KV cache calculation in Kaito's memory estimator, because AWQ only affects the size of weights instead of KV cache. However, quantization for KV cache is available in vLLM: https://docs.vllm.ai/en/latest/features/quantization/quantized_kvcache/. We may add support for it in future.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).
- [x] tested AWQ models on both catalog and non-catalog paths:
<img width="910" height="306" alt="Screenshot 2026-04-28 at 9 10 04 PM" src="https://github.com/user-attachments/assets/6dcd05d8-49ae-4733-a4aa-092ad496951b" />
- [x] verified numbers produced by memory estimator are correct:
<img width="801" height="593" alt="Screenshot 2026-04-28 at 10 39 17 PM" src="https://github.com/user-attachments/assets/3b889be0-1e3b-45fd-821e-894e3fd499e8" />

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: