### PR TITLE
feat: onboard Nvidia Nemotron models to model catalog

### DIFF
--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -371,6 +371,13 @@ func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
 		p.VLLM.ModelRunParams["performance-mode"] = rc.PerformanceMode
 	}
 
+	// Hybrid Mamba/Attention models (e.g., NemotronH) require the hybrid KV cache
+	// manager in vLLM, which is incompatible with LMCache KV cache CPU offloading.
+	// Disable offloading for these architectures to prevent startup crashes.
+	if p.isVLLMHybridKVCacheManagerRequired() {
+		p.VLLM.ModelRunParams["kaito-kv-cache-cpu-memory-utilization"] = "0"
+	}
+
 	// Parallelism strategy follows a 3-tier hierarchy (see configureParallelism):
 	//  1. Data Parallelism (DP)   – model fits on a single GPU
 	//  2. Tensor Parallelism (TP) – model fits on a single node (multiple GPUs)
@@ -480,6 +487,19 @@ func (p *PresetParam) getModelFileSize() *resource.Quantity {
 		}
 	}
 	return nil
+}
+
+// isVLLMHybridKVCacheManagerRequired returns true if the model uses a hybrid
+// architecture (e.g., Mamba/Attention) that requires vLLM's hybrid KV cache manager
+// (https://docs.vllm.ai/en/latest/design/hybrid_kv_cache_manager/)
+func (p *PresetParam) isVLLMHybridKVCacheManagerRequired() bool {
+	for _, arch := range p.Architectures {
+		switch arch {
+		case "NemotronHForCausalLM", "NemotronH_Nano_VL_V2", "NemotronHMTPModel", "NemotronHPuzzleForCausalLM":
+			return true
+		}
+	}
+	return false
 }
 
 // modelFitsOnSingleGPU returns true when the model file size is smaller than

--- a/pkg/model/interface_test.go
+++ b/pkg/model/interface_test.go
@@ -704,3 +704,47 @@ func TestBuildVLLMInferenceCommandDTypeDynamic(t *testing.T) {
 		assert.Contains(t, cmd[2], "dtype=bfloat16")
 	})
 }
+
+func TestBuildVLLMInferenceCommandDisablesKVCacheForHybridModels(t *testing.T) {
+	p := &PresetParam{
+		Metadata: Metadata{
+			Architectures: []string{"NemotronHForCausalLM"},
+		},
+		RuntimeParam: RuntimeParam{
+			VLLM: VLLMParam{
+				BaseCommand:    "vllm serve",
+				ModelRunParams: map[string]string{},
+			},
+		},
+	}
+	rc := RuntimeContext{
+		RuntimeName: RuntimeNameVLLM,
+		SKUNumGPUs:  2,
+		NumNodes:    1,
+	}
+	cmd := p.GetInferenceCommand(rc)
+	require.Len(t, cmd, 3)
+	assert.Contains(t, cmd[2], "kaito-kv-cache-cpu-memory-utilization=0")
+}
+
+func TestBuildVLLMInferenceCommandNoKVCacheOverrideForNonHybrid(t *testing.T) {
+	p := &PresetParam{
+		Metadata: Metadata{
+			Architectures: []string{"LlamaForCausalLM"},
+		},
+		RuntimeParam: RuntimeParam{
+			VLLM: VLLMParam{
+				BaseCommand:    "vllm serve",
+				ModelRunParams: map[string]string{},
+			},
+		},
+	}
+	rc := RuntimeContext{
+		RuntimeName: RuntimeNameVLLM,
+		SKUNumGPUs:  2,
+		NumNodes:    1,
+	}
+	cmd := p.GetInferenceCommand(rc)
+	require.Len(t, cmd, 3)
+	assert.NotContains(t, cmd[2], "kaito-kv-cache-cpu-memory-utilization")
+}

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -69,6 +69,8 @@ var (
 		"MiniMaxM2ForCausalLM":                   "minimax_m2_append_think",
 		"MistralForCausalLM":                     "mistral",
 		"NemotronForCausalLM":                    "nemotron_v3",
+		"NemotronHForCausalLM":                   "nemotron_v3",
+		"NemotronH_Nano_VL_V2":                   "nemotron_v3",
 		"OlmoForCausalLM":                        "olmo3",
 		"Qwen3ForCausalLM":                       "qwen3",
 		"Qwen3MoeForCausalLM":                    "qwen3",
@@ -146,6 +148,8 @@ var (
 		"Ernie4_5_MoeForCausalLM":                "ernie45",
 		"Step3TextForCausalLM":                   "step3",
 		"Step3p5TextForCausalLM":                 "step3p5",
+		"NemotronHForCausalLM":                   "qwen3_coder",
+		"NemotronH_Nano_VL_V2":                   "qwen3_coder",
 		"Phi4MiniForCausalLM":                    "phi4_mini_json",
 		"KimiK2ForCausalLM":                      "kimi_k2",
 		"GigaChat3ForCausalLM":                   "gigachat3",
@@ -377,10 +381,28 @@ func (g *Generator) fetchAndParseConfig() error {
 		return fmt.Errorf("error fetching config: %v", err)
 	}
 
+	configBody = sanitizeJSON(configBody)
+
 	if err := json.Unmarshal(configBody, &g.ModelConfig); err != nil {
 		return fmt.Errorf("error parsing config: %v", err)
 	}
 	return nil
+}
+
+// vLLM delegates the loading of config.json to HuggingFace transformer library
+// (https://github.com/huggingface/transformers/blob/main/src/transformers/configuration_utils.py#L552).
+// The library uses Python's json.loads which accepts non-standard JSON literals (e.g. Infinity, NaN).
+// However, Go's standard library encoding/json only supports standard JSON values. sanitizeJSON replaces
+// non-standard JSON literals (Infinity, -Infinity, NaN) with null so the data can be parsed by encoding/json.
+func sanitizeJSON(data []byte) []byte {
+	// Replace standalone Infinity, -Infinity, NaN with null
+	re := regexp.MustCompile(`(?:(?:^|[,\[:\s])\s*)-?Infinity|(?:(?:^|[,\[:\s])\s*)NaN`)
+	return re.ReplaceAllFunc(data, func(match []byte) []byte {
+		// Preserve the prefix (comma, bracket, colon, whitespace) before the value
+		trimmed := strings.TrimLeft(string(match), " \t\n\r,[:") //nolint:gocritic
+		prefix := string(match[:len(match)-len(trimmed)])
+		return []byte(prefix + "null")
+	})
 }
 
 func (g *Generator) fetchConfigFile(name string) ([]byte, error) {
@@ -388,15 +410,21 @@ func (g *Generator) fetchConfigFile(name string) ([]byte, error) {
 	return g.fetchURL(url)
 }
 
-// mergeTextConfig promotes fields from a nested "text_config" object into the
-// top-level config. This is needed for multimodal models (e.g., Gemma-3,
-// Ministral-3) where architecture-specific parameters live under text_config.
+// mergeTextConfig promotes fields from a nested "text_config" or "llm_config"
+// object into the top-level config. This is needed for multimodal models
+// (e.g., Gemma-3, Ministral-3, Nemotron-VL) where architecture-specific
+// parameters live under a nested config key.
 func (g *Generator) mergeTextConfig() {
-	textConfig, ok := g.ModelConfig["text_config"].(map[string]interface{})
-	if !ok {
+	var nested map[string]interface{}
+	if tc, ok := g.ModelConfig["text_config"].(map[string]interface{}); ok {
+		nested = tc
+	} else if lc, ok := g.ModelConfig["llm_config"].(map[string]interface{}); ok {
+		nested = lc
+	}
+	if nested == nil {
 		return
 	}
-	for k, v := range textConfig {
+	for k, v := range nested {
 		if _, exists := g.ModelConfig[k]; !exists {
 			g.ModelConfig[k] = v
 		}

--- a/presets/workspace/generator/generator_test.go
+++ b/presets/workspace/generator/generator_test.go
@@ -704,3 +704,80 @@ func TestSelectWeightFiles(t *testing.T) {
 		})
 	}
 }
+
+func TestSanitizeJSON(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "replaces Infinity value",
+			input:    `{"rope_scaling": {"factor": Infinity}}`,
+			expected: `{"rope_scaling": {"factor": null}}`,
+		},
+		{
+			name:     "replaces -Infinity value",
+			input:    `{"value": -Infinity}`,
+			expected: `{"value": null}`,
+		},
+		{
+			name:     "replaces NaN value",
+			input:    `{"value": NaN}`,
+			expected: `{"value": null}`,
+		},
+		{
+			name:     "replaces multiple non-standard values",
+			input:    `{"a": Infinity, "b": -Infinity, "c": NaN}`,
+			expected: `{"a": null, "b": null, "c": null}`,
+		},
+		{
+			name:     "does not replace Infinity in string values",
+			input:    `{"name": "Infinity"}`,
+			expected: `{"name": "Infinity"}`,
+		},
+		{
+			name:     "standard JSON unaffected",
+			input:    `{"hidden_size": 4096, "num_layers": 32}`,
+			expected: `{"hidden_size": 4096, "num_layers": 32}`,
+		},
+		{
+			name:     "Infinity in array",
+			input:    `{"values": [1, Infinity, 3]}`,
+			expected: `{"values": [1, null, 3]}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := sanitizeJSON([]byte(tt.input))
+			assert.Equal(t, tt.expected, string(result))
+		})
+	}
+}
+
+func TestMergeTextConfigWithLLMConfig(t *testing.T) {
+	// Tests that llm_config is merged the same way text_config is
+	gen := NewGenerator("test/model", "")
+	gen.ModelConfig = map[string]interface{}{
+		"architectures":           []interface{}{"NemotronH_Nano_VL_V2"},
+		"max_position_embeddings": float64(4096),
+		"llm_config": map[string]interface{}{
+			"hidden_size":         float64(3072),
+			"num_hidden_layers":   float64(32),
+			"num_attention_heads": float64(24),
+			"num_key_value_heads": float64(8),
+		},
+	}
+
+	gen.mergeTextConfig()
+
+	// llm_config fields should be promoted to top-level
+	assert.Equal(t, float64(3072), gen.ModelConfig["hidden_size"])
+	assert.Equal(t, float64(32), gen.ModelConfig["num_hidden_layers"])
+	assert.Equal(t, float64(24), gen.ModelConfig["num_attention_heads"])
+	assert.Equal(t, float64(8), gen.ModelConfig["num_key_value_heads"])
+
+	// Existing top-level value should not be overwritten
+	assert.Equal(t, float64(4096), gen.ModelConfig["max_position_embeddings"])
+}

--- a/presets/workspace/generator/model_catalog.go
+++ b/presets/workspace/generator/model_catalog.go
@@ -63,7 +63,7 @@ var configKeyMap = map[string][]string{
 
 // optionalKeyMap holds catalog fields that are only stored when present and > 0.
 var optionalKeyMap = map[string][]string{
-	"headDim":       {"head_dim"},
+	"headDim":       {"head_dim", "attention_head_dim"},
 	"kvLoraRank":    {"kv_lora_rank"},
 	"qkRopeHeadDim": {"qk_rope_head_dim"},
 }

--- a/presets/workspace/models/model_catalog.yaml
+++ b/presets/workspace/models/model_catalog.yaml
@@ -298,6 +298,7 @@ models:
   numHiddenLayers: 62
   numAttentionHeads: 32
   numKeyValueHeads: 16
+  headDim: 128
 - name: deepseek-ai/DeepSeek-R1-0528
   description: https://huggingface.co/deepseek-ai/DeepSeek-R1-0528
   license: mit
@@ -346,3 +347,84 @@ models:
   headDim: 192
   kvLoraRank: 512
   qkRopeHeadDim: 64
+- name: nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+  description: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16
+  license: other
+  pipelineTag: text-generation
+  modelFileSize: 230.25Gi
+  architectures:
+  - NemotronHForCausalLM
+  modelTokenLimit: 262144
+  hiddenSize: 4096
+  numHiddenLayers: 88
+  numAttentionHeads: 32
+  numKeyValueHeads: 2
+- name: nvidia/Nemotron-Cascade-2-30B-A3B
+  description: https://huggingface.co/nvidia/Nemotron-Cascade-2-30B-A3B
+  license: other
+  pipelineTag: text-generation
+  modelFileSize: 58.82Gi
+  architectures:
+  - NemotronHForCausalLM
+  modelTokenLimit: 262144
+  hiddenSize: 2688
+  numHiddenLayers: 52
+  numAttentionHeads: 32
+  numKeyValueHeads: 2
+  headDim: 128
+- name: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+  description: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+  license: other
+  pipelineTag: text-generation
+  modelFileSize: 58.82Gi
+  architectures:
+  - NemotronHForCausalLM
+  modelTokenLimit: 262144
+  hiddenSize: 2688
+  numHiddenLayers: 52
+  numAttentionHeads: 32
+  numKeyValueHeads: 2
+  headDim: 128
+- name: nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16
+  description: https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16
+  license: other
+  pipelineTag: image-text-to-text
+  modelFileSize: 24.55Gi
+  architectures:
+  - NemotronH_Nano_VL_V2
+  modelTokenLimit: 131072
+  hiddenSize: 5120
+  numHiddenLayers: 62
+  numAttentionHeads: 40
+  numKeyValueHeads: 8
+- name: nvidia/NVIDIA-Nemotron-Nano-9B-v2
+  description: https://huggingface.co/nvidia/NVIDIA-Nemotron-Nano-9B-v2
+  license: other
+  pipelineTag: text-generation
+  baseModel:
+  - nvidia/NVIDIA-Nemotron-Nano-12B-v2-Base
+  - nvidia/NVIDIA-Nemotron-Nano-12B-v2
+  modelFileSize: 16.56Gi
+  architectures:
+  - NemotronHForCausalLM
+  modelTokenLimit: 131072
+  hiddenSize: 4480
+  numHiddenLayers: 56
+  numAttentionHeads: 40
+  numKeyValueHeads: 8
+  headDim: 128
+- name: nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16
+  description: https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16
+  license: other
+  pipelineTag: text-generation
+  baseModel:
+  - nvidia/NVIDIA-Nemotron-Nano-9B-v2
+  modelFileSize: 7.40Gi
+  architectures:
+  - NemotronHForCausalLM
+  modelTokenLimit: 262144
+  hiddenSize: 3136
+  numHiddenLayers: 42
+  numAttentionHeads: 40
+  numKeyValueHeads: 8
+  headDim: 128

--- a/presets/workspace/models/model_catalog_mtbench_scores.md
+++ b/presets/workspace/models/model_catalog_mtbench_scores.md
@@ -35,3 +35,9 @@ All models were deployed as KAITO Workspace CRs on AKS and evaluated using the v
 | deepseek-ai/DeepSeek-R1-0528 | vllm | 5.06 | 7.90 | 7.30 | 3.85 | 2.65 | 1.65 | 5.55 | 5.55 | 6.05 | 2026-04-17 |
 | deepseek-ai/DeepSeek-V3-0324 | vllm | 8.07 | 8.20 | 7.95 | 7.35 | 9.50 | 8.20 | 8.30 | 7.00 | 8.05 | 2026-04-17 |
 | mistralai/Mistral-Large-3-675B-Instruct-2512 | vllm | 7.86 | 8.05 | 7.65 | 7.75 | 9.05 | 7.90 | 8.50 | 7.25 | 6.70 | 2026-04-17 |
+| nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16 | vllm | 6.37 | 6.35 | 5.65 | 6.65 | 9.10 | 5.85 | 7.05 | 6.10 | 4.20 | 2026-04-29 |
+| nvidia/NVIDIA-Nemotron-Nano-9B-v2 | vllm | 5.54 | 6.05 | 4.50 | 5.65 | 7.45 | 4.20 | 6.75 | 5.25 | 4.50 | 2026-04-29 |
+| nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16 | vllm | 7.08 | 7.55 | 6.45 | 6.80 | 9.50 | 6.60 | 6.55 | 6.35 | 6.85 | 2026-04-29 |
+| nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 | vllm | 6.89 | 6.45 | 7.20 | 6.60 | 9.95 | 5.30 | 7.05 | 6.15 | 6.40 | 2026-04-29 |
+| nvidia/Nemotron-Cascade-2-30B-A3B | vllm | 5.71 | 3.40 | 6.85 | 6.60 | 9.20 | 5.65 | 4.15 | 4.90 | 4.95 | 2026-04-29 |
+| nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16 | vllm | 6.91 | 7.35 | 7.30 | 7.05 | 9.65 | 6.35 | 7.25 | 5.40 | 4.90 | 2026-04-29 |

--- a/presets/workspace/models/vllm_model.go
+++ b/presets/workspace/models/vllm_model.go
@@ -137,6 +137,7 @@ func (m *vLLMCompatibleModel) GetInferenceParameters() *model.PresetParam {
 		Runtime:              "tfs",
 		DownloadAtRuntime:    true,
 		DownloadAuthRequired: m.model.DownloadAuthRequired,
+		Architectures:        m.model.Architectures,
 	}
 
 	runParamsVLLM := make(map[string]string)


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
This PR added the following six models to Kaito's model catalog:
- nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16
- nvidia/NVIDIA-Nemotron-Nano-9B-v2
- nvidia/NVIDIA-Nemotron-Nano-12B-v2-VL-BF16
- nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
- nvidia/Nemotron-Cascade-2-30B-A3B
- nvidia/NVIDIA-Nemotron-3-Super-120B-A12B-BF16

NOTE: 
Some of these models are hybrid (i.e. combines different attention types) and require vLLM's builtin hybrid KV cache mamager (https://docs.vllm.ai/en/latest/design/hybrid_kv_cache_manager), which cannot be used together with KV cache offloading. In this PR we explicitly disable KV cache offloading for these hybrid models.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).
- [x] verified deployment of these six models on an AKS cluster and ran mt-bench evaluation. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: