### PR TITLE
feat: 1952 integrate karpenter provisioner

### DIFF
--- a/pkg/nodeprovision/karpenter/nodepool.go
+++ b/pkg/nodeprovision/karpenter/nodepool.go
@@ -28,7 +28,6 @@ import (
 
 const (
 	maxNodePoolNameLen = 253
-	maxLabelValueLen   = 63
 	hashSuffixLen      = 9
 )
 
@@ -52,14 +51,6 @@ func NodePoolName(workspaceNamespace, workspaceName string) string {
 	return truncatedName(workspaceNamespace, workspaceName, maxNodePoolNameLen)
 }
 
-// WorkspaceLabelValue returns a deterministic, label-safe value (≤63 chars)
-// derived from the workspace namespace and name.
-// Used for labels, taints, tolerations, and nodeSelectors — all of which
-// enforce the Kubernetes 63-character label value limit.
-func WorkspaceLabelValue(workspaceNamespace, workspaceName string) string {
-	return truncatedName(workspaceNamespace, workspaceName, maxLabelValueLen)
-}
-
 // resolveNodeClassName determines the NodeClass resource name for a Workspace.
 // It checks for the node-class-name annotation on the workspace, then falls
 // back to the configured default.
@@ -79,7 +70,6 @@ func isInferenceSetWorkspace(ws *kaitov1beta1.Workspace) bool {
 // generateNodePool builds a karpenter NodePool manifest for the given Workspace.
 func generateNodePool(ws *kaitov1beta1.Workspace, cfg NodeClassConfig) *karpenterv1.NodePool {
 	nodePoolName := NodePoolName(ws.Namespace, ws.Name)
-	workspaceLabelVal := WorkspaceLabelValue(ws.Namespace, ws.Name)
 	nodeClassName := resolveNodeClassName(ws, cfg)
 
 	// Drift budget: InferenceSet workspaces start with "0" (blocked),
@@ -91,7 +81,6 @@ func generateNodePool(ws *kaitov1beta1.Workspace, cfg NodeClassConfig) *karpente
 
 	// Template labels propagated to NodeClaims and Nodes.
 	templateLabels := map[string]string{
-		consts.KarpenterWorkspaceKey:          workspaceLabelVal,
 		consts.KarpenterWorkspaceNameKey:      ws.Name,
 		consts.KarpenterWorkspaceNamespaceKey: ws.Namespace,
 	}
@@ -148,8 +137,8 @@ func generateNodePool(ws *kaitov1beta1.Workspace, cfg NodeClassConfig) *karpente
 					},
 					Taints: []corev1.Taint{
 						{
-							Key:    consts.KarpenterWorkspaceKey,
-							Value:  workspaceLabelVal,
+							Key:    consts.SKUString,
+							Value:  consts.GPUString,
 							Effect: corev1.TaintEffectNoSchedule,
 						},
 					},

--- a/pkg/nodeprovision/karpenter/nodepool_test.go
+++ b/pkg/nodeprovision/karpenter/nodepool_test.go
@@ -141,6 +141,11 @@ func newTestWorkspace(ns, name, instanceType string, targetNodeCount int32, labe
 		},
 		Resource: kaitov1beta1.ResourceSpec{
 			InstanceType: instanceType,
+			LabelSelector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"apps": "llm",
+				},
+			},
 		},
 		Status: kaitov1beta1.WorkspaceStatus{
 			TargetNodeCount: targetNodeCount,
@@ -160,7 +165,6 @@ func TestGenerateNodePool_Standalone(t *testing.T) {
 	assert.Equal(t, consts.KarpenterManagedByValue, np.Labels[consts.KarpenterLabelManagedBy])
 
 	// Template labels
-	assert.Equal(t, "default-llama-serve", np.Spec.Template.Labels[consts.KarpenterWorkspaceKey])
 	assert.Equal(t, "llama-serve", np.Spec.Template.Labels[consts.KarpenterWorkspaceNameKey])
 	assert.Equal(t, "default", np.Spec.Template.Labels[consts.KarpenterWorkspaceNamespaceKey])
 
@@ -184,8 +188,8 @@ func TestGenerateNodePool_Standalone(t *testing.T) {
 	// Taints
 	assert.Equal(t, 1, len(np.Spec.Template.Spec.Taints))
 	taint := np.Spec.Template.Spec.Taints[0]
-	assert.Equal(t, consts.KarpenterWorkspaceKey, taint.Key)
-	assert.Equal(t, "default-llama-serve", taint.Value)
+	assert.Equal(t, consts.SKUString, taint.Key)
+	assert.Equal(t, consts.GPUString, taint.Value)
 	assert.Equal(t, corev1.TaintEffectNoSchedule, taint.Effect)
 
 	// Disruption — standalone gets budget "1"

--- a/pkg/nodeprovision/karpenter/provisioner.go
+++ b/pkg/nodeprovision/karpenter/provisioner.go
@@ -230,17 +230,24 @@ func (p *KarpenterProvisioner) waitForNodeClassReady(ctx context.Context, name s
 	})
 }
 
-// countReadyNodes returns the number of non-karpenter ready nodes and the total
-// ready nodes matching the workspace's label selector and instance type.
-// Non-karpenter nodes are those without the karpenter workspace-name label (BYO + legacy).
-func countReadyNodes(ctx context.Context, c client.Client, ws *kaitov1beta1.Workspace) (nonKarpenter int, total int, err error) {
+// countCoveredNodes returns:
+//   - coveredByNonKarpenter: nodes already handled outside karpenter. This includes:
+//     (a) Ready BYO nodes (no NodeClaim, user-managed)
+//     (b) Non-deleting legacy gpu-provisioner NodeClaims (whether their node is ready or not,
+//     because karpenter will either self-heal them or delete them after a timeout,
+//     at which point a reconcile is triggered via the NodeClaim watch)
+//   - readyWithInstanceType: total ready nodes (BYO + legacy + karpenter) with correct instance type.
+func countCoveredNodes(ctx context.Context, c client.Client, ws *kaitov1beta1.Workspace) (coveredByNonKarpenter int, readyWithInstanceType int, err error) {
 	if ws.Resource.LabelSelector == nil {
 		return 0, 0, nil
 	}
+
+	// Count ready nodes (all types).
 	nodeList, err := resources.ListNodes(ctx, c, ws.Resource.LabelSelector.MatchLabels)
 	if err != nil {
 		return 0, 0, fmt.Errorf("listing nodes: %w", err)
 	}
+	byoCount := 0
 	for i := range nodeList.Items {
 		node := &nodeList.Items[i]
 		if !resources.NodeIsReadyAndNotDeleting(node) {
@@ -249,16 +256,41 @@ func countReadyNodes(ctx context.Context, c client.Client, ws *kaitov1beta1.Work
 		if node.Labels[corev1.LabelInstanceTypeStable] != ws.Resource.InstanceType {
 			continue
 		}
-		total++
-		if _, isKarpenter := node.Labels[consts.KarpenterWorkspaceNameKey]; !isKarpenter {
-			nonKarpenter++
+		readyWithInstanceType++
+		// BYO nodes: ready, correct instance type, no karpenter label, no legacy label.
+		_, isKarpenter := node.Labels[consts.KarpenterWorkspaceNameKey]
+		_, isLegacy := node.Labels[kaitov1beta1.LabelWorkspaceName]
+		if !isKarpenter && !isLegacy {
+			byoCount++
 		}
 	}
-	return nonKarpenter, total, nil
+
+	// Count non-deleting legacy NodeClaims (whether ready or not).
+	// These are covered because karpenter engine will self-heal the node or
+	// delete the NodeClaim after a timeout (triggering a reconcile).
+	legacyNodeClaimList := &karpenterv1.NodeClaimList{}
+	if err := c.List(ctx, legacyNodeClaimList,
+		client.MatchingLabels{
+			kaitov1beta1.LabelWorkspaceName:      ws.Name,
+			kaitov1beta1.LabelWorkspaceNamespace: ws.Namespace,
+		},
+	); err != nil {
+		return 0, 0, fmt.Errorf("listing legacy NodeClaims: %w", err)
+	}
+	legacyCount := 0
+	for i := range legacyNodeClaimList.Items {
+		nc := &legacyNodeClaimList.Items[i]
+		if nc.DeletionTimestamp.IsZero() {
+			legacyCount++
+		}
+	}
+
+	coveredByNonKarpenter = byoCount + legacyCount
+	return coveredByNonKarpenter, readyWithInstanceType, nil
 }
 
 // ProvisionNodes creates or updates a NodePool for the Workspace.
-// Computes delta-based replicas: desiredReplicas = max(0, targetNodeCount - nonKarpenterReadyCount).
+// Computes delta-based replicas: desiredReplicas = max(0, targetNodeCount - coveredByNonKarpenterCount).
 // If no NodePool exists and desiredReplicas is 0, no NodePool is created.
 // If a NodePool exists, replicas are only increased (never decreased) to avoid
 // disrupting running karpenter nodes when BYO nodes appear.
@@ -269,12 +301,12 @@ func (p *KarpenterProvisioner) ProvisionNodes(ctx context.Context, ws *kaitov1be
 	}
 
 	// Count non-karpenter ready nodes to compute delta.
-	nonKarpenterCount, _, err := countReadyNodes(ctx, p.client, ws)
+	coveredCount, _, err := countCoveredNodes(ctx, p.client, ws)
 	if err != nil {
 		return fmt.Errorf("counting non-karpenter nodes: %w", err)
 	}
 
-	desiredReplicas := int64(ws.Status.TargetNodeCount) - int64(nonKarpenterCount)
+	desiredReplicas := int64(ws.Status.TargetNodeCount) - int64(coveredCount)
 	if desiredReplicas <= 0 {
 		return nil
 	}
@@ -314,7 +346,7 @@ func (p *KarpenterProvisioner) ProvisionNodes(ctx context.Context, ws *kaitov1be
 	klog.InfoS("Updated NodePool replicas",
 		"nodePool", nodePoolName,
 		"desiredReplicas", desiredReplicas,
-		"nonKarpenterNodes", nonKarpenterCount,
+		"coveredByNonKarpenter", coveredCount,
 		"targetNodeCount", ws.Status.TargetNodeCount)
 	return nil
 }
@@ -347,7 +379,7 @@ func (p *KarpenterProvisioner) DeleteNodes(ctx context.Context, ws *kaitov1beta1
 // duplicating the same list+count logic.
 type nodeReadinessSnapshot struct {
 	readyWithInstanceTypeCount int
-	nonKarpenterReadyCount     int
+	coveredByNonKarpenterCount int
 	targetNodeClaimCount       int
 	readyNodeClaims            []*karpenterv1.NodeClaim
 }
@@ -373,16 +405,16 @@ func (p *KarpenterProvisioner) buildNodeReadinessSnapshot(ctx context.Context, w
 	}
 
 	// Count all ready nodes matching workspace labels (BYO + legacy + karpenter).
-	nonKarpenterReadyCount, readyWithInstanceTypeCount, err := countReadyNodes(ctx, p.client, ws)
+	coveredByNonKarpenterCount, readyWithInstanceTypeCount, err := countCoveredNodes(ctx, p.client, ws)
 	if err != nil {
 		return nil, fmt.Errorf("counting ready nodes: %w", err)
 	}
 
-	targetNodeClaimCount := max(0, int(ws.Status.TargetNodeCount)-nonKarpenterReadyCount)
+	targetNodeClaimCount := max(0, int(ws.Status.TargetNodeCount)-coveredByNonKarpenterCount)
 
 	return &nodeReadinessSnapshot{
 		readyWithInstanceTypeCount: readyWithInstanceTypeCount,
-		nonKarpenterReadyCount:     nonKarpenterReadyCount,
+		coveredByNonKarpenterCount: coveredByNonKarpenterCount,
 		targetNodeClaimCount:       targetNodeClaimCount,
 		readyNodeClaims:            readyNodeClaims,
 	}, nil

--- a/pkg/nodeprovision/karpenter/provisioner.go
+++ b/pkg/nodeprovision/karpenter/provisioner.go
@@ -378,10 +378,18 @@ func (p *KarpenterProvisioner) DeleteNodes(ctx context.Context, ws *kaitov1beta1
 // for a workspace. Used by EnsureNodesReady and CollectNodeStatusInfo to avoid
 // duplicating the same list+count logic.
 type nodeReadinessSnapshot struct {
+	// readyWithInstanceTypeCount is the total number of ready nodes (BYO + legacy + karpenter)
+	// that have the correct instance type for the workspace. Used to determine overall node readiness.
 	readyWithInstanceTypeCount int
+	// coveredByNonKarpenterCount is the number of nodes already handled outside karpenter:
+	// ready BYO nodes + non-deleting legacy gpu-provisioner NodeClaims (regardless of node readiness).
 	coveredByNonKarpenterCount int
-	targetNodeClaimCount       int
-	readyNodeClaims            []*karpenterv1.NodeClaim
+	// targetNodeClaimCount is the number of karpenter NodeClaims needed:
+	// max(0, ws.Status.TargetNodeCount - coveredByNonKarpenterCount).
+	targetNodeClaimCount int
+	// readyNodeClaims is the subset of karpenter-managed NodeClaims that are Ready and not deleting.
+	// Used for GPU plugin readiness checks.
+	readyNodeClaims []*karpenterv1.NodeClaim
 }
 
 // buildNodeReadinessSnapshot lists karpenter NodeClaims and all workspace nodes,

--- a/pkg/nodeprovision/karpenter/provisioner.go
+++ b/pkg/nodeprovision/karpenter/provisioner.go
@@ -230,18 +230,17 @@ func (p *KarpenterProvisioner) waitForNodeClassReady(ctx context.Context, name s
 	})
 }
 
-// countNonKarpenterReadyNodes returns the number of ready, non-deleting nodes
-// that match the workspace's label selector and instance type, excluding
-// karpenter-managed nodes (identified by the workspace-name label).
-func countNonKarpenterReadyNodes(ctx context.Context, c client.Client, ws *kaitov1beta1.Workspace) (int, error) {
+// countReadyNodes returns the number of non-karpenter ready nodes and the total
+// ready nodes matching the workspace's label selector and instance type.
+// Non-karpenter nodes are those without the karpenter workspace-name label (BYO + legacy).
+func countReadyNodes(ctx context.Context, c client.Client, ws *kaitov1beta1.Workspace) (nonKarpenter int, total int, err error) {
 	if ws.Resource.LabelSelector == nil {
-		return 0, nil
+		return 0, 0, nil
 	}
 	nodeList, err := resources.ListNodes(ctx, c, ws.Resource.LabelSelector.MatchLabels)
 	if err != nil {
-		return 0, fmt.Errorf("listing nodes: %w", err)
+		return 0, 0, fmt.Errorf("listing nodes: %w", err)
 	}
-	count := 0
 	for i := range nodeList.Items {
 		node := &nodeList.Items[i]
 		if !resources.NodeIsReadyAndNotDeleting(node) {
@@ -250,13 +249,12 @@ func countNonKarpenterReadyNodes(ctx context.Context, c client.Client, ws *kaito
 		if node.Labels[corev1.LabelInstanceTypeStable] != ws.Resource.InstanceType {
 			continue
 		}
-		// Exclude karpenter-managed nodes — they are tracked by the NodePool's replicas.
-		if _, isKarpenter := node.Labels[consts.KarpenterWorkspaceNameKey]; isKarpenter {
-			continue
+		total++
+		if _, isKarpenter := node.Labels[consts.KarpenterWorkspaceNameKey]; !isKarpenter {
+			nonKarpenter++
 		}
-		count++
 	}
-	return count, nil
+	return nonKarpenter, total, nil
 }
 
 // ProvisionNodes creates or updates a NodePool for the Workspace.
@@ -271,7 +269,7 @@ func (p *KarpenterProvisioner) ProvisionNodes(ctx context.Context, ws *kaitov1be
 	}
 
 	// Count non-karpenter ready nodes to compute delta.
-	nonKarpenterCount, err := countNonKarpenterReadyNodes(ctx, p.client, ws)
+	nonKarpenterCount, _, err := countReadyNodes(ctx, p.client, ws)
 	if err != nil {
 		return fmt.Errorf("counting non-karpenter nodes: %w", err)
 	}
@@ -296,6 +294,7 @@ func (p *KarpenterProvisioner) ProvisionNodes(ctx context.Context, ws *kaitov1be
 			}
 			return fmt.Errorf("creating NodePool %q: %w", np.Name, err)
 		}
+		klog.InfoS("Created NodePool", "nodePool", np.Name, "replicas", desiredReplicas, "workspace", klog.KObj(ws))
 		return nil
 	}
 
@@ -373,29 +372,10 @@ func (p *KarpenterProvisioner) buildNodeReadinessSnapshot(ctx context.Context, w
 		}
 	}
 
-	// List all nodes matching workspace labels (BYO + legacy + karpenter).
-	var matchLabels map[string]string
-	if ws.Resource.LabelSelector != nil {
-		matchLabels = ws.Resource.LabelSelector.MatchLabels
-	}
-	nodeList, err := resources.ListNodes(ctx, p.client, matchLabels)
+	// Count all ready nodes matching workspace labels (BYO + legacy + karpenter).
+	nonKarpenterReadyCount, readyWithInstanceTypeCount, err := countReadyNodes(ctx, p.client, ws)
 	if err != nil {
-		return nil, fmt.Errorf("listing nodes: %w", err)
-	}
-
-	readyWithInstanceTypeCount := 0
-	nonKarpenterReadyCount := 0
-	for i := range nodeList.Items {
-		node := &nodeList.Items[i]
-		if !resources.NodeIsReadyAndNotDeleting(node) {
-			continue
-		}
-		if node.Labels[corev1.LabelInstanceTypeStable] == ws.Resource.InstanceType {
-			readyWithInstanceTypeCount++
-			if _, ok := node.Labels[consts.KarpenterWorkspaceNameKey]; !ok {
-				nonKarpenterReadyCount++
-			}
-		}
+		return nil, fmt.Errorf("counting ready nodes: %w", err)
 	}
 
 	targetNodeClaimCount := max(0, int(ws.Status.TargetNodeCount)-nonKarpenterReadyCount)
@@ -412,8 +392,8 @@ func (p *KarpenterProvisioner) buildNodeReadinessSnapshot(ctx context.Context, w
 // Counts all node types (BYO, legacy, karpenter) against targetNodeCount.
 // Returns:
 //   - ready: true when all expected nodes are present, Ready, and have GPU resources available.
-//   - needRequeue: true when nodes are ready but GPU plugins are not yet installed
-//     (not event-driven, so the caller should poll again).
+//   - needRequeue: true when the caller should poll again because there is no watch/event
+//     that will trigger reconciliation (e.g., Node registration or GPU plugin installation).
 //   - err: non-nil on API errors.
 func (p *KarpenterProvisioner) EnsureNodesReady(ctx context.Context, ws *kaitov1beta1.Workspace) (bool, bool, error) {
 	snap, err := p.buildNodeReadinessSnapshot(ctx, ws)

--- a/pkg/nodeprovision/karpenter/provisioner.go
+++ b/pkg/nodeprovision/karpenter/provisioner.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -35,7 +36,9 @@ import (
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/nodeprovision"
 	"github.com/kaito-project/kaito/pkg/utils"
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/nodeclaim"
+	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/workspace/resource"
 )
 
@@ -227,20 +230,93 @@ func (p *KarpenterProvisioner) waitForNodeClassReady(ctx context.Context, name s
 	})
 }
 
-// ProvisionNodes creates a NodePool for the Workspace. Idempotent — AlreadyExists is ignored.
-// Before creating the NodePool, it verifies the target NodeClass exists and is Ready.
+// countNonKarpenterReadyNodes returns the number of ready, non-deleting nodes
+// that match the workspace's label selector and instance type, excluding
+// karpenter-managed nodes (identified by the workspace-name label).
+func countNonKarpenterReadyNodes(ctx context.Context, c client.Client, ws *kaitov1beta1.Workspace) (int, error) {
+	if ws.Resource.LabelSelector == nil {
+		return 0, nil
+	}
+	nodeList, err := resources.ListNodes(ctx, c, ws.Resource.LabelSelector.MatchLabels)
+	if err != nil {
+		return 0, fmt.Errorf("listing nodes: %w", err)
+	}
+	count := 0
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		if !resources.NodeIsReadyAndNotDeleting(node) {
+			continue
+		}
+		if node.Labels[corev1.LabelInstanceTypeStable] != ws.Resource.InstanceType {
+			continue
+		}
+		// Exclude karpenter-managed nodes — they are tracked by the NodePool's replicas.
+		if _, isKarpenter := node.Labels[consts.KarpenterWorkspaceNameKey]; isKarpenter {
+			continue
+		}
+		count++
+	}
+	return count, nil
+}
+
+// ProvisionNodes creates or updates a NodePool for the Workspace.
+// Computes delta-based replicas: desiredReplicas = max(0, targetNodeCount - nonKarpenterReadyNodes).
+// If no NodePool exists and desiredReplicas is 0, no NodePool is created.
+// If a NodePool exists, replicas are only increased (never decreased) to avoid
+// disrupting running karpenter nodes when BYO nodes appear.
 func (p *KarpenterProvisioner) ProvisionNodes(ctx context.Context, ws *kaitov1beta1.Workspace) error {
 	nodeClassName := resolveNodeClassName(ws, p.nodeClassConfig)
 	if err := p.checkNodeClassReady(ctx, nodeClassName); err != nil {
 		return fmt.Errorf("NodeClass %q is not ready: %w", nodeClassName, err)
 	}
-	np := generateNodePool(ws, p.nodeClassConfig)
-	if err := p.client.Create(ctx, np); err != nil {
-		if apierrors.IsAlreadyExists(err) {
-			return nil
-		}
-		return fmt.Errorf("creating NodePool %q: %w", np.Name, err)
+
+	// Count non-karpenter ready nodes to compute delta.
+	nonKarpenterCount, err := countNonKarpenterReadyNodes(ctx, p.client, ws)
+	if err != nil {
+		return fmt.Errorf("counting non-karpenter nodes: %w", err)
 	}
+
+	desiredReplicas := int64(ws.Status.TargetNodeCount) - int64(nonKarpenterCount)
+	if desiredReplicas <= 0 {
+		return nil
+	}
+
+	nodePoolName := NodePoolName(ws.Namespace, ws.Name)
+	existing := &karpenterv1.NodePool{}
+	err = p.client.Get(ctx, types.NamespacedName{Name: nodePoolName}, existing)
+	if err != nil {
+		if !apierrors.IsNotFound(err) {
+			return fmt.Errorf("getting NodePool %q: %w", nodePoolName, err)
+		}
+		np := generateNodePool(ws, p.nodeClassConfig)
+		np.Spec.Replicas = lo.ToPtr(desiredReplicas)
+		if err := p.client.Create(ctx, np); err != nil {
+			if apierrors.IsAlreadyExists(err) {
+				return nil
+			}
+			return fmt.Errorf("creating NodePool %q: %w", np.Name, err)
+		}
+		return nil
+	}
+
+	// NodePool exists — only increase replicas, never decrease.
+	// This protects running karpenter nodes when BYO nodes appear after provisioning.
+	currentReplicas := int64(0)
+	if existing.Spec.Replicas != nil {
+		currentReplicas = *existing.Spec.Replicas
+	}
+	if desiredReplicas <= currentReplicas {
+		return nil
+	}
+	existing.Spec.Replicas = lo.ToPtr(desiredReplicas)
+	if err := p.client.Update(ctx, existing); err != nil {
+		return fmt.Errorf("updating NodePool %q replicas to %d: %w", nodePoolName, desiredReplicas, err)
+	}
+	klog.InfoS("Updated NodePool replicas",
+		"nodePool", nodePoolName,
+		"desiredReplicas", desiredReplicas,
+		"nonKarpenterNodes", nonKarpenterCount,
+		"targetNodeCount", ws.Status.TargetNodeCount)
 	return nil
 }
 
@@ -267,39 +343,103 @@ func (p *KarpenterProvisioner) DeleteNodes(ctx context.Context, ws *kaitov1beta1
 	return nil
 }
 
-// EnsureNodesReady returns (true, false, nil) when all expected NodeClaims for
-// the Workspace are present, in Ready state, and have GPU resources available.
-// Returns needRequeue=true when NodeClaims are ready but GPU plugins are not,
-// since GPU readiness is not event-driven.
-func (p *KarpenterProvisioner) EnsureNodesReady(ctx context.Context, ws *kaitov1beta1.Workspace) (bool, bool, error) {
+// nodeReadinessSnapshot holds pre-computed data about node and NodeClaim readiness
+// for a workspace. Used by EnsureNodesReady and CollectNodeStatusInfo to avoid
+// duplicating the same list+count logic.
+type nodeReadinessSnapshot struct {
+	readyWithInstanceType int
+	nonKarpenterReady     int
+	targetNodeClaimCount  int
+	readyNodeClaims       []*karpenterv1.NodeClaim
+}
+
+// buildNodeReadinessSnapshot lists karpenter NodeClaims and all workspace nodes,
+// returning counts needed for readiness decisions.
+func (p *KarpenterProvisioner) buildNodeReadinessSnapshot(ctx context.Context, ws *kaitov1beta1.Workspace) (*nodeReadinessSnapshot, error) {
 	nodePoolName := NodePoolName(ws.Namespace, ws.Name)
 
+	// List karpenter NodeClaims.
 	nodeClaimList := &karpenterv1.NodeClaimList{}
 	if err := p.client.List(ctx, nodeClaimList,
 		client.MatchingLabels{karpenterv1.NodePoolLabelKey: nodePoolName},
 	); err != nil {
-		return false, false, fmt.Errorf("listing NodeClaims for NodePool %q: %w", nodePoolName, err)
+		return nil, fmt.Errorf("listing NodeClaims for NodePool %q: %w", nodePoolName, err)
 	}
 
-	if int32(len(nodeClaimList.Items)) < ws.Status.TargetNodeCount {
+	readyNodeClaims := make([]*karpenterv1.NodeClaim, 0, len(nodeClaimList.Items))
+	for i := range nodeClaimList.Items {
+		if nodeclaim.IsNodeClaimReadyNotDeleting(&nodeClaimList.Items[i]) {
+			readyNodeClaims = append(readyNodeClaims, &nodeClaimList.Items[i])
+		}
+	}
+
+	// List all nodes matching workspace labels (BYO + legacy + karpenter).
+	var matchLabels map[string]string
+	if ws.Resource.LabelSelector != nil {
+		matchLabels = ws.Resource.LabelSelector.MatchLabels
+	}
+	nodeList, err := resources.ListNodes(ctx, p.client, matchLabels)
+	if err != nil {
+		return nil, fmt.Errorf("listing nodes: %w", err)
+	}
+
+	readyWithInstanceType := 0
+	nonKarpenterReady := 0
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		if !resources.NodeIsReadyAndNotDeleting(node) {
+			continue
+		}
+		if node.Labels[corev1.LabelInstanceTypeStable] == ws.Resource.InstanceType {
+			readyWithInstanceType++
+			if _, ok := node.Labels[consts.KarpenterWorkspaceNameKey]; !ok {
+				nonKarpenterReady++
+			}
+		}
+	}
+
+	targetNodeClaimCount := max(0, int(ws.Status.TargetNodeCount)-nonKarpenterReady)
+
+	return &nodeReadinessSnapshot{
+		readyWithInstanceType: readyWithInstanceType,
+		nonKarpenterReady:     nonKarpenterReady,
+		targetNodeClaimCount:  targetNodeClaimCount,
+		readyNodeClaims:       readyNodeClaims,
+	}, nil
+}
+
+// EnsureNodesReady checks whether enough nodes are ready for the workspace.
+// Counts all node types (BYO, legacy, karpenter) against targetNodeCount.
+// Returns:
+//   - ready: true when all expected nodes are present, Ready, and have GPU resources available.
+//   - needRequeue: true when nodes are ready but GPU plugins are not yet installed
+//     (not event-driven, so the caller should poll again).
+//   - err: non-nil on API errors.
+func (p *KarpenterProvisioner) EnsureNodesReady(ctx context.Context, ws *kaitov1beta1.Workspace) (bool, bool, error) {
+	snap, err := p.buildNodeReadinessSnapshot(ctx, ws)
+	if err != nil {
+		return false, false, err
+	}
+
+	// Step 1: Check NodeClaim readiness.
+	if len(snap.readyNodeClaims) < snap.targetNodeClaimCount {
 		return false, false, nil
 	}
 
-	existingNodeClaims := make([]*karpenterv1.NodeClaim, 0, len(nodeClaimList.Items))
-	for i := range nodeClaimList.Items {
-		if !nodeclaim.IsNodeClaimReadyNotDeleting(&nodeClaimList.Items[i]) {
-			return false, false, nil
-		}
-		existingNodeClaims = append(existingNodeClaims, &nodeClaimList.Items[i])
+	// Step 2: Check that enough Nodes with the correct instance type are ready.
+	if snap.readyWithInstanceType < int(ws.Status.TargetNodeCount) {
+		return false, true, nil
 	}
 
-	// Verify GPU device plugins are ready on all provisioned nodes.
-	pluginReady, err := p.nodeResourceManager.CheckIfNodePluginsReady(ctx, ws, existingNodeClaims)
-	if err != nil {
-		return false, false, fmt.Errorf("checking GPU plugin readiness: %w", err)
-	}
-	if !pluginReady {
-		return false, true, nil // needRequeue=true, GPU not ready yet
+	// Step 3: Check GPU device plugins on karpenter nodes.
+	if len(snap.readyNodeClaims) > 0 {
+		pluginReady, err := p.nodeResourceManager.CheckIfNodePluginsReady(ctx, ws, snap.readyNodeClaims)
+		if err != nil {
+			return false, true, fmt.Errorf("checking GPU plugin readiness: %w", err)
+		}
+		if !pluginReady {
+			return false, true, nil
+		}
 	}
 
 	return true, false, nil
@@ -351,11 +491,9 @@ func (p *KarpenterProvisioner) setDriftBudget(ctx context.Context, workspaceName
 }
 
 // CollectNodeStatusInfo gathers status conditions for workspace status.
-// For karpenter, we check NodeClaim readiness and derive NodeStatus and
-// ResourceStatus from the same data.
+// Counts all ready nodes (BYO + legacy + karpenter) against targetNodeCount.
+// GPU plugin readiness is checked only on karpenter NodeClaims.
 func (p *KarpenterProvisioner) CollectNodeStatusInfo(ctx context.Context, ws *kaitov1beta1.Workspace) ([]metav1.Condition, error) {
-	nodePoolName := NodePoolName(ws.Namespace, ws.Name)
-
 	nodeClaimCond := metav1.Condition{
 		Type:    string(kaitov1beta1.ConditionTypeNodeClaimStatus),
 		Status:  metav1.ConditionFalse,
@@ -375,41 +513,46 @@ func (p *KarpenterProvisioner) CollectNodeStatusInfo(ctx context.Context, ws *ka
 		Message: "node claim or node status condition not ready",
 	}
 
-	nodeClaimList := &karpenterv1.NodeClaimList{}
-	if err := p.client.List(ctx, nodeClaimList,
-		client.MatchingLabels{karpenterv1.NodePoolLabelKey: nodePoolName},
-	); err != nil {
-		return nil, fmt.Errorf("listing NodeClaims for NodePool %q: %w", nodePoolName, err)
-	}
-
-	// Count ready NodeClaims and collect pointers for GPU check.
-	readyCount := 0
-	existingNodeClaims := make([]*karpenterv1.NodeClaim, 0, len(nodeClaimList.Items))
-	for i := range nodeClaimList.Items {
-		if nodeclaim.IsNodeClaimReadyNotDeleting(&nodeClaimList.Items[i]) {
-			readyCount++
-			existingNodeClaims = append(existingNodeClaims, &nodeClaimList.Items[i])
-		}
+	snap, err := p.buildNodeReadinessSnapshot(ctx, ws)
+	if err != nil {
+		return nil, err
 	}
 
 	targetCount := int(ws.Status.TargetNodeCount)
-	if readyCount >= targetCount {
+
+	// NodeClaim condition: are enough karpenter NodeClaims ready?
+	// Non-karpenter nodes (BYO, legacy gpu-provisioner) reduce the target —
+	// they don't have karpenter NodeClaims, so we only need NodeClaims for the remainder.
+	// Legacy gpu-provisioner nodes also have NodeClaims, but those are already stable
+	// and not managed by this provisioner, so we treat them like BYO here.
+	if len(snap.readyNodeClaims) >= snap.targetNodeClaimCount {
 		nodeClaimCond.Status = metav1.ConditionTrue
 		nodeClaimCond.Reason = "NodeClaimsReady"
 		nodeClaimCond.Message = "Enough NodeClaims are ready"
+	}
 
-		// Check GPU plugin readiness on the underlying nodes.
-		pluginReady, err := p.nodeResourceManager.CheckIfNodePluginsReady(ctx, ws, existingNodeClaims)
-		if err != nil {
-			return nil, fmt.Errorf("checking GPU plugin readiness: %w", err)
-		}
-		if pluginReady {
+	// Node condition: are enough nodes ready with GPU resources?
+	// Uses total ready node count (all types). GPU plugin check only applies
+	// to karpenter NodeClaims — BYO/legacy nodes are assumed GPU-ready.
+	if snap.readyWithInstanceType >= targetCount {
+		if len(snap.readyNodeClaims) > 0 {
+			pluginReady, err := p.nodeResourceManager.CheckIfNodePluginsReady(ctx, ws, snap.readyNodeClaims)
+			if err != nil {
+				return nil, fmt.Errorf("checking GPU plugin readiness: %w", err)
+			}
+			if pluginReady {
+				nodeCond.Status = metav1.ConditionTrue
+				nodeCond.Reason = "NodesReady"
+				nodeCond.Message = "Enough Nodes are ready with GPU resources"
+			} else {
+				nodeCond.Reason = "NodePluginsNotReady"
+				nodeCond.Message = "waiting all node plugins to be ready"
+			}
+		} else {
+			// No karpenter NodeClaims — all nodes are BYO/legacy, assume GPU ready.
 			nodeCond.Status = metav1.ConditionTrue
 			nodeCond.Reason = "NodesReady"
 			nodeCond.Message = "Enough Nodes are ready with GPU resources"
-		} else {
-			nodeCond.Reason = "GPUPluginNotReady"
-			nodeCond.Message = "GPU resources not yet available on nodes"
 		}
 	}
 

--- a/pkg/nodeprovision/karpenter/provisioner.go
+++ b/pkg/nodeprovision/karpenter/provisioner.go
@@ -349,8 +349,8 @@ func (p *KarpenterProvisioner) DeleteNodes(ctx context.Context, ws *kaitov1beta1
 type nodeReadinessSnapshot struct {
 	readyWithInstanceTypeCount int
 	nonKarpenterReadyCount     int
-	targetNodeClaimCount  int
-	readyNodeClaims       []*karpenterv1.NodeClaim
+	targetNodeClaimCount       int
+	readyNodeClaims            []*karpenterv1.NodeClaim
 }
 
 // buildNodeReadinessSnapshot lists karpenter NodeClaims and all workspace nodes,
@@ -403,8 +403,8 @@ func (p *KarpenterProvisioner) buildNodeReadinessSnapshot(ctx context.Context, w
 	return &nodeReadinessSnapshot{
 		readyWithInstanceTypeCount: readyWithInstanceTypeCount,
 		nonKarpenterReadyCount:     nonKarpenterReadyCount,
-		targetNodeClaimCount:  targetNodeClaimCount,
-		readyNodeClaims:       readyNodeClaims,
+		targetNodeClaimCount:       targetNodeClaimCount,
+		readyNodeClaims:            readyNodeClaims,
 	}, nil
 }
 

--- a/pkg/nodeprovision/karpenter/provisioner.go
+++ b/pkg/nodeprovision/karpenter/provisioner.go
@@ -71,18 +71,33 @@ func (p *KarpenterProvisioner) Name() string { return "KarpenterProvisioner" }
 
 const nodeClassConfigMapName = "kaito-nodeclasses"
 
-// Start verifies that the Karpenter NodeClass CRD is installed, creates
+// Start verifies that the Karpenter CRDs are installed, creates
 // NodeClass resources from the ConfigMap, and derives DefaultName from labels.
 // Returns an error if Karpenter is not installed.
 func (p *KarpenterProvisioner) Start(ctx context.Context) error {
-	// Check if the NodeClass CRD exists.
-	crdName := p.nodeClassConfig.ResourceName + "." + p.nodeClassConfig.Group
-	crd := &apiextensionsv1.CustomResourceDefinition{}
-	if err := p.client.Get(ctx, types.NamespacedName{Name: crdName}, crd); err != nil {
-		if apierrors.IsNotFound(err) {
-			return fmt.Errorf("NodeClass CRD %q not found — Karpenter must be installed before KAITO when node-provisioner=karpenter", crdName)
+	// Check if the core Karpenter CRDs exist.
+	coreCRDs := []string{
+		"nodepools.karpenter.sh",
+		"nodeclaims.karpenter.sh",
+	}
+	for _, crdName := range coreCRDs {
+		crd := &apiextensionsv1.CustomResourceDefinition{}
+		if err := p.client.Get(ctx, types.NamespacedName{Name: crdName}, crd); err != nil {
+			if apierrors.IsNotFound(err) {
+				return fmt.Errorf("CRD %q not found — Karpenter must be installed before KAITO when node-provisioner=karpenter", crdName)
+			}
+			return fmt.Errorf("checking CRD %q: %w", crdName, err)
 		}
-		return fmt.Errorf("checking NodeClass CRD %q: %w", crdName, err)
+	}
+
+	// Check if the provider-specific NodeClass CRD exists.
+	nodeClassCRDName := p.nodeClassConfig.ResourceName + "." + p.nodeClassConfig.Group
+	crd := &apiextensionsv1.CustomResourceDefinition{}
+	if err := p.client.Get(ctx, types.NamespacedName{Name: nodeClassCRDName}, crd); err != nil {
+		if apierrors.IsNotFound(err) {
+			return fmt.Errorf("NodeClass CRD %q not found — Karpenter provider must be installed before KAITO when node-provisioner=karpenter", nodeClassCRDName)
+		}
+		return fmt.Errorf("checking NodeClass CRD %q: %w", nodeClassCRDName, err)
 	}
 
 	releaseNS, err := utils.GetReleaseNamespace()

--- a/pkg/nodeprovision/karpenter/provisioner.go
+++ b/pkg/nodeprovision/karpenter/provisioner.go
@@ -260,7 +260,7 @@ func countNonKarpenterReadyNodes(ctx context.Context, c client.Client, ws *kaito
 }
 
 // ProvisionNodes creates or updates a NodePool for the Workspace.
-// Computes delta-based replicas: desiredReplicas = max(0, targetNodeCount - nonKarpenterReadyNodes).
+// Computes delta-based replicas: desiredReplicas = max(0, targetNodeCount - nonKarpenterReadyCount).
 // If no NodePool exists and desiredReplicas is 0, no NodePool is created.
 // If a NodePool exists, replicas are only increased (never decreased) to avoid
 // disrupting running karpenter nodes when BYO nodes appear.
@@ -347,8 +347,8 @@ func (p *KarpenterProvisioner) DeleteNodes(ctx context.Context, ws *kaitov1beta1
 // for a workspace. Used by EnsureNodesReady and CollectNodeStatusInfo to avoid
 // duplicating the same list+count logic.
 type nodeReadinessSnapshot struct {
-	readyWithInstanceType int
-	nonKarpenterReady     int
+	readyWithInstanceTypeCount int
+	nonKarpenterReadyCount     int
 	targetNodeClaimCount  int
 	readyNodeClaims       []*karpenterv1.NodeClaim
 }
@@ -383,26 +383,26 @@ func (p *KarpenterProvisioner) buildNodeReadinessSnapshot(ctx context.Context, w
 		return nil, fmt.Errorf("listing nodes: %w", err)
 	}
 
-	readyWithInstanceType := 0
-	nonKarpenterReady := 0
+	readyWithInstanceTypeCount := 0
+	nonKarpenterReadyCount := 0
 	for i := range nodeList.Items {
 		node := &nodeList.Items[i]
 		if !resources.NodeIsReadyAndNotDeleting(node) {
 			continue
 		}
 		if node.Labels[corev1.LabelInstanceTypeStable] == ws.Resource.InstanceType {
-			readyWithInstanceType++
+			readyWithInstanceTypeCount++
 			if _, ok := node.Labels[consts.KarpenterWorkspaceNameKey]; !ok {
-				nonKarpenterReady++
+				nonKarpenterReadyCount++
 			}
 		}
 	}
 
-	targetNodeClaimCount := max(0, int(ws.Status.TargetNodeCount)-nonKarpenterReady)
+	targetNodeClaimCount := max(0, int(ws.Status.TargetNodeCount)-nonKarpenterReadyCount)
 
 	return &nodeReadinessSnapshot{
-		readyWithInstanceType: readyWithInstanceType,
-		nonKarpenterReady:     nonKarpenterReady,
+		readyWithInstanceTypeCount: readyWithInstanceTypeCount,
+		nonKarpenterReadyCount:     nonKarpenterReadyCount,
 		targetNodeClaimCount:  targetNodeClaimCount,
 		readyNodeClaims:       readyNodeClaims,
 	}, nil
@@ -427,7 +427,7 @@ func (p *KarpenterProvisioner) EnsureNodesReady(ctx context.Context, ws *kaitov1
 	}
 
 	// Step 2: Check that enough Nodes with the correct instance type are ready.
-	if snap.readyWithInstanceType < int(ws.Status.TargetNodeCount) {
+	if snap.readyWithInstanceTypeCount < int(ws.Status.TargetNodeCount) {
 		return false, true, nil
 	}
 
@@ -534,7 +534,7 @@ func (p *KarpenterProvisioner) CollectNodeStatusInfo(ctx context.Context, ws *ka
 	// Node condition: are enough nodes ready with GPU resources?
 	// Uses total ready node count (all types). GPU plugin check only applies
 	// to karpenter NodeClaims — BYO/legacy nodes are assumed GPU-ready.
-	if snap.readyWithInstanceType >= targetCount {
+	if snap.readyWithInstanceTypeCount >= targetCount {
 		if len(snap.readyNodeClaims) > 0 {
 			pluginReady, err := p.nodeResourceManager.CheckIfNodePluginsReady(ctx, ws, snap.readyNodeClaims)
 			if err != nil {

--- a/pkg/nodeprovision/karpenter/provisioner.go
+++ b/pkg/nodeprovision/karpenter/provisioner.go
@@ -375,8 +375,7 @@ func (p *KarpenterProvisioner) DeleteNodes(ctx context.Context, ws *kaitov1beta1
 }
 
 // nodeReadinessSnapshot holds pre-computed data about node and NodeClaim readiness
-// for a workspace. Used by EnsureNodesReady and CollectNodeStatusInfo to avoid
-// duplicating the same list+count logic.
+// for a workspace.
 type nodeReadinessSnapshot struct {
 	// readyWithInstanceTypeCount is the total number of ready nodes (BYO + legacy + karpenter)
 	// that have the correct instance type for the workspace. Used to determine overall node readiness.

--- a/pkg/nodeprovision/karpenter/provisioner_test.go
+++ b/pkg/nodeprovision/karpenter/provisioner_test.go
@@ -21,20 +21,23 @@ import (
 	"github.com/awslabs/operatorpkg/status"
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/nodeprovision"
+	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
-	"github.com/kaito-project/kaito/pkg/utils/test"
 )
 
 var testConfig = NodeClassConfig{
@@ -45,49 +48,27 @@ var testConfig = NodeClassConfig{
 	DefaultName:  "image-family-ubuntu",
 }
 
-// mockNodeClassReady sets up a mock Get call for an unstructured NodeClass that
-// populates the object with a Ready=True condition.
-func mockNodeClassReady(mockClient *test.MockClient, name string) {
-	mockClient.On("Get", mock.IsType(context.Background()), mock.MatchedBy(func(key client.ObjectKey) bool {
-		return key.Name == name
-	}), mock.IsType(&unstructured.Unstructured{}), mock.Anything).
-		Run(func(args mock.Arguments) {
-			obj := args.Get(2).(*unstructured.Unstructured)
-			obj.Object = map[string]interface{}{
-				"status": map[string]interface{}{
-					"conditions": []interface{}{
-						map[string]interface{}{
-							"type":   "Ready",
-							"status": "True",
-						},
-					},
-				},
-			}
-		}).
-		Return(nil)
+// testScheme returns a scheme with all types needed for fake.Client tests.
+func testScheme() *runtime.Scheme {
+	s := runtime.NewScheme()
+	_ = corev1.AddToScheme(s)
+	_ = apiextensionsv1.AddToScheme(s)
+	_ = utils.KarpenterSchemeBuilder.AddToScheme(s)
+	return s
 }
 
-// mockEmptyNodeList sets up an empty NodeList for List calls.
-func mockEmptyNodeList(mockClient *test.MockClient) {
-	mockClient.CreateMapWithType(&corev1.NodeList{})
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+// newFakeClient creates a fake.Client with the test scheme and the given objects.
+func newFakeClient(objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(objs...).Build()
 }
 
-// mockEmptyLegacyNodeClaims sets up an empty NodeClaimList for legacy NodeClaim List calls.
-func mockEmptyLegacyNodeClaims(mockClient *test.MockClient) {
-	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
-}
-
-// mockNodePoolNotFound sets up a Get call for NodePool that returns NotFound.
-func mockNodePoolNotFound(mockClient *test.MockClient, name string) {
-	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "karpenter.sh", Resource: "nodepools"}, name)
-	mockClient.On("Get", mock.IsType(context.Background()), mock.MatchedBy(func(key client.ObjectKey) bool {
-		return key.Name == name
-	}), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(notFoundErr)
+// newFakeClientWithInterceptors creates a fake.Client with custom interceptor functions for error injection.
+func newFakeClientWithInterceptors(funcs interceptor.Funcs, objs ...client.Object) client.Client {
+	return fake.NewClientBuilder().WithScheme(testScheme()).WithObjects(objs...).WithInterceptorFuncs(funcs).Build()
 }
 
 // makeReadyNode creates a ready Node with the given name, instance type, and extra labels.
+// Always includes the workspace label selector label ("apps": "llm").
 func makeReadyNode(name, instanceType string, extraLabels map[string]string) *corev1.Node {
 	labels := map[string]string{
 		"apps":                         "llm",
@@ -109,22 +90,77 @@ func makeReadyNode(name, instanceType string, extraLabels map[string]string) *co
 	}
 }
 
+// makeNodeClassUnstructured creates an unstructured NodeClass object with Ready=True.
+func makeNodeClassUnstructured(name string) *unstructured.Unstructured {
+	obj := &unstructured.Unstructured{}
+	obj.SetGroupVersionKind(schema.GroupVersionKind{
+		Group:   testConfig.Group,
+		Version: testConfig.Version,
+		Kind:    testConfig.Kind,
+	})
+	obj.SetName(name)
+	obj.Object["status"] = map[string]interface{}{
+		"conditions": []interface{}{
+			map[string]interface{}{
+				"type":   "Ready",
+				"status": "True",
+			},
+		},
+	}
+	return obj
+}
+
+// makeLegacyNodeClaim creates a NodeClaim with legacy gpu-provisioner labels.
+func makeLegacyNodeClaim(name, wsName, wsNamespace string) *karpenterv1.NodeClaim {
+	return &karpenterv1.NodeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				kaitov1beta1.LabelWorkspaceName:      wsName,
+				kaitov1beta1.LabelWorkspaceNamespace: wsNamespace,
+			},
+		},
+	}
+}
+
+// makeKarpenterNodeClaim creates a NodeClaim owned by a karpenter NodePool.
+func makeKarpenterNodeClaim(name, nodePoolName string, ready bool) *karpenterv1.NodeClaim {
+	nc := &karpenterv1.NodeClaim{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+			Labels: map[string]string{
+				karpenterv1.NodePoolLabelKey: nodePoolName,
+			},
+		},
+	}
+	if ready {
+		nc.Status.Conditions = []status.Condition{
+			{Type: "Ready", Status: metav1.ConditionTrue},
+		}
+	}
+	return nc
+}
+
 func TestKarpenterProvisionerImplementsInterface(t *testing.T) {
-	mockClient := test.NewClient()
-	var _ nodeprovision.NodeProvisioner = NewKarpenterProvisioner(mockClient, testConfig)
+	var _ nodeprovision.NodeProvisioner = NewKarpenterProvisioner(newFakeClient(), testConfig)
 }
 
 func TestName(t *testing.T) {
-	p := NewKarpenterProvisioner(test.NewClient(), testConfig)
+	p := NewKarpenterProvisioner(newFakeClient(), testConfig)
 	assert.Equal(t, "KarpenterProvisioner", p.Name())
 }
 
 func TestStart_CRDNotFound(t *testing.T) {
-	mockClient := test.NewClient()
-	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"}, "aksnodeclasses.karpenter.azure.com")
-	mockClient.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&apiextensionsv1.CustomResourceDefinition{}), mock.Anything).Return(notFoundErr)
-
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	// Empty cluster — no CRDs registered.
+	c := newFakeClientWithInterceptors(interceptor.Funcs{
+		Get: func(ctx context.Context, client client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*apiextensionsv1.CustomResourceDefinition); ok {
+				return apierrors.NewNotFound(schema.GroupResource{Group: "apiextensions.k8s.io", Resource: "customresourcedefinitions"}, key.Name)
+			}
+			return client.Get(ctx, key, obj, opts...)
+		},
+	})
+	p := NewKarpenterProvisioner(c, testConfig)
 	err := p.Start(context.Background())
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "Karpenter must be installed")
@@ -133,214 +169,160 @@ func TestStart_CRDNotFound(t *testing.T) {
 // --- ProvisionNodes tests ---
 
 func TestProvisionNodes_NoBYONodes_CreatesWithFullReplicas(t *testing.T) {
-	mockClient := test.NewClient()
-	mockNodeClassReady(mockClient, "image-family-ubuntu")
-	mockEmptyNodeList(mockClient)
-	mockEmptyLegacyNodeClaims(mockClient)
-	mockNodePoolNotFound(mockClient, "default-ws1")
-	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
+	c := newFakeClient(nodeClass)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
 
 	err := p.ProvisionNodes(context.Background(), ws)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	// Verify replicas = targetNodeCount (2) since no BYO nodes.
-	for _, call := range mockClient.Calls {
-		if call.Method == "Create" {
-			if np, ok := call.Arguments[1].(*karpenterv1.NodePool); ok {
-				assert.Equal(t, int64(2), *np.Spec.Replicas)
-			}
-		}
-	}
+	// Verify NodePool was created with replicas=2.
+	np := &karpenterv1.NodePool{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, np)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), *np.Spec.Replicas)
 }
 
 func TestProvisionNodes_DeltaWithBYONodes(t *testing.T) {
-	mockClient := test.NewClient()
-	mockNodeClassReady(mockClient, "image-family-ubuntu")
+	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
+	byoNode := makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
+	c := newFakeClient(nodeClass, byoNode)
 
-	// 1 BYO node exists (ready, correct instance type, no karpenter label).
-	nodeList := &corev1.NodeList{}
-	nodeMap := mockClient.CreateMapWithType(nodeList)
-	nodeMap[client.ObjectKeyFromObject(makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil))] =
-		makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
-	mockEmptyLegacyNodeClaims(mockClient)
-
-	mockNodePoolNotFound(mockClient, "default-ws1")
-	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
-
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
 
 	err := p.ProvisionNodes(context.Background(), ws)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	// desiredReplicas = 2 - 1 = 1
-	for _, call := range mockClient.Calls {
-		if call.Method == "Create" {
-			if np, ok := call.Arguments[1].(*karpenterv1.NodePool); ok {
-				assert.Equal(t, int64(1), *np.Spec.Replicas)
-			}
-		}
-	}
+	np := &karpenterv1.NodePool{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, np)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), *np.Spec.Replicas)
 }
 
 func TestProvisionNodes_KarpenterNodesExcludedFromDelta(t *testing.T) {
-	mockClient := test.NewClient()
-	mockNodeClassReady(mockClient, "image-family-ubuntu")
-
-	// 1 karpenter node (has workspace-name label — excluded from non-karpenter count).
-	nodeList := &corev1.NodeList{}
-	nodeMap := mockClient.CreateMapWithType(nodeList)
-	karpenterNode := makeReadyNode("karpenter-1", "Standard_NC24ads_A100_v4", map[string]string{
+	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
+	// A karpenter node should NOT count toward non-karpenter coverage.
+	karpNode := makeReadyNode("karp-1", "Standard_NC24ads_A100_v4", map[string]string{
 		consts.KarpenterWorkspaceNameKey: "ws1",
 	})
-	nodeMap[client.ObjectKeyFromObject(karpenterNode)] = karpenterNode
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
-	mockEmptyLegacyNodeClaims(mockClient)
+	c := newFakeClient(nodeClass, karpNode)
 
-	mockNodePoolNotFound(mockClient, "default-ws1")
-	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
-
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
 
 	err := p.ProvisionNodes(context.Background(), ws)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	// desiredReplicas = 2 (karpenter node excluded from non-karpenter count).
-	for _, call := range mockClient.Calls {
-		if call.Method == "Create" {
-			if np, ok := call.Arguments[1].(*karpenterv1.NodePool); ok {
-				assert.Equal(t, int64(2), *np.Spec.Replicas)
-			}
-		}
-	}
+	np := &karpenterv1.NodePool{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, np)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), *np.Spec.Replicas)
 }
 
 func TestProvisionNodes_ZeroReplicasWhenBYOSufficient_NoCreateCalled(t *testing.T) {
-	mockClient := test.NewClient()
-	mockNodeClassReady(mockClient, "image-family-ubuntu")
+	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
+	byo1 := makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
+	byo2 := makeReadyNode("byo-2", "Standard_NC24ads_A100_v4", nil)
+	c := newFakeClient(nodeClass, byo1, byo2)
 
-	// 2 BYO nodes, target=2 → desiredReplicas=0, no NodePool should be created.
-	nodeList := &corev1.NodeList{}
-	nodeMap := mockClient.CreateMapWithType(nodeList)
-	for _, name := range []string{"byo-1", "byo-2"} {
-		node := makeReadyNode(name, "Standard_NC24ads_A100_v4", nil)
-		nodeMap[client.ObjectKeyFromObject(node)] = node
-	}
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
-	mockEmptyLegacyNodeClaims(mockClient)
-
-	mockNodePoolNotFound(mockClient, "default-ws1")
-
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
 
 	err := p.ProvisionNodes(context.Background(), ws)
-	assert.NoError(t, err)
-	mockClient.AssertNotCalled(t, "Create", mock.Anything, mock.IsType(&karpenterv1.NodePool{}), mock.Anything)
+	require.NoError(t, err)
+
+	// No NodePool should be created.
+	np := &karpenterv1.NodePool{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, np)
+	assert.True(t, apierrors.IsNotFound(err))
 }
 
 func TestProvisionNodes_DoesNotDecreaseReplicas(t *testing.T) {
-	mockClient := test.NewClient()
-	mockNodeClassReady(mockClient, "image-family-ubuntu")
-
-	// 1 BYO node appeared after NodePool was created with replicas=2.
-	nodeList := &corev1.NodeList{}
-	nodeMap := mockClient.CreateMapWithType(nodeList)
-	nodeMap[client.ObjectKeyFromObject(makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil))] =
-		makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
-	mockEmptyLegacyNodeClaims(mockClient)
-
-	// NodePool exists with replicas=2.
+	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
+	// 1 BYO appeared after NodePool was created with replicas=2.
+	byoNode := makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
 	existingNP := &karpenterv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{Name: "default-ws1"},
 		Spec:       karpenterv1.NodePoolSpec{Replicas: lo.ToPtr(int64(2))},
 	}
-	mockClient.CreateOrUpdateObjectInMap(existingNP)
-	mockClient.On("Get", mock.IsType(context.Background()), mock.MatchedBy(func(key client.ObjectKey) bool {
-		return key.Name == "default-ws1"
-	}), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+	c := newFakeClient(nodeClass, byoNode, existingNP)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
 
 	err := p.ProvisionNodes(context.Background(), ws)
-	assert.NoError(t, err)
-	// desiredReplicas=1 < currentReplicas=2 → no update.
-	mockClient.AssertNotCalled(t, "Update", mock.Anything, mock.IsType(&karpenterv1.NodePool{}), mock.Anything)
+	require.NoError(t, err)
+
+	// Replicas should remain 2 (not decrease to 1).
+	np := &karpenterv1.NodePool{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, np)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), *np.Spec.Replicas)
 }
 
 func TestProvisionNodes_IncreasesReplicas(t *testing.T) {
-	mockClient := test.NewClient()
-	mockNodeClassReady(mockClient, "image-family-ubuntu")
-	mockEmptyNodeList(mockClient)
-	mockEmptyLegacyNodeClaims(mockClient)
-
-	// NodePool exists with replicas=1, target=3, no BYO → desired=3 > current=1, should update.
+	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
 	existingNP := &karpenterv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{Name: "default-ws1"},
 		Spec:       karpenterv1.NodePoolSpec{Replicas: lo.ToPtr(int64(1))},
 	}
-	mockClient.CreateOrUpdateObjectInMap(existingNP)
-	mockClient.On("Get", mock.IsType(context.Background()), mock.MatchedBy(func(key client.ObjectKey) bool {
-		return key.Name == "default-ws1"
-	}), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
-	mockClient.On("Update", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+	c := newFakeClient(nodeClass, existingNP)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 3, nil, nil)
 
 	err := p.ProvisionNodes(context.Background(), ws)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	for _, call := range mockClient.Calls {
-		if call.Method == "Update" {
-			if np, ok := call.Arguments[1].(*karpenterv1.NodePool); ok {
-				assert.Equal(t, int64(3), *np.Spec.Replicas)
-			}
-		}
-	}
+	np := &karpenterv1.NodePool{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, np)
+	require.NoError(t, err)
+	assert.Equal(t, int64(3), *np.Spec.Replicas)
 }
 
 func TestProvisionNodes_NoUpdateWhenReplicasUnchanged(t *testing.T) {
-	mockClient := test.NewClient()
-	mockNodeClassReady(mockClient, "image-family-ubuntu")
-	mockEmptyNodeList(mockClient)
-	mockEmptyLegacyNodeClaims(mockClient)
-
-	// NodePool exists with replicas=2, target=2, no BYO → desired=2, no update needed.
+	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
 	existingNP := &karpenterv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{Name: "default-ws1"},
 		Spec:       karpenterv1.NodePoolSpec{Replicas: lo.ToPtr(int64(2))},
 	}
-	mockClient.CreateOrUpdateObjectInMap(existingNP)
-	mockClient.On("Get", mock.IsType(context.Background()), mock.MatchedBy(func(key client.ObjectKey) bool {
-		return key.Name == "default-ws1"
-	}), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+	c := newFakeClient(nodeClass, existingNP)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
 
 	err := p.ProvisionNodes(context.Background(), ws)
-	assert.NoError(t, err)
-	mockClient.AssertNotCalled(t, "Update", mock.Anything, mock.Anything, mock.Anything)
+	require.NoError(t, err)
+
+	// Replicas unchanged.
+	np := &karpenterv1.NodePool{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, np)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), *np.Spec.Replicas)
 }
 
 func TestProvisionNodes_AlreadyExists(t *testing.T) {
-	mockClient := test.NewClient()
-	mockNodeClassReady(mockClient, "image-family-ubuntu")
-	mockEmptyNodeList(mockClient)
-	mockEmptyLegacyNodeClaims(mockClient)
-	mockNodePoolNotFound(mockClient, "default-ws1")
-	alreadyExistsErr := apierrors.NewAlreadyExists(schema.GroupResource{Group: "karpenter.sh", Resource: "nodepools"}, "default-ws1")
-	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(alreadyExistsErr)
+	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
+	// Simulate race: Get returns NotFound, Create returns AlreadyExists.
+	c := newFakeClientWithInterceptors(interceptor.Funcs{
+		Get: func(ctx context.Context, cl client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+			if _, ok := obj.(*karpenterv1.NodePool); ok && key.Name == "default-ws1" {
+				return apierrors.NewNotFound(schema.GroupResource{Group: "karpenter.sh", Resource: "nodepools"}, key.Name)
+			}
+			return cl.Get(ctx, key, obj, opts...)
+		},
+		Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*karpenterv1.NodePool); ok {
+				return apierrors.NewAlreadyExists(schema.GroupResource{Group: "karpenter.sh", Resource: "nodepools"}, "default-ws1")
+			}
+			return cl.Create(ctx, obj, opts...)
+		},
+	}, nodeClass)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
 	err := p.ProvisionNodes(context.Background(), ws)
@@ -348,14 +330,17 @@ func TestProvisionNodes_AlreadyExists(t *testing.T) {
 }
 
 func TestProvisionNodes_CreateError(t *testing.T) {
-	mockClient := test.NewClient()
-	mockNodeClassReady(mockClient, "image-family-ubuntu")
-	mockEmptyNodeList(mockClient)
-	mockEmptyLegacyNodeClaims(mockClient)
-	mockNodePoolNotFound(mockClient, "default-ws1")
-	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(errors.New("API server down"))
+	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
+	c := newFakeClientWithInterceptors(interceptor.Funcs{
+		Create: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			if _, ok := obj.(*karpenterv1.NodePool); ok {
+				return errors.New("API server down")
+			}
+			return cl.Create(ctx, obj, opts...)
+		},
+	}, nodeClass)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
 	err := p.ProvisionNodes(context.Background(), ws)
@@ -364,75 +349,60 @@ func TestProvisionNodes_CreateError(t *testing.T) {
 }
 
 func TestProvisionNodes_UsesDefaultNodeClassName(t *testing.T) {
-	mockClient := test.NewClient()
-	mockNodeClassReady(mockClient, "image-family-ubuntu")
-	mockEmptyNodeList(mockClient)
-	mockEmptyLegacyNodeClaims(mockClient)
-	mockNodePoolNotFound(mockClient, "default-ws1")
-	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
+	c := newFakeClient(nodeClass)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
 	err := p.ProvisionNodes(context.Background(), ws)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	for _, call := range mockClient.Calls {
-		if call.Method == "Create" {
-			if createdNP, ok := call.Arguments[1].(*karpenterv1.NodePool); ok {
-				assert.Equal(t, "image-family-ubuntu", createdNP.Spec.Template.Spec.NodeClassRef.Name)
-			}
-		}
-	}
+	np := &karpenterv1.NodePool{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, np)
+	require.NoError(t, err)
+	assert.Equal(t, "image-family-ubuntu", np.Spec.Template.Spec.NodeClassRef.Name)
 }
 
 func TestProvisionNodes_UsesAnnotationNodeClassName(t *testing.T) {
-	mockClient := test.NewClient()
-	mockNodeClassReady(mockClient, "image-family-azure-linux")
-	mockEmptyNodeList(mockClient)
-	mockEmptyLegacyNodeClaims(mockClient)
-	mockNodePoolNotFound(mockClient, "default-ws1")
-	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+	nodeClass := makeNodeClassUnstructured("image-family-azure-linux")
+	c := newFakeClient(nodeClass)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, map[string]string{
 		kaitov1beta1.AnnotationNodeClassName: "image-family-azure-linux",
 	})
 
 	err := p.ProvisionNodes(context.Background(), ws)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	for _, call := range mockClient.Calls {
-		if call.Method == "Create" {
-			if createdNP, ok := call.Arguments[1].(*karpenterv1.NodePool); ok {
-				assert.Equal(t, "image-family-azure-linux", createdNP.Spec.Template.Spec.NodeClassRef.Name)
-			}
-		}
-	}
+	np := &karpenterv1.NodePool{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, np)
+	require.NoError(t, err)
+	assert.Equal(t, "image-family-azure-linux", np.Spec.Template.Spec.NodeClassRef.Name)
 }
 
 // --- DeleteNodes tests ---
 
 func TestDeleteNodes_Success(t *testing.T) {
-	mockClient := test.NewClient()
 	np := &karpenterv1.NodePool{ObjectMeta: metav1.ObjectMeta{Name: "default-ws1"}}
-	mockClient.CreateOrUpdateObjectInMap(np)
-	mockClient.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
-	mockClient.On("Delete", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+	c := newFakeClient(np)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
 	err := p.DeleteNodes(context.Background(), ws)
 	assert.NoError(t, err)
+
+	// Verify it's gone.
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, &karpenterv1.NodePool{})
+	assert.True(t, apierrors.IsNotFound(err))
 }
 
 func TestDeleteNodes_NotFound(t *testing.T) {
-	mockClient := test.NewClient()
-	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "karpenter.sh", Resource: "nodepools"}, "default-ws1")
-	mockClient.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(notFoundErr)
+	c := newFakeClient() // No NodePool exists.
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
 	err := p.DeleteNodes(context.Background(), ws)
@@ -440,7 +410,6 @@ func TestDeleteNodes_NotFound(t *testing.T) {
 }
 
 func TestDeleteNodes_AlreadyDeleting(t *testing.T) {
-	mockClient := test.NewClient()
 	now := metav1.Now()
 	np := &karpenterv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{
@@ -449,26 +418,30 @@ func TestDeleteNodes_AlreadyDeleting(t *testing.T) {
 			Finalizers:        []string{"karpenter.sh/termination"},
 		},
 	}
-	mockClient.CreateOrUpdateObjectInMap(np)
-	mockClient.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+	c := newFakeClient(np)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
 	err := p.DeleteNodes(context.Background(), ws)
 	assert.NoError(t, err)
-	// Delete should NOT have been called
-	mockClient.AssertNotCalled(t, "Delete", mock.Anything, mock.Anything, mock.Anything)
+	// NodePool should still exist (not deleted again).
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, &karpenterv1.NodePool{})
+	assert.NoError(t, err)
 }
 
 func TestDeleteNodes_DeleteError(t *testing.T) {
-	mockClient := test.NewClient()
 	np := &karpenterv1.NodePool{ObjectMeta: metav1.ObjectMeta{Name: "default-ws1"}}
-	mockClient.CreateOrUpdateObjectInMap(np)
-	mockClient.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
-	mockClient.On("Delete", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(errors.New("forbidden"))
+	c := newFakeClientWithInterceptors(interceptor.Funcs{
+		Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			if _, ok := obj.(*karpenterv1.NodePool); ok {
+				return errors.New("forbidden")
+			}
+			return cl.Delete(ctx, obj, opts...)
+		},
+	}, np)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
 	err := p.DeleteNodes(context.Background(), ws)
@@ -479,8 +452,6 @@ func TestDeleteNodes_DeleteError(t *testing.T) {
 // --- EnableDriftRemediation tests ---
 
 func TestEnableDriftRemediation_Success(t *testing.T) {
-	mockClient := test.NewClient()
-
 	np := &karpenterv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{Name: "default-ws1"},
 		Spec: karpenterv1.NodePoolSpec{
@@ -495,38 +466,27 @@ func TestEnableDriftRemediation_Success(t *testing.T) {
 			},
 		},
 	}
-	mockClient.CreateOrUpdateObjectInMap(np)
-	mockClient.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
-	mockClient.On("Update", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+	c := newFakeClient(np)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	err := p.EnableDriftRemediation(context.Background(), "default", "ws1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	found := false
-	for _, call := range mockClient.Calls {
-		if call.Method == "Update" {
-			updatedNP := call.Arguments[1].(*karpenterv1.NodePool)
-			assert.Equal(t, "1", updatedNP.Spec.Disruption.Budgets[0].Nodes)
-			found = true
-		}
-	}
-	assert.True(t, found, "expected Update to be called")
+	updated := &karpenterv1.NodePool{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, updated)
+	require.NoError(t, err)
+	assert.Equal(t, "1", updated.Spec.Disruption.Budgets[0].Nodes)
 }
 
 func TestEnableDriftRemediation_NodePoolNotFound(t *testing.T) {
-	mockClient := test.NewClient()
-	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "karpenter.sh", Resource: "nodepools"}, "default-ws1")
-	mockClient.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(notFoundErr)
+	c := newFakeClient()
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	err := p.EnableDriftRemediation(context.Background(), "default", "ws1")
 	assert.Error(t, err)
 }
 
 func TestEnableDriftRemediation_NoDriftedBudgetEntry(t *testing.T) {
-	mockClient := test.NewClient()
-
 	np := &karpenterv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{Name: "default-ws1"},
 		Spec: karpenterv1.NodePoolSpec{
@@ -541,10 +501,9 @@ func TestEnableDriftRemediation_NoDriftedBudgetEntry(t *testing.T) {
 			},
 		},
 	}
-	mockClient.CreateOrUpdateObjectInMap(np)
-	mockClient.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+	c := newFakeClient(np)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	err := p.EnableDriftRemediation(context.Background(), "default", "ws1")
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no budget entry with Drifted reason")
@@ -553,8 +512,6 @@ func TestEnableDriftRemediation_NoDriftedBudgetEntry(t *testing.T) {
 // --- DisableDriftRemediation tests ---
 
 func TestDisableDriftRemediation_Success(t *testing.T) {
-	mockClient := test.NewClient()
-
 	np := &karpenterv1.NodePool{
 		ObjectMeta: metav1.ObjectMeta{Name: "default-ws1"},
 		Spec: karpenterv1.NodePoolSpec{
@@ -569,31 +526,22 @@ func TestDisableDriftRemediation_Success(t *testing.T) {
 			},
 		},
 	}
-	mockClient.CreateOrUpdateObjectInMap(np)
-	mockClient.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
-	mockClient.On("Update", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+	c := newFakeClient(np)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	err := p.DisableDriftRemediation(context.Background(), "default", "ws1")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
-	found := false
-	for _, call := range mockClient.Calls {
-		if call.Method == "Update" {
-			updatedNP := call.Arguments[1].(*karpenterv1.NodePool)
-			assert.Equal(t, "0", updatedNP.Spec.Disruption.Budgets[0].Nodes)
-			found = true
-		}
-	}
-	assert.True(t, found, "expected Update to be called")
+	updated := &karpenterv1.NodePool{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, updated)
+	require.NoError(t, err)
+	assert.Equal(t, "0", updated.Spec.Disruption.Budgets[0].Nodes)
 }
 
 func TestDisableDriftRemediation_NodePoolNotFound(t *testing.T) {
-	mockClient := test.NewClient()
-	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "karpenter.sh", Resource: "nodepools"}, "default-ws1")
-	mockClient.On("Get", mock.IsType(context.Background()), mock.Anything, mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(notFoundErr)
+	c := newFakeClient()
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	err := p.DisableDriftRemediation(context.Background(), "default", "ws1")
 	assert.Error(t, err)
 }
@@ -601,90 +549,59 @@ func TestDisableDriftRemediation_NodePoolNotFound(t *testing.T) {
 // --- EnsureNodesReady tests ---
 
 func TestEnsureNodesReady_AllReady_BYOOnly(t *testing.T) {
-	mockClient := test.NewClient()
+	byoNode := makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
+	c := newFakeClient(byoNode)
 
-	// 1 ready BYO node with correct instance type.
-	nodeList := &corev1.NodeList{}
-	nodeMap := mockClient.CreateMapWithType(nodeList)
-	nodeMap[client.ObjectKeyFromObject(makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil))] =
-		makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
-
-	// No karpenter NodeClaims.
-	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
-
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
 	ready, needRequeue, err := p.EnsureNodesReady(context.Background(), ws)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, ready)
 	assert.False(t, needRequeue)
 }
 
 func TestEnsureNodesReady_MixedBYOAndKarpenter(t *testing.T) {
-	mockClient := test.NewClient()
-
-	// 1 BYO + 1 karpenter node, target=2.
-	nodeList := &corev1.NodeList{}
-	nodeMap := mockClient.CreateMapWithType(nodeList)
 	byoNode := makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
 	karpNode := makeReadyNode("karp-1", "Standard_NC24ads_A100_v4", map[string]string{
 		consts.KarpenterWorkspaceNameKey: "ws1",
 	})
-	nodeMap[client.ObjectKeyFromObject(byoNode)] = byoNode
-	nodeMap[client.ObjectKeyFromObject(karpNode)] = karpNode
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+	// Karpenter NodeClaim — labeled with correct NodePool, ready.
+	nc := makeKarpenterNodeClaim("nc-1", "default-ws1", true)
+	c := newFakeClient(byoNode, karpNode, nc)
 
-	// 1 karpenter NodeClaim ready.
-	nc := &karpenterv1.NodeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "nc-1",
-			Labels: map[string]string{karpenterv1.NodePoolLabelKey: "default-ws1"},
-		},
-		Status: karpenterv1.NodeClaimStatus{
-			Conditions: []status.Condition{{Type: "Ready", Status: metav1.ConditionTrue}},
-		},
-	}
-	ncList := &karpenterv1.NodeClaimList{}
-	ncMap := mockClient.CreateMapWithType(ncList)
-	ncMap[client.ObjectKeyFromObject(nc)] = nc
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
-
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
 
 	ready, needRequeue, err := p.EnsureNodesReady(context.Background(), ws)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.True(t, ready)
 	assert.False(t, needRequeue)
 }
 
 func TestEnsureNodesReady_CountBelowTarget(t *testing.T) {
-	mockClient := test.NewClient()
+	c := newFakeClient() // No nodes, no NodeClaims.
 
-	// No karpenter NodeClaims.
-	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
-
-	mockEmptyNodeList(mockClient)
-	mockEmptyLegacyNodeClaims(mockClient)
-
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
 
 	ready, needRequeue, err := p.EnsureNodesReady(context.Background(), ws)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, ready)
 	assert.False(t, needRequeue)
 }
 
 func TestEnsureNodesReady_ListError(t *testing.T) {
-	mockClient := test.NewClient()
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(errors.New("API error"))
+	c := newFakeClientWithInterceptors(interceptor.Funcs{
+		List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if _, ok := list.(*karpenterv1.NodeClaimList); ok {
+				return errors.New("API error")
+			}
+			return cl.List(ctx, list, opts...)
+		},
+	})
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
 	_, _, err := p.EnsureNodesReady(context.Background(), ws)
@@ -693,84 +610,204 @@ func TestEnsureNodesReady_ListError(t *testing.T) {
 }
 
 func TestEnsureNodesReady_DeletingNodeNotCounted(t *testing.T) {
-	mockClient := test.NewClient()
-
-	// No karpenter NodeClaims.
-	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
-
-	// 1 node being deleted — should not count.
 	now := metav1.Now()
 	deletingNode := makeReadyNode("deleting-1", "Standard_NC24ads_A100_v4", nil)
 	deletingNode.DeletionTimestamp = &now
 	deletingNode.Finalizers = []string{"test/finalizer"}
-	nodeList := &corev1.NodeList{}
-	nodeMap := mockClient.CreateMapWithType(nodeList)
-	nodeMap[client.ObjectKeyFromObject(deletingNode)] = deletingNode
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+	c := newFakeClient(deletingNode)
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
 	ready, needRequeue, err := p.EnsureNodesReady(context.Background(), ws)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.False(t, ready)
 	assert.False(t, needRequeue)
+}
+
+// --- countCoveredNodes tests (core new behavior) ---
+
+func TestCountCoveredNodes_NilLabelSelector(t *testing.T) {
+	c := newFakeClient()
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
+	ws.Resource.LabelSelector = nil
+
+	covered, ready, err := countCoveredNodes(context.Background(), c, ws)
+	require.NoError(t, err)
+	assert.Equal(t, 0, covered)
+	assert.Equal(t, 0, ready)
+}
+
+func TestCountCoveredNodes_LegacyNCCountedDespiteNodeNotReady(t *testing.T) {
+	// Core behavior: a non-deleting legacy NodeClaim counts as covered even
+	// when its node is not ready (or doesn't exist at all).
+	legacyNC := makeLegacyNodeClaim("legacy-nc-1", "ws1", "default")
+	c := newFakeClient(legacyNC) // No ready nodes.
+
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
+
+	covered, readyCount, err := countCoveredNodes(context.Background(), c, ws)
+	require.NoError(t, err)
+	assert.Equal(t, 1, covered, "legacy NC should count as covered")
+	assert.Equal(t, 0, readyCount, "no ready nodes exist")
+}
+
+func TestCountCoveredNodes_DeletingLegacyNCExcluded(t *testing.T) {
+	now := metav1.Now()
+	legacyNC := makeLegacyNodeClaim("legacy-nc-1", "ws1", "default")
+	legacyNC.DeletionTimestamp = &now
+	legacyNC.Finalizers = []string{"karpenter.sh/termination"}
+	c := newFakeClient(legacyNC)
+
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
+
+	covered, _, err := countCoveredNodes(context.Background(), c, ws)
+	require.NoError(t, err)
+	assert.Equal(t, 0, covered, "deleting legacy NC should not count as covered")
+}
+
+func TestCountCoveredNodes_LegacyNodeExcludedFromBYO(t *testing.T) {
+	// A ready node with the legacy workspace label should NOT count as BYO.
+	legacyNode := makeReadyNode("legacy-1", "Standard_NC24ads_A100_v4", map[string]string{
+		kaitov1beta1.LabelWorkspaceName: "ws1",
+	})
+	legacyNC := makeLegacyNodeClaim("legacy-nc-1", "ws1", "default")
+	c := newFakeClient(legacyNode, legacyNC)
+
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
+
+	covered, readyCount, err := countCoveredNodes(context.Background(), c, ws)
+	require.NoError(t, err)
+	// coveredByNonKarpenter = 0 BYO + 1 legacy NC = 1
+	assert.Equal(t, 1, covered)
+	// readyWithInstanceType = 1 (the legacy node is still a ready node)
+	assert.Equal(t, 1, readyCount)
+}
+
+func TestCountCoveredNodes_BYOAndLegacyCombinedDelta(t *testing.T) {
+	// 1 BYO node + 1 legacy NC (node not ready) + target 3 → covered=2, need 1 karpenter NodeClaim.
+	byoNode := makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
+	legacyNC := makeLegacyNodeClaim("legacy-nc-1", "ws1", "default")
+	c := newFakeClient(byoNode, legacyNC)
+
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 3, nil, nil)
+
+	covered, readyCount, err := countCoveredNodes(context.Background(), c, ws)
+	require.NoError(t, err)
+	assert.Equal(t, 2, covered, "1 BYO + 1 legacy NC")
+	assert.Equal(t, 1, readyCount, "only the BYO node is ready")
+}
+
+func TestCountCoveredNodes_LegacyNCsForDifferentWorkspaceNotCounted(t *testing.T) {
+	// A legacy NodeClaim for a different workspace should not be counted.
+	otherNC := makeLegacyNodeClaim("other-nc", "other-ws", "default")
+	c := newFakeClient(otherNC)
+
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
+
+	covered, _, err := countCoveredNodes(context.Background(), c, ws)
+	require.NoError(t, err)
+	assert.Equal(t, 0, covered, "NC for different workspace should not count")
+}
+
+func TestCountCoveredNodes_KarpenterNodeNotCountedAsBYO(t *testing.T) {
+	// A karpenter-labeled node should not count toward BYO coverage.
+	karpNode := makeReadyNode("karp-1", "Standard_NC24ads_A100_v4", map[string]string{
+		consts.KarpenterWorkspaceNameKey: "ws1",
+	})
+	c := newFakeClient(karpNode)
+
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
+
+	covered, readyCount, err := countCoveredNodes(context.Background(), c, ws)
+	require.NoError(t, err)
+	assert.Equal(t, 0, covered, "karpenter node should not count as non-karpenter coverage")
+	assert.Equal(t, 1, readyCount, "karpenter node still counted in total ready")
+}
+
+// --- ProvisionNodes delta with legacy NodeClaims ---
+
+func TestProvisionNodes_LegacyNCReducesDelta(t *testing.T) {
+	// 1 legacy NC (node not ready) + target 2 → desiredReplicas = 2 - 1 = 1.
+	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
+	legacyNC := makeLegacyNodeClaim("legacy-nc-1", "ws1", "default")
+	c := newFakeClient(nodeClass, legacyNC)
+
+	p := NewKarpenterProvisioner(c, testConfig)
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
+
+	err := p.ProvisionNodes(context.Background(), ws)
+	require.NoError(t, err)
+
+	np := &karpenterv1.NodePool{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, np)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), *np.Spec.Replicas)
+}
+
+func TestProvisionNodes_DeletingLegacyNCDoesNotReduceDelta(t *testing.T) {
+	// Deleting legacy NC should not count → desiredReplicas stays at target.
+	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
+	now := metav1.Now()
+	legacyNC := makeLegacyNodeClaim("legacy-nc-1", "ws1", "default")
+	legacyNC.DeletionTimestamp = &now
+	legacyNC.Finalizers = []string{"karpenter.sh/termination"}
+	c := newFakeClient(nodeClass, legacyNC)
+
+	p := NewKarpenterProvisioner(c, testConfig)
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
+
+	err := p.ProvisionNodes(context.Background(), ws)
+	require.NoError(t, err)
+
+	np := &karpenterv1.NodePool{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, np)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), *np.Spec.Replicas)
 }
 
 // --- CollectNodeStatusInfo tests ---
 
 func TestCollectNodeStatusInfo_AllReady_BYOOnly(t *testing.T) {
-	mockClient := test.NewClient()
+	byoNode := makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
+	c := newFakeClient(byoNode)
 
-	// 1 ready BYO node.
-	nodeList := &corev1.NodeList{}
-	nodeMap := mockClient.CreateMapWithType(nodeList)
-	nodeMap[client.ObjectKeyFromObject(makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil))] =
-		makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
-
-	// No karpenter NodeClaims.
-	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
-
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
 	conditions, err := p.CollectNodeStatusInfo(context.Background(), ws)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 3, len(conditions))
-
 	for _, cond := range conditions {
 		assert.Equal(t, metav1.ConditionTrue, cond.Status, "condition %s should be True", cond.Type)
 	}
 }
 
 func TestCollectNodeStatusInfo_NotEnoughNodes(t *testing.T) {
-	mockClient := test.NewClient()
-	mockEmptyNodeList(mockClient)
-	mockEmptyLegacyNodeClaims(mockClient)
+	c := newFakeClient() // No nodes.
 
-	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
-
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
 	conditions, err := p.CollectNodeStatusInfo(context.Background(), ws)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, 3, len(conditions))
-
 	for _, cond := range conditions {
 		assert.Equal(t, metav1.ConditionFalse, cond.Status, "condition %s should be False", cond.Type)
 	}
 }
 
 func TestCollectNodeStatusInfo_ListError(t *testing.T) {
-	mockClient := test.NewClient()
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(errors.New("API error"))
+	c := newFakeClientWithInterceptors(interceptor.Funcs{
+		List: func(ctx context.Context, cl client.WithWatch, list client.ObjectList, opts ...client.ListOption) error {
+			if _, ok := list.(*karpenterv1.NodeClaimList); ok {
+				return errors.New("API error")
+			}
+			return cl.List(ctx, list, opts...)
+		},
+	})
 
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
 	_, err := p.CollectNodeStatusInfo(context.Background(), ws)
@@ -779,22 +816,14 @@ func TestCollectNodeStatusInfo_ListError(t *testing.T) {
 }
 
 func TestCollectNodeStatusInfo_ConditionTypes(t *testing.T) {
-	mockClient := test.NewClient()
+	byoNode := makeReadyNode("node-1", "Standard_NC24ads_A100_v4", nil)
+	c := newFakeClient(byoNode)
 
-	nodeList := &corev1.NodeList{}
-	nodeMap := mockClient.CreateMapWithType(nodeList)
-	nodeMap[client.ObjectKeyFromObject(makeReadyNode("node-1", "Standard_NC24ads_A100_v4", nil))] =
-		makeReadyNode("node-1", "Standard_NC24ads_A100_v4", nil)
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
-
-	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
-	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
-
-	p := NewKarpenterProvisioner(mockClient, testConfig)
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
 	conditions, err := p.CollectNodeStatusInfo(context.Background(), ws)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	typeSet := map[string]bool{}
 	for _, cond := range conditions {

--- a/pkg/nodeprovision/karpenter/provisioner_test.go
+++ b/pkg/nodeprovision/karpenter/provisioner_test.go
@@ -73,6 +73,12 @@ func mockEmptyNodeList(mockClient *test.MockClient) {
 	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
 }
 
+// mockEmptyLegacyNodeClaims sets up an empty NodeClaimList for legacy NodeClaim List calls.
+func mockEmptyLegacyNodeClaims(mockClient *test.MockClient) {
+	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
+	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
+}
+
 // mockNodePoolNotFound sets up a Get call for NodePool that returns NotFound.
 func mockNodePoolNotFound(mockClient *test.MockClient, name string) {
 	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "karpenter.sh", Resource: "nodepools"}, name)
@@ -130,6 +136,7 @@ func TestProvisionNodes_NoBYONodes_CreatesWithFullReplicas(t *testing.T) {
 	mockClient := test.NewClient()
 	mockNodeClassReady(mockClient, "image-family-ubuntu")
 	mockEmptyNodeList(mockClient)
+	mockEmptyLegacyNodeClaims(mockClient)
 	mockNodePoolNotFound(mockClient, "default-ws1")
 	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
 
@@ -159,6 +166,7 @@ func TestProvisionNodes_DeltaWithBYONodes(t *testing.T) {
 	nodeMap[client.ObjectKeyFromObject(makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil))] =
 		makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
 	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+	mockEmptyLegacyNodeClaims(mockClient)
 
 	mockNodePoolNotFound(mockClient, "default-ws1")
 	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
@@ -191,6 +199,7 @@ func TestProvisionNodes_KarpenterNodesExcludedFromDelta(t *testing.T) {
 	})
 	nodeMap[client.ObjectKeyFromObject(karpenterNode)] = karpenterNode
 	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+	mockEmptyLegacyNodeClaims(mockClient)
 
 	mockNodePoolNotFound(mockClient, "default-ws1")
 	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
@@ -223,6 +232,7 @@ func TestProvisionNodes_ZeroReplicasWhenBYOSufficient_NoCreateCalled(t *testing.
 		nodeMap[client.ObjectKeyFromObject(node)] = node
 	}
 	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+	mockEmptyLegacyNodeClaims(mockClient)
 
 	mockNodePoolNotFound(mockClient, "default-ws1")
 
@@ -244,6 +254,7 @@ func TestProvisionNodes_DoesNotDecreaseReplicas(t *testing.T) {
 	nodeMap[client.ObjectKeyFromObject(makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil))] =
 		makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
 	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+	mockEmptyLegacyNodeClaims(mockClient)
 
 	// NodePool exists with replicas=2.
 	existingNP := &karpenterv1.NodePool{
@@ -268,6 +279,7 @@ func TestProvisionNodes_IncreasesReplicas(t *testing.T) {
 	mockClient := test.NewClient()
 	mockNodeClassReady(mockClient, "image-family-ubuntu")
 	mockEmptyNodeList(mockClient)
+	mockEmptyLegacyNodeClaims(mockClient)
 
 	// NodePool exists with replicas=1, target=3, no BYO → desired=3 > current=1, should update.
 	existingNP := &karpenterv1.NodePool{
@@ -299,6 +311,7 @@ func TestProvisionNodes_NoUpdateWhenReplicasUnchanged(t *testing.T) {
 	mockClient := test.NewClient()
 	mockNodeClassReady(mockClient, "image-family-ubuntu")
 	mockEmptyNodeList(mockClient)
+	mockEmptyLegacyNodeClaims(mockClient)
 
 	// NodePool exists with replicas=2, target=2, no BYO → desired=2, no update needed.
 	existingNP := &karpenterv1.NodePool{
@@ -322,6 +335,7 @@ func TestProvisionNodes_AlreadyExists(t *testing.T) {
 	mockClient := test.NewClient()
 	mockNodeClassReady(mockClient, "image-family-ubuntu")
 	mockEmptyNodeList(mockClient)
+	mockEmptyLegacyNodeClaims(mockClient)
 	mockNodePoolNotFound(mockClient, "default-ws1")
 	alreadyExistsErr := apierrors.NewAlreadyExists(schema.GroupResource{Group: "karpenter.sh", Resource: "nodepools"}, "default-ws1")
 	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(alreadyExistsErr)
@@ -337,6 +351,7 @@ func TestProvisionNodes_CreateError(t *testing.T) {
 	mockClient := test.NewClient()
 	mockNodeClassReady(mockClient, "image-family-ubuntu")
 	mockEmptyNodeList(mockClient)
+	mockEmptyLegacyNodeClaims(mockClient)
 	mockNodePoolNotFound(mockClient, "default-ws1")
 	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(errors.New("API server down"))
 
@@ -352,6 +367,7 @@ func TestProvisionNodes_UsesDefaultNodeClassName(t *testing.T) {
 	mockClient := test.NewClient()
 	mockNodeClassReady(mockClient, "image-family-ubuntu")
 	mockEmptyNodeList(mockClient)
+	mockEmptyLegacyNodeClaims(mockClient)
 	mockNodePoolNotFound(mockClient, "default-ws1")
 	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
 
@@ -374,6 +390,7 @@ func TestProvisionNodes_UsesAnnotationNodeClassName(t *testing.T) {
 	mockClient := test.NewClient()
 	mockNodeClassReady(mockClient, "image-family-azure-linux")
 	mockEmptyNodeList(mockClient)
+	mockEmptyLegacyNodeClaims(mockClient)
 	mockNodePoolNotFound(mockClient, "default-ws1")
 	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
 
@@ -652,6 +669,7 @@ func TestEnsureNodesReady_CountBelowTarget(t *testing.T) {
 	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
 
 	mockEmptyNodeList(mockClient)
+	mockEmptyLegacyNodeClaims(mockClient)
 
 	p := NewKarpenterProvisioner(mockClient, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
@@ -731,6 +749,7 @@ func TestCollectNodeStatusInfo_AllReady_BYOOnly(t *testing.T) {
 func TestCollectNodeStatusInfo_NotEnoughNodes(t *testing.T) {
 	mockClient := test.NewClient()
 	mockEmptyNodeList(mockClient)
+	mockEmptyLegacyNodeClaims(mockClient)
 
 	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
 	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)

--- a/pkg/nodeprovision/karpenter/provisioner_test.go
+++ b/pkg/nodeprovision/karpenter/provisioner_test.go
@@ -19,8 +19,10 @@ import (
 	"testing"
 
 	"github.com/awslabs/operatorpkg/status"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
+	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,6 +33,7 @@ import (
 
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/nodeprovision"
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/test"
 )
 
@@ -64,6 +67,42 @@ func mockNodeClassReady(mockClient *test.MockClient, name string) {
 		Return(nil)
 }
 
+// mockEmptyNodeList sets up an empty NodeList for List calls.
+func mockEmptyNodeList(mockClient *test.MockClient) {
+	mockClient.CreateMapWithType(&corev1.NodeList{})
+	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+}
+
+// mockNodePoolNotFound sets up a Get call for NodePool that returns NotFound.
+func mockNodePoolNotFound(mockClient *test.MockClient, name string) {
+	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Group: "karpenter.sh", Resource: "nodepools"}, name)
+	mockClient.On("Get", mock.IsType(context.Background()), mock.MatchedBy(func(key client.ObjectKey) bool {
+		return key.Name == name
+	}), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(notFoundErr)
+}
+
+// makeReadyNode creates a ready Node with the given name, instance type, and extra labels.
+func makeReadyNode(name, instanceType string, extraLabels map[string]string) *corev1.Node {
+	labels := map[string]string{
+		"apps":                         "llm",
+		corev1.LabelInstanceTypeStable: instanceType,
+	}
+	for k, v := range extraLabels {
+		labels[k] = v
+	}
+	return &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   name,
+			Labels: labels,
+		},
+		Status: corev1.NodeStatus{
+			Conditions: []corev1.NodeCondition{
+				{Type: corev1.NodeReady, Status: corev1.ConditionTrue},
+			},
+		},
+	}
+}
+
 func TestKarpenterProvisionerImplementsInterface(t *testing.T) {
 	mockClient := test.NewClient()
 	var _ nodeprovision.NodeProvisioner = NewKarpenterProvisioner(mockClient, testConfig)
@@ -87,22 +126,203 @@ func TestStart_CRDNotFound(t *testing.T) {
 
 // --- ProvisionNodes tests ---
 
-func TestProvisionNodes_Success(t *testing.T) {
+func TestProvisionNodes_NoBYONodes_CreatesWithFullReplicas(t *testing.T) {
 	mockClient := test.NewClient()
 	mockNodeClassReady(mockClient, "image-family-ubuntu")
+	mockEmptyNodeList(mockClient)
+	mockNodePoolNotFound(mockClient, "default-ws1")
 	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
 
 	p := NewKarpenterProvisioner(mockClient, testConfig)
-	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
 
 	err := p.ProvisionNodes(context.Background(), ws)
 	assert.NoError(t, err)
-	mockClient.AssertExpectations(t)
+
+	// Verify replicas = targetNodeCount (2) since no BYO nodes.
+	for _, call := range mockClient.Calls {
+		if call.Method == "Create" {
+			if np, ok := call.Arguments[1].(*karpenterv1.NodePool); ok {
+				assert.Equal(t, int64(2), *np.Spec.Replicas)
+			}
+		}
+	}
+}
+
+func TestProvisionNodes_DeltaWithBYONodes(t *testing.T) {
+	mockClient := test.NewClient()
+	mockNodeClassReady(mockClient, "image-family-ubuntu")
+
+	// 1 BYO node exists (ready, correct instance type, no karpenter label).
+	nodeList := &corev1.NodeList{}
+	nodeMap := mockClient.CreateMapWithType(nodeList)
+	nodeMap[client.ObjectKeyFromObject(makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil))] =
+		makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
+	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+
+	mockNodePoolNotFound(mockClient, "default-ws1")
+	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+
+	p := NewKarpenterProvisioner(mockClient, testConfig)
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
+
+	err := p.ProvisionNodes(context.Background(), ws)
+	assert.NoError(t, err)
+
+	// desiredReplicas = 2 - 1 = 1
+	for _, call := range mockClient.Calls {
+		if call.Method == "Create" {
+			if np, ok := call.Arguments[1].(*karpenterv1.NodePool); ok {
+				assert.Equal(t, int64(1), *np.Spec.Replicas)
+			}
+		}
+	}
+}
+
+func TestProvisionNodes_KarpenterNodesExcludedFromDelta(t *testing.T) {
+	mockClient := test.NewClient()
+	mockNodeClassReady(mockClient, "image-family-ubuntu")
+
+	// 1 karpenter node (has workspace-name label — excluded from non-karpenter count).
+	nodeList := &corev1.NodeList{}
+	nodeMap := mockClient.CreateMapWithType(nodeList)
+	karpenterNode := makeReadyNode("karpenter-1", "Standard_NC24ads_A100_v4", map[string]string{
+		consts.KarpenterWorkspaceNameKey: "ws1",
+	})
+	nodeMap[client.ObjectKeyFromObject(karpenterNode)] = karpenterNode
+	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+
+	mockNodePoolNotFound(mockClient, "default-ws1")
+	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+
+	p := NewKarpenterProvisioner(mockClient, testConfig)
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
+
+	err := p.ProvisionNodes(context.Background(), ws)
+	assert.NoError(t, err)
+
+	// desiredReplicas = 2 (karpenter node excluded from non-karpenter count).
+	for _, call := range mockClient.Calls {
+		if call.Method == "Create" {
+			if np, ok := call.Arguments[1].(*karpenterv1.NodePool); ok {
+				assert.Equal(t, int64(2), *np.Spec.Replicas)
+			}
+		}
+	}
+}
+
+func TestProvisionNodes_ZeroReplicasWhenBYOSufficient_NoCreateCalled(t *testing.T) {
+	mockClient := test.NewClient()
+	mockNodeClassReady(mockClient, "image-family-ubuntu")
+
+	// 2 BYO nodes, target=2 → desiredReplicas=0, no NodePool should be created.
+	nodeList := &corev1.NodeList{}
+	nodeMap := mockClient.CreateMapWithType(nodeList)
+	for _, name := range []string{"byo-1", "byo-2"} {
+		node := makeReadyNode(name, "Standard_NC24ads_A100_v4", nil)
+		nodeMap[client.ObjectKeyFromObject(node)] = node
+	}
+	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+
+	mockNodePoolNotFound(mockClient, "default-ws1")
+
+	p := NewKarpenterProvisioner(mockClient, testConfig)
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
+
+	err := p.ProvisionNodes(context.Background(), ws)
+	assert.NoError(t, err)
+	mockClient.AssertNotCalled(t, "Create", mock.Anything, mock.IsType(&karpenterv1.NodePool{}), mock.Anything)
+}
+
+func TestProvisionNodes_DoesNotDecreaseReplicas(t *testing.T) {
+	mockClient := test.NewClient()
+	mockNodeClassReady(mockClient, "image-family-ubuntu")
+
+	// 1 BYO node appeared after NodePool was created with replicas=2.
+	nodeList := &corev1.NodeList{}
+	nodeMap := mockClient.CreateMapWithType(nodeList)
+	nodeMap[client.ObjectKeyFromObject(makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil))] =
+		makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
+	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+
+	// NodePool exists with replicas=2.
+	existingNP := &karpenterv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-ws1"},
+		Spec:       karpenterv1.NodePoolSpec{Replicas: lo.ToPtr(int64(2))},
+	}
+	mockClient.CreateOrUpdateObjectInMap(existingNP)
+	mockClient.On("Get", mock.IsType(context.Background()), mock.MatchedBy(func(key client.ObjectKey) bool {
+		return key.Name == "default-ws1"
+	}), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+
+	p := NewKarpenterProvisioner(mockClient, testConfig)
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
+
+	err := p.ProvisionNodes(context.Background(), ws)
+	assert.NoError(t, err)
+	// desiredReplicas=1 < currentReplicas=2 → no update.
+	mockClient.AssertNotCalled(t, "Update", mock.Anything, mock.IsType(&karpenterv1.NodePool{}), mock.Anything)
+}
+
+func TestProvisionNodes_IncreasesReplicas(t *testing.T) {
+	mockClient := test.NewClient()
+	mockNodeClassReady(mockClient, "image-family-ubuntu")
+	mockEmptyNodeList(mockClient)
+
+	// NodePool exists with replicas=1, target=3, no BYO → desired=3 > current=1, should update.
+	existingNP := &karpenterv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-ws1"},
+		Spec:       karpenterv1.NodePoolSpec{Replicas: lo.ToPtr(int64(1))},
+	}
+	mockClient.CreateOrUpdateObjectInMap(existingNP)
+	mockClient.On("Get", mock.IsType(context.Background()), mock.MatchedBy(func(key client.ObjectKey) bool {
+		return key.Name == "default-ws1"
+	}), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+	mockClient.On("Update", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+
+	p := NewKarpenterProvisioner(mockClient, testConfig)
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 3, nil, nil)
+
+	err := p.ProvisionNodes(context.Background(), ws)
+	assert.NoError(t, err)
+
+	for _, call := range mockClient.Calls {
+		if call.Method == "Update" {
+			if np, ok := call.Arguments[1].(*karpenterv1.NodePool); ok {
+				assert.Equal(t, int64(3), *np.Spec.Replicas)
+			}
+		}
+	}
+}
+
+func TestProvisionNodes_NoUpdateWhenReplicasUnchanged(t *testing.T) {
+	mockClient := test.NewClient()
+	mockNodeClassReady(mockClient, "image-family-ubuntu")
+	mockEmptyNodeList(mockClient)
+
+	// NodePool exists with replicas=2, target=2, no BYO → desired=2, no update needed.
+	existingNP := &karpenterv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-ws1"},
+		Spec:       karpenterv1.NodePoolSpec{Replicas: lo.ToPtr(int64(2))},
+	}
+	mockClient.CreateOrUpdateObjectInMap(existingNP)
+	mockClient.On("Get", mock.IsType(context.Background()), mock.MatchedBy(func(key client.ObjectKey) bool {
+		return key.Name == "default-ws1"
+	}), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
+
+	p := NewKarpenterProvisioner(mockClient, testConfig)
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
+
+	err := p.ProvisionNodes(context.Background(), ws)
+	assert.NoError(t, err)
+	mockClient.AssertNotCalled(t, "Update", mock.Anything, mock.Anything, mock.Anything)
 }
 
 func TestProvisionNodes_AlreadyExists(t *testing.T) {
 	mockClient := test.NewClient()
 	mockNodeClassReady(mockClient, "image-family-ubuntu")
+	mockEmptyNodeList(mockClient)
+	mockNodePoolNotFound(mockClient, "default-ws1")
 	alreadyExistsErr := apierrors.NewAlreadyExists(schema.GroupResource{Group: "karpenter.sh", Resource: "nodepools"}, "default-ws1")
 	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(alreadyExistsErr)
 
@@ -116,6 +336,8 @@ func TestProvisionNodes_AlreadyExists(t *testing.T) {
 func TestProvisionNodes_CreateError(t *testing.T) {
 	mockClient := test.NewClient()
 	mockNodeClassReady(mockClient, "image-family-ubuntu")
+	mockEmptyNodeList(mockClient)
+	mockNodePoolNotFound(mockClient, "default-ws1")
 	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(errors.New("API server down"))
 
 	p := NewKarpenterProvisioner(mockClient, testConfig)
@@ -129,6 +351,8 @@ func TestProvisionNodes_CreateError(t *testing.T) {
 func TestProvisionNodes_UsesDefaultNodeClassName(t *testing.T) {
 	mockClient := test.NewClient()
 	mockNodeClassReady(mockClient, "image-family-ubuntu")
+	mockEmptyNodeList(mockClient)
+	mockNodePoolNotFound(mockClient, "default-ws1")
 	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
 
 	p := NewKarpenterProvisioner(mockClient, testConfig)
@@ -137,22 +361,20 @@ func TestProvisionNodes_UsesDefaultNodeClassName(t *testing.T) {
 	err := p.ProvisionNodes(context.Background(), ws)
 	assert.NoError(t, err)
 
-	found := false
 	for _, call := range mockClient.Calls {
 		if call.Method == "Create" {
-			createdNP, ok := call.Arguments[1].(*karpenterv1.NodePool)
-			if ok {
+			if createdNP, ok := call.Arguments[1].(*karpenterv1.NodePool); ok {
 				assert.Equal(t, "image-family-ubuntu", createdNP.Spec.Template.Spec.NodeClassRef.Name)
-				found = true
 			}
 		}
 	}
-	assert.True(t, found, "expected Create to be called with a NodePool")
 }
 
 func TestProvisionNodes_UsesAnnotationNodeClassName(t *testing.T) {
 	mockClient := test.NewClient()
 	mockNodeClassReady(mockClient, "image-family-azure-linux")
+	mockEmptyNodeList(mockClient)
+	mockNodePoolNotFound(mockClient, "default-ws1")
 	mockClient.On("Create", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodePool{}), mock.Anything).Return(nil)
 
 	p := NewKarpenterProvisioner(mockClient, testConfig)
@@ -165,8 +387,7 @@ func TestProvisionNodes_UsesAnnotationNodeClassName(t *testing.T) {
 
 	for _, call := range mockClient.Calls {
 		if call.Method == "Create" {
-			createdNP, ok := call.Arguments[1].(*karpenterv1.NodePool)
-			if ok {
+			if createdNP, ok := call.Arguments[1].(*karpenterv1.NodePool); ok {
 				assert.Equal(t, "image-family-azure-linux", createdNP.Spec.Template.Spec.NodeClassRef.Name)
 			}
 		}
@@ -362,26 +583,18 @@ func TestDisableDriftRemediation_NodePoolNotFound(t *testing.T) {
 
 // --- EnsureNodesReady tests ---
 
-func TestEnsureNodesReady_AllReady(t *testing.T) {
+func TestEnsureNodesReady_AllReady_BYOOnly(t *testing.T) {
 	mockClient := test.NewClient()
 
-	nc := &karpenterv1.NodeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "nc-1",
-			Labels: map[string]string{
-				karpenterv1.NodePoolLabelKey: "default-ws1",
-			},
-		},
-		Status: karpenterv1.NodeClaimStatus{
-			Conditions: []status.Condition{
-				{Type: "Ready", Status: metav1.ConditionTrue},
-			},
-		},
-	}
-	nodeClaimList := &karpenterv1.NodeClaimList{}
-	relevantMap := mockClient.CreateMapWithType(nodeClaimList)
-	relevantMap[client.ObjectKeyFromObject(nc)] = nc
+	// 1 ready BYO node with correct instance type.
+	nodeList := &corev1.NodeList{}
+	nodeMap := mockClient.CreateMapWithType(nodeList)
+	nodeMap[client.ObjectKeyFromObject(makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil))] =
+		makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
+	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
 
+	// No karpenter NodeClaims.
+	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
 	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
 
 	p := NewKarpenterProvisioner(mockClient, testConfig)
@@ -393,42 +606,52 @@ func TestEnsureNodesReady_AllReady(t *testing.T) {
 	assert.False(t, needRequeue)
 }
 
-func TestEnsureNodesReady_SomeNotReady(t *testing.T) {
+func TestEnsureNodesReady_MixedBYOAndKarpenter(t *testing.T) {
 	mockClient := test.NewClient()
 
+	// 1 BYO + 1 karpenter node, target=2.
+	nodeList := &corev1.NodeList{}
+	nodeMap := mockClient.CreateMapWithType(nodeList)
+	byoNode := makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
+	karpNode := makeReadyNode("karp-1", "Standard_NC24ads_A100_v4", map[string]string{
+		consts.KarpenterWorkspaceNameKey: "ws1",
+	})
+	nodeMap[client.ObjectKeyFromObject(byoNode)] = byoNode
+	nodeMap[client.ObjectKeyFromObject(karpNode)] = karpNode
+	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
+
+	// 1 karpenter NodeClaim ready.
 	nc := &karpenterv1.NodeClaim{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: "nc-1",
-			Labels: map[string]string{
-				karpenterv1.NodePoolLabelKey: "default-ws1",
-			},
+			Name:   "nc-1",
+			Labels: map[string]string{karpenterv1.NodePoolLabelKey: "default-ws1"},
 		},
 		Status: karpenterv1.NodeClaimStatus{
-			Conditions: []status.Condition{
-				{Type: "Ready", Status: metav1.ConditionFalse},
-			},
+			Conditions: []status.Condition{{Type: "Ready", Status: metav1.ConditionTrue}},
 		},
 	}
-	nodeClaimList := &karpenterv1.NodeClaimList{}
-	relevantMap := mockClient.CreateMapWithType(nodeClaimList)
-	relevantMap[client.ObjectKeyFromObject(nc)] = nc
-
+	ncList := &karpenterv1.NodeClaimList{}
+	ncMap := mockClient.CreateMapWithType(ncList)
+	ncMap[client.ObjectKeyFromObject(nc)] = nc
 	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
 
 	p := NewKarpenterProvisioner(mockClient, testConfig)
-	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
 
 	ready, needRequeue, err := p.EnsureNodesReady(context.Background(), ws)
 	assert.NoError(t, err)
-	assert.False(t, ready)
+	assert.True(t, ready)
 	assert.False(t, needRequeue)
 }
 
 func TestEnsureNodesReady_CountBelowTarget(t *testing.T) {
 	mockClient := test.NewClient()
 
+	// No karpenter NodeClaims.
 	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
 	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
+
+	mockEmptyNodeList(mockClient)
 
 	p := NewKarpenterProvisioner(mockClient, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
@@ -451,30 +674,22 @@ func TestEnsureNodesReady_ListError(t *testing.T) {
 	assert.Contains(t, err.Error(), "API error")
 }
 
-func TestEnsureNodesReady_NodeClaimBeingDeleted(t *testing.T) {
+func TestEnsureNodesReady_DeletingNodeNotCounted(t *testing.T) {
 	mockClient := test.NewClient()
 
-	now := metav1.Now()
-	nc := &karpenterv1.NodeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:              "nc-1",
-			DeletionTimestamp: &now,
-			Finalizers:        []string{"karpenter.sh/termination"},
-			Labels: map[string]string{
-				karpenterv1.NodePoolLabelKey: "default-ws1",
-			},
-		},
-		Status: karpenterv1.NodeClaimStatus{
-			Conditions: []status.Condition{
-				{Type: "Ready", Status: metav1.ConditionTrue},
-			},
-		},
-	}
-	nodeClaimList := &karpenterv1.NodeClaimList{}
-	relevantMap := mockClient.CreateMapWithType(nodeClaimList)
-	relevantMap[client.ObjectKeyFromObject(nc)] = nc
-
+	// No karpenter NodeClaims.
+	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
 	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
+
+	// 1 node being deleted — should not count.
+	now := metav1.Now()
+	deletingNode := makeReadyNode("deleting-1", "Standard_NC24ads_A100_v4", nil)
+	deletingNode.DeletionTimestamp = &now
+	deletingNode.Finalizers = []string{"test/finalizer"}
+	nodeList := &corev1.NodeList{}
+	nodeMap := mockClient.CreateMapWithType(nodeList)
+	nodeMap[client.ObjectKeyFromObject(deletingNode)] = deletingNode
+	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
 
 	p := NewKarpenterProvisioner(mockClient, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
@@ -487,26 +702,18 @@ func TestEnsureNodesReady_NodeClaimBeingDeleted(t *testing.T) {
 
 // --- CollectNodeStatusInfo tests ---
 
-func TestCollectNodeStatusInfo_AllReady(t *testing.T) {
+func TestCollectNodeStatusInfo_AllReady_BYOOnly(t *testing.T) {
 	mockClient := test.NewClient()
 
-	nc := &karpenterv1.NodeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "nc-1",
-			Labels: map[string]string{
-				karpenterv1.NodePoolLabelKey: "default-ws1",
-			},
-		},
-		Status: karpenterv1.NodeClaimStatus{
-			Conditions: []status.Condition{
-				{Type: "Ready", Status: metav1.ConditionTrue},
-			},
-		},
-	}
-	nodeClaimList := &karpenterv1.NodeClaimList{}
-	relevantMap := mockClient.CreateMapWithType(nodeClaimList)
-	relevantMap[client.ObjectKeyFromObject(nc)] = nc
+	// 1 ready BYO node.
+	nodeList := &corev1.NodeList{}
+	nodeMap := mockClient.CreateMapWithType(nodeList)
+	nodeMap[client.ObjectKeyFromObject(makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil))] =
+		makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
+	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
 
+	// No karpenter NodeClaims.
+	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
 	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
 
 	p := NewKarpenterProvisioner(mockClient, testConfig)
@@ -521,8 +728,9 @@ func TestCollectNodeStatusInfo_AllReady(t *testing.T) {
 	}
 }
 
-func TestCollectNodeStatusInfo_NotEnoughNodeClaims(t *testing.T) {
+func TestCollectNodeStatusInfo_NotEnoughNodes(t *testing.T) {
 	mockClient := test.NewClient()
+	mockEmptyNodeList(mockClient)
 
 	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
 	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
@@ -554,23 +762,13 @@ func TestCollectNodeStatusInfo_ListError(t *testing.T) {
 func TestCollectNodeStatusInfo_ConditionTypes(t *testing.T) {
 	mockClient := test.NewClient()
 
-	nc := &karpenterv1.NodeClaim{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: "nc-1",
-			Labels: map[string]string{
-				karpenterv1.NodePoolLabelKey: "default-ws1",
-			},
-		},
-		Status: karpenterv1.NodeClaimStatus{
-			Conditions: []status.Condition{
-				{Type: "Ready", Status: metav1.ConditionTrue},
-			},
-		},
-	}
-	nodeClaimList := &karpenterv1.NodeClaimList{}
-	relevantMap := mockClient.CreateMapWithType(nodeClaimList)
-	relevantMap[client.ObjectKeyFromObject(nc)] = nc
+	nodeList := &corev1.NodeList{}
+	nodeMap := mockClient.CreateMapWithType(nodeList)
+	nodeMap[client.ObjectKeyFromObject(makeReadyNode("node-1", "Standard_NC24ads_A100_v4", nil))] =
+		makeReadyNode("node-1", "Standard_NC24ads_A100_v4", nil)
+	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
 
+	mockClient.CreateMapWithType(&karpenterv1.NodeClaimList{})
 	mockClient.On("List", mock.IsType(context.Background()), mock.IsType(&karpenterv1.NodeClaimList{}), mock.Anything).Return(nil)
 
 	p := NewKarpenterProvisioner(mockClient, testConfig)

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -117,7 +117,6 @@ const (
 	SpotInstanceValue         = "spot"
 
 	// Karpenter NodePool management labels and values.
-	KarpenterWorkspaceKey             = "karpenter.kaito.sh/workspace"
 	KarpenterWorkspaceNameKey         = "karpenter.kaito.sh/workspace-name"
 	KarpenterWorkspaceNamespaceKey    = "karpenter.kaito.sh/workspace-namespace"
 	KarpenterInferenceSetKey          = "karpenter.kaito.sh/inferenceset"

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -57,7 +57,7 @@ var (
 
 	KarpenterWorkspaceSelector, _ = metav1.LabelSelectorAsSelector(&metav1.LabelSelector{
 		MatchExpressions: []metav1.LabelSelectorRequirement{
-			{Key: consts.KarpenterWorkspaceKey, Operator: metav1.LabelSelectorOpExists},
+			{Key: consts.KarpenterWorkspaceNameKey, Operator: metav1.LabelSelectorOpExists},
 		},
 	})
 

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -33,7 +33,6 @@ import (
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
-	"github.com/kaito-project/kaito/pkg/nodeprovision/karpenter"
 	"github.com/kaito-project/kaito/pkg/sku"
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
@@ -103,17 +102,6 @@ func defaultTolerations(ws *v1beta1.Workspace) []corev1.Toleration {
 			Key:      consts.SpotInstanceKey,
 			Operator: corev1.TolerationOpEqual,
 			Value:    consts.SpotInstanceValue,
-		})
-	}
-
-	// Tolerate the karpenter workspace taint so inference pods can schedule
-	// on karpenter-provisioned GPU nodes.
-	if consts.IsKarpenterProvisioner() {
-		tolerations = append(tolerations, corev1.Toleration{
-			Effect:   corev1.TaintEffectNoSchedule,
-			Key:      consts.KarpenterWorkspaceKey,
-			Operator: corev1.TolerationOpEqual,
-			Value:    karpenter.WorkspaceLabelValue(ws.Namespace, ws.Name),
 		})
 	}
 

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -478,11 +478,6 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 			},
 		})
 
-		if consts.IsKarpenterProvisioner() {
-			spec.NodeSelector = map[string]string{
-				consts.KarpenterWorkspaceKey: karpenter.WorkspaceLabelValue(ctx.Workspace.Namespace, ctx.Workspace.Name),
-			}
-		}
 		spec.Affinity = &corev1.Affinity{
 			NodeAffinity: &corev1.NodeAffinity{
 				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -34,7 +34,6 @@ import (
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
-	"github.com/kaito-project/kaito/pkg/nodeprovision/karpenter"
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/generator"
@@ -275,14 +274,6 @@ func GenerateManifestWithPodTemplate(workspaceObj *kaitov1beta1.Workspace, toler
 			templateCopy.ObjectMeta.Labels[consts.WorkspaceCreatedByInferenceSetLabel] = createdBy
 			labelselector.MatchLabels[consts.WorkspaceCreatedByInferenceSetLabel] = createdBy
 		}
-	}
-
-	// Pin pods to nodes provisioned for this workspace (karpenter only).
-	if consts.IsKarpenterProvisioner() {
-		if templateCopy.Spec.NodeSelector == nil {
-			templateCopy.Spec.NodeSelector = make(map[string]string)
-		}
-		templateCopy.Spec.NodeSelector[consts.KarpenterWorkspaceKey] = karpenter.WorkspaceLabelValue(workspaceObj.Namespace, workspaceObj.Name)
 	}
 
 	// Overwrite affinity


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
Integrated karpenter provisioner into kaito. Supports mixed usage of nodes from Karpenter, legacy gpuprovisioner, and byo nodes.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Closes #1952 
**Notes for Reviewers**:

## Updated Design (Current Implementation)

The implementation has evolved significantly from the original issue description. Key changes:

### Architecture

- **No feature gate / runtime NodeClaim inspection for provisioner selection.**
  The provisioner is selected at startup via `--node-provisioner=karpenter|azure-gpu-provisioner|byo`.
  When karpenter mode is active, it handles all workspaces.

- **No workspace-specific nodeSelector or toleration on pods.**
  Pods schedule through `nodeAffinity` matching the workspace's `labelSelector`.

- **`sku=gpu:NoSchedule` taint** on NodePool template.
  All workspace pods tolerate this through `defaultTolerations()`, similar to legacy workspaces.

- **Delta-based provisioning.**
  `desiredReplicas = max(0, targetNodeCount - coveredByNonKarpenterCount)`
  BYO nodes and legacy nodeclaims are counted as already covered.

- **Monotonic replicas.**
  Replicas only increase, never decrease.

- **No NodePool if `desiredReplicas = 0`.**

- **No GC controller.**
  Legacy NodeClaims continue running and reduce provisioning target.

- **Owner references for cleanup.**
  Workspace deletion cascades to NodePool → NodeClaim → Node → VM.

Note: We consider legacy nodeclaims to count towards target node because when legacy nodeclaims nodes are down, Karpenter will wait for it to self-heal for 10 minutes. In case it recovers, we won't provision a new nodeclaim to replace it. Once the 10-minute timeout passes, the nodeclaim will be deleted by Karpenter and trigger a reconcile, which will provision a new nodeclaim. This is consistent with how the Karpenter static provisioning behaves.
During the 10-minute timeout window, the node will attempt to reboot after 5 minute, so we give it at least a chance to reboot.
### Readiness Checks (3-step)

1. **NodeClaim readiness:**
   `readyNodeClaimCount >= max(0, target - coveredBynonKarpenterNodes)`

2. **Node readiness:**
   `readyWithInstanceType >= targetNodeCount`

3. **GPU plugin readiness:**
   `CheckIfNodePluginsReady()` (only for karpenter NodeClaims). For byo nodes and legacy gpuprovisioner nodeclaims, we assume GPU plugin is ready.

### Status Conditions

Reported on `workspace.status.conditions`:

- `NodeClaimReady` — enough karpenter NodeClaims ready. Target nodeclaims count is the target node count minus the number of ready BYO nodes minus the number of legacy Nodeclaims (regardless of readiness).
- `NodesReady` — enough GPU-ready nodes
- `ResourceReady` — overall readiness

### NodePool Structure

- Labels:
  `karpenter.kaito.sh/managed-by=kaito`, workspace name/namespace

- InferenceSet adds:
  `karpenter.kaito.sh/inferenceset`

- Taint:
  `sku=gpu:NoSchedule`

- Requirements:
  `node.kubernetes.io/instance-type In [<instanceType>]`

- Disruption budget:
  `nodes: "1"` (standalone) or `nodes: "0"` (InferenceSet)

- `consolidateAfter: 0s`

## Updated Scenario Matrix

| # | Scenario | BYO Nodes | Legacy NodeClaims | Karpenter NodeClaims | Provisioner Mode | Expected Behavior |
|---|----------|-----------|-------------------|---------------------|-----------------|-------------------|
| 1 | Fresh standalone workspace, no BYO | 0 | 0 | 0 | karpenter | Creates NodePool with replicas=targetNodeCount |
| 2 | Fresh standalone workspace, BYO covers all | ≥target | 0 | 0 | karpenter | No NodePool created (desiredReplicas=0) |
| 3 | Fresh standalone workspace, BYO partial | <target | 0 | 0 | karpenter | Creates NodePool with replicas=(target-BYO) |
| 4 | InferenceSet workspace, no BYO | 0 | 0 | 0 | karpenter | Creates NodePool with budget "0" for drift, InferenceSet labels |
| 5 | Existing workspace with legacy nodes | 0 | >0 | 0 | karpenter | Non-deleting legacy NCs counted as covered (even if node is down); no NodePool if they suffice |
| 6 | Mixed legacy + karpenter | 0 | >0 | >0 | karpenter | Both counted toward readiness. karpenter replicas not decreased |
| 11 | Legacy NC node down — no duplicate provisioning | 0 | >0 (node down) | 0 | karpenter | No replacement provisioned while NC exists. Once NC GCed (10 min timeout), karpenter provisions |
| 7 | Scale-up: target increases | varies | 0 | >0 | karpenter | NodePool replicas increase (never decrease) |
| 8 | BYO appears after karpenter provisioned | >0 (new) | 0 | >0 | karpenter | NodePool replicas stay same (monotonic — never decrease) |
| 9 | Concurrent standalone workspaces | 0 | 0 | 0 | karpenter | Each gets its own NodePool. no interference |
| 10 | InferenceSet with multiple replicas | 0 | 0 | 0 | karpenter | Each workspace gets isolated NodePool with IS labels |

### Non-karpenter Node Identification

A node is considered **non-karpenter** if it lacks the label:
`karpenter.kaito.sh/workspace-name`

This includes:
- BYO nodes (no NodeClaim)
- Legacy gpu-provisioner nodes

### Verified the following cases locally:
1. Standalone workspace: NodePool created with correct structure (labels, taints, requirements, disruption budget "1"), NodeClaim provisioned, all three node conditions become True
2. BYO-covered workspace: no NodePool created when a matching BYO node already satisfies the requirement; NodeClaimReady=True via 0 >= 0 delta logic
3. Monotonic replicas: NodePool replicas don't decrease when a BYO node is labeled to match an already-provisioned workspace
4. InferenceSet single replica: workspace gets InferenceSet labels on NodePool template (karpenter.kaito.sh/inferenceset, karpenter.kaito.sh/inferenceset-namespace), drift budget nodes: "0"
5. InferenceSet multi-replica isolation: each replica workspace gets its own NodePool and NodeClaim, no sharing
InferenceSet cascade deletion. Deleting InferenceSet cleans up all child workspaces and their NodePools
6. Legacy node migration: after switching from gpu-provisioner to karpenter mode, existing legacy nodes are counted as nonKarpenterReady, so no NodePool is created (targetNodeClaimCount=0)
7. Full deletion cascade: workspace delete → NodePool (owner ref) → NodeClaim (karpenter) → Node → VM termination
8. NodeClass annotation override: `kaito.sh/node-class-name: image-family-azure-linux` correctly overrides the default `image-family-ubuntu` in the NodePool's nodeClassRef
9. Multi-node scale-up: targetNodeCount=2, NodePool with replicas=2, and 2 NodeClaims provisioned to separate nodes
10. Partial BYO (1 of 2 nodes): BYO covers 1 of 2 needed nodes, NodePool created with replicas=1 (delta: 2 - 1 BYO = 1)
11. Karpenter takeover: legacy NodeClaim deleted while in karpenter mode → karpenter creates replacement NodePool and NodeClaim, full recovery
12. Mixed BYO + legacy + karpenter: BYO + legacy fully cover targetNodeCount=2 (no NodePool), then legacy removed → karpenter fills the gap with replicas=1, final state 1 BYO + 1 karpenter
#### The bahviors is only verified locally. E2E tests will be implemented in a separate PR for issue #1953