### PR TITLE
feat: support vllm inference for GGUF models

### DIFF
--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -377,10 +377,14 @@ func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
 		p.VLLM.ModelRunParams["enable-lora"] = ""
 	}
 	if p.DownloadAtRuntime {
-		repoId, revision, _ := utils.ParseHuggingFaceModelVersion(p.Version)
-		p.VLLM.ModelRunParams["model"] = repoId
-		if revision != "" {
-			p.VLLM.ModelRunParams["code-revision"] = revision
+		// Only set --model from Version URL if not already set by the generator
+		// (e.g., GGUF models set --model to repo_id:quant_type in FinalizeParams).
+		if _, hasModel := p.VLLM.ModelRunParams["model"]; !hasModel {
+			repoId, revision, _ := utils.ParseHuggingFaceModelVersion(p.Version)
+			p.VLLM.ModelRunParams["model"] = repoId
+			if revision != "" {
+				p.VLLM.ModelRunParams["code-revision"] = revision
+			}
 		}
 		p.VLLM.ModelRunParams["download-dir"] = utils.DefaultWeightsVolumePath
 	}

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -42,6 +42,7 @@ var (
 	safetensorRegex = regexp.MustCompile(`.*\.safetensors`)
 	binRegex        = regexp.MustCompile(`.*\.bin`)
 	mistralRegex    = regexp.MustCompile(`consolidated.*\.safetensors`)
+	ggufRegex       = regexp.MustCompile(`.*\.gguf`)
 	// source: https://github.com/vllm-project/vllm/blob/main/vllm/reasoning/__init__.py
 	reasoningParserModeNamePrefixMap = map[string]string{
 		"deepseek-r1":  "deepseek_r1",
@@ -251,10 +252,13 @@ var (
 
 type Generator struct {
 	ModelRepo      string
+	QuantType      string // GGUF quantization type (e.g., "Q4_K_M"); empty for non-GGUF models
 	Token          string
 	Param          model.PresetParam
 	CatalogData    []byte // Optional embedded catalog YAML
+	IsGGUFModel    bool
 	IsMistralModel bool
+	BaseModel      string
 
 	// Analyzed params
 	LoadFormat    string
@@ -264,11 +268,31 @@ type Generator struct {
 }
 
 func NewGenerator(modelRepo, token string) *Generator {
+	// Strip GGUF quant suffix (e.g., "unsloth/Qwen3-0.6B-GGUF:Q4_K_M" -> repo="unsloth/Qwen3-0.6B-GGUF", quant="Q4_K_M")
+	var quantType string
+	var isGGUF bool
+	if idx := strings.LastIndex(modelRepo, ":"); idx > 0 {
+		// Only split if the colon is after a "/" (i.e., it's repo_id:quant, not a scheme)
+		if strings.Contains(modelRepo[:idx], "/") {
+			quantType = modelRepo[idx+1:]
+			modelRepo = modelRepo[:idx]
+			isGGUF = true
+		}
+	}
+
+	// Lowercase non-GGUF repo IDs for consistent registry keys and prefix matching.
+	// Preserve original case for GGUF models to avoid model resolvement issues on vLLM.
+	if !isGGUF {
+		modelRepo = strings.ToLower(modelRepo)
+	}
+
 	nameParts := strings.Split(modelRepo, "/")
 	modelNameSafe := strings.ToLower(nameParts[len(nameParts)-1])
 
 	gen := &Generator{
 		ModelRepo:     modelRepo,
+		QuantType:     quantType,
+		IsGGUFModel:   isGGUF,
 		Token:         token,
 		LoadFormat:    "auto",
 		ConfigFormat:  "auto",
@@ -342,11 +366,19 @@ func (g *Generator) FetchModelMetadata() error {
 
 	selectedFiles := g.selectWeightFiles(files)
 	if len(selectedFiles) == 0 {
-		return fmt.Errorf("no .safetensors or .bin files found")
+		return fmt.Errorf("no .safetensors or .bin or .gguf files found")
 	}
 
 	if g.IsMistralModel {
 		g.setMistralMode()
+	}
+	if g.IsGGUFModel {
+		g.setGGUFMode()
+		// Auto-deduce the base model from HuggingFace model card metadata.
+		_, _, baseModels := fetchModelInfo(g, g.ModelRepo)
+		if len(baseModels) > 0 {
+			g.BaseModel = baseModels[0]
+		}
 	}
 
 	g.Param.Metadata.ModelFileSize = calculateModelFileSize(selectedFiles)
@@ -378,10 +410,11 @@ func (g *Generator) listRepoFiles() ([]FileInfo, error) {
 // selectWeightFiles picks the model weight files to use and detects whether
 // the model uses Mistral format. For Mistral-format models (those with
 // consolidated*.safetensors), it sets g.IsMistralModel and returns only the
-// consolidated files. For standard models, it prefers .safetensors over .bin
+// consolidated files. For GGUF models, it returns the single GGUF file matching
+// the requested quant type. For standard models, it prefers .safetensors over .bin
 // when both are present.
 func (g *Generator) selectWeightFiles(files []FileInfo) []FileInfo {
-	var safetensors, bins, mistral []FileInfo
+	var safetensors, bins, mistral, ggufs []FileInfo
 
 	for _, f := range files {
 		if mistralRegex.MatchString(f.Path) {
@@ -391,7 +424,14 @@ func (g *Generator) selectWeightFiles(files []FileInfo) []FileInfo {
 			safetensors = append(safetensors, f)
 		} else if binRegex.MatchString(f.Path) {
 			bins = append(bins, f)
+		} else if ggufRegex.MatchString(f.Path) {
+			ggufs = append(ggufs, f)
 		}
+	}
+
+	// GGUF mode: filter by quant type if specified
+	if g.IsGGUFModel && len(ggufs) > 0 {
+		return g.selectGGUFFile(ggufs)
 	}
 
 	if len(mistral) > 0 {
@@ -406,10 +446,29 @@ func (g *Generator) selectWeightFiles(files []FileInfo) []FileInfo {
 	return bins
 }
 
+// selectGGUFFile finds the GGUF file matching the requested quant type.
+// It matches files containing the quant type string (case-insensitive).
+func (g *Generator) selectGGUFFile(ggufs []FileInfo) []FileInfo {
+	quantUpper := strings.ToUpper(g.QuantType)
+	for _, f := range ggufs {
+		fileUpper := strings.ToUpper(f.Path)
+		if strings.Contains(fileUpper, quantUpper) {
+			return []FileInfo{f}
+		}
+	}
+	return nil
+}
+
 func (g *Generator) setMistralMode() {
 	g.LoadFormat = "mistral"
 	g.ConfigFormat = "mistral"
 	g.TokenizerMode = "mistral"
+}
+
+func (g *Generator) setGGUFMode() {
+	g.LoadFormat = "gguf"
+	g.ConfigFormat = "auto"
+	g.TokenizerMode = "auto"
 }
 
 func calculateModelFileSize(files []FileInfo) string {
@@ -423,11 +482,17 @@ func calculateModelFileSize(files []FileInfo) string {
 
 // fetchAndParseConfig downloads and parses the model's config.json. For
 // Mistral-format models, it falls back to params.json if config.json is absent.
+// For GGUF models without config.json, it falls back to the base model's config.json.
 func (g *Generator) fetchAndParseConfig() error {
 	configBody, err := g.fetchConfigFile("config.json")
 	if err != nil && g.IsMistralModel {
 		// config.json not available; fall back to params.json (Mistral native format).
 		configBody, err = g.fetchConfigFile("params.json")
+	}
+	if err != nil && g.BaseModel != "" {
+		// config.json not available in model repo; fall back to base model repo.
+		url := fmt.Sprintf("%s/%s/resolve/main/config.json", HuggingFaceWebsite, g.BaseModel)
+		configBody, err = g.fetchURL(url)
 	}
 	if err != nil {
 		return fmt.Errorf("error fetching config: %v", err)
@@ -674,6 +739,17 @@ func (g *Generator) FinalizeParams() {
 		}
 	}
 
+	// For GGUF models, set --model to the full repo_id:quant_type format.
+	if g.IsGGUFModel {
+		g.Param.VLLM.ModelRunParams["model"] = g.ModelRepo + ":" + g.QuantType
+	}
+
+	// For GGUF models, auto-set --hf-config-path and --tokenizer from the base model.
+	if g.BaseModel != "" {
+		g.Param.VLLM.ModelRunParams["hf-config-path"] = g.BaseModel
+		g.Param.VLLM.ModelRunParams["tokenizer"] = g.BaseModel
+	}
+
 	// Set attention backend based on model name prefix
 	for prefix, backend := range vllmAttentionBackendPrefixMap {
 		if strings.HasPrefix(g.Param.Metadata.Name, prefix) {
@@ -723,8 +799,13 @@ func (g *Generator) loadFromCatalog() bool {
 	}
 
 	var entry *CatalogEntry
+	// For GGUF models, match by full repo:quant name; otherwise match by repo.
+	lookupName := g.ModelRepo
+	if g.IsGGUFModel && g.QuantType != "" {
+		lookupName = g.ModelRepo + ":" + g.QuantType
+	}
 	for i, m := range catalog.Models {
-		if strings.EqualFold(m.Name, g.ModelRepo) {
+		if strings.EqualFold(m.Name, lookupName) {
 			entry = &catalog.Models[i]
 			break
 		}
@@ -771,18 +852,18 @@ func (g *Generator) loadFromCatalog() bool {
 	g.Param.Metadata.ModelFileSize = entry.ModelFileSize
 	g.Param.VLLM.ModelRunParams = make(map[string]string)
 
+	if len(entry.BaseModel) > 0 {
+		g.BaseModel = entry.BaseModel[0]
+	}
+
 	if entry.LoadFormat != "" {
 		g.LoadFormat = entry.LoadFormat
 	}
 	if entry.ConfigFormat != "" {
 		g.ConfigFormat = entry.ConfigFormat
-	} else if entry.LoadFormat != "" {
-		g.ConfigFormat = entry.LoadFormat
 	}
 	if entry.TokenizerMode != "" {
 		g.TokenizerMode = entry.TokenizerMode
-	} else if entry.LoadFormat != "" {
-		g.TokenizerMode = entry.LoadFormat
 	}
 
 	return true

--- a/presets/workspace/generator/generator_test.go
+++ b/presets/workspace/generator/generator_test.go
@@ -38,7 +38,7 @@ func TestGeneratePreset(t *testing.T) {
 					Name:                   "phi-4-mini-instruct",
 					Architectures:          []string{"Phi3ForCausalLM"},
 					ModelType:              "tfs",
-					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "microsoft/Phi-4-mini-instruct"),
+					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "microsoft/phi-4-mini-instruct"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
 					ModelFileSize:          "7.15Gi",
@@ -92,7 +92,7 @@ func TestGeneratePreset(t *testing.T) {
 					Name:                   "ministral-3-8b-instruct-2512",
 					Architectures:          []string{"Mistral3ForConditionalGeneration"},
 					ModelType:              "tfs",
-					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "mistralai/Ministral-3-8B-Instruct-2512"),
+					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "mistralai/ministral-3-8b-instruct-2512"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
 					ModelFileSize:          "9.70Gi",
@@ -120,7 +120,7 @@ func TestGeneratePreset(t *testing.T) {
 					Name:                   "mistral-large-3-675b-instruct-2512",
 					Architectures:          []string{"MistralLarge3ForCausalLM"},
 					ModelType:              "tfs",
-					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "mistralai/Mistral-Large-3-675B-Instruct-2512"),
+					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "mistralai/mistral-large-3-675b-instruct-2512"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
 					ModelFileSize:          "634.70Gi",
@@ -149,7 +149,7 @@ func TestGeneratePreset(t *testing.T) {
 					Name:                   "qwen3-coder-30b-a3b-instruct",
 					Architectures:          []string{"Qwen3MoeForCausalLM"},
 					ModelType:              "tfs",
-					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "Qwen/Qwen3-Coder-30B-A3B-Instruct"),
+					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "qwen/qwen3-coder-30b-a3b-instruct"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
 					ModelFileSize:          "56.87Gi",
@@ -178,7 +178,7 @@ func TestGeneratePreset(t *testing.T) {
 					Name:                   "qwen3-8b",
 					Architectures:          []string{"Qwen3ForCausalLM"},
 					ModelType:              "tfs",
-					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "Qwen/Qwen3-8B"),
+					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "qwen/qwen3-8b"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
 					ModelFileSize:          "15.26Gi",
@@ -207,7 +207,7 @@ func TestGeneratePreset(t *testing.T) {
 					Name:                   "deepseek-v3.1",
 					Architectures:          []string{"DeepseekV3ForCausalLM"},
 					ModelType:              "tfs",
-					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "deepseek-ai/DeepSeek-V3.1"),
+					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "deepseek-ai/deepseek-v3.1"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
 					ModelFileSize:          "641.30Gi",
@@ -237,7 +237,7 @@ func TestGeneratePreset(t *testing.T) {
 					Name:                   "deepseek-v3",
 					Architectures:          []string{"DeepseekV3ForCausalLM"},
 					ModelType:              "tfs",
-					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "deepseek-ai/DeepSeek-V3"),
+					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "deepseek-ai/deepseek-v3"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
 					ModelFileSize:          "641.30Gi",
@@ -267,7 +267,7 @@ func TestGeneratePreset(t *testing.T) {
 					Name:                   "nemotron-orchestrator-8b",
 					Architectures:          []string{"Qwen3ForCausalLM"},
 					ModelType:              "tfs",
-					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "nvidia/Nemotron-Orchestrator-8B"),
+					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "nvidia/nemotron-orchestrator-8b"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
 					ModelFileSize:          "30.51Gi",
@@ -296,7 +296,7 @@ func TestGeneratePreset(t *testing.T) {
 					Name:                   "qwen3-8b-awq",
 					Architectures:          []string{"Qwen3ForCausalLM"},
 					ModelType:              "tfs",
-					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "Qwen/Qwen3-8B-AWQ"),
+					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "qwen/qwen3-8b-awq"),
 					DownloadAtRuntime:      true,
 					DownloadAuthRequired:   false,
 					ModelFileSize:          "5.68Gi",
@@ -484,7 +484,7 @@ func TestLoadFromCatalog(t *testing.T) {
 					Name:                   "phi-4-mini-instruct",
 					Architectures:          []string{"Phi3ForCausalLM"},
 					ModelType:              "tfs",
-					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "microsoft/Phi-4-mini-instruct"),
+					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "microsoft/phi-4-mini-instruct"),
 					DownloadAtRuntime:      true,
 					ModelFileSize:          "7.15Gi",
 					BytesPerToken:          131072,
@@ -539,7 +539,7 @@ func TestLoadFromCatalog(t *testing.T) {
 					Name:                   "mistral-7b-v0.3",
 					Architectures:          []string{"MistralForCausalLM"},
 					ModelType:              "tfs",
-					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "mistralai/Mistral-7B-v0.3"),
+					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "mistralai/mistral-7b-v0.3"),
 					DownloadAtRuntime:      true,
 					ModelFileSize:          "13.50Gi",
 					BytesPerToken:          131072,
@@ -558,7 +558,7 @@ func TestLoadFromCatalog(t *testing.T) {
 					Name:                   "ministral-3-8b-instruct-2512",
 					Architectures:          []string{"Mistral3ForConditionalGeneration"},
 					ModelType:              "tfs",
-					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "mistralai/Ministral-3-8B-Instruct-2512"),
+					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "mistralai/ministral-3-8b-instruct-2512"),
 					DownloadAtRuntime:      true,
 					ModelFileSize:          "9.70Gi",
 					BytesPerToken:          139264,
@@ -571,6 +571,26 @@ func TestLoadFromCatalog(t *testing.T) {
 		{
 			modelRepo:   "some-org/unknown-model",
 			expectFound: false,
+		},
+		{
+			modelRepo:   "Qwen/Qwen3-8B-GGUF:Q4_K_M",
+			expectFound: true,
+			expectedParam: model.PresetParam{
+				Metadata: model.Metadata{
+					Name:                   "qwen3-8b-gguf",
+					Architectures:          []string{"Qwen3ForCausalLM"},
+					ModelType:              "tfs",
+					Version:                fmt.Sprintf("%s/%s", HuggingFaceWebsite, "Qwen/Qwen3-8B-GGUF"),
+					DownloadAtRuntime:      true,
+					ModelFileSize:          "4.68Gi",
+					BytesPerToken:          147456,
+					ModelTokenLimit:        40960,
+					DiskStorageRequirement: "84Gi",
+					ReasoningParser:        "qwen3",
+					ToolCallParser:         "hermes",
+				},
+				AttnType: "GQA",
+			},
 		},
 	}
 
@@ -603,6 +623,17 @@ func TestLoadFromCatalog(t *testing.T) {
 			assert.Equal(t, tc.expectedParam.Metadata.DiskStorageRequirement, gen.Param.Metadata.DiskStorageRequirement)
 			assert.Equal(t, tc.expectedParam.Metadata.ToolCallParser, gen.Param.Metadata.ToolCallParser)
 			assert.Equal(t, tc.expectedParam.AttnType, gen.Param.AttnType)
+
+			// GGUF-specific assertions
+			if gen.IsGGUFModel {
+				assert.Equal(t, "gguf", gen.Param.VLLM.ModelRunParams["load_format"])
+				assert.Equal(t, "auto", gen.Param.VLLM.ModelRunParams["config_format"], "GGUF models must use config_format=auto, not gguf")
+				assert.Equal(t, "auto", gen.Param.VLLM.ModelRunParams["tokenizer_mode"], "GGUF models must use tokenizer_mode=auto, not gguf")
+				assert.Equal(t, gen.ModelRepo+":"+gen.QuantType, gen.Param.VLLM.ModelRunParams["model"])
+				assert.NotEmpty(t, gen.BaseModel, "BaseModel should be auto-populated from catalog")
+				assert.Equal(t, gen.BaseModel, gen.Param.VLLM.ModelRunParams["hf-config-path"])
+				assert.Equal(t, gen.BaseModel, gen.Param.VLLM.ModelRunParams["tokenizer"])
+			}
 		})
 	}
 }
@@ -817,4 +848,121 @@ func TestMergeTextConfigWithLLMConfig(t *testing.T) {
 
 	// Existing top-level value should not be overwritten
 	assert.Equal(t, float64(4096), gen.ModelConfig["max_position_embeddings"])
+}
+
+func TestNewGenerator_GGUFNameParsing(t *testing.T) {
+	cases := []struct {
+		name          string
+		modelRepo     string
+		wantBase      string
+		wantQuantType string
+	}{
+		{
+			name:          "GGUF with quant type",
+			modelRepo:     "unsloth/Qwen3-0.6B-GGUF:Q4_K_M",
+			wantBase:      "unsloth/Qwen3-0.6B-GGUF",
+			wantQuantType: "Q4_K_M",
+		},
+		{
+			name:          "Standard model without colon",
+			modelRepo:     "microsoft/Phi-4-mini-instruct",
+			wantBase:      "microsoft/phi-4-mini-instruct",
+			wantQuantType: "",
+		},
+		{
+			name:          "GGUF with extended quant type",
+			modelRepo:     "bartowski/Qwen3-8B-GGUF:Q5_K_L",
+			wantBase:      "bartowski/Qwen3-8B-GGUF",
+			wantQuantType: "Q5_K_L",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gen := NewGenerator(tc.modelRepo, "")
+			assert.Equal(t, tc.wantBase, gen.ModelRepo)
+			assert.Equal(t, tc.wantQuantType, gen.QuantType)
+		})
+	}
+}
+
+func TestSelectWeightFiles_GGUF(t *testing.T) {
+	files := []FileInfo{
+		{Path: "Qwen3-0.6B-BF16.gguf", Size: 1198182848},
+		{Path: "Qwen3-0.6B-Q4_K_M.gguf", Size: 531116736},
+		{Path: "Qwen3-0.6B-Q8_0.gguf", Size: 678919104},
+		{Path: "config.json", Size: 1024},
+	}
+
+	t.Run("selects matching GGUF file by quant type", func(t *testing.T) {
+		gen := NewGenerator("unsloth/Qwen3-0.6B-GGUF:Q4_K_M", "")
+		selected := gen.selectWeightFiles(files)
+		assert.Len(t, selected, 1)
+		assert.Equal(t, "Qwen3-0.6B-Q4_K_M.gguf", selected[0].Path)
+		assert.Equal(t, int64(531116736), selected[0].Size)
+	})
+
+	t.Run("returns nil when no GGUF file matches", func(t *testing.T) {
+		gen := NewGenerator("unsloth/Qwen3-0.6B-GGUF:Q3_K_S", "")
+		selected := gen.selectWeightFiles(files)
+		assert.Nil(t, selected)
+	})
+
+	t.Run("non-GGUF model ignores GGUF files", func(t *testing.T) {
+		mixedFiles := []FileInfo{
+			{Path: "model.safetensors", Size: 1000000},
+			{Path: "Qwen3-0.6B-Q4_K_M.gguf", Size: 531116736},
+		}
+		gen := NewGenerator("some-org/some-model", "")
+		selected := gen.selectWeightFiles(mixedFiles)
+		assert.Len(t, selected, 1)
+		assert.Equal(t, "model.safetensors", selected[0].Path)
+	})
+}
+
+func TestSetGGUFMode(t *testing.T) {
+	gen := NewGenerator("unsloth/Qwen3-0.6B-GGUF:Q4_K_M", "")
+	gen.setGGUFMode()
+	assert.Equal(t, "gguf", gen.LoadFormat)
+	assert.Equal(t, "auto", gen.ConfigFormat)
+	assert.Equal(t, "auto", gen.TokenizerMode)
+}
+
+func TestFinalizeParams_GGUF(t *testing.T) {
+	gen := NewGenerator("unsloth/Qwen3-0.6B-GGUF:Q4_K_M", "")
+	gen.setGGUFMode()
+	gen.ModelConfig = map[string]interface{}{
+		"hidden_size":             float64(1024),
+		"num_hidden_layers":       float64(28),
+		"num_attention_heads":     float64(16),
+		"num_key_value_heads":     float64(8),
+		"head_dim":                float64(128),
+		"max_position_embeddings": float64(40960),
+	}
+
+	gen.FinalizeParams()
+
+	assert.Equal(t, "unsloth/Qwen3-0.6B-GGUF:Q4_K_M", gen.Param.VLLM.ModelRunParams["model"])
+	assert.Equal(t, "gguf", gen.Param.VLLM.ModelRunParams["load_format"])
+	assert.Equal(t, "auto", gen.Param.VLLM.ModelRunParams["config_format"])
+}
+
+func TestFinalizeParams_BaseModel(t *testing.T) {
+	gen := NewGenerator("unsloth/Qwen3-0.6B-GGUF:Q4_K_M", "")
+	gen.BaseModel = "Qwen/Qwen3-0.6B"
+	gen.setGGUFMode()
+	gen.ModelConfig = map[string]interface{}{
+		"hidden_size":             float64(1024),
+		"num_hidden_layers":       float64(28),
+		"num_attention_heads":     float64(16),
+		"num_key_value_heads":     float64(8),
+		"head_dim":                float64(128),
+		"max_position_embeddings": float64(40960),
+	}
+
+	gen.FinalizeParams()
+
+	assert.Equal(t, "Qwen/Qwen3-0.6B", gen.Param.VLLM.ModelRunParams["hf-config-path"])
+	assert.Equal(t, "Qwen/Qwen3-0.6B", gen.Param.VLLM.ModelRunParams["tokenizer"])
+	assert.Equal(t, "unsloth/Qwen3-0.6B-GGUF:Q4_K_M", gen.Param.VLLM.ModelRunParams["model"])
 }

--- a/presets/workspace/generator/model_catalog.go
+++ b/presets/workspace/generator/model_catalog.go
@@ -131,7 +131,12 @@ func FetchCatalogEntry(repo, token string) (*CatalogEntry, error) {
 	g := NewGenerator(repo, token)
 
 	// Fetch model info (license, pipeline, base_model)
-	license, pipelineTag, baseModel := fetchModelInfo(g, repo)
+	// For GGUF models, use g.ModelRepo which has the quant suffix stripped.
+	infoRepo := repo
+	if g.IsGGUFModel {
+		infoRepo = g.ModelRepo
+	}
+	license, pipelineTag, baseModel := fetchModelInfo(g, infoRepo)
 
 	if err := g.FetchModelMetadata(); err != nil {
 		return nil, err
@@ -141,7 +146,7 @@ func FetchCatalogEntry(repo, token string) (*CatalogEntry, error) {
 
 	entry := &CatalogEntry{
 		Name:          repo,
-		Description:   fmt.Sprintf("%s/%s", HuggingFaceWebsite, repo),
+		Description:   fmt.Sprintf("%s/%s", HuggingFaceWebsite, infoRepo),
 		License:       license,
 		PipelineTag:   pipelineTag,
 		BaseModel:     baseModel,

--- a/presets/workspace/inference/vllm/benchmark_entrypoint.py
+++ b/presets/workspace/inference/vllm/benchmark_entrypoint.py
@@ -396,20 +396,36 @@ def _resolve_processor() -> str:
 
 
 def _resolve_processor_from_hf_cache(cache_dir: Path) -> str:
-    """Resolve the first cached HF repo id from a cache directory."""
+    """Resolve a cached HF repo id that has a usable tokenizer.
+
+    Iterates through cached repos (sorted alphabetically) and returns the
+    first one whose tokenizer can be successfully loaded. This handles GGUF
+    repos gracefully — they typically lack tokenizer files and will be skipped
+    in favor of the base model repo that was downloaded via --tokenizer.
+    """
     if not cache_dir.exists():
         return ""
     try:
         cache_info = scan_cache_dir(cache_dir=str(cache_dir))
         repos = sorted(cache_info.repos, key=lambda r: r.repo_id)
-        if repos:
-            # repo_id is the HuggingFace model identifier (e.g. "microsoft/Phi-3-mini-4k-instruct"),
-            # not a local path. guidellm/vLLM accept it as the --processor value and resolve the
-            # tokenizer from the HF Hub (or local cache if HF_HUB_OFFLINE is set).
-            return repos[0].repo_id
     except Exception:
-        pass
+        return ""
+
+    for repo in repos:
+        if _has_tokenizer(repo.repo_id):
+            return repo.repo_id
     return ""
+
+
+def _has_tokenizer(repo_id: str) -> bool:
+    """Check whether a HF repo has a loadable tokenizer."""
+    try:
+        from transformers import AutoTokenizer
+
+        AutoTokenizer.from_pretrained(repo_id, trust_remote_code=True)
+        return True
+    except Exception:
+        return False
 
 
 def _predownload_processor(processor: str) -> str:

--- a/presets/workspace/models/model_catalog.yaml
+++ b/presets/workspace/models/model_catalog.yaml
@@ -39,7 +39,6 @@ models:
 - name: deepseek-ai/DeepSeek-R1-Distill-Qwen-14B
   description: https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-14B
   license: mit
-  pipelineTag: text-generation
   modelFileSize: 27.51Gi
   architectures:
   - Qwen2ForCausalLM
@@ -738,3 +737,18 @@ models:
   configFormat: mistral
   tokenizerMode: mistral
   quantMethod: fp8
+- name: Qwen/Qwen3-8B-GGUF:Q4_K_M
+  description: https://huggingface.co/Qwen/Qwen3-8B-GGUF
+  license: apache-2.0
+  pipelineTag: text-generation
+  baseModel:
+  - Qwen/Qwen3-8B
+  modelFileSize: 4.68Gi
+  architectures:
+  - Qwen3ForCausalLM
+  modelTokenLimit: 40960
+  hiddenSize: 4096
+  numHiddenLayers: 36
+  numAttentionHeads: 32
+  numKeyValueHeads: 8
+  loadFormat: gguf

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -5,6 +5,7 @@ models:
     runtime: tfs
     tag: 0.3.1
     # Tag history:
+    # 0.3.2 - update benchmark_entrypoint.py to support GGUF models that use tokenizer from base model
     # 0.3.1 - add NixlConnector kv_transfer_config for P/D disaggregation
     # 0.3.0 - bump vllm to 0.19.1, transformers to 5.6.0
     # 0.2.8 - update benchmark_entrypoint.py to poll kv cache size for concurrency calculation and pin venv transformer to 5.3.0

--- a/presets/workspace/models/vllm_model.go
+++ b/presets/workspace/models/vllm_model.go
@@ -42,15 +42,16 @@ func registerModel(hfModelCardID string, param *model.PresetParam) model.Model {
 		return nil
 	}
 
+	registryKey := strings.ToLower(hfModelCardID)
 	model := &vLLMCompatibleModel{
 		model:              param.Metadata,
 		generatedRunParams: param.VLLM.ModelRunParams,
 	}
 	r := &plugin.Registration{
-		Name:     hfModelCardID,
+		Name:     registryKey,
 		Instance: model,
 	}
-	klog.InfoS("Registering VLLM-compatible model", "model", hfModelCardID, "metadata", param.Metadata)
+	klog.InfoS("Registering VLLM-compatible model", "model", registryKey, "metadata", param.Metadata)
 	plugin.KaitoModelRegister.Register(r)
 	return model
 }
@@ -60,13 +61,14 @@ func registerModel(hfModelCardID string, param *model.PresetParam) model.Model {
 // Kubernetes Secret lookups; the caller is responsible for obtaining the token beforehand.
 // Pass an empty string for token when working with public models that require no authentication.
 func GetModelByNameWithToken(ctx context.Context, modelName, token string) (model.Model, error) {
-	modelName = strings.ToLower(modelName)
+	lookupKey := strings.ToLower(modelName)
 	// Redirect legacy preset names (e.g. "phi-4") to their full HuggingFace
 	// model ID (e.g. "microsoft/phi-4").
-	if hfName, ok := plugin.LegacyBuiltinToCatalog[modelName]; ok {
+	if hfName, ok := plugin.LegacyBuiltinToCatalog[lookupKey]; ok {
 		modelName = hfName
+		lookupKey = strings.ToLower(hfName)
 	}
-	if m := plugin.KaitoModelRegister.MustGet(modelName); m != nil {
+	if m := plugin.KaitoModelRegister.MustGet(lookupKey); m != nil {
 		return m, nil
 	}
 	if strings.Contains(modelName, "/") {
@@ -81,13 +83,14 @@ func GetModelByNameWithToken(ctx context.Context, modelName, token string) (mode
 // then generates a preset for the corresponding HuggingFace model.
 // Prefer GetModelByNameWithToken when the token has already been resolved by the caller.
 func GetModelByName(ctx context.Context, modelName, secretName, secretNamespace string, kubeClient client.Client) (model.Model, error) {
-	modelName = strings.ToLower(modelName)
+	lookupKey := strings.ToLower(modelName)
 	// Redirect legacy preset names (e.g. "phi-4") to their full HuggingFace
 	// model ID (e.g. "microsoft/phi-4").
-	if hfName, ok := plugin.LegacyBuiltinToCatalog[modelName]; ok {
+	if hfName, ok := plugin.LegacyBuiltinToCatalog[lookupKey]; ok {
 		modelName = hfName
+		lookupKey = strings.ToLower(hfName)
 	}
-	if m := plugin.KaitoModelRegister.MustGet(modelName); m != nil {
+	if m := plugin.KaitoModelRegister.MustGet(lookupKey); m != nil {
 		return m, nil
 	}
 	if !strings.Contains(modelName, "/") {

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -57,6 +57,7 @@ const (
 	PresetMinistral33BInstructModel  = "mistralai/ministral-3-3b-instruct-2512"
 	PresetQwen3_8BAWQModel           = "Qwen/Qwen3-8B-AWQ"
 	PresetQwen3_5_2BModel            = "Qwen/Qwen3.5-2B"
+	PresetQwen3_8BGGUFModel          = "Qwen/Qwen3-8B-GGUF:Q4_K_M"
 	WorkspaceHashAnnotation          = "workspace.kaito.io/hash"
 	// WorkspaceRevisionAnnotation represents the revision number of the workload managed by the workspace
 	WorkspaceRevisionAnnotation = "workspace.kaito.io/revision"
@@ -1370,6 +1371,11 @@ func validateInferenceConfig(workspaceObj *kaitov1beta1.Workspace) {
 
 // getModelName: extract the model name from the preset name, e.g., "meta-llama/Llama-3-8B-Instruct" -> "llama-3-8b-instruct"
 func getModelName(presetName string) string {
+	// Strip GGUF quant suffix (e.g. ":Q4_K_M") before extracting the model name,
+	// matching how the generator computes the served-model-name.
+	if idx := strings.Index(presetName, ":"); idx != -1 {
+		presetName = presetName[:idx]
+	}
 	nameParts := strings.Split(strings.ToLower(presetName), "/")
 	return strings.ToLower(nameParts[len(nameParts)-1])
 }

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -458,6 +458,29 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateModelsEndpoint(workspaceObj)
 		validateChatCompletionsEndpoint(workspaceObj)
 	})
+
+	It("should create a qwen3-8b-gguf workspace with GGUF quantization successfully", utils.GinkgoLabelFastCheck, func() {
+		numOfNode := 1
+		workspaceObj := createQwen3_8BGGUFWorkspaceWithPresetPublicModeAndVLLM(numOfNode)
+
+		defer cleanupResources(workspaceObj)
+		time.Sleep(30 * time.Second)
+
+		validateCreateNode(workspaceObj, numOfNode)
+		validateResourceStatus(workspaceObj)
+
+		time.Sleep(30 * time.Second)
+
+		validateAssociatedService(workspaceObj)
+		validateInferenceConfig(workspaceObj)
+
+		validateInferenceResource(workspaceObj, int32(numOfNode))
+
+		validateWorkspaceReadiness(workspaceObj)
+		validateWorkspaceBenchmarkCompleted(workspaceObj)
+		validateModelsEndpoint(workspaceObj)
+		validateChatCompletionsEndpoint(workspaceObj)
+	})
 })
 
 func createPhi4WorkspaceWithAdapterAndVLLM(numOfNode int, validAdapters []kaitov1beta1.AdapterSpec) *kaitov1beta1.Workspace {
@@ -917,6 +940,20 @@ func validateInferenceSetNodePools(inferenceSetObj *kaitov1alpha1.InferenceSet, 
 
 	// Verify isolation between child workspaces
 	utils.ValidateNodePoolIsolation(ctx, workspaces)
+}
+
+func createQwen3_8BGGUFWorkspaceWithPresetPublicModeAndVLLM(numOfNode int) *kaitov1beta1.Workspace {
+	workspaceObj := &kaitov1beta1.Workspace{}
+	By("Creating a workspace CR with Qwen3-8B-GGUF preset public mode and vLLM", func() {
+		uniqueID := fmt.Sprint("preset-qwen3-8b-gguf-", rand.Intn(1000))
+		workspaceObj = utils.GenerateInferenceWorkspaceManifestWithVLLM(uniqueID, namespaceName, "", numOfNode, "Standard_NV36ads_A10_v5",
+			&metav1.LabelSelector{
+				MatchLabels: map[string]string{"kaito-workspace": "public-preset-e2e-test-qwen3-8b-gguf-vllm"},
+			}, nil, PresetQwen3_8BGGUFModel, nil, nil, nil, "", "")
+
+		createAndValidateWorkspace(workspaceObj)
+	})
+	return workspaceObj
 }
 
 func validateGatewayAPIInferenceExtensionResources(iObj *kaitov1alpha1.InferenceSet) {


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
GGUF (GPT-Generated Unified Format) is a binary file format for storing large language models (LLMs), introduced by the llama.cpp project and designed for efficient local inference. Currently it has experimental support in vLLM: https://docs.vllm.ai/en/stable/features/quantization/gguf/. **Caveat: there is an ongoing disucssion about whether to keep GGUF support in vLLM: https://github.com/vllm-project/vllm/issues/39583**.

This PR enabled GGUF model deployment in Kaito through the non-catalog path (model catalog support for GGUF models will be added in another PR). Changes include:
- Added preset options `hfConfigPath` and `tokenizer` and passed them to vLLM when available. `hfConfigPath` supports user-provided path to HF model config and is used when a GGUF model is missing config.json. `tokenizer`supports user-provided path to base model's tokenizer as suggusted by vLLM (https://docs.vllm.ai/en/stable/features/quantization/gguf/). 
- Allowed quantization type of GGUF models to be provided as model name suffix, e.g. Qwen/Qwen3-4B-GGUF:Q4_K_M. This is consistent with how model name and quantization type should be passed to vLLM.
- Refactored GetModelByName to preserve the original case of model repo ID for GGUF models (i.e. Qwen/Qwen3-4B-GGUF:Q4_K_M instead of qwen/qwen3-4b-gguf:q4_k_m) and avoid model resolvement failures (this may be a bug in vLLM given GGUF support is experimental).
- Updated _resolve_processor() in benchmark_entrypoint.py to scan default HF cache as well. This is needed when the original HF repo doesn't contain tokenizer.json (e.g. unsloth/Qwen3-8B-GGUF) and the model needs to use a tokenizer from another repo. Since benchmark_entrypoint.py is part of Kaito's base image, we need to bump base image version to 0.3.1.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).
- [x] tested deployment of models Qwen/Qwen3-4B-GGUF:Q4_K_M (missing config.json) and unsloth/Qwen3-8B-GGUF:Q4_K_M:
<img width="878" height="103" alt="Screenshot 2026-05-01 at 4 37 41 PM" src="https://github.com/user-attachments/assets/68a07b53-bb88-41ca-9ed6-c2f4063ba6ba" />
  

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Fixes #2002

**Notes for Reviewers**: