### PR TITLE
chore: enable TPM benchmark by default

### DIFF
--- a/api/v1alpha1/condition_types.go
+++ b/api/v1alpha1/condition_types.go
@@ -47,7 +47,7 @@ const (
 	// InferenceSetConditionTypeReady is the InferenceSet state when starts to get ready.
 	InferenceSetConditionTypeReady = ConditionType("InferenceSetReady")
 
-	// InferenceSetConditionTypeBenchmarkCompleted is set when benchmark annotation is present.
+	// InferenceSetConditionTypeBenchmarkCompleted is set when benchmark is enabled (default).
 	// True means all desired replicas have a benchmark result; False means some are still pending.
 	InferenceSetConditionTypeBenchmarkCompleted = ConditionType("BenchmarkCompleted")
 

--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -114,3 +114,13 @@ func GetInferenceSetRuntimeName(iObj *InferenceSet) model.RuntimeName {
 func IsRunBenchmarkEnabled(iObj *InferenceSet) bool {
 	return iObj.Annotations[AnnotationDisableBenchmark] != "true"
 }
+
+// ShouldRunBenchmark reports whether the InferenceSet's child workspaces should
+// run the post-load benchmark. Same criteria as the Workspace-level check:
+// benchmark must be enabled, runtime must be vLLM, and the template must use a
+// preset (not a custom container template).
+func ShouldRunBenchmark(iObj *InferenceSet) bool {
+	return IsRunBenchmarkEnabled(iObj) &&
+		GetInferenceSetRuntimeName(iObj) == model.RuntimeNameVLLM &&
+		iObj.Spec.Template.Inference.Preset != nil
+}

--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -59,9 +59,10 @@ const (
 	// AnnotationNodeImageFamily specifies node image family used by generated NodeClaim.
 	AnnotationNodeImageFamily = KAITOPrefix + "node-image-family"
 
-	// AnnotationRunBenchmark enables the post-load inference benchmark when set to "true".
+	// AnnotationDisableBenchmark disables the post-load inference benchmark.
+	// The benchmark is enabled by default. Set to "true" to disable it.
 	// When set on an InferenceSet, it is propagated to all Workspaces the InferenceSet creates.
-	AnnotationRunBenchmark = KAITOPrefix + "run-benchmark"
+	AnnotationDisableBenchmark = KAITOPrefix + "disable-benchmark"
 )
 
 // GetWorkspaceRuntimeName returns the runtime name of the workspace.
@@ -107,8 +108,9 @@ func GetInferenceSetRuntimeName(iObj *InferenceSet) model.RuntimeName {
 	return runtime
 }
 
-// IsRunBenchmarkEnabled reports whether the InferenceSet has the benchmark
-// annotation set to "true".
+// IsRunBenchmarkEnabled reports whether the InferenceSet benchmark is enabled.
+// The benchmark is on by default; it is only disabled when the annotation
+// kaito.sh/disable-benchmark is explicitly set to "true".
 func IsRunBenchmarkEnabled(iObj *InferenceSet) bool {
-	return iObj.Annotations[AnnotationRunBenchmark] == "true"
+	return iObj.Annotations[AnnotationDisableBenchmark] != "true"
 }

--- a/api/v1beta1/condition_types.go
+++ b/api/v1beta1/condition_types.go
@@ -56,6 +56,6 @@ const (
 
 	// WorkspaceConditionTypeBenchmarkCompleted is the state after the post-load benchmark has run.
 	// True means the benchmark completed and results are stored in status.benchmarkResult.
-	// Only set when the kaito.sh/run-benchmark annotation is "true".
+	// Set by default; omitted when kaito.sh/disable-benchmark is "true".
 	WorkspaceConditionTypeBenchmarkCompleted = ConditionType("BenchmarkCompleted")
 )

--- a/api/v1beta1/labels.go
+++ b/api/v1beta1/labels.go
@@ -61,10 +61,10 @@ const (
 	// as the NodeClassRef name instead of the configured default.
 	AnnotationNodeClassName = KAITOPrefix + "node-class-name"
 
-	// AnnotationRunBenchmark enables the post-load throughput benchmark stage.
-	// When set to "true" on a Workspace, the inference container runs a guidellm
-	// benchmark after the model loads before marking the container as ready.
-	AnnotationRunBenchmark = KAITOPrefix + "run-benchmark"
+	// AnnotationDisableBenchmark disables the post-load throughput benchmark stage.
+	// The benchmark is enabled by default. Set to "true" on a Workspace to
+	// disable it; when absent or any other value, the benchmark runs.
+	AnnotationDisableBenchmark = KAITOPrefix + "disable-benchmark"
 
 	// AnnotationPerformanceMode selects the vLLM performance preset.
 	// Valid values are "balanced" (default), "interactivity", and "throughput".
@@ -106,10 +106,11 @@ func GetWorkspaceRuntimeName(ws *Workspace) model.RuntimeName {
 	return runtime
 }
 
-// IsRunBenchmarkEnabled reports whether the workspace has the benchmark
-// annotation set to "true".
+// IsRunBenchmarkEnabled reports whether the workspace benchmark is enabled.
+// The benchmark is on by default; it is only disabled when the annotation
+// kaito.sh/disable-benchmark is explicitly set to "true".
 func IsRunBenchmarkEnabled(ws *Workspace) bool {
-	return ws.Annotations[AnnotationRunBenchmark] == "true"
+	return ws.Annotations[AnnotationDisableBenchmark] != "true"
 }
 
 // GetPerformanceMode returns the performance mode annotation value, defaulting to

--- a/api/v1beta1/labels.go
+++ b/api/v1beta1/labels.go
@@ -113,6 +113,18 @@ func IsRunBenchmarkEnabled(ws *Workspace) bool {
 	return ws.Annotations[AnnotationDisableBenchmark] != "true"
 }
 
+// ShouldRunBenchmark reports whether the workspace should run the post-load
+// benchmark. The benchmark requires all of the following:
+//  1. The benchmark is not disabled via annotation.
+//  2. The workspace uses the vLLM runtime (benchmark_entrypoint.py is vLLM-only).
+//  3. The workspace uses a preset inference config (template workspaces use
+//     custom containers that do not include the benchmark entrypoint).
+func ShouldRunBenchmark(ws *Workspace) bool {
+	return IsRunBenchmarkEnabled(ws) &&
+		GetWorkspaceRuntimeName(ws) == model.RuntimeNameVLLM &&
+		ws.Inference != nil && ws.Inference.Preset != nil
+}
+
 // GetPerformanceMode returns the performance mode annotation value, defaulting to
 // PerformanceModeBalanced when the annotation is absent or empty.
 func GetPerformanceMode(ws *Workspace) string {

--- a/api/v1beta1/workspace_types.go
+++ b/api/v1beta1/workspace_types.go
@@ -234,7 +234,7 @@ type WorkspaceStatus struct {
 	TargetNodeCount int32 `json:"targetNodeCount,omitempty"`
 
 	// Performance holds the metrics from the post-load inference benchmark.
-	// Only populated when the kaito.sh/run-benchmark annotation is "true".
+	// Populated by default; omitted when kaito.sh/disable-benchmark is set to "true".
 	// +optional
 	Performance *Performance `json:"performance,omitempty"`
 }

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -319,7 +319,7 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 		status.ReadyReplicas = readyReplicas
 		// set selector for HPA/VPA
 		status.Selector = fmt.Sprintf("%s=%s", consts.WorkspaceCreatedByInferenceSetLabel, iObj.Name)
-		if kaitov1alpha1.IsRunBenchmarkEnabled(iObj) {
+		if kaitov1alpha1.ShouldRunBenchmark(iObj) {
 			if hasBenchmarkTPMResult {
 				if status.Performance == nil {
 					status.Performance = &kaitov1alpha1.Performance{}
@@ -374,7 +374,7 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 	}
 
 	// Surface benchmark progress when the annotation is set.
-	if kaitov1alpha1.IsRunBenchmarkEnabled(iObj) {
+	if kaitov1alpha1.ShouldRunBenchmark(iObj) {
 		if benchmarkedReplicas == iObj.Spec.Replicas && iObj.Spec.Replicas > 0 {
 			if err = inferenceset.UpdateStatusConditionIfNotMatch(ctx, c.Client, iObj, kaitov1alpha1.InferenceSetConditionTypeBenchmarkCompleted, metav1.ConditionTrue,
 				"BenchmarkCompleted", fmt.Sprintf("%d/%d replicas benchmarked", benchmarkedReplicas, iObj.Spec.Replicas)); err != nil {

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -284,13 +284,13 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 
 			// Start with annotations from the template metadata.
 			workspaceAnnotations := maps.Clone(iObj.Spec.Template.Annotations)
-			// Propagate the run-benchmark annotation so each workspace runs the
-			// post-load benchmark and the InferenceSet can aggregate the TPM results.
-			if kaitov1alpha1.IsRunBenchmarkEnabled(iObj) {
+			// Propagate the disable-benchmark opt-out so each child workspace inherits it.
+			// Benchmark is on by default; only propagate when explicitly disabled.
+			if !kaitov1alpha1.IsRunBenchmarkEnabled(iObj) {
 				if workspaceAnnotations == nil {
 					workspaceAnnotations = make(map[string]string)
 				}
-				workspaceAnnotations[kaitov1beta1.AnnotationRunBenchmark] = "true"
+				workspaceAnnotations[kaitov1beta1.AnnotationDisableBenchmark] = "true"
 			}
 			workspaceObj.Annotations = workspaceAnnotations
 			workspaceObj.OwnerReferences = []metav1.OwnerReference{

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -388,14 +388,14 @@ func TestInferenceSetBenchmarkAggregation(t *testing.T) {
 		return ws
 	}
 
-	makeInferenceSet := func(replicas int, withBenchmarkAnnotation bool) *v1alpha1.InferenceSet {
+	makeInferenceSet := func(replicas int, benchmarkOff bool) *v1alpha1.InferenceSet {
 		iObj := &v1alpha1.InferenceSet{
 			ObjectMeta: v1.ObjectMeta{Name: "phi-4-mini", Namespace: "default"},
 			Spec:       v1alpha1.InferenceSetSpec{Replicas: replicas},
 		}
-		if withBenchmarkAnnotation {
+		if benchmarkOff {
 			iObj.Annotations = map[string]string{
-				v1alpha1.AnnotationRunBenchmark: "true",
+				v1alpha1.AnnotationDisableBenchmark: "true",
 			}
 		}
 		return iObj
@@ -414,7 +414,7 @@ func TestInferenceSetBenchmarkAggregation(t *testing.T) {
 				makeWorkspace("ws-0", "100000"),
 				makeWorkspace("ws-1", "200000"),
 			},
-			inferenceset:          makeInferenceSet(2, true),
+			inferenceset:          makeInferenceSet(2, false),
 			expectedTPM:           "300000",
 			expectBenchmarkCond:   true,
 			expectBenchmarkStatus: v1.ConditionTrue,
@@ -425,7 +425,7 @@ func TestInferenceSetBenchmarkAggregation(t *testing.T) {
 				makeWorkspace("ws-0", "100000"),
 				makeWorkspace("ws-1", ""), // no result yet
 			},
-			inferenceset:          makeInferenceSet(2, true),
+			inferenceset:          makeInferenceSet(2, false),
 			expectedTPM:           "100000",
 			expectBenchmarkCond:   true,
 			expectBenchmarkStatus: v1.ConditionFalse,
@@ -436,18 +436,18 @@ func TestInferenceSetBenchmarkAggregation(t *testing.T) {
 				makeWorkspace("ws-0", ""),
 				makeWorkspace("ws-1", ""),
 			},
-			inferenceset:          makeInferenceSet(2, true),
+			inferenceset:          makeInferenceSet(2, false),
 			expectedTPM:           "",
 			expectBenchmarkCond:   true,
 			expectBenchmarkStatus: v1.ConditionFalse,
 			expectBenchmarkMsg:    "0/2 replicas benchmarked",
 		},
-		"benchmark annotation absent — no condition set, TPM not written": {
+		"benchmark explicitly disabled — no condition set, TPM not written": {
 			workspaces: []v1beta1.Workspace{
 				makeWorkspace("ws-0", "100000"),
 			},
-			inferenceset: makeInferenceSet(1, false),
-			// TPM is aggregated regardless, but not written to status without the annotation.
+			inferenceset: makeInferenceSet(1, true),
+			// TPM is aggregated regardless, but not written to status when benchmark is disabled.
 			// We verify only that the annotation gate works, not the aggregation itself.
 			expectedTPM:         "100000",
 			expectBenchmarkCond: false,
@@ -458,7 +458,7 @@ func TestInferenceSetBenchmarkAggregation(t *testing.T) {
 				makeWorkspace("ws-0", "100000"),
 				makeWorkspace("ws-1", "200000"),
 			},
-			inferenceset:          makeInferenceSet(3, true),
+			inferenceset:          makeInferenceSet(3, false),
 			expectedTPM:           "300000",
 			expectBenchmarkCond:   true,
 			expectBenchmarkStatus: v1.ConditionFalse,

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -709,7 +709,7 @@ func applyInferenceWorkspaceStatus(ctx context.Context, status *kaitov1beta1.Wor
 		setWorkspaceCondition(status, generation, appendMessage,
 			kaitov1beta1.WorkspaceConditionTypeInferenceStatus, metav1.ConditionTrue, "WorkspaceInferenceStatusSuccess", "Inference has been deployed successfully")
 
-		if kaitov1beta1.IsRunBenchmarkEnabled(wObj) && kaitov1beta1.GetWorkspaceRuntimeName(wObj) == pkgmodel.RuntimeNameVLLM {
+		if kaitov1beta1.ShouldRunBenchmark(wObj) {
 			if err := applyBenchmarkStatus(ctx, status, wObj, generation, appendMessage); err != nil {
 				setWorkspaceCondition(status, generation, appendMessage,
 					kaitov1beta1.WorkspaceConditionTypeSucceeded, metav1.ConditionFalse, "BenchmarkFailed", err.Error())
@@ -730,7 +730,7 @@ func applyInferenceWorkspaceStatus(ctx context.Context, status *kaitov1beta1.Wor
 		kaitov1beta1.WorkspaceConditionTypeSucceeded, metav1.ConditionFalse, "workspacePending", "workspace is waiting for inference workload readiness")
 	// Clear benchmark state so applyBenchmarkStatus re-runs once inference recovers.
 	// This ensures a pod restart or rolling update doesn't leave stale results.
-	if kaitov1beta1.IsRunBenchmarkEnabled(wObj) && kaitov1beta1.GetWorkspaceRuntimeName(wObj) == pkgmodel.RuntimeNameVLLM {
+	if kaitov1beta1.ShouldRunBenchmark(wObj) {
 		meta.RemoveStatusCondition(&status.Conditions, string(kaitov1beta1.WorkspaceConditionTypeBenchmarkCompleted))
 		status.Performance = nil
 	}

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -709,7 +709,7 @@ func applyInferenceWorkspaceStatus(ctx context.Context, status *kaitov1beta1.Wor
 		setWorkspaceCondition(status, generation, appendMessage,
 			kaitov1beta1.WorkspaceConditionTypeInferenceStatus, metav1.ConditionTrue, "WorkspaceInferenceStatusSuccess", "Inference has been deployed successfully")
 
-		if kaitov1beta1.IsRunBenchmarkEnabled(wObj) {
+		if kaitov1beta1.IsRunBenchmarkEnabled(wObj) && kaitov1beta1.GetWorkspaceRuntimeName(wObj) == pkgmodel.RuntimeNameVLLM {
 			if err := applyBenchmarkStatus(ctx, status, wObj, generation, appendMessage); err != nil {
 				setWorkspaceCondition(status, generation, appendMessage,
 					kaitov1beta1.WorkspaceConditionTypeSucceeded, metav1.ConditionFalse, "BenchmarkFailed", err.Error())
@@ -730,7 +730,7 @@ func applyInferenceWorkspaceStatus(ctx context.Context, status *kaitov1beta1.Wor
 		kaitov1beta1.WorkspaceConditionTypeSucceeded, metav1.ConditionFalse, "workspacePending", "workspace is waiting for inference workload readiness")
 	// Clear benchmark state so applyBenchmarkStatus re-runs once inference recovers.
 	// This ensures a pod restart or rolling update doesn't leave stale results.
-	if kaitov1beta1.IsRunBenchmarkEnabled(wObj) {
+	if kaitov1beta1.IsRunBenchmarkEnabled(wObj) && kaitov1beta1.GetWorkspaceRuntimeName(wObj) == pkgmodel.RuntimeNameVLLM {
 		meta.RemoveStatusCondition(&status.Conditions, string(kaitov1beta1.WorkspaceConditionTypeBenchmarkCompleted))
 		status.Performance = nil
 	}

--- a/pkg/workspace/controllers/workspace_controller_test.go
+++ b/pkg/workspace/controllers/workspace_controller_test.go
@@ -1005,7 +1005,11 @@ func TestSyncWorkspaceStatus(t *testing.T) {
 			expectedSucceededStatus:  v1.ConditionFalse,
 		},
 		"inference ready": {
-			workspace: test.MockWorkspaceDistributedModel.DeepCopy(),
+			workspace: func() *v1beta1.Workspace {
+				ws := test.MockWorkspaceDistributedModel.DeepCopy()
+				ws.Annotations = map[string]string{v1beta1.AnnotationDisableBenchmark: "true"}
+				return ws
+			}(),
 			statefulSet: &appsv1.StatefulSet{
 				ObjectMeta: v1.ObjectMeta{Name: test.MockWorkspaceDistributedModel.Name, Namespace: test.MockWorkspaceDistributedModel.Namespace},
 				Spec: appsv1.StatefulSetSpec{
@@ -1168,7 +1172,8 @@ func TestBuildReconcileErrMessageAppender(t *testing.T) {
 func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 	t.Run("ready when inference and resource are ready", func(t *testing.T) {
 		status := &v1beta1.WorkspaceStatus{State: v1beta1.WorkspaceStatePending}
-		applyInferenceWorkspaceStatus(context.Background(), status, &v1beta1.Workspace{}, buildReconcileErrMessageAppender(nil), true, v1.ConditionTrue)
+		wObj := &v1beta1.Workspace{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{v1beta1.AnnotationDisableBenchmark: "true"}}}
+		applyInferenceWorkspaceStatus(context.Background(), status, wObj, buildReconcileErrMessageAppender(nil), true, v1.ConditionTrue)
 
 		assert.Equal(t, v1beta1.WorkspaceStateReady, status.State)
 		inferenceCondition := meta.FindStatusCondition(status.Conditions, string(v1beta1.WorkspaceConditionTypeInferenceStatus))
@@ -1190,11 +1195,9 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 		assert.Equal(t, v1.ConditionFalse, inferenceCondition.Status)
 	})
 
-	t.Run("not-ready path clears benchmark condition and result when annotation is set", func(t *testing.T) {
+	t.Run("not-ready path clears benchmark condition and result (benchmark on by default)", func(t *testing.T) {
 		wObj := &v1beta1.Workspace{
-			ObjectMeta: v1.ObjectMeta{
-				Annotations: map[string]string{v1beta1.AnnotationRunBenchmark: "true"},
-			},
+			ObjectMeta: v1.ObjectMeta{},
 		}
 		// Pre-populate status as if a previous reconcile completed the benchmark.
 		status := &v1beta1.WorkspaceStatus{
@@ -1224,9 +1227,8 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 	t.Run("benchmark guard skips StreamLogs when BenchmarkCompleted is already True", func(t *testing.T) {
 		wObj := &v1beta1.Workspace{
 			ObjectMeta: v1.ObjectMeta{
-				Name:        "ws",
-				Namespace:   "default",
-				Annotations: map[string]string{v1beta1.AnnotationRunBenchmark: "true"},
+				Name:      "ws",
+				Namespace: "default",
 			},
 		}
 		status := &v1beta1.WorkspaceStatus{

--- a/pkg/workspace/controllers/workspace_controller_test.go
+++ b/pkg/workspace/controllers/workspace_controller_test.go
@@ -1198,6 +1198,11 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 	t.Run("not-ready path clears benchmark condition and result (benchmark on by default)", func(t *testing.T) {
 		wObj := &v1beta1.Workspace{
 			ObjectMeta: v1.ObjectMeta{},
+			Inference: &v1beta1.InferenceSpec{
+				Preset: &v1beta1.PresetSpec{
+					PresetMeta: v1beta1.PresetMeta{Name: "test-model"},
+				},
+			},
 		}
 		// Pre-populate status as if a previous reconcile completed the benchmark.
 		status := &v1beta1.WorkspaceStatus{

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -193,7 +193,7 @@ func GeneratePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspac
 	if distributed {
 		podOpts = append(podOpts, SetDistributedInferenceProbe)
 	}
-	if v1beta1.IsRunBenchmarkEnabled(workspaceObj) && v1beta1.GetWorkspaceRuntimeName(workspaceObj) == pkgmodel.RuntimeNameVLLM {
+	if v1beta1.ShouldRunBenchmark(workspaceObj) {
 		podOpts = append(podOpts, SetBenchmarkConfig(distributed))
 	}
 

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -193,7 +193,7 @@ func GeneratePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspac
 	if distributed {
 		podOpts = append(podOpts, SetDistributedInferenceProbe)
 	}
-	if v1beta1.IsRunBenchmarkEnabled(workspaceObj) {
+	if v1beta1.IsRunBenchmarkEnabled(workspaceObj) && v1beta1.GetWorkspaceRuntimeName(workspaceObj) == pkgmodel.RuntimeNameVLLM {
 		podOpts = append(podOpts, SetBenchmarkConfig(distributed))
 	}
 

--- a/test/e2e/preset_azurelinux_test.go
+++ b/test/e2e/preset_azurelinux_test.go
@@ -56,6 +56,7 @@ var _ = Describe("Workspace Preset AzureLinux", utils.GinkgoLabelAzureLinux, fun
 		validateInferenceResource(workspaceObj, int32(numOfNode))
 
 		validateWorkspaceReadiness(workspaceObj)
+		validateWorkspaceBenchmarkCompleted(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
 		validateChatCompletionsEndpoint(workspaceObj)
 	})

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -307,7 +307,6 @@ func GenerateInferenceWorkspaceManifestWithVLLM(name, namespace, imageName strin
 		workspace.Annotations = make(map[string]string)
 	}
 	workspace.Annotations[kaitov1beta1.AnnotationWorkspaceRuntime] = string(model.RuntimeNameVLLM)
-	workspace.Annotations[kaitov1beta1.AnnotationRunBenchmark] = "true"
 	return workspace
 }
 
@@ -322,7 +321,6 @@ func GenerateInferenceSetManifestWithVLLM(name, namespace, imageName string, rep
 		inferenceSet.Annotations = make(map[string]string)
 	}
 	inferenceSet.Annotations[kaitov1beta1.AnnotationWorkspaceRuntime] = string(model.RuntimeNameVLLM)
-	inferenceSet.Annotations[kaitov1alpha1.AnnotationRunBenchmark] = "true"
 	return inferenceSet
 }
 

--- a/website/docs/inference.md
+++ b/website/docs/inference.md
@@ -139,6 +139,35 @@ Key vLLM parameters include:
 
 For the complete list of vLLM parameters, refer to the [vLLM documentation](https://docs.vllm.ai/en/latest/serving/engine_args.html).
 
+### Inference benchmark
+
+When using the vLLM runtime, KAITO automatically runs a post-load throughput benchmark (via [guidellm](https://github.com/neuralmagic/guidellm)) after the model loads and before marking the workspace as ready. The benchmark result is stored in `status.performance.metrics` and the `BenchmarkCompleted` condition is set on the workspace.
+
+To disable the benchmark, set the `kaito.sh/disable-benchmark` annotation to `"true"` on a Workspace or InferenceSet:
+
+```yaml
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  name: workspace-phi-4-mini
+  annotations:
+    kaito.sh/disable-benchmark: "true"
+resource:
+  instanceType: "Standard_NC24ads_A100_v4"
+  labelSelector:
+    matchLabels:
+      apps: phi-4-mini
+inference:
+  preset:
+    name: "phi-4-mini"
+```
+
+When set on an InferenceSet, the annotation is propagated to all child Workspaces it creates.
+
+:::note
+The benchmark only runs with the vLLM runtime. It is not supported with the `transformers` runtime.
+:::
+
 ### Inference with LoRA adapters
 
 KAITO also supports running the inference workload with LoRA adapters produced by [model fine-tuning jobs](./tuning.md). Users can specify one or more adapters in the `adapters` field of the `inference` spec. For example,


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
Enabled TPM benchmark by default, disabled it for non-vllm runtime, and added documentations for the disable annotation.

Removed the original `run-benchmark` annotation, and added `disable-benchmark: true` annotation on workspace and inferenceset to disable benchmarking.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Closes #2015 
**Notes for Reviewers**: