### PR TITLE
feat: legacy nodeprovisioner nodeclaim garbage collection controller

### DIFF
--- a/cmd/workspace/main.go
+++ b/cmd/workspace/main.go
@@ -48,6 +48,7 @@ import (
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
 	drift "github.com/kaito-project/kaito/pkg/controllers/drift"
+	gc "github.com/kaito-project/kaito/pkg/controllers/gc"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/inferenceset"
 	"github.com/kaito-project/kaito/pkg/k8sclient"
@@ -289,6 +290,17 @@ func main() {
 			)
 			if err = driftReconciler.SetupWithManager(mgr); err != nil {
 				klog.ErrorS(err, "unable to create controller", "controller", "Drift")
+				exitWithErrorFunc()
+			}
+		}
+
+		if consts.IsKarpenterProvisioner() {
+			gcController := gc.NewLegacyNodeClaimGCController(
+				kClient,
+				mgr.GetEventRecorderFor("legacy-gc-controller"),
+			)
+			if err = mgr.Add(gcController); err != nil {
+				klog.ErrorS(err, "unable to add controller", "controller", "LegacyNodeClaimGC")
 				exitWithErrorFunc()
 			}
 		}

--- a/pkg/controllers/gc/controller.go
+++ b/pkg/controllers/gc/controller.go
@@ -1,0 +1,288 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gc
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/utils/consts"
+	"github.com/kaito-project/kaito/pkg/utils/nodeclaim"
+)
+
+const (
+	gcInterval = 10 * time.Second
+)
+
+// LegacyNodeClaimGCController periodically scans for and deletes orphaned
+// legacy gpu-provisioner NodeClaims that have been superseded by Ready
+// Karpenter-managed NodeClaims for the same workspace.
+type LegacyNodeClaimGCController struct {
+	client   client.Client
+	recorder record.EventRecorder
+	interval time.Duration
+}
+
+// NewLegacyNodeClaimGCController creates a new GC controller.
+func NewLegacyNodeClaimGCController(c client.Client, recorder record.EventRecorder) *LegacyNodeClaimGCController {
+	return &LegacyNodeClaimGCController{
+		client:   c,
+		recorder: recorder,
+		interval: gcInterval,
+	}
+}
+
+type workspaceKey struct {
+	name      string
+	namespace string
+}
+
+func (c *LegacyNodeClaimGCController) Start(ctx context.Context) error {
+	ticker := time.NewTicker(c.interval)
+	defer ticker.Stop()
+
+	klog.InfoS("Legacy NodeClaim GC controller started", "interval", c.interval)
+
+	for {
+		select {
+		case <-ctx.Done():
+			klog.InfoS("Legacy NodeClaim GC controller stopped")
+			return nil
+		case <-ticker.C:
+			if err := c.runGCCycle(ctx); err != nil {
+				klog.ErrorS(err, "GC cycle failed")
+			}
+		}
+	}
+}
+
+// runGCCycle performs one full scan: list legacy NodeClaims, group by workspace,
+// check Karpenter replacements, and delete superseded legacy NodeClaims.
+func (c *LegacyNodeClaimGCController) runGCCycle(ctx context.Context) error {
+	// 1. List all legacy NodeClaims (labeled kaito.sh/workspace).
+	legacyList := &karpenterv1.NodeClaimList{}
+	if err := c.client.List(ctx, legacyList,
+		client.HasLabels{kaitov1beta1.LabelWorkspaceName},
+	); err != nil {
+		return err
+	}
+
+	if len(legacyList.Items) == 0 {
+		return nil
+	}
+
+	// 2. Group by workspace (name, namespace).
+	grouped := make(map[workspaceKey][]*karpenterv1.NodeClaim)
+	for i := range legacyList.Items {
+		nc := &legacyList.Items[i]
+		labels := nc.GetLabels()
+		name := labels[kaitov1beta1.LabelWorkspaceName]
+		ns := labels[kaitov1beta1.LabelWorkspaceNamespace]
+
+		if name == "" || ns == "" {
+			klog.InfoS("Legacy NodeClaim missing workspace name or namespace label, skipping",
+				"nodeClaim", nc.Name,
+				"labels", labels)
+			continue
+		}
+
+		key := workspaceKey{name: name, namespace: ns}
+		grouped[key] = append(grouped[key], nc)
+	}
+
+	// 3. For each workspace group, check Karpenter replacements and delete if ready.
+	var firstErr error
+	for wsKey, legacyNodeClaims := range grouped {
+		if err := c.processWorkspace(ctx, wsKey, legacyNodeClaims); err != nil {
+			klog.ErrorS(err, "Failed to process workspace for GC",
+				"workspace", klog.KRef(wsKey.namespace, wsKey.name))
+			if firstErr == nil {
+				firstErr = err
+			}
+			// Continue processing other workspaces.
+		}
+	}
+
+	return firstErr
+}
+
+// isWorkspaceReady returns true if the Workspace has WorkspaceSucceeded=True.
+func isWorkspaceReady(ws *kaitov1beta1.Workspace) bool {
+	for _, c := range ws.Status.Conditions {
+		if c.Type == string(kaitov1beta1.WorkspaceConditionTypeSucceeded) {
+			return c.Status == metav1.ConditionTrue
+		}
+	}
+	return false
+}
+
+// arePodsOnKarpenterNodes checks that all workspace pods are running on nodes
+// backed by Karpenter NodeClaims (not legacy nodes). This prevents GC from
+// deleting legacy NodeClaims while pods are still running on them.
+func (c *LegacyNodeClaimGCController) arePodsOnKarpenterNodes(
+	ctx context.Context,
+	ws *kaitov1beta1.Workspace,
+	karpenterList *karpenterv1.NodeClaimList,
+) (bool, error) {
+	// Set of node names from Karpenter NodeClaims.
+	karpenterNodes := make(map[string]bool, len(karpenterList.Items))
+	for i := range karpenterList.Items {
+		if nodeName := karpenterList.Items[i].Status.NodeName; nodeName != "" {
+			karpenterNodes[nodeName] = true
+		}
+	}
+
+	if len(karpenterNodes) == 0 {
+		return false, nil
+	}
+
+	// List pods under the workspace.
+	podList := &corev1.PodList{}
+	labelSelector := labels.SelectorFromSet(labels.Set{
+		kaitov1beta1.LabelWorkspaceName:      ws.Name,
+		kaitov1beta1.LabelWorkspaceNamespace: ws.Namespace,
+	})
+	if err := c.client.List(ctx, podList,
+		&client.ListOptions{LabelSelector: labelSelector},
+	); err != nil {
+		return false, err
+	}
+
+	if len(podList.Items) == 0 {
+		return false, nil
+	}
+
+	// All pods must run on Karpenter nodes.
+	for i := range podList.Items {
+		pod := &podList.Items[i]
+		if pod.Status.Phase != corev1.PodRunning {
+			return false, nil
+		}
+		if !karpenterNodes[pod.Spec.NodeName] {
+			return false, nil
+		}
+	}
+
+	return true, nil
+}
+
+// processWorkspace checks if the workspace is fully replaced by Karpenter before
+// deleting legacy NodeClaims. Three conditions must hold:
+//  1. All Karpenter NodeClaims are Ready and not Deleting.
+//  2. The number of Karpenter NodeClaims matches the workspace's TargetNodeCount.
+//  3. The workspace is Ready (WorkspaceSucceeded=True).
+//
+// If the workspace no longer exists, the legacy NodeClaims are definitively orphaned
+// and are deleted unconditionally (provided Karpenter replacements are Ready).
+func (c *LegacyNodeClaimGCController) processWorkspace(
+	ctx context.Context,
+	wsKey workspaceKey,
+	legacyNodeClaims []*karpenterv1.NodeClaim,
+) error {
+	karpenterList := &karpenterv1.NodeClaimList{}
+	if err := c.client.List(ctx, karpenterList,
+		client.MatchingLabels{
+			consts.KarpenterWorkspaceNameKey:      wsKey.name,
+			consts.KarpenterWorkspaceNamespaceKey: wsKey.namespace,
+		},
+	); err != nil {
+		return err
+	}
+
+	if len(karpenterList.Items) == 0 {
+		return nil
+	}
+
+	// Condition 1: All Karpenter NodeClaims must be Ready and not Deleting.
+	for i := range karpenterList.Items {
+		if !nodeclaim.IsNodeClaimReadyNotDeleting(&karpenterList.Items[i]) {
+			klog.V(4).InfoS("Karpenter replacement not yet ready, skipping GC",
+				"workspace", klog.KRef(wsKey.namespace, wsKey.name),
+				"nodeClaim", karpenterList.Items[i].Name)
+			return nil
+		}
+	}
+
+	// Look up the Workspace.
+	ws := &kaitov1beta1.Workspace{}
+	wsFound := true
+	if err := c.client.Get(ctx, types.NamespacedName{
+		Name:      wsKey.name,
+		Namespace: wsKey.namespace,
+	}, ws); err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+		// Workspace deleted — legacy NodeClaims are definitively orphaned.
+		wsFound = false
+	}
+
+	if wsFound {
+		// Condition 2: Karpenter NodeClaim count must match the target.
+		if ws.Status.TargetNodeCount > 0 && int(ws.Status.TargetNodeCount) != len(karpenterList.Items) {
+			klog.V(4).InfoS("Karpenter NodeClaim count does not match target, skipping GC",
+				"workspace", klog.KRef(wsKey.namespace, wsKey.name),
+				"karpenterCount", len(karpenterList.Items),
+				"targetNodeCount", ws.Status.TargetNodeCount)
+			return nil
+		}
+		// Condition 3: Workspace must be Ready.
+		if !isWorkspaceReady(ws) {
+			klog.V(4).InfoS("Workspace not yet ready, skipping GC",
+				"workspace", klog.KRef(wsKey.namespace, wsKey.name))
+			return nil
+		}
+		// Condition 4: All workspace pods must be running on Karpenter nodes.
+		podsOnKarpenter, err := c.arePodsOnKarpenterNodes(ctx, ws, karpenterList)
+		if err != nil {
+			return err
+		}
+		if !podsOnKarpenter {
+			klog.V(4).InfoS("Workspace pods not yet running on Karpenter nodes, skipping GC",
+				"workspace", klog.KRef(wsKey.namespace, wsKey.name))
+			return nil
+		}
+	}
+
+	// All conditions met — delete legacy NodeClaims.
+	for _, nc := range legacyNodeClaims {
+		klog.V(2).InfoS("Deleting legacy NodeClaim superseded by Karpenter",
+			"nodeClaim", nc.Name,
+			"workspace", klog.KRef(wsKey.namespace, wsKey.name))
+		if err := c.client.Delete(ctx, nc); err != nil {
+			if !errors.IsNotFound(err) {
+				klog.ErrorS(err, "Failed to delete legacy NodeClaim",
+					"nodeClaim", nc.Name)
+			}
+			continue
+		}
+		if wsFound {
+			c.recorder.Eventf(ws, "Normal", "LegacyNodeClaimGC",
+				"Deleted legacy NodeClaim %s superseded by Karpenter", nc.Name)
+		}
+	}
+
+	return nil
+}

--- a/pkg/controllers/gc/controller.go
+++ b/pkg/controllers/gc/controller.go
@@ -59,6 +59,12 @@ type workspaceKey struct {
 	namespace string
 }
 
+// NeedLeaderElection implements controller-runtime's LeaderElectionRunnable
+// so that the GC loop only runs on the leader replica.
+func (c *LegacyNodeClaimGCController) NeedLeaderElection() bool {
+	return true
+}
+
 func (c *LegacyNodeClaimGCController) Start(ctx context.Context) error {
 	ticker := time.NewTicker(c.interval)
 	defer ticker.Stop()

--- a/pkg/controllers/gc/controller_test.go
+++ b/pkg/controllers/gc/controller_test.go
@@ -1,0 +1,449 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gc
+
+import (
+	"context"
+	"testing"
+
+	"github.com/awslabs/operatorpkg/status"
+	"gotest.tools/assert"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
+
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/utils/consts"
+)
+
+func newTestScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	gv := schema.GroupVersion{Group: "karpenter.sh", Version: "v1"}
+	s.AddKnownTypes(gv,
+		&karpenterv1.NodeClaim{},
+		&karpenterv1.NodeClaimList{},
+		&karpenterv1.NodePool{},
+		&karpenterv1.NodePoolList{},
+	)
+	metav1.AddToGroupVersion(s, gv)
+	wsGV := schema.GroupVersion{Group: "kaito.sh", Version: "v1beta1"}
+	s.AddKnownTypes(wsGV,
+		&kaitov1beta1.Workspace{},
+		&kaitov1beta1.WorkspaceList{},
+	)
+	metav1.AddToGroupVersion(s, wsGV)
+	coreGV := schema.GroupVersion{Group: "", Version: "v1"}
+	s.AddKnownTypes(coreGV,
+		&corev1.Pod{},
+		&corev1.PodList{},
+	)
+	metav1.AddToGroupVersion(s, coreGV)
+	return s
+}
+
+// Helper: create a legacy NodeClaim (gpu-provisioner style).
+func makeLegacyNodeClaim(name, wsName, wsNamespace string) *karpenterv1.NodeClaim {
+	return &karpenterv1.NodeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				kaitov1beta1.LabelWorkspaceName:      wsName,
+				kaitov1beta1.LabelWorkspaceNamespace: wsNamespace,
+			},
+		},
+	}
+}
+
+// Helper: create a Karpenter-managed NodeClaim.
+func makeKarpenterNodeClaim(name, wsName, wsNamespace string, ready bool) *karpenterv1.NodeClaim {
+	nc := &karpenterv1.NodeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				consts.KarpenterWorkspaceNameKey:      wsName,
+				consts.KarpenterWorkspaceNamespaceKey: wsNamespace,
+			},
+		},
+		Status: karpenterv1.NodeClaimStatus{
+			NodeName: "node-" + name,
+		},
+	}
+	if ready {
+		nc.Status.Conditions = []status.Condition{
+			{
+				Type:   "Ready",
+				Status: "True",
+			},
+		}
+	}
+	return nc
+}
+
+// Helper: create a pod running on a given node for the workspace.
+func makePodOnNode(name, wsName, wsNamespace, nodeName string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: wsNamespace,
+			Labels: map[string]string{
+				kaitov1beta1.LabelWorkspaceName:      wsName,
+				kaitov1beta1.LabelWorkspaceNamespace: wsNamespace,
+			},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: nodeName,
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodRunning,
+		},
+	}
+}
+
+// Helper: create a Workspace with Ready status and TargetNodeCount.
+func makeReadyWorkspace(name, namespace string, targetNodeCount int32) *kaitov1beta1.Workspace {
+	return &kaitov1beta1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: kaitov1beta1.WorkspaceStatus{
+			TargetNodeCount: targetNodeCount,
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(kaitov1beta1.WorkspaceConditionTypeSucceeded),
+					Status: metav1.ConditionTrue,
+				},
+			},
+		},
+	}
+}
+
+// Helper: create a Workspace that is NOT ready.
+func makeNotReadyWorkspace(name, namespace string, targetNodeCount int32) *kaitov1beta1.Workspace {
+	return &kaitov1beta1.Workspace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Status: kaitov1beta1.WorkspaceStatus{
+			TargetNodeCount: targetNodeCount,
+			Conditions: []metav1.Condition{
+				{
+					Type:   string(kaitov1beta1.WorkspaceConditionTypeSucceeded),
+					Status: metav1.ConditionFalse,
+				},
+			},
+		},
+	}
+}
+
+func newFakeGC(objs ...client.Object) *LegacyNodeClaimGCController {
+	s := newTestScheme()
+	fc := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		Build()
+	return &LegacyNodeClaimGCController{
+		client:   fc,
+		recorder: record.NewFakeRecorder(10),
+	}
+}
+
+func TestGC_NoLegacyNodeClaims(t *testing.T) {
+	gc := newFakeGC()
+	err := gc.runGCCycle(context.Background())
+	assert.NilError(t, err)
+}
+
+func TestGC_LegacyExists_NoKarpenterReplacement(t *testing.T) {
+	legacy := makeLegacyNodeClaim("legacy-1", "ws-a", "default")
+	ws := makeReadyWorkspace("ws-a", "default", 1)
+	gc := newFakeGC(legacy, ws)
+
+	err := gc.runGCCycle(context.Background())
+	assert.NilError(t, err)
+
+	// Legacy NodeClaim should still exist — no Karpenter replacements.
+	list := &karpenterv1.NodeClaimList{}
+	err = gc.client.List(context.Background(), list)
+	assert.NilError(t, err)
+	assert.Equal(t, len(list.Items), 1)
+}
+
+func TestGC_LegacyExists_KarpenterNotReady(t *testing.T) {
+	legacy := makeLegacyNodeClaim("legacy-1", "ws-a", "default")
+	karpNC := makeKarpenterNodeClaim("karp-1", "ws-a", "default", false)
+	ws := makeReadyWorkspace("ws-a", "default", 1)
+	gc := newFakeGC(legacy, karpNC, ws)
+
+	err := gc.runGCCycle(context.Background())
+	assert.NilError(t, err)
+
+	// Legacy should still exist — Karpenter replacement not ready.
+	list := &karpenterv1.NodeClaimList{}
+	err = gc.client.List(context.Background(), list)
+	assert.NilError(t, err)
+	assert.Equal(t, len(list.Items), 2)
+}
+
+func TestGC_LegacyExists_KarpenterReady_WorkspaceReady_DeletesLegacy(t *testing.T) {
+	legacy := makeLegacyNodeClaim("legacy-1", "ws-a", "default")
+	karpNC := makeKarpenterNodeClaim("karp-1", "ws-a", "default", true)
+	ws := makeReadyWorkspace("ws-a", "default", 1)
+	pod := makePodOnNode("pod-1", "ws-a", "default", "node-karp-1")
+	gc := newFakeGC(legacy, karpNC, ws, pod)
+
+	err := gc.runGCCycle(context.Background())
+	assert.NilError(t, err)
+
+	// Legacy should be deleted; only karpenter NodeClaim remains.
+	list := &karpenterv1.NodeClaimList{}
+	err = gc.client.List(context.Background(), list)
+	assert.NilError(t, err)
+	assert.Equal(t, len(list.Items), 1)
+	assert.Equal(t, list.Items[0].Name, "karp-1")
+}
+
+func TestGC_WorkspaceNotReady_SkipsGC(t *testing.T) {
+	legacy := makeLegacyNodeClaim("legacy-1", "ws-a", "default")
+	karpNC := makeKarpenterNodeClaim("karp-1", "ws-a", "default", true)
+	ws := makeNotReadyWorkspace("ws-a", "default", 1)
+	gc := newFakeGC(legacy, karpNC, ws)
+
+	err := gc.runGCCycle(context.Background())
+	assert.NilError(t, err)
+
+	// Legacy should still exist — workspace not ready.
+	list := &karpenterv1.NodeClaimList{}
+	err = gc.client.List(context.Background(), list)
+	assert.NilError(t, err)
+	assert.Equal(t, len(list.Items), 2)
+}
+
+func TestGC_KarpenterCountMismatch_SkipsGC(t *testing.T) {
+	// Workspace needs 2 nodes, but only 1 Karpenter NodeClaim exists.
+	legacy1 := makeLegacyNodeClaim("legacy-1", "ws-a", "default")
+	legacy2 := makeLegacyNodeClaim("legacy-2", "ws-a", "default")
+	karpNC := makeKarpenterNodeClaim("karp-1", "ws-a", "default", true)
+	ws := makeReadyWorkspace("ws-a", "default", 2)
+	gc := newFakeGC(legacy1, legacy2, karpNC, ws)
+
+	err := gc.runGCCycle(context.Background())
+	assert.NilError(t, err)
+
+	// Both legacy should still exist — karpenter count (1) != target (2).
+	list := &karpenterv1.NodeClaimList{}
+	err = gc.client.List(context.Background(), list)
+	assert.NilError(t, err)
+	assert.Equal(t, len(list.Items), 3)
+}
+
+func TestGC_KarpenterCountMatchesTarget_DeletesLegacy(t *testing.T) {
+	// Workspace needs 2 nodes, 2 Karpenter NodeClaims exist and are ready.
+	legacy1 := makeLegacyNodeClaim("legacy-1", "ws-a", "default")
+	legacy2 := makeLegacyNodeClaim("legacy-2", "ws-a", "default")
+	karpNC1 := makeKarpenterNodeClaim("karp-1", "ws-a", "default", true)
+	karpNC2 := makeKarpenterNodeClaim("karp-2", "ws-a", "default", true)
+	ws := makeReadyWorkspace("ws-a", "default", 2)
+	pod1 := makePodOnNode("pod-1", "ws-a", "default", "node-karp-1")
+	pod2 := makePodOnNode("pod-2", "ws-a", "default", "node-karp-2")
+	gc := newFakeGC(legacy1, legacy2, karpNC1, karpNC2, ws, pod1, pod2)
+
+	err := gc.runGCCycle(context.Background())
+	assert.NilError(t, err)
+
+	// Both legacy should be deleted.
+	list := &karpenterv1.NodeClaimList{}
+	err = gc.client.List(context.Background(), list)
+	assert.NilError(t, err)
+	assert.Equal(t, len(list.Items), 2)
+	names := make(map[string]bool)
+	for _, nc := range list.Items {
+		names[nc.Name] = true
+	}
+	assert.Assert(t, names["karp-1"])
+	assert.Assert(t, names["karp-2"])
+}
+
+func TestGC_LegacyMissingNamespaceLabel_Skipped(t *testing.T) {
+	legacy := &karpenterv1.NodeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "legacy-no-ns",
+			Labels: map[string]string{
+				kaitov1beta1.LabelWorkspaceName: "ws-a",
+			},
+		},
+	}
+	karpNC := makeKarpenterNodeClaim("karp-1", "ws-a", "default", true)
+	ws := makeReadyWorkspace("ws-a", "default", 1)
+	gc := newFakeGC(legacy, karpNC, ws)
+
+	err := gc.runGCCycle(context.Background())
+	assert.NilError(t, err)
+
+	// Legacy should still exist — skipped due to missing namespace label.
+	list := &karpenterv1.NodeClaimList{}
+	err = gc.client.List(context.Background(), list)
+	assert.NilError(t, err)
+	assert.Equal(t, len(list.Items), 2)
+}
+
+func TestGC_MultipleWorkspaces_OnlyReadyOneGCd(t *testing.T) {
+	// Workspace A: ready, karpenter ready, count matches, pod on karpenter → should GC legacy.
+	legacyA := makeLegacyNodeClaim("legacy-a", "ws-a", "default")
+	karpA := makeKarpenterNodeClaim("karp-a", "ws-a", "default", true)
+	wsA := makeReadyWorkspace("ws-a", "default", 1)
+	podA := makePodOnNode("pod-a", "ws-a", "default", "node-karp-a")
+
+	// Workspace B: karpenter NOT ready → should keep legacy.
+	legacyB := makeLegacyNodeClaim("legacy-b", "ws-b", "default")
+	karpB := makeKarpenterNodeClaim("karp-b", "ws-b", "default", false)
+	wsB := makeReadyWorkspace("ws-b", "default", 1)
+
+	gc := newFakeGC(legacyA, karpA, wsA, podA, legacyB, karpB, wsB)
+
+	err := gc.runGCCycle(context.Background())
+	assert.NilError(t, err)
+
+	list := &karpenterv1.NodeClaimList{}
+	err = gc.client.List(context.Background(), list)
+	assert.NilError(t, err)
+
+	// Should have 3 remaining: karp-a, legacy-b, karp-b.
+	assert.Equal(t, len(list.Items), 3)
+	names := make(map[string]bool)
+	for _, nc := range list.Items {
+		names[nc.Name] = true
+	}
+	assert.Assert(t, !names["legacy-a"], "legacy-a should have been deleted")
+	assert.Assert(t, names["legacy-b"], "legacy-b should still exist")
+	assert.Assert(t, names["karp-a"])
+	assert.Assert(t, names["karp-b"])
+}
+
+func TestGC_KarpenterNodeClaimDeleting_SkipsGC(t *testing.T) {
+	legacy := makeLegacyNodeClaim("legacy-1", "ws-a", "default")
+	karpNC := makeKarpenterNodeClaim("karp-1", "ws-a", "default", true)
+	now := metav1.Now()
+	karpNC.DeletionTimestamp = &now
+	karpNC.Finalizers = []string{"test-finalizer"}
+	ws := makeReadyWorkspace("ws-a", "default", 1)
+
+	gc := newFakeGC(legacy, karpNC, ws)
+
+	err := gc.runGCCycle(context.Background())
+	assert.NilError(t, err)
+
+	// Legacy should still exist — replacement is deleting.
+	list := &karpenterv1.NodeClaimList{}
+	err = gc.client.List(context.Background(), list)
+	assert.NilError(t, err)
+	assert.Equal(t, len(list.Items), 2)
+}
+
+func TestGC_WorkspaceDeleted_LegacyOrphansStillGCd(t *testing.T) {
+	// Workspace no longer exists, but legacy NodeClaims remain alongside ready Karpenter ones.
+	legacy := makeLegacyNodeClaim("legacy-1", "ws-gone", "default")
+	karpNC := makeKarpenterNodeClaim("karp-1", "ws-gone", "default", true)
+	// No Workspace object — simulates deleted workspace.
+	gc := newFakeGC(legacy, karpNC)
+
+	err := gc.runGCCycle(context.Background())
+	assert.NilError(t, err)
+
+	// Legacy should be deleted even though workspace is gone.
+	list := &karpenterv1.NodeClaimList{}
+	err = gc.client.List(context.Background(), list)
+	assert.NilError(t, err)
+	assert.Equal(t, len(list.Items), 1)
+	assert.Equal(t, list.Items[0].Name, "karp-1")
+}
+
+func TestGC_MultipleLegacyPerWorkspace_AllDeleted(t *testing.T) {
+	legacy1 := makeLegacyNodeClaim("legacy-1", "ws-a", "default")
+	legacy2 := makeLegacyNodeClaim("legacy-2", "ws-a", "default")
+	karpNC1 := makeKarpenterNodeClaim("karp-1", "ws-a", "default", true)
+	karpNC2 := makeKarpenterNodeClaim("karp-2", "ws-a", "default", true)
+	ws := makeReadyWorkspace("ws-a", "default", 2)
+	pod1 := makePodOnNode("pod-1", "ws-a", "default", "node-karp-1")
+	pod2 := makePodOnNode("pod-2", "ws-a", "default", "node-karp-2")
+	gc := newFakeGC(legacy1, legacy2, karpNC1, karpNC2, ws, pod1, pod2)
+
+	err := gc.runGCCycle(context.Background())
+	assert.NilError(t, err)
+
+	// Both legacy NodeClaims should be deleted.
+	list := &karpenterv1.NodeClaimList{}
+	err = gc.client.List(context.Background(), list)
+	assert.NilError(t, err)
+	assert.Equal(t, len(list.Items), 2)
+	names := make(map[string]bool)
+	for _, nc := range list.Items {
+		names[nc.Name] = true
+	}
+	assert.Assert(t, names["karp-1"])
+	assert.Assert(t, names["karp-2"])
+}
+
+func TestGC_PodsStillOnLegacyNode_SkipsGC(t *testing.T) {
+	legacy := makeLegacyNodeClaim("legacy-1", "ws-a", "default")
+	karpNC := makeKarpenterNodeClaim("karp-1", "ws-a", "default", true)
+	ws := makeReadyWorkspace("ws-a", "default", 1)
+	// Pod is running on a legacy node, not the Karpenter node.
+	pod := makePodOnNode("pod-1", "ws-a", "default", "legacy-node-xyz")
+	gc := newFakeGC(legacy, karpNC, ws, pod)
+
+	err := gc.runGCCycle(context.Background())
+	assert.NilError(t, err)
+
+	// Legacy should still exist — pod not on Karpenter node.
+	list := &karpenterv1.NodeClaimList{}
+	err = gc.client.List(context.Background(), list)
+	assert.NilError(t, err)
+	assert.Equal(t, len(list.Items), 2)
+}
+
+func TestGC_PodsPending_SkipsGC(t *testing.T) {
+	legacy := makeLegacyNodeClaim("legacy-1", "ws-a", "default")
+	karpNC := makeKarpenterNodeClaim("karp-1", "ws-a", "default", true)
+	ws := makeReadyWorkspace("ws-a", "default", 1)
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "pod-1",
+			Namespace: "default",
+			Labels: map[string]string{
+				kaitov1beta1.LabelWorkspaceName:      "ws-a",
+				kaitov1beta1.LabelWorkspaceNamespace: "default",
+			},
+		},
+		Status: corev1.PodStatus{
+			Phase: corev1.PodPending,
+		},
+	}
+	gc := newFakeGC(legacy, karpNC, ws, pod)
+
+	err := gc.runGCCycle(context.Background())
+	assert.NilError(t, err)
+
+	// Legacy should still exist — pod is Pending.
+	list := &karpenterv1.NodeClaimList{}
+	err = gc.client.List(context.Background(), list)
+	assert.NilError(t, err)
+	assert.Equal(t, len(list.Items), 2)
+}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
Adds a LegacyNodeClaimGCController that periodically scans for legacy gpu-provisioner NodeClaims (kaito.sh/workspace label) and deletes them once safely replaced.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Closes #1949 
**Notes for Reviewers**:

Important Design Decisions that I made:

GC Controller (this PR)
Four conditions must all hold before deletion when the workspace exists:

1. All Karpenter replacement NodeClaims are Ready and not Deleting
2. Karpenter NodeClaim count matches status.targetNodeCount
3. Workspace has WorkspaceSucceeded=True
4. All workspace pods are Running on Karpenter nodes (not legacy nodes)
Condition 4 prevents the race where GC deletes legacy NodeClaims while the workspace is "Ready" from pods still running on those nodes.

When the workspace is deleted, legacy NodeClaims are orphaned, so GC deletes them unconditionally (only condition 1 required). gpu-provisioner may not be running to clean these up, which is why GC exists as a separate controller.

Future: Workspace Controller Migration Patch (not in this PR)
When legacy NodeClaims exist and karpenter mode is active, the workspace controller will:

1. Detect migration state (legacy NodeClaims + karpenter mode + NodePool exists)
2. Wait for all Karpenter NodeClaims to be Ready
3. Patch the StatefulSet pod template's nodeSelector from affinity-based (legacy) to karpenter.kaito.sh/workspace.
4. Rolling update moves pods to Karpenter nodes (zero downtime since nodes are pre-provisioned)
5. The workspace controller does NOT delete legacy NodeClaims. GC will do it. Once pods land on Karpenter nodes, GC's condition 4 is satisfied and it cleans up the legacy NodeClaims.

The reason for this design is that it maintains service liveness during the transition if there are more than one pod and avoids pod eviction for a shorter downtime for single-pod service.

Note that GC controller only runs when karpenter is set as the nodeprovisioner in helm, so it won't run until karpenter migration is fully released.