### PR TITLE
refactor: introduce local apis.FieldError shim for non-webhook callers

### DIFF
--- a/pkg/apis/fielderror.go
+++ b/pkg/apis/fielderror.go
@@ -12,8 +12,9 @@
 // limitations under the License.
 
 // Package apis provides a lightweight replacement for knative.dev/pkg/apis
-// error types used in webhook validation. It implements the same chaining
-// API (Also, ViaField) so validation code requires only an import path change.
+// types used by KAITO. This first slice exposes only what non-webhook callers
+// need; chaining helpers (Also, ViaField, ErrGeneric) will be added in the
+// follow-up PR that migrates the validation files themselves.
 package apis
 
 import (
@@ -21,98 +22,22 @@ import (
 	"strings"
 )
 
-// FieldError represents one or more validation errors, supporting
-// nil-safe chaining with Also() and field-path scoping with ViaField().
+// FieldError represents a validation error for one or more fields. It satisfies
+// the error interface so it can be returned from APIs typed as error.
 type FieldError struct {
 	Message string
 	Paths   []string
-	Details string
-	errors  []*FieldError // child errors accumulated via Also()
 }
 
 // Error implements the error interface.
 func (fe *FieldError) Error() string {
-	if fe == nil {
+	if fe == nil || fe.Message == "" {
 		return ""
 	}
-	var msgs []string
-	fe.collectMessages(&msgs)
-	return strings.Join(msgs, "; ")
-}
-
-func (fe *FieldError) collectMessages(msgs *[]string) {
-	if fe == nil {
-		return
+	if path := strings.Join(fe.Paths, ", "); path != "" {
+		return fmt.Sprintf("%s: %s", fe.Message, path)
 	}
-	if fe.Message != "" {
-		path := strings.Join(fe.Paths, ", ")
-		if path != "" {
-			*msgs = append(*msgs, fmt.Sprintf("%s: %s", fe.Message, path))
-		} else {
-			*msgs = append(*msgs, fe.Message)
-		}
-	}
-	for _, child := range fe.errors {
-		child.collectMessages(msgs)
-	}
-}
-
-// Also accumulates another FieldError. Both receiver and argument may be nil.
-func (fe *FieldError) Also(others ...*FieldError) *FieldError {
-	var nonNil []*FieldError
-	if fe != nil {
-		nonNil = append(nonNil, fe)
-	}
-	for _, o := range others {
-		if o != nil {
-			nonNil = append(nonNil, o)
-		}
-	}
-	switch len(nonNil) {
-	case 0:
-		return nil
-	case 1:
-		return nonNil[0]
-	default:
-		return &FieldError{errors: nonNil}
-	}
-}
-
-// ViaField prepends a field path segment to all errors in this FieldError.
-func (fe *FieldError) ViaField(field string) *FieldError {
-	if fe == nil || field == "" {
-		return fe
-	}
-	fe.prependPath(field)
-	return fe
-}
-
-func (fe *FieldError) prependPath(prefix string) {
-	if fe == nil {
-		return
-	}
-	if len(fe.Paths) > 0 {
-		for i, p := range fe.Paths {
-			if p == "" {
-				fe.Paths[i] = prefix
-			} else {
-				fe.Paths[i] = prefix + "." + p
-			}
-		}
-	} else if fe.Message != "" {
-		fe.Paths = []string{prefix}
-	}
-	for _, child := range fe.errors {
-		child.prependPath(prefix)
-	}
-}
-
-// ErrGeneric creates a FieldError with the given message and optional field paths.
-func ErrGeneric(msg string, paths ...string) *FieldError {
-	return &FieldError{
-		Message: msg,
-		Paths:   paths,
-	}
+	return fe.Message
 }
 
 // ErrInvalidValue creates a FieldError indicating an invalid value.
@@ -131,9 +56,10 @@ func ErrMissingField(fields ...string) *FieldError {
 	}
 }
 
-// ConditionType is a type for condition type constants.
+// ConditionType is a type for condition type constants. It mirrors
+// knative.dev/pkg/apis.ConditionType so call sites can be migrated one
+// package at a time.
 type ConditionType string
 
 // ConditionReady is a condition type indicating readiness.
-// This replaces knative.dev/pkg/apis.ConditionReady.
 const ConditionReady ConditionType = "Ready"

--- a/pkg/apis/fielderror.go
+++ b/pkg/apis/fielderror.go
@@ -1,0 +1,139 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package apis provides a lightweight replacement for knative.dev/pkg/apis
+// error types used in webhook validation. It implements the same chaining
+// API (Also, ViaField) so validation code requires only an import path change.
+package apis
+
+import (
+	"fmt"
+	"strings"
+)
+
+// FieldError represents one or more validation errors, supporting
+// nil-safe chaining with Also() and field-path scoping with ViaField().
+type FieldError struct {
+	Message string
+	Paths   []string
+	Details string
+	errors  []*FieldError // child errors accumulated via Also()
+}
+
+// Error implements the error interface.
+func (fe *FieldError) Error() string {
+	if fe == nil {
+		return ""
+	}
+	var msgs []string
+	fe.collectMessages(&msgs)
+	return strings.Join(msgs, "; ")
+}
+
+func (fe *FieldError) collectMessages(msgs *[]string) {
+	if fe == nil {
+		return
+	}
+	if fe.Message != "" {
+		path := strings.Join(fe.Paths, ", ")
+		if path != "" {
+			*msgs = append(*msgs, fmt.Sprintf("%s: %s", fe.Message, path))
+		} else {
+			*msgs = append(*msgs, fe.Message)
+		}
+	}
+	for _, child := range fe.errors {
+		child.collectMessages(msgs)
+	}
+}
+
+// Also accumulates another FieldError. Both receiver and argument may be nil.
+func (fe *FieldError) Also(others ...*FieldError) *FieldError {
+	var nonNil []*FieldError
+	if fe != nil {
+		nonNil = append(nonNil, fe)
+	}
+	for _, o := range others {
+		if o != nil {
+			nonNil = append(nonNil, o)
+		}
+	}
+	switch len(nonNil) {
+	case 0:
+		return nil
+	case 1:
+		return nonNil[0]
+	default:
+		return &FieldError{errors: nonNil}
+	}
+}
+
+// ViaField prepends a field path segment to all errors in this FieldError.
+func (fe *FieldError) ViaField(field string) *FieldError {
+	if fe == nil || field == "" {
+		return fe
+	}
+	fe.prependPath(field)
+	return fe
+}
+
+func (fe *FieldError) prependPath(prefix string) {
+	if fe == nil {
+		return
+	}
+	if len(fe.Paths) > 0 {
+		for i, p := range fe.Paths {
+			if p == "" {
+				fe.Paths[i] = prefix
+			} else {
+				fe.Paths[i] = prefix + "." + p
+			}
+		}
+	} else if fe.Message != "" {
+		fe.Paths = []string{prefix}
+	}
+	for _, child := range fe.errors {
+		child.prependPath(prefix)
+	}
+}
+
+// ErrGeneric creates a FieldError with the given message and optional field paths.
+func ErrGeneric(msg string, paths ...string) *FieldError {
+	return &FieldError{
+		Message: msg,
+		Paths:   paths,
+	}
+}
+
+// ErrInvalidValue creates a FieldError indicating an invalid value.
+func ErrInvalidValue(value interface{}, field string) *FieldError {
+	return &FieldError{
+		Message: fmt.Sprintf("invalid value: %v", value),
+		Paths:   []string{field},
+	}
+}
+
+// ErrMissingField creates a FieldError indicating a required field is missing.
+func ErrMissingField(fields ...string) *FieldError {
+	return &FieldError{
+		Message: "missing field(s)",
+		Paths:   fields,
+	}
+}
+
+// ConditionType is a type for condition type constants.
+type ConditionType string
+
+// ConditionReady is a condition type indicating readiness.
+// This replaces knative.dev/pkg/apis.ConditionReady.
+const ConditionReady ConditionType = "Ready"

--- a/pkg/ragengine/controllers/ragengine_controller_test.go
+++ b/pkg/ragengine/controllers/ragengine_controller_test.go
@@ -36,12 +36,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
-	"knative.dev/pkg/apis"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	"github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/apis"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/test"
 )

--- a/pkg/utils/common.go
+++ b/pkg/utils/common.go
@@ -31,11 +31,11 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	karpenterapis "sigs.k8s.io/karpenter/pkg/apis"
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
+	"github.com/kaito-project/kaito/pkg/apis"
 	"github.com/kaito-project/kaito/pkg/sku"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 )

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
 	"k8s.io/utils/clock"
-	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -41,6 +40,7 @@ import (
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/apis"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 )

--- a/pkg/utils/nodeclaim/nodeclaim_test.go
+++ b/pkg/utils/nodeclaim/nodeclaim_test.go
@@ -25,11 +25,11 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
-	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/apis"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/test"
 )

--- a/test/e2e/utils/nodeclaim.go
+++ b/test/e2e/utils/nodeclaim.go
@@ -24,11 +24,11 @@ import (
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
-	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 
 	"github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/apis"
 )
 
 // ValidateNodeClaimCreation Logic to validate the nodeClaim creation.


### PR DESCRIPTION
Add pkg/apis/fielderror.go as a drop-in replacement for the subset of knative.dev/pkg/apis used outside the webhook framework. Migrate the five files that only use apis.ConditionReady or apis error helpers via the error interface; these don't participate in knative's GenericCRD contract so they can swap in isolation.

Validation files in api/v1alpha1 and api/v1beta1, and the webhook runtime itself, will follow in a separate PR — they're coupled to the GenericCRD interface and can't be swapped without simultaneously replacing the webhook framework.

Refs #1981

**Reason for Change**:
Fixes https://github.com/kaito-project/kaito/issues/1981

**Requirements**

- [] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
First part of https://github.com/kaito-project/kaito/issues/1981 

**Notes for Reviewers**: