### PR TITLE
feat: inject NixlConnector kv-transfer-config for P/D disaggregated inference

### DIFF
--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -12,9 +12,6 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-
 env:
   KIND_VERSION: "0.31.0"
   KUBECTL_VERSION: "1.33.0"
@@ -86,7 +83,7 @@ jobs:
           # Install via Helm
           # CSI Local Node cannot be configured to not deploy and it crashes on kind on github runners for unknown reasons
           # so we need to filter it out its components
-          helm template kaito-workspace ./charts/kaito/workspace --namespace ${{ env.KAITO_NAMESPACE }} --set featureGates.disableNodeAutoProvisioning="true" --set featureGates.enableInferenceSetController="true" --set featureGates.gatewayAPIInferenceExtension="true" --include-crds --debug --wait | awk '
+          helm template kaito-workspace ./charts/kaito/workspace --namespace ${{ env.KAITO_NAMESPACE }} --set featureGates.disableNodeAutoProvisioning="true" --set featureGates.enableInferenceSetController="true" --include-crds --debug --wait | awk '
             BEGIN { RS="---\n"; ORS="---\n"; csi=0 }
             /kind: ServiceAccount/ && /name: csi-local-node/ { csi=1 }
             /kind: StorageClass/ && /name: kaito-local-nvme-disk/ { csi=1 }
@@ -95,7 +92,7 @@ jobs:
             /kind: DaemonSet/ && /name: csi-local-node/ { csi=1 }
             !csi { print }
             { csi=0 }
-          ' | kubectl apply --namespace ${{ env.KAITO_NAMESPACE }} -f -
+          ' | kubectl apply -f -
 
           # Wait for controller to be ready
           kubectl wait --for=condition=available --timeout=300s deployment/kaito-workspace -n ${{ env.KAITO_NAMESPACE }}
@@ -150,7 +147,6 @@ jobs:
             labelSelector:
               matchLabels:
                 apps: aikit-test
-                kaito.sh/inference-role: decode
             replicas: 1
             template:
               inference:
@@ -174,216 +170,6 @@ jobs:
         run: |
           echo "Waiting for inferenceset to be ready..."
           kubectl wait --for='jsonpath={.status.readyReplicas}=1' inferenceset/inferenceset-aikit-test --timeout 300s
-
-      - name: Validate GWIE infrastructure
-        run: |
-          # Note: GWIE resource chain (OCIRepository → HelmRelease → InferencePool → EPP)
-          # is only created for vLLM preset-based InferenceSet workloads.
-          # AIKit uses custom template inference, so GWIE resources won't be created.
-          # Here we validate that the GWIE infrastructure is correctly deployed.
-
-          echo "=== Checking Flux CRDs are installed ==="
-          kubectl get crd ocirepositories.source.toolkit.fluxcd.io
-          echo "✓ Flux OCIRepository CRD installed"
-          kubectl get crd helmreleases.helm.toolkit.fluxcd.io
-          echo "✓ Flux HelmRelease CRD installed"
-
-          echo "=== Checking GWIE CRDs are installed ==="
-          kubectl get crd inferencepools.inference.networking.k8s.io
-          echo "✓ InferencePool CRD installed"
-          kubectl get crd inferenceobjectives.inference.networking.x-k8s.io
-          echo "✓ InferenceObjective CRD installed"
-
-          echo "=== Checking Flux controllers are running ==="
-          # Flux helm-controller and source-controller are deployed as part of the flux2 subchart
-          kubectl get deployments -n ${{ env.KAITO_NAMESPACE }} -o wide
-          for controller in helm-controller source-controller; do
-            if kubectl get deployment $controller -n ${{ env.KAITO_NAMESPACE }} >/dev/null 2>&1; then
-              kubectl wait --for=condition=available --timeout=120s deployment/$controller -n ${{ env.KAITO_NAMESPACE }}
-              echo "✓ $controller is available"
-            else
-              echo "✗ $controller deployment not found"
-              exit 1
-            fi
-          done
-
-          echo "=== Checking controller feature gates ==="
-          CONTROLLER_ARGS=$(kubectl get deployment kaito-workspace -n ${{ env.KAITO_NAMESPACE }} -o jsonpath='{.spec.template.spec.containers[0].args}')
-          echo "Controller args: $CONTROLLER_ARGS"
-          if echo "$CONTROLLER_ARGS" | grep -q "gatewayAPIInferenceExtension=true"; then
-            echo "✓ gatewayAPIInferenceExtension feature gate enabled"
-          else
-            echo "✗ gatewayAPIInferenceExtension feature gate not found"
-            exit 1
-          fi
-          if echo "$CONTROLLER_ARGS" | grep -q "enableInferenceSetController=true"; then
-            echo "✓ enableInferenceSetController feature gate enabled"
-          else
-            echo "✗ enableInferenceSetController feature gate not found"
-            exit 1
-          fi
-
-          echo "=== Verifying GWIE not created for non-preset InferenceSet (expected) ==="
-          POOL_NAME="inferenceset-aikit-test-inferencepool"
-          if kubectl get ocirepository $POOL_NAME 2>/dev/null; then
-            echo "✗ Unexpected: GWIE resources found for custom template InferenceSet"
-            exit 1
-          else
-            echo "✓ Confirmed: GWIE resources not created for AIKit custom template (only vLLM preset supported)"
-          fi
-
-      - name: Create preset InferenceSet for GWIE resource chain test
-        run: |
-          # Strategy: Pre-create a dummy Workspace with the correct label so the
-          # InferenceSet controller finds it during reconciliation and proceeds to
-          # ensureGatewayAPIInferenceExtension(). We can't let the controller create
-          # the Workspace itself because the Workspace webhook calls the HuggingFace
-          # API for preset validation, which fails on CI without a token.
-          #
-          # 1. Create dummy Workspace first (with matching label, custom template to avoid HF API)
-          # 2. Create InferenceSet with preset (triggers GWIE code path)
-          # 3. Controller sees workspace count >= 1, skips creation, proceeds to GWIE
-
-          # Create a dummy Workspace with the controller's label so it counts as
-          # an existing workspace. Use custom template (no preset) to avoid webhook
-          # calling HuggingFace API.
-          cat << 'EOF' > dummy-workspace.yaml
-          apiVersion: kaito.sh/v1beta1
-          kind: Workspace
-          metadata:
-            name: inferenceset-preset-gwie-test-dummy
-            labels:
-              inferenceset.kaito.sh/created-by: inferenceset-preset-gwie-test
-              apps: gwie-preset-test
-          resource:
-            labelSelector:
-              matchLabels:
-                apps: gwie-preset-test
-          inference:
-            template:
-              spec:
-                containers:
-                  - name: dummy
-                    image: registry.k8s.io/pause:3.10
-          EOF
-          kubectl apply -f dummy-workspace.yaml
-
-          # Now create the preset InferenceSet
-          cat << 'EOF' > preset-inferenceset.yaml
-          apiVersion: kaito.sh/v1alpha1
-          kind: InferenceSet
-          metadata:
-            name: inferenceset-preset-gwie-test
-          spec:
-            labelSelector:
-              matchLabels:
-                apps: gwie-preset-test
-            replicas: 1
-            template:
-              resource:
-                instanceType: ""
-              inference:
-                preset:
-                  name: phi-4-mini-instruct
-          EOF
-          kubectl apply -f preset-inferenceset.yaml
-
-          # Add ownerReference to the dummy workspace for proper garbage collection.
-          # Note: the controller finds workspaces by the inferenceset.kaito.sh/created-by label,
-          # not by ownerReferences. The ownerRef ensures K8s GC cleans up the workspace.
-          IS_UID=$(kubectl get inferenceset inferenceset-preset-gwie-test -o jsonpath='{.metadata.uid}')
-          kubectl patch workspace inferenceset-preset-gwie-test-dummy --type=merge -p "{
-            \"metadata\": {
-              \"ownerReferences\": [{
-                \"apiVersion\": \"kaito.sh/v1alpha1\",
-                \"kind\": \"InferenceSet\",
-                \"name\": \"inferenceset-preset-gwie-test\",
-                \"uid\": \"$IS_UID\",
-                \"controller\": true,
-                \"blockOwnerDeletion\": true
-              }]
-            }
-          }"
-
-          echo "✓ Created dummy Workspace + preset InferenceSet for GWIE test"
-
-      - name: Wait for GWIE resource chain to be created
-        run: |
-          POOL_NAME="inferenceset-preset-gwie-test-inferencepool"
-
-          # The dummy Workspace is already created. Wait for the InferenceSet controller
-          # to reconcile and create GWIE resources (OCIRepository, HelmRelease).
-
-          # Wait for OCIRepository to be created (indicates GWIE reconciliation ran)
-          echo "Waiting for GWIE OCIRepository to be created..."
-          OCI_FOUND=false
-          for i in $(seq 1 60); do
-            if kubectl get ocirepository "$POOL_NAME" 2>/dev/null; then
-              echo "✓ OCIRepository $POOL_NAME created"
-              OCI_FOUND=true
-              break
-            fi
-            echo "  Attempt $i/60: waiting for OCIRepository..."
-            sleep 5
-          done
-          if [ "$OCI_FOUND" != "true" ]; then
-            echo "✗ Timed out waiting for OCIRepository $POOL_NAME (300s)"
-            exit 1
-          fi
-
-          # Wait for HelmRelease to be created
-          echo "Waiting for GWIE HelmRelease to be created..."
-          HR_FOUND=false
-          for i in $(seq 1 60); do
-            if kubectl get helmrelease "$POOL_NAME" 2>/dev/null; then
-              echo "✓ HelmRelease $POOL_NAME created"
-              HR_FOUND=true
-              break
-            fi
-            echo "  Attempt $i/60: waiting for HelmRelease..."
-            sleep 5
-          done
-          if [ "$HR_FOUND" != "true" ]; then
-            echo "✗ Timed out waiting for HelmRelease $POOL_NAME (300s)"
-            exit 1
-          fi
-
-      - name: Validate GWIE resource chain for preset InferenceSet
-        run: |
-          POOL_NAME="inferenceset-preset-gwie-test-inferencepool"
-
-          echo "=== Validating OCIRepository ==="
-          if ! kubectl get ocirepository "$POOL_NAME" -o yaml; then
-            echo "✗ OCIRepository $POOL_NAME not found"
-            exit 1
-          fi
-          echo "✓ OCIRepository exists"
-
-          echo "=== Validating HelmRelease ==="
-          if ! kubectl get helmrelease "$POOL_NAME" -o yaml; then
-            echo "✗ HelmRelease $POOL_NAME not found"
-            exit 1
-          fi
-          echo "✓ HelmRelease exists"
-
-          # Validate HelmRelease references the correct OCIRepository
-          CHART_REF=$(kubectl get helmrelease "$POOL_NAME" -o jsonpath='{.spec.chartRef.name}')
-          if [ "$CHART_REF" != "$POOL_NAME" ]; then
-            echo "✗ HelmRelease chartRef.name is '$CHART_REF', expected '$POOL_NAME'"
-            exit 1
-          fi
-          echo "✓ HelmRelease references correct OCIRepository"
-
-          # Validate HelmRelease has correct owner reference
-          OWNER=$(kubectl get helmrelease "$POOL_NAME" -o json | jq -r '.metadata.ownerReferences[] | select(.kind=="InferenceSet") | .kind')
-          if [ "$OWNER" != "InferenceSet" ]; then
-            echo "✗ HelmRelease owner is '$OWNER', expected 'InferenceSet'"
-            exit 1
-          fi
-          echo "✓ HelmRelease has correct InferenceSet owner reference"
-
-          echo "=== GWIE resource chain validation passed ==="
-          echo "✓ Full GWIE resource chain created for vLLM preset InferenceSet"
 
       - name: Validate response content
         run: |
@@ -479,27 +265,3 @@ jobs:
 
           echo "=== Node information ==="
           kubectl describe nodes
-
-          echo "=== GWIE: OCIRepository ==="
-          kubectl get ocirepository -A -o yaml || true
-
-          echo "=== GWIE: HelmRelease ==="
-          kubectl get helmrelease -A -o yaml || true
-
-          echo "=== GWIE: InferencePool ==="
-          kubectl get inferencepool -A -o yaml || true
-
-          echo "=== GWIE: EPP Deployment ==="
-          kubectl get deployment -l app=inferenceset-aikit-test-inferencepool-epp -o yaml || true
-
-          echo "=== GWIE: EPP Pod Logs ==="
-          kubectl logs -l app=inferenceset-aikit-test-inferencepool-epp --tail=50 || true
-
-          echo "=== Preset GWIE Test: InferenceSet Status ==="
-          kubectl get inferenceset inferenceset-preset-gwie-test -o yaml || true
-
-          echo "=== Preset GWIE Test: Child Workspaces ==="
-          kubectl get workspace -l inferenceset.kaito.sh/created-by=inferenceset-preset-gwie-test -o yaml || true
-
-          echo "=== Preset GWIE Test: Node Labels ==="
-          kubectl get nodes --show-labels || true

--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -12,6 +12,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   KIND_VERSION: "0.31.0"
   KUBECTL_VERSION: "1.33.0"
@@ -83,7 +86,7 @@ jobs:
           # Install via Helm
           # CSI Local Node cannot be configured to not deploy and it crashes on kind on github runners for unknown reasons
           # so we need to filter it out its components
-          helm template kaito-workspace ./charts/kaito/workspace --namespace ${{ env.KAITO_NAMESPACE }} --set featureGates.disableNodeAutoProvisioning="true" --set featureGates.enableInferenceSetController="true" --include-crds --debug --wait | awk '
+          helm template kaito-workspace ./charts/kaito/workspace --namespace ${{ env.KAITO_NAMESPACE }} --set featureGates.disableNodeAutoProvisioning="true" --set featureGates.enableInferenceSetController="true" --set featureGates.gatewayAPIInferenceExtension="true" --include-crds --debug --wait | awk '
             BEGIN { RS="---\n"; ORS="---\n"; csi=0 }
             /kind: ServiceAccount/ && /name: csi-local-node/ { csi=1 }
             /kind: StorageClass/ && /name: kaito-local-nvme-disk/ { csi=1 }
@@ -92,7 +95,7 @@ jobs:
             /kind: DaemonSet/ && /name: csi-local-node/ { csi=1 }
             !csi { print }
             { csi=0 }
-          ' | kubectl apply -f -
+          ' | kubectl apply --namespace ${{ env.KAITO_NAMESPACE }} -f -
 
           # Wait for controller to be ready
           kubectl wait --for=condition=available --timeout=300s deployment/kaito-workspace -n ${{ env.KAITO_NAMESPACE }}
@@ -170,6 +173,216 @@ jobs:
         run: |
           echo "Waiting for inferenceset to be ready..."
           kubectl wait --for='jsonpath={.status.readyReplicas}=1' inferenceset/inferenceset-aikit-test --timeout 300s
+
+      - name: Validate GWIE infrastructure
+        run: |
+          # Note: GWIE resource chain (OCIRepository → HelmRelease → InferencePool → EPP)
+          # is only created for vLLM preset-based InferenceSet workloads.
+          # AIKit uses custom template inference, so GWIE resources won't be created.
+          # Here we validate that the GWIE infrastructure is correctly deployed.
+
+          echo "=== Checking Flux CRDs are installed ==="
+          kubectl get crd ocirepositories.source.toolkit.fluxcd.io
+          echo "✓ Flux OCIRepository CRD installed"
+          kubectl get crd helmreleases.helm.toolkit.fluxcd.io
+          echo "✓ Flux HelmRelease CRD installed"
+
+          echo "=== Checking GWIE CRDs are installed ==="
+          kubectl get crd inferencepools.inference.networking.k8s.io
+          echo "✓ InferencePool CRD installed"
+          kubectl get crd inferenceobjectives.inference.networking.x-k8s.io
+          echo "✓ InferenceObjective CRD installed"
+
+          echo "=== Checking Flux controllers are running ==="
+          # Flux helm-controller and source-controller are deployed as part of the flux2 subchart
+          kubectl get deployments -n ${{ env.KAITO_NAMESPACE }} -o wide
+          for controller in helm-controller source-controller; do
+            if kubectl get deployment $controller -n ${{ env.KAITO_NAMESPACE }} >/dev/null 2>&1; then
+              kubectl wait --for=condition=available --timeout=120s deployment/$controller -n ${{ env.KAITO_NAMESPACE }}
+              echo "✓ $controller is available"
+            else
+              echo "✗ $controller deployment not found"
+              exit 1
+            fi
+          done
+
+          echo "=== Checking controller feature gates ==="
+          CONTROLLER_ARGS=$(kubectl get deployment kaito-workspace -n ${{ env.KAITO_NAMESPACE }} -o jsonpath='{.spec.template.spec.containers[0].args}')
+          echo "Controller args: $CONTROLLER_ARGS"
+          if echo "$CONTROLLER_ARGS" | grep -q "gatewayAPIInferenceExtension=true"; then
+            echo "✓ gatewayAPIInferenceExtension feature gate enabled"
+          else
+            echo "✗ gatewayAPIInferenceExtension feature gate not found"
+            exit 1
+          fi
+          if echo "$CONTROLLER_ARGS" | grep -q "enableInferenceSetController=true"; then
+            echo "✓ enableInferenceSetController feature gate enabled"
+          else
+            echo "✗ enableInferenceSetController feature gate not found"
+            exit 1
+          fi
+
+          echo "=== Verifying GWIE not created for non-preset InferenceSet (expected) ==="
+          POOL_NAME="inferenceset-aikit-test-inferencepool"
+          if kubectl get ocirepository $POOL_NAME 2>/dev/null; then
+            echo "✗ Unexpected: GWIE resources found for custom template InferenceSet"
+            exit 1
+          else
+            echo "✓ Confirmed: GWIE resources not created for AIKit custom template (only vLLM preset supported)"
+          fi
+
+      - name: Create preset InferenceSet for GWIE resource chain test
+        run: |
+          # Strategy: Pre-create a dummy Workspace with the correct label so the
+          # InferenceSet controller finds it during reconciliation and proceeds to
+          # ensureGatewayAPIInferenceExtension(). We can't let the controller create
+          # the Workspace itself because the Workspace webhook calls the HuggingFace
+          # API for preset validation, which fails on CI without a token.
+          #
+          # 1. Create dummy Workspace first (with matching label, custom template to avoid HF API)
+          # 2. Create InferenceSet with preset (triggers GWIE code path)
+          # 3. Controller sees workspace count >= 1, skips creation, proceeds to GWIE
+
+          # Create a dummy Workspace with the controller's label so it counts as
+          # an existing workspace. Use custom template (no preset) to avoid webhook
+          # calling HuggingFace API.
+          cat << 'EOF' > dummy-workspace.yaml
+          apiVersion: kaito.sh/v1beta1
+          kind: Workspace
+          metadata:
+            name: inferenceset-preset-gwie-test-dummy
+            labels:
+              inferenceset.kaito.sh/created-by: inferenceset-preset-gwie-test
+              apps: gwie-preset-test
+          resource:
+            labelSelector:
+              matchLabels:
+                apps: gwie-preset-test
+          inference:
+            template:
+              spec:
+                containers:
+                  - name: dummy
+                    image: registry.k8s.io/pause:3.10
+          EOF
+          kubectl apply -f dummy-workspace.yaml
+
+          # Now create the preset InferenceSet
+          cat << 'EOF' > preset-inferenceset.yaml
+          apiVersion: kaito.sh/v1alpha1
+          kind: InferenceSet
+          metadata:
+            name: inferenceset-preset-gwie-test
+          spec:
+            labelSelector:
+              matchLabels:
+                apps: gwie-preset-test
+            replicas: 1
+            template:
+              resource:
+                instanceType: ""
+              inference:
+                preset:
+                  name: phi-4-mini-instruct
+          EOF
+          kubectl apply -f preset-inferenceset.yaml
+
+          # Add ownerReference to the dummy workspace for proper garbage collection.
+          # Note: the controller finds workspaces by the inferenceset.kaito.sh/created-by label,
+          # not by ownerReferences. The ownerRef ensures K8s GC cleans up the workspace.
+          IS_UID=$(kubectl get inferenceset inferenceset-preset-gwie-test -o jsonpath='{.metadata.uid}')
+          kubectl patch workspace inferenceset-preset-gwie-test-dummy --type=merge -p "{
+            \"metadata\": {
+              \"ownerReferences\": [{
+                \"apiVersion\": \"kaito.sh/v1alpha1\",
+                \"kind\": \"InferenceSet\",
+                \"name\": \"inferenceset-preset-gwie-test\",
+                \"uid\": \"$IS_UID\",
+                \"controller\": true,
+                \"blockOwnerDeletion\": true
+              }]
+            }
+          }"
+
+          echo "✓ Created dummy Workspace + preset InferenceSet for GWIE test"
+
+      - name: Wait for GWIE resource chain to be created
+        run: |
+          POOL_NAME="inferenceset-preset-gwie-test-inferencepool"
+
+          # The dummy Workspace is already created. Wait for the InferenceSet controller
+          # to reconcile and create GWIE resources (OCIRepository, HelmRelease).
+
+          # Wait for OCIRepository to be created (indicates GWIE reconciliation ran)
+          echo "Waiting for GWIE OCIRepository to be created..."
+          OCI_FOUND=false
+          for i in $(seq 1 60); do
+            if kubectl get ocirepository "$POOL_NAME" 2>/dev/null; then
+              echo "✓ OCIRepository $POOL_NAME created"
+              OCI_FOUND=true
+              break
+            fi
+            echo "  Attempt $i/60: waiting for OCIRepository..."
+            sleep 5
+          done
+          if [ "$OCI_FOUND" != "true" ]; then
+            echo "✗ Timed out waiting for OCIRepository $POOL_NAME (300s)"
+            exit 1
+          fi
+
+          # Wait for HelmRelease to be created
+          echo "Waiting for GWIE HelmRelease to be created..."
+          HR_FOUND=false
+          for i in $(seq 1 60); do
+            if kubectl get helmrelease "$POOL_NAME" 2>/dev/null; then
+              echo "✓ HelmRelease $POOL_NAME created"
+              HR_FOUND=true
+              break
+            fi
+            echo "  Attempt $i/60: waiting for HelmRelease..."
+            sleep 5
+          done
+          if [ "$HR_FOUND" != "true" ]; then
+            echo "✗ Timed out waiting for HelmRelease $POOL_NAME (300s)"
+            exit 1
+          fi
+
+      - name: Validate GWIE resource chain for preset InferenceSet
+        run: |
+          POOL_NAME="inferenceset-preset-gwie-test-inferencepool"
+
+          echo "=== Validating OCIRepository ==="
+          if ! kubectl get ocirepository "$POOL_NAME" -o yaml; then
+            echo "✗ OCIRepository $POOL_NAME not found"
+            exit 1
+          fi
+          echo "✓ OCIRepository exists"
+
+          echo "=== Validating HelmRelease ==="
+          if ! kubectl get helmrelease "$POOL_NAME" -o yaml; then
+            echo "✗ HelmRelease $POOL_NAME not found"
+            exit 1
+          fi
+          echo "✓ HelmRelease exists"
+
+          # Validate HelmRelease references the correct OCIRepository
+          CHART_REF=$(kubectl get helmrelease "$POOL_NAME" -o jsonpath='{.spec.chartRef.name}')
+          if [ "$CHART_REF" != "$POOL_NAME" ]; then
+            echo "✗ HelmRelease chartRef.name is '$CHART_REF', expected '$POOL_NAME'"
+            exit 1
+          fi
+          echo "✓ HelmRelease references correct OCIRepository"
+
+          # Validate HelmRelease has correct owner reference
+          OWNER=$(kubectl get helmrelease "$POOL_NAME" -o json | jq -r '.metadata.ownerReferences[] | select(.kind=="InferenceSet") | .kind')
+          if [ "$OWNER" != "InferenceSet" ]; then
+            echo "✗ HelmRelease owner is '$OWNER', expected 'InferenceSet'"
+            exit 1
+          fi
+          echo "✓ HelmRelease has correct InferenceSet owner reference"
+
+          echo "=== GWIE resource chain validation passed ==="
+          echo "✓ Full GWIE resource chain created for vLLM preset InferenceSet"
 
       - name: Validate response content
         run: |
@@ -265,3 +478,27 @@ jobs:
 
           echo "=== Node information ==="
           kubectl describe nodes
+
+          echo "=== GWIE: OCIRepository ==="
+          kubectl get ocirepository -A -o yaml || true
+
+          echo "=== GWIE: HelmRelease ==="
+          kubectl get helmrelease -A -o yaml || true
+
+          echo "=== GWIE: InferencePool ==="
+          kubectl get inferencepool -A -o yaml || true
+
+          echo "=== GWIE: EPP Deployment ==="
+          kubectl get deployment -l app=inferenceset-aikit-test-inferencepool-epp -o yaml || true
+
+          echo "=== GWIE: EPP Pod Logs ==="
+          kubectl logs -l app=inferenceset-aikit-test-inferencepool-epp --tail=50 || true
+
+          echo "=== Preset GWIE Test: InferenceSet Status ==="
+          kubectl get inferenceset inferenceset-preset-gwie-test -o yaml || true
+
+          echo "=== Preset GWIE Test: Child Workspaces ==="
+          kubectl get workspace -l inferenceset.kaito.sh/created-by=inferenceset-preset-gwie-test -o yaml || true
+
+          echo "=== Preset GWIE Test: Node Labels ==="
+          kubectl get nodes --show-labels || true

--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -150,6 +150,7 @@ jobs:
             labelSelector:
               matchLabels:
                 apps: aikit-test
+                kaito.sh/inference-role: decode
             replicas: 1
             template:
               inference:

--- a/api/v1alpha1/inferenceset_types.go
+++ b/api/v1alpha1/inferenceset_types.go
@@ -31,6 +31,7 @@ type InferenceSetTemplate struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
+	// +kubebuilder:validation:XPreserveUnknownFields
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// +optional
 	Resource  InferenceSetResourceSpec   `json:"resource"`

--- a/api/v1alpha1/inferenceset_types.go
+++ b/api/v1alpha1/inferenceset_types.go
@@ -31,7 +31,8 @@ type InferenceSetTemplate struct {
 	// Standard object's metadata.
 	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
-	// +kubebuilder:validation:XPreserveUnknownFields
+	// +kubebuilder:validation:Schemaless
+	// +kubebuilder:pruning:PreserveUnknownFields
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	// +optional
 	Resource  InferenceSetResourceSpec   `json:"resource"`

--- a/api/v1beta1/labels.go
+++ b/api/v1beta1/labels.go
@@ -68,6 +68,11 @@ const (
 	// disable it; when absent or any other value, the benchmark runs.
 	AnnotationDisableBenchmark = KAITOPrefix + "disable-benchmark"
 
+	// LabelInferenceRole indicates the inference role of a workspace in P/D disaggregated serving.
+	// Propagated from InferenceSet.Spec.Template.Metadata.Labels onto child workspaces by the InferenceSet controller.
+	// Valid values: "prefill", "decode".
+	LabelInferenceRole = KAITOPrefix + "inference-role"
+
 	// AnnotationPerformanceMode selects the vLLM performance preset.
 	// Valid values are "balanced" (default), "interactivity", and "throughput".
 	//   - "interactivity": optimizes for low per-request latency (fine-grained CUDA

--- a/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
+++ b/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
@@ -219,6 +219,7 @@ spec:
                       Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   resource:
                     properties:
                       instanceType:

--- a/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
+++ b/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
@@ -218,6 +218,7 @@ spec:
                     description: |-
                       Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                   resource:
                     properties:

--- a/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
+++ b/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
@@ -218,7 +218,6 @@ spec:
                     description: |-
                       Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                   resource:
                     properties:

--- a/charts/kaito/workspace/templates/supported-models-configmap.yaml
+++ b/charts/kaito/workspace/templates/supported-models-configmap.yaml
@@ -11,7 +11,7 @@ data:
       - name: base
         type: text-generation
         runtime: tfs
-        tag: 0.3.0
+        tag: 0.3.1
       - name: llama-3.1-8b-instruct
         type: text-generation
         version: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/commit/0e9e39f249a16976918f6564b8830bc894c89659

--- a/config/crd/bases/kaito.sh_inferencesets.yaml
+++ b/config/crd/bases/kaito.sh_inferencesets.yaml
@@ -219,6 +219,7 @@ spec:
                       Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
                     type: object
+                    x-kubernetes-preserve-unknown-fields: true
                   resource:
                     properties:
                       instanceType:

--- a/config/crd/bases/kaito.sh_inferencesets.yaml
+++ b/config/crd/bases/kaito.sh_inferencesets.yaml
@@ -218,6 +218,7 @@ spec:
                     description: |-
                       Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
+                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                   resource:
                     properties:

--- a/config/crd/bases/kaito.sh_inferencesets.yaml
+++ b/config/crd/bases/kaito.sh_inferencesets.yaml
@@ -218,7 +218,6 @@ spec:
                     description: |-
                       Standard object's metadata.
                       More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
-                    type: object
                     x-kubernetes-preserve-unknown-fields: true
                   resource:
                     properties:

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -114,7 +114,7 @@ const (
 	RoutingSidecarTag   = "v0.7.1"
 
 	// When the routing sidecar is present, vLLM moves to this internal port.
-	PortInferenceServerInternal = 5001
+	PortInferenceServerInternal = int32(5001)
 
 	// Inference role constants for P/D disaggregated serving.
 	InferenceRoleEnvName = "KAITO_INFERENCE_ROLE"

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -116,8 +116,10 @@ const (
 	// When the routing sidecar is present, vLLM moves to this internal port.
 	PortInferenceServerInternal = int32(5001)
 
-	// InferenceRoleEnvName is the environment variable used to pass the inference role to vLLM.
+	// Inference role constants for P/D disaggregated serving.
 	InferenceRoleEnvName = "KAITO_INFERENCE_ROLE"
+	InferenceRolePrefill = "prefill"
+	InferenceRoleDecode  = "decode"
 
 	// ConditionReady is the condition type for a ready condition.
 	ConditionReady = "Ready"

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -113,7 +113,6 @@ const (
 	RoutingSidecarImage = "mcr.microsoft.com/oss/v2/llm-d/llm-d-routing-sidecar"
 	RoutingSidecarTag   = "v0.7.1"
 
-	// When the routing sidecar is present, vLLM moves to this internal port.
 	// PortRoutingSidecar is the port the routing sidecar listens on.
 	// When the sidecar is present, the Service targetPort points here
 	// instead of PortInferenceServer so all external traffic flows

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -106,6 +106,21 @@ const (
 	EPPImageName = "llm-d-inference-scheduler"
 	EPPImageTag  = "v0.7.1"
 
+	// Routing sidecar for P/D disaggregation on decode workspaces.
+	// The sidecar takes over the public-facing port (5000) so the Service
+	// routes traffic to it. It then forwards to vLLM on the internal port (5001).
+	// See: https://github.com/llm-d/llm-d-routing-sidecar
+	RoutingSidecarImage = "mcr.microsoft.com/oss/v2/llm-d/llm-d-routing-sidecar"
+	RoutingSidecarTag   = "v0.7.1"
+
+	// When the routing sidecar is present, vLLM moves to this internal port.
+	PortInferenceServerInternal = 5001
+
+	// Inference role constants for P/D disaggregated serving.
+	InferenceRoleEnvName = "KAITO_INFERENCE_ROLE"
+	InferenceRolePrefill = "prefill"
+	InferenceRoleDecode  = "decode"
+
 	// ConditionReady is the condition type for a ready condition.
 	ConditionReady = "Ready"
 

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -116,10 +116,8 @@ const (
 	// When the routing sidecar is present, vLLM moves to this internal port.
 	PortInferenceServerInternal = int32(5001)
 
-	// Inference role constants for P/D disaggregated serving.
+	// InferenceRoleEnvName is the environment variable used to pass the inference role to vLLM.
 	InferenceRoleEnvName = "KAITO_INFERENCE_ROLE"
-	InferenceRolePrefill = "prefill"
-	InferenceRoleDecode  = "decode"
 
 	// ConditionReady is the condition type for a ready condition.
 	ConditionReady = "Ready"

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -107,8 +107,9 @@ const (
 	EPPImageTag  = "v0.7.1"
 
 	// Routing sidecar for P/D disaggregation on decode workspaces.
-	// The sidecar takes over the public-facing port (5000) so the Service
-	// routes traffic to it. It then forwards to vLLM on the internal port (5001).
+	// The sidecar listens on port 5001 (PortRoutingSidecar) and forwards
+	// to vLLM on port 5000 (PortInferenceServer). The Service targetPort
+	// is set to 5001 so external traffic flows through the routing layer.
 	// See: https://github.com/llm-d/llm-d-routing-sidecar
 	RoutingSidecarImage = "mcr.microsoft.com/oss/v2/llm-d/llm-d-routing-sidecar"
 	RoutingSidecarTag   = "v0.7.1"

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -114,7 +114,11 @@ const (
 	RoutingSidecarTag   = "v0.7.1"
 
 	// When the routing sidecar is present, vLLM moves to this internal port.
-	PortInferenceServerInternal = int32(5001)
+	// PortRoutingSidecar is the port the routing sidecar listens on.
+	// When the sidecar is present, the Service targetPort points here
+	// instead of PortInferenceServer so all external traffic flows
+	// through the routing layer. vLLM keeps its default port (5000).
+	PortRoutingSidecar = int32(5001)
 
 	// Inference role constants for P/D disaggregated serving.
 	InferenceRoleEnvName = "KAITO_INFERENCE_ROLE"

--- a/pkg/workspace/controllers/benchmark.go
+++ b/pkg/workspace/controllers/benchmark.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
@@ -176,27 +175,11 @@ func extractTagPayload(line, tag string) string {
 func reconcileBenchmarkResult(ctx context.Context, wObj *kaitov1beta1.Workspace) (*kaitov1beta1.Performance, error) {
 	podName := wObj.Name + benchmarkPodIndexSuffix
 
-	// Only set Container when the pod has multiple containers (e.g., routing sidecar).
-	// For single-container pods, leaving it empty lets Kubernetes auto-select.
 	tailLines := benchmarkLogTailLines
-	logOpts := &corev1.PodLogOptions{
+	req := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).GetLogs(podName, &corev1.PodLogOptions{
 		TailLines: &tailLines,
-	}
-
-	pod, err := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).Get(ctx, podName, metav1.GetOptions{})
-	if err == nil && len(pod.Spec.Containers) > 1 {
-		// Prefer a container named after the Workspace; fall back to the first container.
-		containerName := pod.Spec.Containers[0].Name
-		for _, c := range pod.Spec.Containers {
-			if c.Name == wObj.Name {
-				containerName = wObj.Name
-				break
-			}
-		}
-		logOpts.Container = containerName
-	}
-
-	req := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).GetLogs(podName, logOpts)
+		Container: wObj.Name,
+	})
 	stream, err := req.Stream(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("streaming logs for pod %s/%s: %w", wObj.Namespace, podName, err)

--- a/pkg/workspace/controllers/benchmark.go
+++ b/pkg/workspace/controllers/benchmark.go
@@ -177,6 +177,7 @@ func reconcileBenchmarkResult(ctx context.Context, wObj *kaitov1beta1.Workspace)
 
 	tailLines := benchmarkLogTailLines
 	req := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).GetLogs(podName, &corev1.PodLogOptions{
+		Container: wObj.Name,
 		TailLines: &tailLines,
 	})
 	stream, err := req.Stream(ctx)

--- a/pkg/workspace/controllers/benchmark.go
+++ b/pkg/workspace/controllers/benchmark.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
@@ -176,19 +175,13 @@ func extractTagPayload(line, tag string) string {
 func reconcileBenchmarkResult(ctx context.Context, wObj *kaitov1beta1.Workspace) (*kaitov1beta1.Performance, error) {
 	podName := wObj.Name + benchmarkPodIndexSuffix
 
-	// Determine container name for log streaming. When the pod has a sidecar
-	// (e.g., llm-d-routing-sidecar), Kubernetes requires an explicit container
-	// name. We always use wObj.Name which matches the primary inference container
-	// name set by the workspace generator, regardless of container ordering.
-	var containerName string
-	pod, podErr := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).Get(ctx, podName, metav1.GetOptions{})
-	if podErr != nil || len(pod.Spec.Containers) > 1 {
-		containerName = wObj.Name
-	}
-
+	// Always set Container to wObj.Name which matches the primary inference
+	// container name set by the workspace generator. This works for both
+	// single-container and multi-container (sidecar) pods, avoiding an
+	// extra Pod GET call.
 	tailLines := benchmarkLogTailLines
 	req := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).GetLogs(podName, &corev1.PodLogOptions{
-		Container: containerName,
+		Container: wObj.Name,
 		TailLines: &tailLines,
 	})
 	stream, err := req.Stream(ctx)

--- a/pkg/workspace/controllers/benchmark.go
+++ b/pkg/workspace/controllers/benchmark.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
@@ -175,9 +176,18 @@ func extractTagPayload(line, tag string) string {
 func reconcileBenchmarkResult(ctx context.Context, wObj *kaitov1beta1.Workspace) (*kaitov1beta1.Performance, error) {
 	podName := wObj.Name + benchmarkPodIndexSuffix
 
+	// Determine container name for log streaming. When the pod has a sidecar
+	// (e.g., llm-d-routing-sidecar), Kubernetes requires an explicit container
+	// name. We fetch the pod to check, and only set Container when needed.
+	var containerName string
+	pod, err := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err == nil && len(pod.Spec.Containers) > 1 {
+		containerName = wObj.Name
+	}
+
 	tailLines := benchmarkLogTailLines
 	req := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).GetLogs(podName, &corev1.PodLogOptions{
-		Container: wObj.Name,
+		Container: containerName,
 		TailLines: &tailLines,
 	})
 	stream, err := req.Stream(ctx)

--- a/pkg/workspace/controllers/benchmark.go
+++ b/pkg/workspace/controllers/benchmark.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/klog/v2"
 
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
@@ -175,15 +176,19 @@ func extractTagPayload(line, tag string) string {
 func reconcileBenchmarkResult(ctx context.Context, wObj *kaitov1beta1.Workspace) (*kaitov1beta1.Performance, error) {
 	podName := wObj.Name + benchmarkPodIndexSuffix
 
-	// Always set Container to wObj.Name which matches the primary inference
-	// container name set by the workspace generator. This works for both
-	// single-container and multi-container (sidecar) pods, avoiding an
-	// extra Pod GET call.
+	// Only set Container when the pod has multiple containers (e.g., routing sidecar).
+	// For single-container pods, leaving it empty lets Kubernetes auto-select.
 	tailLines := benchmarkLogTailLines
-	req := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).GetLogs(podName, &corev1.PodLogOptions{
-		Container: wObj.Name,
+	logOpts := &corev1.PodLogOptions{
 		TailLines: &tailLines,
-	})
+	}
+
+	pod, err := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).Get(ctx, podName, metav1.GetOptions{})
+	if err == nil && len(pod.Spec.Containers) > 1 {
+		logOpts.Container = wObj.Name
+	}
+
+	req := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).GetLogs(podName, logOpts)
 	stream, err := req.Stream(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("streaming logs for pod %s/%s: %w", wObj.Namespace, podName, err)

--- a/pkg/workspace/controllers/benchmark.go
+++ b/pkg/workspace/controllers/benchmark.go
@@ -180,8 +180,12 @@ func reconcileBenchmarkResult(ctx context.Context, wObj *kaitov1beta1.Workspace)
 	// (e.g., llm-d-routing-sidecar), Kubernetes requires an explicit container
 	// name. We fetch the pod to check, and only set Container when needed.
 	var containerName string
-	pod, err := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).Get(ctx, podName, metav1.GetOptions{})
-	if err == nil && len(pod.Spec.Containers) > 1 {
+	pod, podErr := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).Get(ctx, podName, metav1.GetOptions{})
+	if podErr != nil {
+		// If we can't fetch the pod, fall back to workspace name as container name
+		// to handle multi-container pods gracefully.
+		containerName = wObj.Name
+	} else if len(pod.Spec.Containers) > 1 {
 		containerName = pod.Spec.Containers[0].Name
 	}
 

--- a/pkg/workspace/controllers/benchmark.go
+++ b/pkg/workspace/controllers/benchmark.go
@@ -185,7 +185,15 @@ func reconcileBenchmarkResult(ctx context.Context, wObj *kaitov1beta1.Workspace)
 
 	pod, err := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err == nil && len(pod.Spec.Containers) > 1 {
-		logOpts.Container = wObj.Name
+		// Prefer a container named after the Workspace; fall back to the first container.
+		containerName := pod.Spec.Containers[0].Name
+		for _, c := range pod.Spec.Containers {
+			if c.Name == wObj.Name {
+				containerName = wObj.Name
+				break
+			}
+		}
+		logOpts.Container = containerName
 	}
 
 	req := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).GetLogs(podName, logOpts)

--- a/pkg/workspace/controllers/benchmark.go
+++ b/pkg/workspace/controllers/benchmark.go
@@ -178,15 +178,12 @@ func reconcileBenchmarkResult(ctx context.Context, wObj *kaitov1beta1.Workspace)
 
 	// Determine container name for log streaming. When the pod has a sidecar
 	// (e.g., llm-d-routing-sidecar), Kubernetes requires an explicit container
-	// name. We fetch the pod to check, and only set Container when needed.
+	// name. We always use wObj.Name which matches the primary inference container
+	// name set by the workspace generator, regardless of container ordering.
 	var containerName string
 	pod, podErr := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).Get(ctx, podName, metav1.GetOptions{})
-	if podErr != nil {
-		// If we can't fetch the pod, fall back to workspace name as container name
-		// to handle multi-container pods gracefully.
+	if podErr != nil || len(pod.Spec.Containers) > 1 {
 		containerName = wObj.Name
-	} else if len(pod.Spec.Containers) > 1 {
-		containerName = pod.Spec.Containers[0].Name
 	}
 
 	tailLines := benchmarkLogTailLines

--- a/pkg/workspace/controllers/benchmark.go
+++ b/pkg/workspace/controllers/benchmark.go
@@ -182,7 +182,7 @@ func reconcileBenchmarkResult(ctx context.Context, wObj *kaitov1beta1.Workspace)
 	var containerName string
 	pod, err := k8sclient.GetGlobalClientGoClient().CoreV1().Pods(wObj.Namespace).Get(ctx, podName, metav1.GetOptions{})
 	if err == nil && len(pod.Spec.Containers) > 1 {
-		containerName = wObj.Name
+		containerName = pod.Spec.Containers[0].Name
 	}
 
 	tailLines := benchmarkLogTailLines

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -523,7 +523,7 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 			},
 		}
 
-		applyInferenceRoleEnv(ctx.Workspace.Labels, spec)
+		applyInferenceRoleEnv(ctx.Workspace.Labels, ctx.Workspace.Name, spec)
 
 		if isSidecarNeeded {
 			injectRoutingSidecar(spec)
@@ -708,22 +708,24 @@ func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec
 	return nil
 }
 
-// applyInferenceRoleEnv sets KAITO_INFERENCE_ROLE env var on the first container
-// (the main inference container) when the workspace has a valid inference-role
-// label (prefill or decode). Only the main container needs this env var;
-// sidecar containers do not use it.
-func applyInferenceRoleEnv(labels map[string]string, spec *corev1.PodSpec) {
-	if len(spec.Containers) == 0 {
-		return
-	}
+// applyInferenceRoleEnv sets KAITO_INFERENCE_ROLE env var on the main inference
+// container (identified by containerName) when the workspace has a valid
+// inference-role label (prefill or decode). Only the main container needs this
+// env var; sidecar containers do not use it.
+func applyInferenceRoleEnv(labels map[string]string, containerName string, spec *corev1.PodSpec) {
 	role, ok := labels[v1beta1.LabelInferenceRole]
 	if !ok || (role != consts.InferenceRolePrefill && role != consts.InferenceRoleDecode) {
 		return
 	}
-	spec.Containers[0].Env = append(spec.Containers[0].Env, corev1.EnvVar{
-		Name:  consts.InferenceRoleEnvName,
-		Value: role,
-	})
+	for i := range spec.Containers {
+		if spec.Containers[i].Name == containerName {
+			spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
+				Name:  consts.InferenceRoleEnvName,
+				Value: role,
+			})
+			return
+		}
+	}
 }
 
 // injectRoutingSidecar rewrites the first container's containerPorts and probes

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -456,7 +456,10 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 		// When the routing sidecar is needed, vLLM must use the internal port
 		// to avoid conflicting with the sidecar on the public port.
 		isSidecarNeeded := needsRoutingSidecar(ctx.Workspace)
-		if isSidecarNeeded && inferenceParam.VLLM.ModelRunParams != nil {
+		if isSidecarNeeded {
+			if inferenceParam.VLLM.ModelRunParams == nil {
+				inferenceParam.VLLM.ModelRunParams = make(map[string]string)
+			}
 			inferenceParam.VLLM.ModelRunParams["port"] = strconv.FormatInt(int64(consts.PortInferenceServerInternal), 10)
 		}
 

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -867,6 +867,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 	sidecarArgs := []string{
 		fmt.Sprintf("--port=%d", consts.PortInferenceServer),
 		fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
+		"--secure-proxy=false",
 	}
 
 	if sidecarExists {

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -794,28 +794,16 @@ func injectRoutingSidecarInline(spec *corev1.PodSpec) {
 	}
 
 	// Command: rewrite port references (format is known: --port=5000, --vllm-port=5000)
-	portArgFound := false
 	for j, cmd := range c.Command {
-		if strings.Contains(cmd, "--port="+oldPortStr) || strings.Contains(cmd, "--port "+oldPortStr) {
-			portArgFound = true
-		}
 		updated := strings.ReplaceAll(cmd, "--vllm-port="+oldPortStr, "--vllm-port="+newPortStr)
 		updated = strings.ReplaceAll(updated, "--port="+oldPortStr, "--port="+newPortStr)
 		updated = strings.ReplaceAll(updated, "--port "+oldPortStr, "--port "+newPortStr)
 		c.Command[j] = updated
 	}
-	// If no --port argument was found in the command, inject it so vLLM binds
-	// to the internal port instead of its default (5000).
-	if !portArgFound && len(c.Command) > 0 {
-		// For shell commands ("/bin/sh", "-c", "script..."), append to the script string.
-		// For direct exec commands, append as extra slice elements.
-		lastIdx := len(c.Command) - 1
-		if len(c.Command) >= 3 && c.Command[0] == "/bin/sh" && c.Command[1] == "-c" {
-			c.Command[lastIdx] = c.Command[lastIdx] + " --port=" + newPortStr
-		} else {
-			c.Command = append(c.Command, "--port="+newPortStr)
-		}
-	}
+	// Note: if no --port argument exists in the command, we rely on KAITO_VLLM_PORT
+	// env var (set below) which inference_api.py reads as the final --port override.
+	// We do NOT append --port to the shell script to avoid breaking multi-statement
+	// commands (e.g., "if ...; fi --port=5001" would be invalid).
 
 	// Set KAITO_VLLM_PORT env var to ensure the internal port takes priority
 	// even if a config file overrides --port (inference_api.py reads this last).

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -858,7 +858,16 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 		}
 	}
 
-	expectedBackendURL := fmt.Sprintf("http://localhost:%d", consts.PortInferenceServerInternal)
+
+	// The llm-d routing sidecar uses command-line flags (not environment variables)
+	// to configure its listening port and backend vLLM port:
+	//   --port=<listen-port>       (default: 8000)
+	//   --vllm-port=<backend-port> (default: 8001)
+	// We must explicitly set these to match our port scheme (5000 / 5001).
+	sidecarArgs := []string{
+		fmt.Sprintf("--port=%d", consts.PortInferenceServer),
+		fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
+	}
 
 	if sidecarExists {
 		// Reconcile existing sidecar to ensure its config matches expected values
@@ -866,24 +875,10 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			if spec.Containers[i].Name != "llm-d-routing-sidecar" {
 				continue
 			}
-			// Ensure BACKEND_URL points to the internal port
-			backendFound := false
-			for j := range spec.Containers[i].Env {
-				if spec.Containers[i].Env[j].Name == "BACKEND_URL" {
-					spec.Containers[i].Env[j].Value = expectedBackendURL
-					backendFound = true
-					break
-				}
-			}
-			if !backendFound {
-				spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
-					Name:  "BACKEND_URL",
-					Value: expectedBackendURL,
-				})
-			}
 			// Ensure image is up to date
 			spec.Containers[i].Image = fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag)
-			// Ensure port is set correctly
+			// Ensure args include correct port flags
+			spec.Containers[i].Args = sidecarArgs
 			// Set ports to exactly the expected single port struct for deterministic spec
 			spec.Containers[i].Ports = []corev1.ContainerPort{
 				{ContainerPort: consts.PortInferenceServer, Name: "sidecar", Protocol: corev1.ProtocolTCP},
@@ -906,6 +901,14 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 					},
 				})
 			}
+			// Remove stale BACKEND_URL env if present (no longer used)
+			envs := spec.Containers[i].Env[:0]
+			for _, e := range spec.Containers[i].Env {
+				if e.Name != "BACKEND_URL" {
+					envs = append(envs, e)
+				}
+			}
+			spec.Containers[i].Env = envs
 			break
 		}
 	} else {
@@ -913,6 +916,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 		sidecar := corev1.Container{
 			Name:  "llm-d-routing-sidecar",
 			Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
+			Args:  sidecarArgs,
 			Ports: []corev1.ContainerPort{
 				{
 					ContainerPort: consts.PortInferenceServer,
@@ -921,10 +925,6 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 				},
 			},
 			Env: []corev1.EnvVar{
-				{
-					Name:  "BACKEND_URL",
-					Value: expectedBackendURL,
-				},
 				{
 					Name: "POD_IP",
 					ValueFrom: &corev1.EnvVarSource{

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -806,27 +806,45 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			// Insert or rewrite --port to override vLLM's default listen port.
 			// Use string replacement to handle both single-node and multi-node
 			// shell script commands (where appending at end would break the script).
-			// If --port already exists with a different value, rewrite it to the internal port.
-			internalPort := fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)
+			// Handles both "--port <n>" (space form) and "--port=<n>" (equals form).
+			internalPortSpace := fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)
+			internalPortEquals := fmt.Sprintf("--port=%d", consts.PortInferenceServerInternal)
 			if !portOverrideAdded && strings.Contains(cmd, "inference_api.py") {
-				// Check for any existing --port flag and rewrite it
-				if idx := strings.Index(cmd, "--port "); idx >= 0 {
-					// Find the end of the port number
-					portStart := idx + len("--port ")
+				rewritten := false
+				// Check for "--port=<n>" form first (e.g., from BuildCmdStr)
+				if idx := strings.Index(cmd, "--port="); idx >= 0 {
+					portStart := idx + len("--port=")
 					portEnd := portStart
 					for portEnd < len(cmd) && cmd[portEnd] >= '0' && cmd[portEnd] <= '9' {
 						portEnd++
 					}
 					if portEnd > portStart {
 						existing := cmd[idx:portEnd]
-						spec.Containers[i].Command[j] = strings.Replace(cmd, existing, internalPort, 1)
+						spec.Containers[i].Command[j] = strings.Replace(cmd, existing, internalPortEquals, 1)
+						rewritten = true
 					}
-				} else {
-					// No existing --port, insert after inference_api.py
+				}
+				// Check for "--port <n>" form (space-separated)
+				if !rewritten {
+					if idx := strings.Index(cmd, "--port "); idx >= 0 {
+						portStart := idx + len("--port ")
+						portEnd := portStart
+						for portEnd < len(cmd) && cmd[portEnd] >= '0' && cmd[portEnd] <= '9' {
+							portEnd++
+						}
+						if portEnd > portStart {
+							existing := cmd[idx:portEnd]
+							spec.Containers[i].Command[j] = strings.Replace(cmd, existing, internalPortSpace, 1)
+							rewritten = true
+						}
+					}
+				}
+				// No existing --port flag, insert after inference_api.py
+				if !rewritten {
 					spec.Containers[i].Command[j] = strings.Replace(
 						cmd,
 						"inference_api.py",
-						"inference_api.py "+internalPort,
+						"inference_api.py "+internalPortSpace,
 						1,
 					)
 				}
@@ -872,6 +890,24 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 				}
 			} else {
 				spec.Containers[i].Ports[0].ContainerPort = consts.PortInferenceServer
+			}
+			// Ensure POD_IP env is present
+			podIPFound := false
+			for j := range spec.Containers[i].Env {
+				if spec.Containers[i].Env[j].Name == "POD_IP" {
+					podIPFound = true
+					break
+				}
+			}
+			if !podIPFound {
+				spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
+					Name: "POD_IP",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "status.podIP",
+						},
+					},
+				})
 			}
 			break
 		}

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -495,27 +495,71 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 			readinessTimeout = defaultStartupProbeTimeout
 		}
 
+		// Determine if the routing sidecar is needed (decode workspace on vLLM).
+		// When present, vLLM uses the internal port (5001) and the sidecar takes the public port (5000).
+		inferencePort := containerPorts
+		inferenceCommands := commands
+		if needsRoutingSidecar(ctx.Workspace) {
+			inferencePort = []corev1.ContainerPort{{ContainerPort: consts.PortInferenceServerInternal}}
+			inferenceCommands = rewritePortInCommands(commands, consts.PortInferenceServer, consts.PortInferenceServerInternal)
+		}
+
 		spec.Containers = []corev1.Container{
 			{
 				Name:           ctx.Workspace.Name,
 				Image:          GetBaseImageName(),
-				Command:        commands,
+				Command:        inferenceCommands,
 				Resources:      resourceReq,
-				Ports:          containerPorts,
+				Ports:          inferencePort,
 				StartupProbe:   buildStartupProbe(readinessTimeout),
 				LivenessProbe:  defaultLivenessProbe,
 				ReadinessProbe: defaultReadinessProbe,
 				VolumeMounts:   volumeMounts,
 			},
 		}
+
+		if needsRoutingSidecar(ctx.Workspace) {
+			// Rewrite probes to use the internal port
+			c := &spec.Containers[0]
+			rewriteProbePort := func(probe *corev1.Probe) {
+				if probe == nil {
+					return
+				}
+				if probe.HTTPGet != nil && probe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+					probe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
+				}
+			}
+			c.ReadinessProbe = c.ReadinessProbe.DeepCopy()
+			rewriteProbePort(c.ReadinessProbe)
+			c.LivenessProbe = c.LivenessProbe.DeepCopy()
+			rewriteProbePort(c.LivenessProbe)
+			c.StartupProbe = c.StartupProbe.DeepCopy()
+			rewriteProbePort(c.StartupProbe)
+
+			spec.Containers = append(spec.Containers, corev1.Container{
+				Name:  "llm-d-routing-sidecar",
+				Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
+				Args: []string{
+					fmt.Sprintf("--port=%d", consts.PortInferenceServer),
+					fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
+					"--secure-proxy=false",
+				},
+				Ports: []corev1.ContainerPort{
+					{ContainerPort: int32(consts.PortInferenceServer), Name: "sidecar", Protocol: corev1.ProtocolTCP},
+				},
+				Env: []corev1.EnvVar{
+					{
+						Name: "POD_IP",
+						ValueFrom: &corev1.EnvVarSource{
+							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+						},
+					},
+				},
+			})
+		}
+
 		spec.Tolerations = defaultTolerations(ctx.Workspace)
 		spec.Volumes = volumes
-
-		// If this is a decode workspace on vLLM, inject the routing sidecar.
-		// The sidecar takes the public port (5000), vLLM moves to internal port (5001).
-		if needsRoutingSidecar(ctx.Workspace) {
-			injectRoutingSidecar(spec)
-		}
 
 		return nil
 	}
@@ -733,114 +777,29 @@ func needsRoutingSidecar(ws *v1beta1.Workspace) bool {
 	return v1beta1.GetWorkspaceRuntimeName(ws) == pkgmodel.RuntimeNameVLLM
 }
 
-// injectRoutingSidecar modifies the podSpec in-place:
-// 1. Moves the main container's port from 5000 to 5001
-// 2. Updates probes to use the internal port
-// 3. Updates command args to use --port 5001 (appends if not present)
-// 4. Appends the llm-d routing sidecar container on port 5000
-func injectRoutingSidecar(spec *corev1.PodSpec) {
-	if len(spec.Containers) == 0 {
-		return
-	}
-	internalPort := consts.PortInferenceServerInternal
-	publicPort := consts.PortInferenceServer
+// rewritePortInCommands rewrites port references in the command slice.
+// If --port=<oldPort> or --port <oldPort> is found, it's replaced with the new port.
+// If no --port is found, appends --port <newPort> to the last command element.
+func rewritePortInCommands(commands []string, oldPort, newPort int32) []string {
+	oldPortStr := strconv.Itoa(int(oldPort))
+	newPortStr := strconv.Itoa(int(newPort))
 
-	// Rewrite the main container (always index 0 at this point)
-	c := &spec.Containers[0]
+	result := make([]string, len(commands))
+	copy(result, commands)
 
-	// Ports: deep-copy to avoid mutating the package-level containerPorts slice
-	newPorts := make([]corev1.ContainerPort, len(c.Ports))
-	copy(newPorts, c.Ports)
-	c.Ports = newPorts
-	for j := range c.Ports {
-		if c.Ports[j].ContainerPort == int32(publicPort) {
-			c.Ports[j].ContainerPort = internalPort
-		}
-	}
-
-	oldPortStr := strconv.Itoa(int(publicPort))
-	newPortStr := strconv.Itoa(int(internalPort))
-
-	// Probes: rewrite both HTTPGet and Exec probe ports
-	rewriteProbePort := func(probe *corev1.Probe) {
-		if probe == nil {
-			return
-		}
-		if probe.HTTPGet != nil && probe.HTTPGet.Port.IntValue() == int(publicPort) {
-			probe.HTTPGet.Port = intstr.FromInt32(internalPort)
-		}
-		// Also rewrite Exec probes (e.g., multi-node-health-check.py with vllm-port=5000)
-		if probe.Exec != nil {
-			for j, cmd := range probe.Exec.Command {
-				updated := strings.ReplaceAll(cmd, "--vllm-port="+oldPortStr, "--vllm-port="+newPortStr)
-				updated = strings.ReplaceAll(updated, "--port="+oldPortStr, "--port="+newPortStr)
-				updated = strings.ReplaceAll(updated, "--port "+oldPortStr, "--port "+newPortStr)
-				probe.Exec.Command[j] = updated
-			}
-		}
-	}
-	// DeepCopy probes to avoid mutating shared package-level defaults
-	if c.ReadinessProbe != nil {
-		c.ReadinessProbe = c.ReadinessProbe.DeepCopy()
-		rewriteProbePort(c.ReadinessProbe)
-	}
-	if c.LivenessProbe != nil {
-		c.LivenessProbe = c.LivenessProbe.DeepCopy()
-		rewriteProbePort(c.LivenessProbe)
-	}
-	if c.StartupProbe != nil {
-		c.StartupProbe = c.StartupProbe.DeepCopy()
-		rewriteProbePort(c.StartupProbe)
-	}
-
-	// Command: rewrite existing port references and append --port if not present
 	portFound := false
-	for j, cmd := range c.Command {
+	for j, cmd := range result {
 		if strings.Contains(cmd, "--port="+oldPortStr) || strings.Contains(cmd, "--port "+oldPortStr) {
 			portFound = true
 		}
 		updated := strings.ReplaceAll(cmd, "--vllm-port="+oldPortStr, "--vllm-port="+newPortStr)
 		updated = strings.ReplaceAll(updated, "--port="+oldPortStr, "--port="+newPortStr)
 		updated = strings.ReplaceAll(updated, "--port "+oldPortStr, "--port "+newPortStr)
-		c.Command[j] = updated
+		result[j] = updated
 	}
-	// If no --port was found in the command, append it to the shell script.
-	// Command format is ["/bin/sh", "-c", "<script>"], so we append to the last element.
-	if !portFound && len(c.Command) > 0 {
-		c.Command[len(c.Command)-1] += " --port " + newPortStr
+	// If no --port was found, append it to the last element (shell script body).
+	if !portFound && len(result) > 0 {
+		result[len(result)-1] += " --port " + newPortStr
 	}
-
-	// Upsert sidecar container
-	desiredSidecar := corev1.Container{
-		Name:  "llm-d-routing-sidecar",
-		Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
-		Args: []string{
-			fmt.Sprintf("--port=%d", publicPort),
-			fmt.Sprintf("--vllm-port=%d", internalPort),
-			"--secure-proxy=false",
-		},
-		Ports: []corev1.ContainerPort{
-			{ContainerPort: int32(publicPort), Name: "sidecar", Protocol: corev1.ProtocolTCP},
-		},
-		Env: []corev1.EnvVar{
-			{
-				Name: "POD_IP",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
-				},
-			},
-		},
-	}
-	sidecarIdx := -1
-	for i, existing := range spec.Containers {
-		if existing.Name == "llm-d-routing-sidecar" {
-			sidecarIdx = i
-			break
-		}
-	}
-	if sidecarIdx >= 0 {
-		spec.Containers[sidecarIdx] = desiredSidecar
-	} else {
-		spec.Containers = append(spec.Containers, desiredSidecar)
-	}
+	return result
 }

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -682,8 +682,9 @@ func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec
 
 // SetInferenceRoleEnv propagates the kaito.sh/inference-role label from the workspace
 // to the KAITO_INFERENCE_ROLE environment variable on the main inference container.
-// This is used by the vLLM inference_api.py to set LMCache kv_transfer_config
-// for P/D disaggregated inference. The label is propagated from
+// This is used by the vLLM inference_api.py to configure kv_transfer_config for
+// P/D disaggregated inference (NixlConnector when role is set, LMCacheConnectorV1
+// when CPU offload is enabled). The label is propagated from
 // InferenceSet.Spec.Template.Metadata.Labels onto child workspaces by the InferenceSet controller.
 func SetInferenceRoleEnv(ctx *generator.WorkspaceGeneratorContext, spec *corev1.PodSpec) error {
 	role, ok := ctx.Workspace.Labels[v1beta1.LabelInferenceRole]

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -690,6 +690,9 @@ func SetInferenceRoleEnv(ctx *generator.WorkspaceGeneratorContext, spec *corev1.
 	if !ok || (role != consts.InferenceRolePrefill && role != consts.InferenceRoleDecode) {
 		return nil
 	}
+	if len(spec.Containers) == 0 {
+		return nil
+	}
 	envVar := corev1.EnvVar{
 		Name:  consts.InferenceRoleEnvName,
 		Value: role,
@@ -725,6 +728,9 @@ func needsRoutingSidecar(ws *v1beta1.Workspace) bool {
 // 3. Updates command args to use --port=5001
 // 4. Appends the llm-d routing sidecar container on port 5000
 func injectRoutingSidecarInline(spec *corev1.PodSpec) {
+	if len(spec.Containers) == 0 {
+		return
+	}
 	internalPort := consts.PortInferenceServerInternal
 	publicPort := consts.PortInferenceServer
 

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -694,19 +694,18 @@ func SetInferenceRoleEnv(ctx *generator.WorkspaceGeneratorContext, spec *corev1.
 		Name:  consts.InferenceRoleEnvName,
 		Value: role,
 	}
-	for i := range spec.Containers {
-		// Upsert: replace existing entry if present to avoid duplicates
-		found := false
-		for j, env := range spec.Containers[i].Env {
-			if env.Name == consts.InferenceRoleEnvName {
-				spec.Containers[i].Env[j] = envVar
-				found = true
-				break
-			}
+	// Only set on the main inference container (index 0)
+	c := &spec.Containers[0]
+	found := false
+	for j, env := range c.Env {
+		if env.Name == consts.InferenceRoleEnvName {
+			c.Env[j] = envVar
+			found = true
+			break
 		}
-		if !found {
-			spec.Containers[i].Env = append(spec.Containers[i].Env, envVar)
-		}
+	}
+	if !found {
+		c.Env = append(c.Env, envVar)
 	}
 	return nil
 }
@@ -732,7 +731,10 @@ func injectRoutingSidecarInline(spec *corev1.PodSpec) {
 	// Rewrite the main container (always index 0 at this point)
 	c := &spec.Containers[0]
 
-	// Ports
+	// Ports: deep-copy to avoid mutating the package-level containerPorts slice
+	newPorts := make([]corev1.ContainerPort, len(c.Ports))
+	copy(newPorts, c.Ports)
+	c.Ports = newPorts
 	for j := range c.Ports {
 		if c.Ports[j].ContainerPort == int32(publicPort) {
 			c.Ports[j].ContainerPort = internalPort
@@ -762,38 +764,12 @@ func injectRoutingSidecarInline(spec *corev1.PodSpec) {
 		rewriteProbePort(c.StartupProbe)
 	}
 
-	// Command: rewrite --port and --vllm-port references
+	// Command: rewrite port references (format is known: --port=5000, --vllm-port=5000)
 	oldPortStr := strconv.Itoa(int(publicPort))
 	newPortStr := strconv.Itoa(int(internalPort))
 	for j, cmd := range c.Command {
-		updated := cmd
-		// Rewrite --vllm-port=5000 -> --vllm-port=5001
-		updated = strings.ReplaceAll(updated, "--vllm-port="+oldPortStr, "--vllm-port="+newPortStr)
-		// Rewrite or insert --port for inference_api.py
-		if strings.Contains(updated, "inference_api.py") {
-			portArg := fmt.Sprintf("--port=%d", internalPort)
-			portArgSpace := fmt.Sprintf("--port %d", internalPort)
-			if strings.Contains(updated, "--port=") {
-				// Replace existing --port=N
-				idx := strings.Index(updated, "--port=")
-				end := idx + len("--port=")
-				for end < len(updated) && updated[end] >= '0' && updated[end] <= '9' {
-					end++
-				}
-				updated = updated[:idx] + portArg + updated[end:]
-			} else if strings.Contains(updated, "--port ") {
-				// Replace existing --port N
-				idx := strings.Index(updated, "--port ")
-				end := idx + len("--port ")
-				for end < len(updated) && updated[end] >= '0' && updated[end] <= '9' {
-					end++
-				}
-				updated = updated[:idx] + portArgSpace + updated[end:]
-			} else {
-				// Insert after inference_api.py
-				updated = strings.Replace(updated, "inference_api.py", "inference_api.py "+portArgSpace, 1)
-			}
-		}
+		updated := strings.ReplaceAll(cmd, "--vllm-port="+oldPortStr, "--vllm-port="+newPortStr)
+		updated = strings.ReplaceAll(updated, "--port="+oldPortStr, "--port="+newPortStr)
 		c.Command[j] = updated
 	}
 
@@ -819,4 +795,3 @@ func injectRoutingSidecarInline(spec *corev1.PodSpec) {
 		},
 	})
 }
-

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kaito-project/kaito/api/v1alpha1"
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
@@ -719,7 +718,7 @@ func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec
 // env var; sidecar containers do not use it.
 func applyInferenceRoleEnv(labels map[string]string, containerName string, spec *corev1.PodSpec) {
 	role, ok := labels[v1beta1.LabelInferenceRole]
-	if !ok || (role != string(v1alpha1.MultiRoleInferenceRolePrefill) && role != string(v1alpha1.MultiRoleInferenceRoleDecode)) {
+	if !ok || (role != consts.InferenceRolePrefill && role != consts.InferenceRoleDecode) {
 		return
 	}
 	for i := range spec.Containers {
@@ -797,7 +796,7 @@ func injectRoutingSidecar(spec *corev1.PodSpec) {
 // needsRoutingSidecar returns true if the workspace requires the llm-d routing sidecar.
 func needsRoutingSidecar(ws *v1beta1.Workspace) bool {
 	role, ok := ws.Labels[v1beta1.LabelInferenceRole]
-	if !ok || role != string(v1alpha1.MultiRoleInferenceRoleDecode) {
+	if !ok || role != consts.InferenceRoleDecode {
 		return false
 	}
 	return v1beta1.GetWorkspaceRuntimeName(ws) == pkgmodel.RuntimeNameVLLM

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -196,7 +196,7 @@ func GeneratePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspac
 		podOpts = append(podOpts, SetDefaultModelWeightsVolume)
 	}
 
-	podOpts = append(podOpts, SetInferenceRoleEnv, SetRoutingSidecar)
+	podOpts = append(podOpts, SetRoutingSidecar, SetInferenceRoleEnv)
 
 	podSpec, err := generator.GenerateManifest(gctx, podOpts...)
 	if err != nil {
@@ -674,7 +674,9 @@ func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec
 }
 
 // SetInferenceRoleEnv propagates the kaito.sh/inference-role label from the workspace
-// to the KAITO_INFERENCE_ROLE environment variable on all containers.
+// to the KAITO_INFERENCE_ROLE environment variable on existing containers in the pod spec.
+// Note: This modifier should run after SetRoutingSidecar so that the sidecar container
+// also receives the environment variable. If ordering changes, verify all containers are covered.
 // This is used by the vLLM inference_api.py to inject NixlConnector kv-transfer-config
 // for P/D disaggregated inference. The label is propagated from
 // InferenceSet.Spec.Template.Metadata.Labels onto child workspaces by the InferenceSet controller.

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -806,34 +806,53 @@ func injectRoutingSidecarInline(spec *corev1.PodSpec) {
 		}
 	}
 
-	// Append sidecar container (upsert: skip if already present)
-	hasSidecar := false
-	for _, existing := range spec.Containers {
-		if existing.Name == "llm-d-routing-sidecar" {
-			hasSidecar = true
+	// Set KAITO_VLLM_PORT env var to ensure the internal port takes priority
+	// even if a config file overrides --port (inference_api.py reads this last).
+	portEnv := corev1.EnvVar{Name: "KAITO_VLLM_PORT", Value: newPortStr}
+	portEnvFound := false
+	for j, env := range c.Env {
+		if env.Name == "KAITO_VLLM_PORT" {
+			c.Env[j] = portEnv
+			portEnvFound = true
 			break
 		}
 	}
-	if !hasSidecar {
-		spec.Containers = append(spec.Containers, corev1.Container{
-			Name:  "llm-d-routing-sidecar",
-			Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
-			Args: []string{
-				fmt.Sprintf("--port=%d", publicPort),
-				fmt.Sprintf("--vllm-port=%d", internalPort),
-				"--secure-proxy=false",
-			},
-			Ports: []corev1.ContainerPort{
-				{ContainerPort: int32(publicPort), Name: "sidecar", Protocol: corev1.ProtocolTCP},
-			},
-			Env: []corev1.EnvVar{
-				{
-					Name: "POD_IP",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
-					},
+	if !portEnvFound {
+		c.Env = append(c.Env, portEnv)
+	}
+
+	// Upsert sidecar container
+	desiredSidecar := corev1.Container{
+		Name:  "llm-d-routing-sidecar",
+		Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
+		Args: []string{
+			fmt.Sprintf("--port=%d", publicPort),
+			fmt.Sprintf("--vllm-port=%d", internalPort),
+			"--secure-proxy=false",
+		},
+		Ports: []corev1.ContainerPort{
+			{ContainerPort: int32(publicPort), Name: "sidecar", Protocol: corev1.ProtocolTCP},
+		},
+		Env: []corev1.EnvVar{
+			{
+				Name: "POD_IP",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
 				},
 			},
-		})
+		},
+	}
+	sidecarIdx := -1
+	for i, existing := range spec.Containers {
+		if existing.Name == "llm-d-routing-sidecar" {
+			sidecarIdx = i
+			break
+		}
+	}
+	if sidecarIdx >= 0 {
+		// Reconcile existing sidecar to desired spec
+		spec.Containers[sidecarIdx] = desiredSidecar
+	} else {
+		spec.Containers = append(spec.Containers, desiredSidecar)
 	}
 }

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -572,6 +572,18 @@ func SetAdapterPuller(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Pod
 		return nil
 	}
 
+	// Find the main inference container by workspace name.
+	mainIdx := -1
+	for i := range spec.Containers {
+		if spec.Containers[i].Name == ctx.Workspace.Name {
+			mainIdx = i
+			break
+		}
+	}
+	if mainIdx == -1 {
+		return fmt.Errorf("main inference container %q not found", ctx.Workspace.Name)
+	}
+
 	// Separate adapters by source type
 	var imageAdapters []v1beta1.AdapterSpec
 	var volumeAdapters []v1beta1.AdapterSpec
@@ -587,18 +599,14 @@ func SetAdapterPuller(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Pod
 	if len(imageAdapters) > 0 {
 		adapterVolume, adapterVolumeMount := utils.ConfigAdapterVolume(nil)
 		spec.Volumes = append(spec.Volumes, adapterVolume)
-		for i := range spec.Containers { // FIXME: assume only one container in the pod
-			spec.Containers[i].VolumeMounts = append(spec.Containers[i].VolumeMounts, adapterVolumeMount)
-		}
+		spec.Containers[mainIdx].VolumeMounts = append(spec.Containers[mainIdx].VolumeMounts, adapterVolumeMount)
 
 		// add container to pull adapters
 		volumeMounts := []corev1.VolumeMount{adapterVolumeMount}
 		pullerContainers, pullerEnvVars, pullerVolumes := manifests.GeneratePullerContainers(ctx.Workspace, imageAdapters, volumeMounts)
 		spec.InitContainers = append(spec.InitContainers, pullerContainers...)
 		spec.Volumes = append(spec.Volumes, pullerVolumes...)
-		for i := range spec.Containers { // FIXME: assume only one container in the pod
-			spec.Containers[i].Env = append(spec.Containers[i].Env, pullerEnvVars...)
-		}
+		spec.Containers[mainIdx].Env = append(spec.Containers[mainIdx].Env, pullerEnvVars...)
 	}
 
 	// Handle volume-based adapters (mount volume directly, no puller needed)
@@ -616,9 +624,7 @@ func SetAdapterPuller(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Pod
 			MountPath: mountPath,
 		}
 		spec.Volumes = append(spec.Volumes, volume)
-		for i := range spec.Containers {
-			spec.Containers[i].VolumeMounts = append(spec.Containers[i].VolumeMounts, volumeMount)
-		}
+		spec.Containers[mainIdx].VolumeMounts = append(spec.Containers[mainIdx].VolumeMounts, volumeMount)
 
 		// Propagate strength env vars for volume adapters
 		if adapter.Strength != nil {
@@ -626,9 +632,7 @@ func SetAdapterPuller(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Pod
 				Name:  sourceName,
 				Value: *adapter.Strength,
 			}
-			for i := range spec.Containers {
-				spec.Containers[i].Env = append(spec.Containers[i].Env, envVar)
-			}
+			spec.Containers[mainIdx].Env = append(spec.Containers[mainIdx].Env, envVar)
 		}
 	}
 

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -196,6 +196,8 @@ func GeneratePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspac
 		podOpts = append(podOpts, SetDefaultModelWeightsVolume)
 	}
 
+	podOpts = append(podOpts, SetInferenceRoleEnv, SetRoutingSidecar)
+
 	podSpec, err := generator.GenerateManifest(gctx, podOpts...)
 	if err != nil {
 		return nil, err

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -202,7 +202,14 @@ func GeneratePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspac
 	if err != nil {
 		return nil, err
 	}
-	ssOpts = append(ssOpts, manifests.SetStatefulSetPodSpec(podSpec), InjectRoutingSidecar)
+
+	// If this is a decode workspace on vLLM, inject the routing sidecar directly.
+	// The sidecar takes the public port (5000), vLLM moves to internal port (5001).
+	if needsRoutingSidecar(workspaceObj) {
+		injectRoutingSidecarInline(podSpec)
+	}
+
+	ssOpts = append(ssOpts, manifests.SetStatefulSetPodSpec(podSpec))
 
 	return generator.GenerateManifest(gctx, ssOpts...)
 }
@@ -704,244 +711,112 @@ func SetInferenceRoleEnv(ctx *generator.WorkspaceGeneratorContext, spec *corev1.
 	return nil
 }
 
-// InjectRoutingSidecar is a StatefulSet-level modifier that adds the llm-d routing sidecar
-// to decode workspace pods. When the workspace has inference-role: decode and uses the vLLM
-// runtime, the sidecar is injected alongside the main container. The sidecar takes over
-// the public-facing port (5000) and vLLM is moved to an internal port (5001).
-func InjectRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, ss *appsv1.StatefulSet) error {
-	role, ok := ctx.Workspace.Labels[v1beta1.LabelInferenceRole]
+// needsRoutingSidecar returns true if the workspace requires the llm-d routing sidecar.
+func needsRoutingSidecar(ws *v1beta1.Workspace) bool {
+	role, ok := ws.Labels[v1beta1.LabelInferenceRole]
 	if !ok || role != consts.InferenceRoleDecode {
-		return nil
+		return false
 	}
-
-	runtimeName := v1beta1.GetWorkspaceRuntimeName(ctx.Workspace)
-	if runtimeName != pkgmodel.RuntimeNameVLLM {
-		return nil
-	}
-
-	spec := &ss.Spec.Template.Spec
-
-	// Check if sidecar already exists to avoid duplicate injection
-	sidecarExists := false
-	for _, c := range spec.Containers {
-		if c.Name == "llm-d-routing-sidecar" {
-			sidecarExists = true
-			break
-		}
-	}
-
-	// Move vLLM to internal port so the sidecar can take over the public-facing port.
-	// Update container ports, readiness/liveness probes, and vllm-port arg/command.
-	// Deep-copy mutable slices to avoid contaminating shared package-level defaults.
-	oldPort := strconv.Itoa(int(consts.PortInferenceServer))
-	newPort := strconv.Itoa(int(consts.PortInferenceServerInternal))
-	for i := range spec.Containers {
-		if spec.Containers[i].Name == "llm-d-routing-sidecar" {
-			continue
-		}
-		// Deep-copy ports to avoid mutating shared defaults
-		if len(spec.Containers[i].Ports) > 0 {
-			portsCopy := make([]corev1.ContainerPort, len(spec.Containers[i].Ports))
-			copy(portsCopy, spec.Containers[i].Ports)
-			spec.Containers[i].Ports = portsCopy
-			for j := range spec.Containers[i].Ports {
-				if spec.Containers[i].Ports[j].ContainerPort == int32(consts.PortInferenceServer) {
-					spec.Containers[i].Ports[j].ContainerPort = consts.PortInferenceServerInternal
-				}
-			}
-		}
-		// Update readiness probe port (HTTPGet or Exec)
-		if spec.Containers[i].ReadinessProbe != nil {
-			spec.Containers[i].ReadinessProbe = spec.Containers[i].ReadinessProbe.DeepCopy()
-			if spec.Containers[i].ReadinessProbe.HTTPGet != nil {
-				if spec.Containers[i].ReadinessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-					spec.Containers[i].ReadinessProbe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
-				}
-			}
-			if spec.Containers[i].ReadinessProbe.Exec != nil {
-				for j, cmd := range spec.Containers[i].ReadinessProbe.Exec.Command {
-					if strings.Contains(cmd, "--vllm-port="+oldPort) {
-						spec.Containers[i].ReadinessProbe.Exec.Command[j] = strings.ReplaceAll(cmd, "--vllm-port="+oldPort, "--vllm-port="+newPort)
-					}
-				}
-			}
-		}
-		// Update liveness probe port (HTTPGet or Exec)
-		if spec.Containers[i].LivenessProbe != nil {
-			spec.Containers[i].LivenessProbe = spec.Containers[i].LivenessProbe.DeepCopy()
-			if spec.Containers[i].LivenessProbe.HTTPGet != nil {
-				if spec.Containers[i].LivenessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-					spec.Containers[i].LivenessProbe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
-				}
-			}
-			if spec.Containers[i].LivenessProbe.Exec != nil {
-				for j, cmd := range spec.Containers[i].LivenessProbe.Exec.Command {
-					if strings.Contains(cmd, "--vllm-port="+oldPort) {
-						spec.Containers[i].LivenessProbe.Exec.Command[j] = strings.ReplaceAll(cmd, "--vllm-port="+oldPort, "--vllm-port="+newPort)
-					}
-				}
-			}
-		}
-		// Update startup probe port (HTTPGet or Exec)
-		if spec.Containers[i].StartupProbe != nil {
-			spec.Containers[i].StartupProbe = spec.Containers[i].StartupProbe.DeepCopy()
-			if spec.Containers[i].StartupProbe.HTTPGet != nil {
-				if spec.Containers[i].StartupProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-					spec.Containers[i].StartupProbe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
-				}
-			}
-			if spec.Containers[i].StartupProbe.Exec != nil {
-				for j, cmd := range spec.Containers[i].StartupProbe.Exec.Command {
-					if strings.Contains(cmd, "--vllm-port="+oldPort) {
-						spec.Containers[i].StartupProbe.Exec.Command[j] = strings.ReplaceAll(cmd, "--vllm-port="+oldPort, "--vllm-port="+newPort)
-					}
-				}
-			}
-		}
-		// Update --vllm-port in container command and args
-		portOverrideAdded := false
-		for j, cmd := range spec.Containers[i].Command {
-			// Use a working copy so all transformations within the same
-			// command string are cumulative (avoid clobbering earlier rewrites).
-			updated := cmd
-
-			if strings.Contains(updated, "--vllm-port="+oldPort) {
-				updated = strings.ReplaceAll(updated, "--vllm-port="+oldPort, "--vllm-port="+newPort)
-			}
-			// Insert or rewrite --port to override vLLM's default listen port.
-			// Use string replacement to handle both single-node and multi-node
-			// shell script commands (where appending at end would break the script).
-			// Handles both "--port <n>" (space form) and "--port=<n>" (equals form).
-			internalPortSpace := fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)
-			internalPortEquals := fmt.Sprintf("--port=%d", consts.PortInferenceServerInternal)
-			if !portOverrideAdded && strings.Contains(updated, "inference_api.py") {
-				rewritten := false
-				// Check for "--port=<n>" form first (e.g., from BuildCmdStr)
-				if idx := strings.Index(updated, "--port="); idx >= 0 {
-					portStart := idx + len("--port=")
-					portEnd := portStart
-					for portEnd < len(updated) && updated[portEnd] >= '0' && updated[portEnd] <= '9' {
-						portEnd++
-					}
-					if portEnd > portStart {
-						existing := updated[idx:portEnd]
-						updated = strings.Replace(updated, existing, internalPortEquals, 1)
-						rewritten = true
-					}
-				}
-				// Check for "--port <n>" form (space-separated)
-				if !rewritten {
-					if idx := strings.Index(updated, "--port "); idx >= 0 {
-						portStart := idx + len("--port ")
-						portEnd := portStart
-						for portEnd < len(updated) && updated[portEnd] >= '0' && updated[portEnd] <= '9' {
-							portEnd++
-						}
-						if portEnd > portStart {
-							existing := updated[idx:portEnd]
-							updated = strings.Replace(updated, existing, internalPortSpace, 1)
-							rewritten = true
-						}
-					}
-				}
-				// No existing --port flag, insert after inference_api.py
-				if !rewritten {
-					updated = strings.Replace(
-						updated,
-						"inference_api.py",
-						"inference_api.py "+internalPortSpace,
-						1,
-					)
-				}
-				portOverrideAdded = true
-			}
-			spec.Containers[i].Command[j] = updated
-		}
-		for j, arg := range spec.Containers[i].Args {
-			if strings.Contains(arg, "--vllm-port="+oldPort) {
-				spec.Containers[i].Args[j] = strings.ReplaceAll(arg, "--vllm-port="+oldPort, "--vllm-port="+newPort)
-			}
-		}
-	}
-
-	// The llm-d routing sidecar uses command-line flags (not environment variables)
-	// to configure its listening port and backend vLLM port:
-	//   --port=<listen-port>       (default: 8000)
-	//   --vllm-port=<backend-port> (default: 8001)
-	// We must explicitly set these to match our port scheme (5000 / 5001).
-	sidecarArgs := []string{
-		fmt.Sprintf("--port=%d", consts.PortInferenceServer),
-		fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
-		"--secure-proxy=false",
-	}
-
-	if sidecarExists {
-		// Reconcile existing sidecar to ensure its config matches expected values
-		for i := range spec.Containers {
-			if spec.Containers[i].Name != "llm-d-routing-sidecar" {
-				continue
-			}
-			// Ensure image is up to date
-			spec.Containers[i].Image = fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag)
-			// Ensure args include correct port flags
-			spec.Containers[i].Args = sidecarArgs
-			// Set ports to exactly the expected single port struct for deterministic spec
-			spec.Containers[i].Ports = []corev1.ContainerPort{
-				{ContainerPort: consts.PortInferenceServer, Name: "sidecar", Protocol: corev1.ProtocolTCP},
-			}
-			// Ensure POD_IP env is present
-			podIPFound := false
-			for j := range spec.Containers[i].Env {
-				if spec.Containers[i].Env[j].Name == "POD_IP" {
-					podIPFound = true
-					break
-				}
-			}
-			if !podIPFound {
-				spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
-					Name: "POD_IP",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "status.podIP",
-						},
-					},
-				})
-			}
-			// Remove stale BACKEND_URL env if present (no longer used)
-			envs := spec.Containers[i].Env[:0]
-			for _, e := range spec.Containers[i].Env {
-				if e.Name != "BACKEND_URL" {
-					envs = append(envs, e)
-				}
-			}
-			spec.Containers[i].Env = envs
-			break
-		}
-	} else {
-		// Inject new sidecar container
-		sidecar := corev1.Container{
-			Name:  "llm-d-routing-sidecar",
-			Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
-			Args:  sidecarArgs,
-			Ports: []corev1.ContainerPort{
-				{
-					ContainerPort: consts.PortInferenceServer,
-					Name:          "sidecar",
-					Protocol:      corev1.ProtocolTCP,
-				},
-			},
-			Env: []corev1.EnvVar{
-				{
-					Name: "POD_IP",
-					ValueFrom: &corev1.EnvVarSource{
-						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "status.podIP",
-						},
-					},
-				},
-			},
-		}
-		spec.Containers = append(spec.Containers, sidecar)
-	}
-	return nil
+	return v1beta1.GetWorkspaceRuntimeName(ws) == pkgmodel.RuntimeNameVLLM
 }
+
+// injectRoutingSidecarInline modifies the podSpec in-place:
+// 1. Moves the main container's port from 5000 to 5001
+// 2. Updates probes to use the internal port
+// 3. Updates command args to use --port=5001
+// 4. Appends the llm-d routing sidecar container on port 5000
+func injectRoutingSidecarInline(spec *corev1.PodSpec) {
+	internalPort := consts.PortInferenceServerInternal
+	publicPort := consts.PortInferenceServer
+
+	// Rewrite the main container (always index 0 at this point)
+	c := &spec.Containers[0]
+
+	// Ports
+	for j := range c.Ports {
+		if c.Ports[j].ContainerPort == int32(publicPort) {
+			c.Ports[j].ContainerPort = internalPort
+		}
+	}
+
+	// Probes
+	rewriteProbePort := func(probe *corev1.Probe) {
+		if probe == nil {
+			return
+		}
+		if probe.HTTPGet != nil && probe.HTTPGet.Port.IntValue() == int(publicPort) {
+			probe.HTTPGet.Port = intstr.FromInt32(internalPort)
+		}
+	}
+	// DeepCopy probes to avoid mutating shared package-level defaults
+	if c.ReadinessProbe != nil {
+		c.ReadinessProbe = c.ReadinessProbe.DeepCopy()
+		rewriteProbePort(c.ReadinessProbe)
+	}
+	if c.LivenessProbe != nil {
+		c.LivenessProbe = c.LivenessProbe.DeepCopy()
+		rewriteProbePort(c.LivenessProbe)
+	}
+	if c.StartupProbe != nil {
+		c.StartupProbe = c.StartupProbe.DeepCopy()
+		rewriteProbePort(c.StartupProbe)
+	}
+
+	// Command: rewrite --port and --vllm-port references
+	oldPortStr := strconv.Itoa(int(publicPort))
+	newPortStr := strconv.Itoa(int(internalPort))
+	for j, cmd := range c.Command {
+		updated := cmd
+		// Rewrite --vllm-port=5000 -> --vllm-port=5001
+		updated = strings.ReplaceAll(updated, "--vllm-port="+oldPortStr, "--vllm-port="+newPortStr)
+		// Rewrite or insert --port for inference_api.py
+		if strings.Contains(updated, "inference_api.py") {
+			portArg := fmt.Sprintf("--port=%d", internalPort)
+			portArgSpace := fmt.Sprintf("--port %d", internalPort)
+			if strings.Contains(updated, "--port=") {
+				// Replace existing --port=N
+				idx := strings.Index(updated, "--port=")
+				end := idx + len("--port=")
+				for end < len(updated) && updated[end] >= '0' && updated[end] <= '9' {
+					end++
+				}
+				updated = updated[:idx] + portArg + updated[end:]
+			} else if strings.Contains(updated, "--port ") {
+				// Replace existing --port N
+				idx := strings.Index(updated, "--port ")
+				end := idx + len("--port ")
+				for end < len(updated) && updated[end] >= '0' && updated[end] <= '9' {
+					end++
+				}
+				updated = updated[:idx] + portArgSpace + updated[end:]
+			} else {
+				// Insert after inference_api.py
+				updated = strings.Replace(updated, "inference_api.py", "inference_api.py "+portArgSpace, 1)
+			}
+		}
+		c.Command[j] = updated
+	}
+
+	// Append sidecar container
+	spec.Containers = append(spec.Containers, corev1.Container{
+		Name:  "llm-d-routing-sidecar",
+		Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
+		Args: []string{
+			fmt.Sprintf("--port=%d", publicPort),
+			fmt.Sprintf("--vllm-port=%d", internalPort),
+			"--secure-proxy=false",
+		},
+		Ports: []corev1.ContainerPort{
+			{ContainerPort: int32(publicPort), Name: "sidecar", Protocol: corev1.ProtocolTCP},
+		},
+		Env: []corev1.EnvVar{
+			{
+				Name: "POD_IP",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+				},
+			},
+		},
+	})
+}
+

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -196,8 +196,6 @@ func GeneratePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspac
 		podOpts = append(podOpts, SetDefaultModelWeightsVolume)
 	}
 
-	podOpts = append(podOpts, SetInferenceRoleEnv)
-
 	podSpec, err := generator.GenerateManifest(gctx, podOpts...)
 	if err != nil {
 		return nil, err
@@ -518,6 +516,16 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 			},
 		}
 
+		// Set KAITO_INFERENCE_ROLE env var for P/D disaggregated inference.
+		// inference_api.py uses this to configure kv_transfer_config (NixlConnector).
+		if role, ok := ctx.Workspace.Labels[v1beta1.LabelInferenceRole]; ok &&
+			(role == consts.InferenceRolePrefill || role == consts.InferenceRoleDecode) {
+			spec.Containers[0].Env = append(spec.Containers[0].Env, corev1.EnvVar{
+				Name:  consts.InferenceRoleEnvName,
+				Value: role,
+			})
+		}
+
 		if needsRoutingSidecar(ctx.Workspace) {
 			// Rewrite probes to use the internal port
 			c := &spec.Containers[0]
@@ -721,50 +729,6 @@ func SetDistributedInferenceProbe(ctx *generator.WorkspaceGeneratorContext, spec
 
 func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec *corev1.PodSpec) error {
 	spec.Volumes = append(spec.Volumes, utils.DefaultModelWeightsVolume)
-	return nil
-}
-
-// SetInferenceRoleEnv propagates the kaito.sh/inference-role label from the workspace
-// to the KAITO_INFERENCE_ROLE environment variable on the main inference container.
-// This is used by the vLLM inference_api.py to configure kv_transfer_config for
-// P/D disaggregated inference (NixlConnector when role is set, LMCacheConnectorV1
-// when CPU offload is enabled). The label is propagated from
-// InferenceSet.Spec.Template.Metadata.Labels onto child workspaces by the InferenceSet controller.
-func SetInferenceRoleEnv(ctx *generator.WorkspaceGeneratorContext, spec *corev1.PodSpec) error {
-	role, ok := ctx.Workspace.Labels[v1beta1.LabelInferenceRole]
-	if !ok || (role != consts.InferenceRolePrefill && role != consts.InferenceRoleDecode) {
-		return nil
-	}
-	if len(spec.Containers) == 0 {
-		return nil
-	}
-	envVar := corev1.EnvVar{
-		Name:  consts.InferenceRoleEnvName,
-		Value: role,
-	}
-	// Find the main inference container by workspace name (consistent with other modifiers).
-	// Fall back to index 0 if not found by name.
-	var c *corev1.Container
-	for i := range spec.Containers {
-		if spec.Containers[i].Name == ctx.Workspace.Name {
-			c = &spec.Containers[i]
-			break
-		}
-	}
-	if c == nil {
-		c = &spec.Containers[0]
-	}
-	found := false
-	for j, env := range c.Env {
-		if env.Name == consts.InferenceRoleEnvName {
-			c.Env[j] = envVar
-			found = true
-			break
-		}
-	}
-	if !found {
-		c.Env = append(c.Env, envVar)
-	}
 	return nil
 }
 

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -20,6 +20,16 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
@@ -30,16 +40,6 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/workspace/manifests"
 	metadata "github.com/kaito-project/kaito/presets/workspace/models"
-
-	"github.com/samber/lo"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -674,7 +674,7 @@ func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec
 // to the KAITO_INFERENCE_ROLE environment variable on all containers.
 // This is used by the vLLM inference_api.py to inject NixlConnector kv-transfer-config
 // for P/D disaggregated inference. The label is propagated from
-// InferenceSet.Spec.Template.Labels onto child workspaces by the InferenceSet controller.
+// InferenceSet.Spec.Template.Metadata.Labels onto child workspaces by the InferenceSet controller.
 func SetInferenceRoleEnv(ctx *generator.WorkspaceGeneratorContext, spec *corev1.PodSpec) error {
 	role, ok := ctx.Workspace.Labels[v1beta1.LabelInferenceRole]
 	if !ok || (role != consts.InferenceRolePrefill && role != consts.InferenceRoleDecode) {

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -747,13 +747,25 @@ func injectRoutingSidecarInline(spec *corev1.PodSpec) {
 		}
 	}
 
-	// Probes
+	oldPortStr := strconv.Itoa(int(publicPort))
+	newPortStr := strconv.Itoa(int(internalPort))
+
+	// Probes: rewrite both HTTPGet and Exec probe ports
 	rewriteProbePort := func(probe *corev1.Probe) {
 		if probe == nil {
 			return
 		}
 		if probe.HTTPGet != nil && probe.HTTPGet.Port.IntValue() == int(publicPort) {
 			probe.HTTPGet.Port = intstr.FromInt32(internalPort)
+		}
+		// Also rewrite Exec probes (e.g., multi-node-health-check.py with vllm-port=5000)
+		if probe.Exec != nil {
+			for j, cmd := range probe.Exec.Command {
+				updated := strings.ReplaceAll(cmd, "--vllm-port="+oldPortStr, "--vllm-port="+newPortStr)
+				updated = strings.ReplaceAll(updated, "--port="+oldPortStr, "--port="+newPortStr)
+				updated = strings.ReplaceAll(updated, "--port "+oldPortStr, "--port "+newPortStr)
+				probe.Exec.Command[j] = updated
+			}
 		}
 	}
 	// DeepCopy probes to avoid mutating shared package-level defaults
@@ -771,8 +783,6 @@ func injectRoutingSidecarInline(spec *corev1.PodSpec) {
 	}
 
 	// Command: rewrite port references (format is known: --port=5000, --vllm-port=5000)
-	oldPortStr := strconv.Itoa(int(publicPort))
-	newPortStr := strconv.Itoa(int(internalPort))
 	portArgFound := false
 	for j, cmd := range c.Command {
 		if strings.Contains(cmd, "--port="+oldPortStr) || strings.Contains(cmd, "--port "+oldPortStr) {
@@ -783,31 +793,47 @@ func injectRoutingSidecarInline(spec *corev1.PodSpec) {
 		updated = strings.ReplaceAll(updated, "--port "+oldPortStr, "--port "+newPortStr)
 		c.Command[j] = updated
 	}
-	// If no --port argument was found in the command, append it explicitly
-	// so vLLM binds to the internal port instead of its default (5000).
+	// If no --port argument was found in the command, inject it so vLLM binds
+	// to the internal port instead of its default (5000).
 	if !portArgFound && len(c.Command) > 0 {
-		c.Command = append(c.Command, "--port", newPortStr)
+		// For shell commands ("/bin/sh", "-c", "script..."), append to the script string.
+		// For direct exec commands, append as extra slice elements.
+		lastIdx := len(c.Command) - 1
+		if len(c.Command) >= 3 && c.Command[0] == "/bin/sh" && c.Command[1] == "-c" {
+			c.Command[lastIdx] = c.Command[lastIdx] + " --port=" + newPortStr
+		} else {
+			c.Command = append(c.Command, "--port="+newPortStr)
+		}
 	}
 
-	// Append sidecar container
-	spec.Containers = append(spec.Containers, corev1.Container{
-		Name:  "llm-d-routing-sidecar",
-		Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
-		Args: []string{
-			fmt.Sprintf("--port=%d", publicPort),
-			fmt.Sprintf("--vllm-port=%d", internalPort),
-			"--secure-proxy=false",
-		},
-		Ports: []corev1.ContainerPort{
-			{ContainerPort: int32(publicPort), Name: "sidecar", Protocol: corev1.ProtocolTCP},
-		},
-		Env: []corev1.EnvVar{
-			{
-				Name: "POD_IP",
-				ValueFrom: &corev1.EnvVarSource{
-					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+	// Append sidecar container (upsert: skip if already present)
+	hasSidecar := false
+	for _, existing := range spec.Containers {
+		if existing.Name == "llm-d-routing-sidecar" {
+			hasSidecar = true
+			break
+		}
+	}
+	if !hasSidecar {
+		spec.Containers = append(spec.Containers, corev1.Container{
+			Name:  "llm-d-routing-sidecar",
+			Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
+			Args: []string{
+				fmt.Sprintf("--port=%d", publicPort),
+				fmt.Sprintf("--vllm-port=%d", internalPort),
+				"--secure-proxy=false",
+			},
+			Ports: []corev1.ContainerPort{
+				{ContainerPort: int32(publicPort), Name: "sidecar", Protocol: corev1.ProtocolTCP},
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name: "POD_IP",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+					},
 				},
 			},
-		},
-	})
+		})
+	}
 }

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -677,7 +677,7 @@ func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec
 // to the KAITO_INFERENCE_ROLE environment variable on existing containers in the pod spec.
 // Note: This modifier should run after SetRoutingSidecar so that the sidecar container
 // also receives the environment variable. If ordering changes, verify all containers are covered.
-// This is used by the vLLM inference_api.py to inject NixlConnector kv-transfer-config
+// This is used by the vLLM inference_api.py to set LMCache kv_transfer_config
 // for P/D disaggregated inference. The label is propagated from
 // InferenceSet.Spec.Template.Metadata.Labels onto child workspaces by the InferenceSet controller.
 func SetInferenceRoleEnv(ctx *generator.WorkspaceGeneratorContext, spec *corev1.PodSpec) error {

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -259,7 +259,8 @@ func checkIfNVMeAvailable(ctx context.Context, gpuConfig *sku.GPUConfig, kubeCli
 }
 
 // getDistributedInferenceProbe returns a container probe configuration for the distributed inference workload.
-func getDistributedInferenceProbe(probeType probeType, wObj *v1beta1.Workspace, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold int32) *corev1.Probe {
+// vllmPort specifies the port vLLM is listening on (may differ from the public port when a routing sidecar is present).
+func getDistributedInferenceProbe(probeType probeType, wObj *v1beta1.Workspace, vllmPort int32, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold int32) *corev1.Probe {
 	args := map[string]string{
 		"leader-address": utils.GetRayLeaderHost(wObj.ObjectMeta),
 	}
@@ -267,7 +268,7 @@ func getDistributedInferenceProbe(probeType probeType, wObj *v1beta1.Workspace, 
 	case probeTypeLiveness:
 		args["ray-port"] = strconv.Itoa(pkgmodel.PortRayCluster)
 	case probeTypeReadiness:
-		args["vllm-port"] = strconv.FormatInt(int64(consts.PortInferenceServer), 10)
+		args["vllm-port"] = strconv.FormatInt(int64(vllmPort), 10)
 	}
 
 	// for distributed inference, we cannot use the default http probe since only the leader pod
@@ -312,11 +313,11 @@ func buildStartupProbe(timeout time.Duration) *corev1.Probe {
 	}
 }
 
-func buildDistributedStartupProbe(timeout time.Duration, wObj *v1beta1.Workspace) *corev1.Probe {
+func buildDistributedStartupProbe(timeout time.Duration, wObj *v1beta1.Workspace, vllmPort int32) *corev1.Probe {
 	const periodSeconds = int32(10)
 	const timeoutSeconds = int32(1)
 	failureThreshold := int32(math.Ceil(timeout.Seconds() / float64(periodSeconds)))
-	return getDistributedInferenceProbe(probeTypeReadiness, wObj, 0, periodSeconds, timeoutSeconds, failureThreshold)
+	return getDistributedInferenceProbe(probeTypeReadiness, wObj, vllmPort, 0, periodSeconds, timeoutSeconds, failureThreshold)
 }
 
 // buildBenchmarkStartupProbe returns an exec startup probe that runs
@@ -711,10 +712,16 @@ func SetDistributedInferenceProbe(ctx *generator.WorkspaceGeneratorContext, spec
 		readinessTimeout = defaultStartupProbeTimeout
 	}
 
+	// When the routing sidecar is present, vLLM runs on the internal port.
+	vllmPort := consts.PortInferenceServer
+	if needsRoutingSidecar(ctx.Workspace) {
+		vllmPort = consts.PortInferenceServerInternal
+	}
+
 	// 60 seconds initial delay for liveness probe to allow workers to join the cluster
-	livenessProbe := getDistributedInferenceProbe(probeTypeLiveness, ctx.Workspace, 60, 10, 5, 1)
-	readinessProbe := getDistributedInferenceProbe(probeTypeReadiness, ctx.Workspace, 0, 10, 1, 1)
-	startupProbe := buildDistributedStartupProbe(readinessTimeout, ctx.Workspace)
+	livenessProbe := getDistributedInferenceProbe(probeTypeLiveness, ctx.Workspace, vllmPort, 60, 10, 5, 1)
+	readinessProbe := getDistributedInferenceProbe(probeTypeReadiness, ctx.Workspace, vllmPort, 0, 10, 1, 1)
+	startupProbe := buildDistributedStartupProbe(readinessTimeout, ctx.Workspace, vllmPort)
 	envVar := corev1.EnvVar{
 		Name: "POD_INDEX",
 		ValueFrom: &corev1.EnvVarSource{

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -20,16 +20,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/samber/lo"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/klog/v2"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
@@ -40,6 +30,16 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/workspace/manifests"
 	metadata "github.com/kaito-project/kaito/presets/workspace/models"
+
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -857,7 +857,6 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			}
 		}
 	}
-
 
 	// The llm-d routing sidecar uses command-line flags (not environment variables)
 	// to configure its listening port and backend vLLM port:

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -709,7 +709,9 @@ func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec
 }
 
 // applyInferenceRoleEnv sets KAITO_INFERENCE_ROLE env var on the first container
-// when the workspace has a valid inference-role label (prefill or decode).
+// (the main inference container) when the workspace has a valid inference-role
+// label (prefill or decode). Only the main container needs this env var;
+// sidecar containers do not use it.
 func applyInferenceRoleEnv(labels map[string]string, spec *corev1.PodSpec) {
 	if len(spec.Containers) == 0 {
 		return

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"math"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/samber/lo"

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -196,13 +196,13 @@ func GeneratePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspac
 		podOpts = append(podOpts, SetDefaultModelWeightsVolume)
 	}
 
-	podOpts = append(podOpts, SetRoutingSidecar, SetInferenceRoleEnv)
+	podOpts = append(podOpts, SetInferenceRoleEnv)
 
 	podSpec, err := generator.GenerateManifest(gctx, podOpts...)
 	if err != nil {
 		return nil, err
 	}
-	ssOpts = append(ssOpts, manifests.SetStatefulSetPodSpec(podSpec))
+	ssOpts = append(ssOpts, manifests.SetStatefulSetPodSpec(podSpec), InjectRoutingSidecar)
 
 	return generator.GenerateManifest(gctx, ssOpts...)
 }
@@ -674,9 +674,7 @@ func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec
 }
 
 // SetInferenceRoleEnv propagates the kaito.sh/inference-role label from the workspace
-// to the KAITO_INFERENCE_ROLE environment variable on existing containers in the pod spec.
-// Note: This modifier should run after SetRoutingSidecar so that the sidecar container
-// also receives the environment variable. If ordering changes, verify all containers are covered.
+// to the KAITO_INFERENCE_ROLE environment variable on the main inference container.
 // This is used by the vLLM inference_api.py to set LMCache kv_transfer_config
 // for P/D disaggregated inference. The label is propagated from
 // InferenceSet.Spec.Template.Metadata.Labels onto child workspaces by the InferenceSet controller.
@@ -706,24 +704,22 @@ func SetInferenceRoleEnv(ctx *generator.WorkspaceGeneratorContext, spec *corev1.
 	return nil
 }
 
-// SetRoutingSidecar adds the llm-d routing sidecar container to decode workspace pods.
-// When the workspace has the inference-role: decode label, the sidecar is injected
-// alongside the main vLLM container. The sidecar takes over the public-facing port (5000)
-// and vLLM is moved to an internal port (5001). The sidecar orchestrates P/D disaggregation
-// (contacting prefill pods if needed via x-prefiller-host-port header) and forwards to
-// the local vLLM engine on port 5001. When no header is present, it transparently proxies.
-// Prefill workspaces (inference-role: prefill) do not get the sidecar.
-func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.PodSpec) error {
+// InjectRoutingSidecar is a StatefulSet-level modifier that adds the llm-d routing sidecar
+// to decode workspace pods. When the workspace has inference-role: decode and uses the vLLM
+// runtime, the sidecar is injected alongside the main container. The sidecar takes over
+// the public-facing port (5000) and vLLM is moved to an internal port (5001).
+func InjectRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, ss *appsv1.StatefulSet) error {
 	role, ok := ctx.Workspace.Labels[v1beta1.LabelInferenceRole]
 	if !ok || role != consts.InferenceRoleDecode {
 		return nil
 	}
 
-	// Only apply to vLLM runtime — other runtimes don't support P/D disaggregation
 	runtimeName := v1beta1.GetWorkspaceRuntimeName(ctx.Workspace)
 	if runtimeName != pkgmodel.RuntimeNameVLLM {
 		return nil
 	}
+
+	spec := &ss.Spec.Template.Spec
 
 	// Check if sidecar already exists to avoid duplicate injection
 	sidecarExists := false

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -592,8 +592,10 @@ func SetModelDownloadInfo(ctx *generator.WorkspaceGeneratorContext, spec *corev1
 			}
 
 			for i := range spec.Containers {
-				// add HF_TOKEN env var to all containers
-				spec.Containers[i].Env = append(spec.Containers[i].Env, envvar)
+				// add HF_TOKEN env var to the main inference container only
+				if spec.Containers[i].Name == ctx.Workspace.Name {
+					spec.Containers[i].Env = append(spec.Containers[i].Env, envvar)
+				}
 			}
 		}
 		return nil

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -523,54 +523,10 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 			},
 		}
 
-		// Set KAITO_INFERENCE_ROLE env var for P/D disaggregated inference.
-		// inference_api.py uses this to configure kv_transfer_config (NixlConnector).
-		if role, ok := ctx.Workspace.Labels[v1beta1.LabelInferenceRole]; ok &&
-			(role == consts.InferenceRolePrefill || role == consts.InferenceRoleDecode) {
-			spec.Containers[0].Env = append(spec.Containers[0].Env, corev1.EnvVar{
-				Name:  consts.InferenceRoleEnvName,
-				Value: role,
-			})
-		}
+		applyInferenceRoleEnv(ctx.Workspace.Labels, spec)
 
 		if isSidecarNeeded {
-			// Rewrite probes to use the internal port
-			c := &spec.Containers[0]
-			rewriteProbePort := func(probe *corev1.Probe) {
-				if probe == nil {
-					return
-				}
-				if probe.HTTPGet != nil && probe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-					probe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
-				}
-			}
-			c.ReadinessProbe = c.ReadinessProbe.DeepCopy()
-			rewriteProbePort(c.ReadinessProbe)
-			c.LivenessProbe = c.LivenessProbe.DeepCopy()
-			rewriteProbePort(c.LivenessProbe)
-			c.StartupProbe = c.StartupProbe.DeepCopy()
-			rewriteProbePort(c.StartupProbe)
-
-			spec.Containers = append(spec.Containers, corev1.Container{
-				Name:  "llm-d-routing-sidecar",
-				Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
-				Args: []string{
-					fmt.Sprintf("--port=%d", consts.PortInferenceServer),
-					fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
-					"--secure-proxy=false",
-				},
-				Ports: []corev1.ContainerPort{
-					{ContainerPort: int32(consts.PortInferenceServer), Name: "sidecar", Protocol: corev1.ProtocolTCP},
-				},
-				Env: []corev1.EnvVar{
-					{
-						Name: "POD_IP",
-						ValueFrom: &corev1.EnvVarSource{
-							FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
-						},
-					},
-				},
-			})
+			injectRoutingSidecar(spec)
 		}
 
 		spec.Tolerations = defaultTolerations(ctx.Workspace)
@@ -750,6 +706,72 @@ func SetDistributedInferenceProbe(ctx *generator.WorkspaceGeneratorContext, spec
 func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec *corev1.PodSpec) error {
 	spec.Volumes = append(spec.Volumes, utils.DefaultModelWeightsVolume)
 	return nil
+}
+
+// applyInferenceRoleEnv sets KAITO_INFERENCE_ROLE env var on the first container
+// when the workspace has a valid inference-role label (prefill or decode).
+func applyInferenceRoleEnv(labels map[string]string, spec *corev1.PodSpec) {
+	if len(spec.Containers) == 0 {
+		return
+	}
+	role, ok := labels[v1beta1.LabelInferenceRole]
+	if !ok || (role != consts.InferenceRolePrefill && role != consts.InferenceRoleDecode) {
+		return
+	}
+	spec.Containers[0].Env = append(spec.Containers[0].Env, corev1.EnvVar{
+		Name:  consts.InferenceRoleEnvName,
+		Value: role,
+	})
+}
+
+// injectRoutingSidecar rewrites the first container's probes/ports to the internal port
+// and appends the llm-d routing sidecar container to the pod spec.
+func injectRoutingSidecar(spec *corev1.PodSpec) {
+	if len(spec.Containers) == 0 {
+		return
+	}
+	c := &spec.Containers[0]
+	rewriteProbePort := func(probe *corev1.Probe) {
+		if probe == nil {
+			return
+		}
+		if probe.HTTPGet != nil && probe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+			probe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
+		}
+	}
+	if c.ReadinessProbe != nil {
+		c.ReadinessProbe = c.ReadinessProbe.DeepCopy()
+		rewriteProbePort(c.ReadinessProbe)
+	}
+	if c.LivenessProbe != nil {
+		c.LivenessProbe = c.LivenessProbe.DeepCopy()
+		rewriteProbePort(c.LivenessProbe)
+	}
+	if c.StartupProbe != nil {
+		c.StartupProbe = c.StartupProbe.DeepCopy()
+		rewriteProbePort(c.StartupProbe)
+	}
+
+	spec.Containers = append(spec.Containers, corev1.Container{
+		Name:  "llm-d-routing-sidecar",
+		Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
+		Args: []string{
+			fmt.Sprintf("--port=%d", consts.PortInferenceServer),
+			fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
+			"--secure-proxy=false",
+		},
+		Ports: []corev1.ContainerPort{
+			{ContainerPort: int32(consts.PortInferenceServer), Name: "sidecar", Protocol: corev1.ProtocolTCP},
+		},
+		Env: []corev1.EnvVar{
+			{
+				Name: "POD_IP",
+				ValueFrom: &corev1.EnvVarSource{
+					FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+				},
+			},
+		},
+	})
 }
 
 // needsRoutingSidecar returns true if the workspace requires the llm-d routing sidecar.

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -800,21 +800,10 @@ func injectRoutingSidecarInline(spec *corev1.PodSpec) {
 		updated = strings.ReplaceAll(updated, "--port "+oldPortStr, "--port "+newPortStr)
 		c.Command[j] = updated
 	}
-	// If no --port argument was found in the command, append it explicitly.
-	// This is critical for backward compatibility: older preset images don't
-	// read KAITO_VLLM_PORT, so the only way to override the port is via CLI args.
-	// The command format is ["/bin/sh", "-c", "<script>"], so we append to the
-	// last element of the command slice which is the shell script body.
-	portArgFound := false
-	for _, cmd := range c.Command {
-		if strings.Contains(cmd, "--port=") || strings.Contains(cmd, "--port ") {
-			portArgFound = true
-			break
-		}
-	}
-	if !portArgFound && len(c.Command) > 0 {
-		c.Command[len(c.Command)-1] = c.Command[len(c.Command)-1] + " --port=" + newPortStr
-	}
+	// Note: if no --port argument exists in the command, we rely on KAITO_VLLM_PORT
+	// env var (set below) which inference_api.py reads as the final --port override.
+	// We do NOT append --port to the shell script to avoid breaking multi-statement
+	// commands (e.g., "if ...; fi --port=5001" would be invalid).
 
 	// Set KAITO_VLLM_PORT env var to ensure the internal port takes priority
 	// even if a config file overrides --port (inference_api.py reads this last).

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -697,8 +697,18 @@ func SetInferenceRoleEnv(ctx *generator.WorkspaceGeneratorContext, spec *corev1.
 		Name:  consts.InferenceRoleEnvName,
 		Value: role,
 	}
-	// Only set on the main inference container (index 0)
-	c := &spec.Containers[0]
+	// Find the main inference container by workspace name (consistent with other modifiers).
+	// Fall back to index 0 if not found by name.
+	var c *corev1.Container
+	for i := range spec.Containers {
+		if spec.Containers[i].Name == ctx.Workspace.Name {
+			c = &spec.Containers[i]
+			break
+		}
+	}
+	if c == nil {
+		c = &spec.Containers[0]
+	}
 	found := false
 	for j, env := range c.Env {
 		if env.Name == consts.InferenceRoleEnvName {

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -30,6 +30,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/kaito-project/kaito/api/v1alpha1"
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
@@ -718,7 +719,7 @@ func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec
 // env var; sidecar containers do not use it.
 func applyInferenceRoleEnv(labels map[string]string, containerName string, spec *corev1.PodSpec) {
 	role, ok := labels[v1beta1.LabelInferenceRole]
-	if !ok || (role != consts.InferenceRolePrefill && role != consts.InferenceRoleDecode) {
+	if !ok || (role != string(v1alpha1.MultiRoleInferenceRolePrefill) && role != string(v1alpha1.MultiRoleInferenceRoleDecode)) {
 		return
 	}
 	for i := range spec.Containers {
@@ -796,7 +797,7 @@ func injectRoutingSidecar(spec *corev1.PodSpec) {
 // needsRoutingSidecar returns true if the workspace requires the llm-d routing sidecar.
 func needsRoutingSidecar(ws *v1beta1.Workspace) bool {
 	role, ok := ws.Labels[v1beta1.LabelInferenceRole]
-	if !ok || role != consts.InferenceRoleDecode {
+	if !ok || role != string(v1alpha1.MultiRoleInferenceRoleDecode) {
 		return false
 	}
 	return v1beta1.GetWorkspaceRuntimeName(ws) == pkgmodel.RuntimeNameVLLM

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -724,13 +724,24 @@ func applyInferenceRoleEnv(labels map[string]string, spec *corev1.PodSpec) {
 	})
 }
 
-// injectRoutingSidecar rewrites the first container's probes/ports to the internal port
-// and appends the llm-d routing sidecar container to the pod spec.
+// injectRoutingSidecar rewrites the first container's containerPorts and probes
+// from the public inference port to the internal port, then appends the llm-d
+// routing sidecar container to the pod spec.
 func injectRoutingSidecar(spec *corev1.PodSpec) {
 	if len(spec.Containers) == 0 {
 		return
 	}
 	c := &spec.Containers[0]
+
+	// Rewrite containerPorts: public port → internal port so there is no
+	// conflict with the sidecar that will listen on the public port.
+	for i := range c.Ports {
+		if c.Ports[i].ContainerPort == int32(consts.PortInferenceServer) {
+			c.Ports[i].ContainerPort = consts.PortInferenceServerInternal
+		}
+	}
+
+	// Rewrite probe ports.
 	rewriteProbePort := func(probe *corev1.Probe) {
 		if probe == nil {
 			return

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -745,7 +745,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			spec.Containers[i].Ports = portsCopy
 			for j := range spec.Containers[i].Ports {
 				if spec.Containers[i].Ports[j].ContainerPort == int32(consts.PortInferenceServer) {
-					spec.Containers[i].Ports[j].ContainerPort = int32(consts.PortInferenceServerInternal)
+					spec.Containers[i].Ports[j].ContainerPort = consts.PortInferenceServerInternal
 				}
 			}
 		}
@@ -754,7 +754,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			spec.Containers[i].ReadinessProbe = spec.Containers[i].ReadinessProbe.DeepCopy()
 			if spec.Containers[i].ReadinessProbe.HTTPGet != nil {
 				if spec.Containers[i].ReadinessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-					spec.Containers[i].ReadinessProbe.HTTPGet.Port = intstr.FromInt32(int32(consts.PortInferenceServerInternal))
+					spec.Containers[i].ReadinessProbe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
 				}
 			}
 			if spec.Containers[i].ReadinessProbe.Exec != nil {
@@ -770,7 +770,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			spec.Containers[i].LivenessProbe = spec.Containers[i].LivenessProbe.DeepCopy()
 			if spec.Containers[i].LivenessProbe.HTTPGet != nil {
 				if spec.Containers[i].LivenessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-					spec.Containers[i].LivenessProbe.HTTPGet.Port = intstr.FromInt32(int32(consts.PortInferenceServerInternal))
+					spec.Containers[i].LivenessProbe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
 				}
 			}
 			if spec.Containers[i].LivenessProbe.Exec != nil {
@@ -786,7 +786,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			spec.Containers[i].StartupProbe = spec.Containers[i].StartupProbe.DeepCopy()
 			if spec.Containers[i].StartupProbe.HTTPGet != nil {
 				if spec.Containers[i].StartupProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-					spec.Containers[i].StartupProbe.HTTPGet.Port = intstr.FromInt32(int32(consts.PortInferenceServerInternal))
+					spec.Containers[i].StartupProbe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
 				}
 			}
 			if spec.Containers[i].StartupProbe.Exec != nil {
@@ -840,8 +840,43 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 		}
 	}
 
-	// Only inject sidecar container if not already present
-	if !sidecarExists {
+	expectedBackendURL := fmt.Sprintf("http://localhost:%d", consts.PortInferenceServerInternal)
+
+	if sidecarExists {
+		// Reconcile existing sidecar to ensure its config matches expected values
+		for i := range spec.Containers {
+			if spec.Containers[i].Name != "llm-d-routing-sidecar" {
+				continue
+			}
+			// Ensure BACKEND_URL points to the internal port
+			backendFound := false
+			for j := range spec.Containers[i].Env {
+				if spec.Containers[i].Env[j].Name == "BACKEND_URL" {
+					spec.Containers[i].Env[j].Value = expectedBackendURL
+					backendFound = true
+					break
+				}
+			}
+			if !backendFound {
+				spec.Containers[i].Env = append(spec.Containers[i].Env, corev1.EnvVar{
+					Name:  "BACKEND_URL",
+					Value: expectedBackendURL,
+				})
+			}
+			// Ensure image is up to date
+			spec.Containers[i].Image = fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag)
+			// Ensure port is set correctly
+			if len(spec.Containers[i].Ports) == 0 {
+				spec.Containers[i].Ports = []corev1.ContainerPort{
+					{ContainerPort: consts.PortInferenceServer, Name: "sidecar", Protocol: corev1.ProtocolTCP},
+				}
+			} else {
+				spec.Containers[i].Ports[0].ContainerPort = consts.PortInferenceServer
+			}
+			break
+		}
+	} else {
+		// Inject new sidecar container
 		sidecar := corev1.Container{
 			Name:  "llm-d-routing-sidecar",
 			Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
@@ -855,7 +890,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			Env: []corev1.EnvVar{
 				{
 					Name:  "BACKEND_URL",
-					Value: fmt.Sprintf("http://localhost:%d", consts.PortInferenceServerInternal),
+					Value: expectedBackendURL,
 				},
 				{
 					Name: "POD_IP",

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"math"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/samber/lo"
@@ -454,6 +453,13 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 			}
 		}
 
+		// When the routing sidecar is needed, vLLM must use the internal port
+		// to avoid conflicting with the sidecar on the public port.
+		isSidecarNeeded := needsRoutingSidecar(ctx.Workspace)
+		if isSidecarNeeded && inferenceParam.VLLM.ModelRunParams != nil {
+			inferenceParam.VLLM.ModelRunParams["port"] = strconv.FormatInt(int64(consts.PortInferenceServerInternal), 10)
+		}
+
 		commands := inferenceParam.GetInferenceCommand(pkgmodel.RuntimeContext{
 			RuntimeName:          runtimeName,
 			GPUConfig:            gpuConfig,
@@ -493,20 +499,17 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 			readinessTimeout = defaultStartupProbeTimeout
 		}
 
-		// Determine if the routing sidecar is needed (decode workspace on vLLM).
-		// When present, vLLM uses the internal port (5001) and the sidecar takes the public port (5000).
+		// Determine container port based on whether the routing sidecar is needed.
 		inferencePort := containerPorts
-		inferenceCommands := commands
-		if needsRoutingSidecar(ctx.Workspace) {
+		if isSidecarNeeded {
 			inferencePort = []corev1.ContainerPort{{ContainerPort: consts.PortInferenceServerInternal}}
-			inferenceCommands = rewritePortInCommands(commands, consts.PortInferenceServer, consts.PortInferenceServerInternal)
 		}
 
 		spec.Containers = []corev1.Container{
 			{
 				Name:           ctx.Workspace.Name,
 				Image:          GetBaseImageName(),
-				Command:        inferenceCommands,
+				Command:        commands,
 				Resources:      resourceReq,
 				Ports:          inferencePort,
 				StartupProbe:   buildStartupProbe(readinessTimeout),
@@ -526,7 +529,7 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 			})
 		}
 
-		if needsRoutingSidecar(ctx.Workspace) {
+		if isSidecarNeeded {
 			// Rewrite probes to use the internal port
 			c := &spec.Containers[0]
 			rewriteProbePort := func(probe *corev1.Probe) {
@@ -739,31 +742,4 @@ func needsRoutingSidecar(ws *v1beta1.Workspace) bool {
 		return false
 	}
 	return v1beta1.GetWorkspaceRuntimeName(ws) == pkgmodel.RuntimeNameVLLM
-}
-
-// rewritePortInCommands rewrites port references in the command slice.
-// If --port=<oldPort> or --port <oldPort> is found, it's replaced with the new port.
-// If no --port is found, appends --port <newPort> to the last command element.
-func rewritePortInCommands(commands []string, oldPort, newPort int32) []string {
-	oldPortStr := strconv.Itoa(int(oldPort))
-	newPortStr := strconv.Itoa(int(newPort))
-
-	result := make([]string, len(commands))
-	copy(result, commands)
-
-	portFound := false
-	for j, cmd := range result {
-		if strings.Contains(cmd, "--port="+oldPortStr) || strings.Contains(cmd, "--port "+oldPortStr) {
-			portFound = true
-		}
-		updated := strings.ReplaceAll(cmd, "--vllm-port="+oldPortStr, "--vllm-port="+newPortStr)
-		updated = strings.ReplaceAll(updated, "--port="+oldPortStr, "--port="+newPortStr)
-		updated = strings.ReplaceAll(updated, "--port "+oldPortStr, "--port "+newPortStr)
-		result[j] = updated
-	}
-	// If no --port was found, append it to the last element (shell script body).
-	if !portFound && len(result) > 0 {
-		result[len(result)-1] += " --port " + newPortStr
-	}
-	return result
 }

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -884,12 +884,9 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			// Ensure image is up to date
 			spec.Containers[i].Image = fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag)
 			// Ensure port is set correctly
-			if len(spec.Containers[i].Ports) == 0 {
-				spec.Containers[i].Ports = []corev1.ContainerPort{
-					{ContainerPort: consts.PortInferenceServer, Name: "sidecar", Protocol: corev1.ProtocolTCP},
-				}
-			} else {
-				spec.Containers[i].Ports[0].ContainerPort = consts.PortInferenceServer
+			// Set ports to exactly the expected single port struct for deterministic spec
+			spec.Containers[i].Ports = []corev1.ContainerPort{
+				{ContainerPort: consts.PortInferenceServer, Name: "sidecar", Protocol: corev1.ProtocolTCP},
 			}
 			// Ensure POD_IP env is present
 			podIPFound := false

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -203,12 +203,6 @@ func GeneratePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspac
 		return nil, err
 	}
 
-	// If this is a decode workspace on vLLM, inject the routing sidecar directly.
-	// The sidecar takes the public port (5000), vLLM moves to internal port (5001).
-	if needsRoutingSidecar(workspaceObj) {
-		injectRoutingSidecarInline(podSpec)
-	}
-
 	ssOpts = append(ssOpts, manifests.SetStatefulSetPodSpec(podSpec))
 
 	return generator.GenerateManifest(gctx, ssOpts...)
@@ -517,6 +511,12 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 		spec.Tolerations = defaultTolerations(ctx.Workspace)
 		spec.Volumes = volumes
 
+		// If this is a decode workspace on vLLM, inject the routing sidecar.
+		// The sidecar takes the public port (5000), vLLM moves to internal port (5001).
+		if needsRoutingSidecar(ctx.Workspace) {
+			injectRoutingSidecar(spec)
+		}
+
 		return nil
 	}
 }
@@ -733,12 +733,12 @@ func needsRoutingSidecar(ws *v1beta1.Workspace) bool {
 	return v1beta1.GetWorkspaceRuntimeName(ws) == pkgmodel.RuntimeNameVLLM
 }
 
-// injectRoutingSidecarInline modifies the podSpec in-place:
+// injectRoutingSidecar modifies the podSpec in-place:
 // 1. Moves the main container's port from 5000 to 5001
 // 2. Updates probes to use the internal port
-// 3. Updates command args to use --port=5001
+// 3. Updates command args to use --port 5001 (appends if not present)
 // 4. Appends the llm-d routing sidecar container on port 5000
-func injectRoutingSidecarInline(spec *corev1.PodSpec) {
+func injectRoutingSidecar(spec *corev1.PodSpec) {
 	if len(spec.Containers) == 0 {
 		return
 	}
@@ -793,31 +793,21 @@ func injectRoutingSidecarInline(spec *corev1.PodSpec) {
 		rewriteProbePort(c.StartupProbe)
 	}
 
-	// Command: rewrite port references (format is known: --port=5000, --vllm-port=5000)
+	// Command: rewrite existing port references and append --port if not present
+	portFound := false
 	for j, cmd := range c.Command {
+		if strings.Contains(cmd, "--port="+oldPortStr) || strings.Contains(cmd, "--port "+oldPortStr) {
+			portFound = true
+		}
 		updated := strings.ReplaceAll(cmd, "--vllm-port="+oldPortStr, "--vllm-port="+newPortStr)
 		updated = strings.ReplaceAll(updated, "--port="+oldPortStr, "--port="+newPortStr)
 		updated = strings.ReplaceAll(updated, "--port "+oldPortStr, "--port "+newPortStr)
 		c.Command[j] = updated
 	}
-	// Note: if no --port argument exists in the command, we rely on KAITO_VLLM_PORT
-	// env var (set below) which inference_api.py reads as the final --port override.
-	// We do NOT append --port to the shell script to avoid breaking multi-statement
-	// commands (e.g., "if ...; fi --port=5001" would be invalid).
-
-	// Set KAITO_VLLM_PORT env var to ensure the internal port takes priority
-	// even if a config file overrides --port (inference_api.py reads this last).
-	portEnv := corev1.EnvVar{Name: "KAITO_VLLM_PORT", Value: newPortStr}
-	portEnvFound := false
-	for j, env := range c.Env {
-		if env.Name == "KAITO_VLLM_PORT" {
-			c.Env[j] = portEnv
-			portEnvFound = true
-			break
-		}
-	}
-	if !portEnvFound {
-		c.Env = append(c.Env, portEnv)
+	// If no --port was found in the command, append it to the shell script.
+	// Command format is ["/bin/sh", "-c", "<script>"], so we append to the last element.
+	if !portFound && len(c.Command) > 0 {
+		c.Command[len(c.Command)-1] += " --port " + newPortStr
 	}
 
 	// Upsert sidecar container
@@ -849,7 +839,6 @@ func injectRoutingSidecarInline(spec *corev1.PodSpec) {
 		}
 	}
 	if sidecarIdx >= 0 {
-		// Reconcile existing sidecar to desired spec
 		spec.Containers[sidecarIdx] = desiredSidecar
 	} else {
 		spec.Containers = append(spec.Containers, desiredSidecar)

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -669,3 +669,205 @@ func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec
 	spec.Volumes = append(spec.Volumes, utils.DefaultModelWeightsVolume)
 	return nil
 }
+
+// SetInferenceRoleEnv propagates the kaito.sh/inference-role label from the workspace
+// to the KAITO_INFERENCE_ROLE environment variable on all containers.
+// This is used by the vLLM inference_api.py to inject NixlConnector kv-transfer-config
+// for P/D disaggregated inference. The label is propagated from
+// InferenceSet.Spec.Template.Labels onto child workspaces by the InferenceSet controller.
+func SetInferenceRoleEnv(ctx *generator.WorkspaceGeneratorContext, spec *corev1.PodSpec) error {
+	role, ok := ctx.Workspace.Labels[v1beta1.LabelInferenceRole]
+	if !ok || (role != consts.InferenceRolePrefill && role != consts.InferenceRoleDecode) {
+		return nil
+	}
+	envVar := corev1.EnvVar{
+		Name:  consts.InferenceRoleEnvName,
+		Value: role,
+	}
+	for i := range spec.Containers {
+		// Upsert: replace existing entry if present to avoid duplicates
+		found := false
+		for j, env := range spec.Containers[i].Env {
+			if env.Name == consts.InferenceRoleEnvName {
+				spec.Containers[i].Env[j] = envVar
+				found = true
+				break
+			}
+		}
+		if !found {
+			spec.Containers[i].Env = append(spec.Containers[i].Env, envVar)
+		}
+	}
+	return nil
+}
+
+// SetRoutingSidecar adds the llm-d routing sidecar container to decode workspace pods.
+// When the workspace has the inference-role: decode label, the sidecar is injected
+// alongside the main vLLM container. The sidecar takes over the public-facing port (5000)
+// and vLLM is moved to an internal port (5001). The sidecar orchestrates P/D disaggregation
+// (contacting prefill pods if needed via x-prefiller-host-port header) and forwards to
+// the local vLLM engine on port 5001. When no header is present, it transparently proxies.
+// Prefill workspaces (inference-role: prefill) do not get the sidecar.
+func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.PodSpec) error {
+	role, ok := ctx.Workspace.Labels[v1beta1.LabelInferenceRole]
+	if !ok || role != consts.InferenceRoleDecode {
+		return nil
+	}
+
+	// Only apply to vLLM runtime — other runtimes don't support P/D disaggregation
+	runtimeName := v1beta1.GetWorkspaceRuntimeName(ctx.Workspace)
+	if runtimeName != pkgmodel.RuntimeNameVLLM {
+		return nil
+	}
+
+	// Check if sidecar already exists to avoid duplicate injection
+	sidecarExists := false
+	for _, c := range spec.Containers {
+		if c.Name == "llm-d-routing-sidecar" {
+			sidecarExists = true
+			break
+		}
+	}
+
+	// Move vLLM to internal port so the sidecar can take over the public-facing port.
+	// Update container ports, readiness/liveness probes, and vllm-port arg/command.
+	// Deep-copy mutable slices to avoid contaminating shared package-level defaults.
+	oldPort := strconv.Itoa(int(consts.PortInferenceServer))
+	newPort := strconv.Itoa(int(consts.PortInferenceServerInternal))
+	for i := range spec.Containers {
+		if spec.Containers[i].Name == "llm-d-routing-sidecar" {
+			continue
+		}
+		// Deep-copy ports to avoid mutating shared defaults
+		if len(spec.Containers[i].Ports) > 0 {
+			portsCopy := make([]corev1.ContainerPort, len(spec.Containers[i].Ports))
+			copy(portsCopy, spec.Containers[i].Ports)
+			spec.Containers[i].Ports = portsCopy
+			for j := range spec.Containers[i].Ports {
+				if spec.Containers[i].Ports[j].ContainerPort == int32(consts.PortInferenceServer) {
+					spec.Containers[i].Ports[j].ContainerPort = int32(consts.PortInferenceServerInternal)
+				}
+			}
+		}
+		// Update readiness probe port (HTTPGet or Exec)
+		if spec.Containers[i].ReadinessProbe != nil {
+			spec.Containers[i].ReadinessProbe = spec.Containers[i].ReadinessProbe.DeepCopy()
+			if spec.Containers[i].ReadinessProbe.HTTPGet != nil {
+				if spec.Containers[i].ReadinessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+					spec.Containers[i].ReadinessProbe.HTTPGet.Port = intstr.FromInt32(int32(consts.PortInferenceServerInternal))
+				}
+			}
+			if spec.Containers[i].ReadinessProbe.Exec != nil {
+				for j, cmd := range spec.Containers[i].ReadinessProbe.Exec.Command {
+					if strings.Contains(cmd, "--vllm-port="+oldPort) {
+						spec.Containers[i].ReadinessProbe.Exec.Command[j] = strings.ReplaceAll(cmd, "--vllm-port="+oldPort, "--vllm-port="+newPort)
+					}
+				}
+			}
+		}
+		// Update liveness probe port (HTTPGet or Exec)
+		if spec.Containers[i].LivenessProbe != nil {
+			spec.Containers[i].LivenessProbe = spec.Containers[i].LivenessProbe.DeepCopy()
+			if spec.Containers[i].LivenessProbe.HTTPGet != nil {
+				if spec.Containers[i].LivenessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+					spec.Containers[i].LivenessProbe.HTTPGet.Port = intstr.FromInt32(int32(consts.PortInferenceServerInternal))
+				}
+			}
+			if spec.Containers[i].LivenessProbe.Exec != nil {
+				for j, cmd := range spec.Containers[i].LivenessProbe.Exec.Command {
+					if strings.Contains(cmd, "--vllm-port="+oldPort) {
+						spec.Containers[i].LivenessProbe.Exec.Command[j] = strings.ReplaceAll(cmd, "--vllm-port="+oldPort, "--vllm-port="+newPort)
+					}
+				}
+			}
+		}
+		// Update startup probe port (HTTPGet or Exec)
+		if spec.Containers[i].StartupProbe != nil {
+			spec.Containers[i].StartupProbe = spec.Containers[i].StartupProbe.DeepCopy()
+			if spec.Containers[i].StartupProbe.HTTPGet != nil {
+				if spec.Containers[i].StartupProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+					spec.Containers[i].StartupProbe.HTTPGet.Port = intstr.FromInt32(int32(consts.PortInferenceServerInternal))
+				}
+			}
+			if spec.Containers[i].StartupProbe.Exec != nil {
+				for j, cmd := range spec.Containers[i].StartupProbe.Exec.Command {
+					if strings.Contains(cmd, "--vllm-port="+oldPort) {
+						spec.Containers[i].StartupProbe.Exec.Command[j] = strings.ReplaceAll(cmd, "--vllm-port="+oldPort, "--vllm-port="+newPort)
+					}
+				}
+			}
+		}
+		// Update --vllm-port in container command and args
+		portOverrideAdded := false
+		for j, cmd := range spec.Containers[i].Command {
+			if strings.Contains(cmd, "--vllm-port="+oldPort) {
+				spec.Containers[i].Command[j] = strings.ReplaceAll(cmd, "--vllm-port="+oldPort, "--vllm-port="+newPort)
+			}
+			// Insert or rewrite --port to override vLLM's default listen port.
+			// Use string replacement to handle both single-node and multi-node
+			// shell script commands (where appending at end would break the script).
+			// If --port already exists with a different value, rewrite it to the internal port.
+			internalPort := fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)
+			if !portOverrideAdded && strings.Contains(cmd, "inference_api.py") {
+				// Check for any existing --port flag and rewrite it
+				if idx := strings.Index(cmd, "--port "); idx >= 0 {
+					// Find the end of the port number
+					portStart := idx + len("--port ")
+					portEnd := portStart
+					for portEnd < len(cmd) && cmd[portEnd] >= '0' && cmd[portEnd] <= '9' {
+						portEnd++
+					}
+					if portEnd > portStart {
+						existing := cmd[idx:portEnd]
+						spec.Containers[i].Command[j] = strings.Replace(cmd, existing, internalPort, 1)
+					}
+				} else {
+					// No existing --port, insert after inference_api.py
+					spec.Containers[i].Command[j] = strings.Replace(
+						cmd,
+						"inference_api.py",
+						"inference_api.py "+internalPort,
+						1,
+					)
+				}
+				portOverrideAdded = true
+			}
+		}
+		for j, arg := range spec.Containers[i].Args {
+			if strings.Contains(arg, "--vllm-port="+oldPort) {
+				spec.Containers[i].Args[j] = strings.ReplaceAll(arg, "--vllm-port="+oldPort, "--vllm-port="+newPort)
+			}
+		}
+	}
+
+	// Only inject sidecar container if not already present
+	if !sidecarExists {
+		sidecar := corev1.Container{
+			Name:  "llm-d-routing-sidecar",
+			Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
+			Ports: []corev1.ContainerPort{
+				{
+					ContainerPort: consts.PortInferenceServer,
+					Name:          "sidecar",
+					Protocol:      corev1.ProtocolTCP,
+				},
+			},
+			Env: []corev1.EnvVar{
+				{
+					Name:  "BACKEND_URL",
+					Value: fmt.Sprintf("http://localhost:%d", consts.PortInferenceServerInternal),
+				},
+				{
+					Name: "POD_IP",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "status.podIP",
+						},
+					},
+				},
+			},
+		}
+		spec.Containers = append(spec.Containers, sidecar)
+	}
+	return nil
+}

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -800,10 +800,21 @@ func injectRoutingSidecarInline(spec *corev1.PodSpec) {
 		updated = strings.ReplaceAll(updated, "--port "+oldPortStr, "--port "+newPortStr)
 		c.Command[j] = updated
 	}
-	// Note: if no --port argument exists in the command, we rely on KAITO_VLLM_PORT
-	// env var (set below) which inference_api.py reads as the final --port override.
-	// We do NOT append --port to the shell script to avoid breaking multi-statement
-	// commands (e.g., "if ...; fi --port=5001" would be invalid).
+	// If no --port argument was found in the command, append it explicitly.
+	// This is critical for backward compatibility: older preset images don't
+	// read KAITO_VLLM_PORT, so the only way to override the port is via CLI args.
+	// The command format is ["/bin/sh", "-c", "<script>"], so we append to the
+	// last element of the command slice which is the shell script body.
+	portArgFound := false
+	for _, cmd := range c.Command {
+		if strings.Contains(cmd, "--port=") || strings.Contains(cmd, "--port ") {
+			portArgFound = true
+			break
+		}
+	}
+	if !portArgFound && len(c.Command) > 0 {
+		c.Command[len(c.Command)-1] = c.Command[len(c.Command)-1] + " --port=" + newPortStr
+	}
 
 	// Set KAITO_VLLM_PORT env var to ensure the internal port takes priority
 	// even if a config file overrides --port (inference_api.py reads this last).

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -333,7 +333,7 @@ func buildDistributedStartupProbe(timeout time.Duration, wObj *v1beta1.Workspace
 // workers to the standard multi-node health check.
 //
 // timeoutSeconds is set to 600 to prevent kubelet killing the process mid-benchmark.
-func buildBenchmarkStartupProbe(timeout time.Duration, wObj *v1beta1.Workspace, distributed bool) *corev1.Probe {
+func buildBenchmarkStartupProbe(timeout time.Duration, wObj *v1beta1.Workspace, distributed bool, vllmPort int32) *corev1.Probe {
 	const periodSeconds = int32(10)
 	const timeoutSeconds = int32(600) // covers benchmark duration + drain + buffer
 	failureThreshold := int32(math.Ceil(timeout.Seconds() / float64(periodSeconds)))
@@ -346,7 +346,7 @@ func buildBenchmarkStartupProbe(timeout time.Duration, wObj *v1beta1.Workspace, 
 			fmt.Sprintf("%s readiness", DefaultVLLMMultiNodeHealthCheckCommand),
 			map[string]string{
 				"leader-address": utils.GetRayLeaderHost(wObj.ObjectMeta),
-				"vllm-port":      strconv.FormatInt(int64(consts.PortInferenceServer), 10),
+				"vllm-port":      strconv.FormatInt(int64(vllmPort), 10),
 			},
 		)
 		cmd := fmt.Sprintf(
@@ -694,7 +694,12 @@ func SetBenchmarkConfig(distributed bool) generator.TypedManifestModifier[genera
 		if distributed {
 			wObj = ctx.Workspace
 		}
-		startupProbe := buildBenchmarkStartupProbe(readinessTimeout, wObj, distributed)
+		// When the routing sidecar is present, vLLM runs on the internal port.
+		vllmPort := consts.PortInferenceServer
+		if needsRoutingSidecar(ctx.Workspace) {
+			vllmPort = consts.PortInferenceServerInternal
+		}
+		startupProbe := buildBenchmarkStartupProbe(readinessTimeout, wObj, distributed, vllmPort)
 
 		for i := range spec.Containers {
 			if spec.Containers[i].Name == ctx.Workspace.Name {

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -767,10 +767,20 @@ func injectRoutingSidecarInline(spec *corev1.PodSpec) {
 	// Command: rewrite port references (format is known: --port=5000, --vllm-port=5000)
 	oldPortStr := strconv.Itoa(int(publicPort))
 	newPortStr := strconv.Itoa(int(internalPort))
+	portArgFound := false
 	for j, cmd := range c.Command {
+		if strings.Contains(cmd, "--port="+oldPortStr) || strings.Contains(cmd, "--port "+oldPortStr) {
+			portArgFound = true
+		}
 		updated := strings.ReplaceAll(cmd, "--vllm-port="+oldPortStr, "--vllm-port="+newPortStr)
 		updated = strings.ReplaceAll(updated, "--port="+oldPortStr, "--port="+newPortStr)
+		updated = strings.ReplaceAll(updated, "--port "+oldPortStr, "--port "+newPortStr)
 		c.Command[j] = updated
+	}
+	// If no --port argument was found in the command, append it explicitly
+	// so vLLM binds to the internal port instead of its default (5000).
+	if !portArgFound && len(c.Command) > 0 {
+		c.Command = append(c.Command, "--port", newPortStr)
 	}
 
 	// Append sidecar container

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -259,8 +259,7 @@ func checkIfNVMeAvailable(ctx context.Context, gpuConfig *sku.GPUConfig, kubeCli
 }
 
 // getDistributedInferenceProbe returns a container probe configuration for the distributed inference workload.
-// vllmPort specifies the port vLLM is listening on (may differ from the public port when a routing sidecar is present).
-func getDistributedInferenceProbe(probeType probeType, wObj *v1beta1.Workspace, vllmPort int32, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold int32) *corev1.Probe {
+func getDistributedInferenceProbe(probeType probeType, wObj *v1beta1.Workspace, initialDelaySeconds, periodSeconds, timeoutSeconds, failureThreshold int32) *corev1.Probe {
 	args := map[string]string{
 		"leader-address": utils.GetRayLeaderHost(wObj.ObjectMeta),
 	}
@@ -268,7 +267,7 @@ func getDistributedInferenceProbe(probeType probeType, wObj *v1beta1.Workspace, 
 	case probeTypeLiveness:
 		args["ray-port"] = strconv.Itoa(pkgmodel.PortRayCluster)
 	case probeTypeReadiness:
-		args["vllm-port"] = strconv.FormatInt(int64(vllmPort), 10)
+		args["vllm-port"] = strconv.FormatInt(int64(consts.PortInferenceServer), 10)
 	}
 
 	// for distributed inference, we cannot use the default http probe since only the leader pod
@@ -313,11 +312,11 @@ func buildStartupProbe(timeout time.Duration) *corev1.Probe {
 	}
 }
 
-func buildDistributedStartupProbe(timeout time.Duration, wObj *v1beta1.Workspace, vllmPort int32) *corev1.Probe {
+func buildDistributedStartupProbe(timeout time.Duration, wObj *v1beta1.Workspace) *corev1.Probe {
 	const periodSeconds = int32(10)
 	const timeoutSeconds = int32(1)
 	failureThreshold := int32(math.Ceil(timeout.Seconds() / float64(periodSeconds)))
-	return getDistributedInferenceProbe(probeTypeReadiness, wObj, vllmPort, 0, periodSeconds, timeoutSeconds, failureThreshold)
+	return getDistributedInferenceProbe(probeTypeReadiness, wObj, 0, periodSeconds, timeoutSeconds, failureThreshold)
 }
 
 // buildBenchmarkStartupProbe returns an exec startup probe that runs
@@ -333,7 +332,7 @@ func buildDistributedStartupProbe(timeout time.Duration, wObj *v1beta1.Workspace
 // workers to the standard multi-node health check.
 //
 // timeoutSeconds is set to 600 to prevent kubelet killing the process mid-benchmark.
-func buildBenchmarkStartupProbe(timeout time.Duration, wObj *v1beta1.Workspace, distributed bool, vllmPort int32) *corev1.Probe {
+func buildBenchmarkStartupProbe(timeout time.Duration, wObj *v1beta1.Workspace, distributed bool) *corev1.Probe {
 	const periodSeconds = int32(10)
 	const timeoutSeconds = int32(600) // covers benchmark duration + drain + buffer
 	failureThreshold := int32(math.Ceil(timeout.Seconds() / float64(periodSeconds)))
@@ -346,7 +345,7 @@ func buildBenchmarkStartupProbe(timeout time.Duration, wObj *v1beta1.Workspace, 
 			fmt.Sprintf("%s readiness", DefaultVLLMMultiNodeHealthCheckCommand),
 			map[string]string{
 				"leader-address": utils.GetRayLeaderHost(wObj.ObjectMeta),
-				"vllm-port":      strconv.FormatInt(int64(vllmPort), 10),
+				"vllm-port":      strconv.FormatInt(int64(consts.PortInferenceServer), 10),
 			},
 		)
 		cmd := fmt.Sprintf(
@@ -454,15 +453,9 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 			}
 		}
 
-		// When the routing sidecar is needed, vLLM must use the internal port
-		// to avoid conflicting with the sidecar on the public port.
+		// When the routing sidecar is needed, it will be injected after the
+		// main container is created. vLLM keeps its default port (5000).
 		isSidecarNeeded := needsRoutingSidecar(ctx.Workspace)
-		if isSidecarNeeded {
-			if inferenceParam.VLLM.ModelRunParams == nil {
-				inferenceParam.VLLM.ModelRunParams = make(map[string]string)
-			}
-			inferenceParam.VLLM.ModelRunParams["port"] = strconv.FormatInt(int64(consts.PortInferenceServerInternal), 10)
-		}
 
 		commands := inferenceParam.GetInferenceCommand(pkgmodel.RuntimeContext{
 			RuntimeName:          runtimeName,
@@ -503,19 +496,13 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 			readinessTimeout = defaultStartupProbeTimeout
 		}
 
-		// Determine container port based on whether the routing sidecar is needed.
-		inferencePort := containerPorts
-		if isSidecarNeeded {
-			inferencePort = []corev1.ContainerPort{{ContainerPort: consts.PortInferenceServerInternal}}
-		}
-
 		spec.Containers = []corev1.Container{
 			{
 				Name:           ctx.Workspace.Name,
 				Image:          GetBaseImageName(),
 				Command:        commands,
 				Resources:      resourceReq,
-				Ports:          inferencePort,
+				Ports:          containerPorts,
 				StartupProbe:   buildStartupProbe(readinessTimeout),
 				LivenessProbe:  defaultLivenessProbe,
 				ReadinessProbe: defaultReadinessProbe,
@@ -654,12 +641,7 @@ func SetBenchmarkConfig(distributed bool) generator.TypedManifestModifier[genera
 		if distributed {
 			wObj = ctx.Workspace
 		}
-		// When the routing sidecar is present, vLLM runs on the internal port.
-		vllmPort := consts.PortInferenceServer
-		if needsRoutingSidecar(ctx.Workspace) {
-			vllmPort = consts.PortInferenceServerInternal
-		}
-		startupProbe := buildBenchmarkStartupProbe(readinessTimeout, wObj, distributed, vllmPort)
+		startupProbe := buildBenchmarkStartupProbe(readinessTimeout, wObj, distributed)
 
 		for i := range spec.Containers {
 			if spec.Containers[i].Name == ctx.Workspace.Name {
@@ -677,16 +659,10 @@ func SetDistributedInferenceProbe(ctx *generator.WorkspaceGeneratorContext, spec
 		readinessTimeout = defaultStartupProbeTimeout
 	}
 
-	// When the routing sidecar is present, vLLM runs on the internal port.
-	vllmPort := consts.PortInferenceServer
-	if needsRoutingSidecar(ctx.Workspace) {
-		vllmPort = consts.PortInferenceServerInternal
-	}
-
 	// 60 seconds initial delay for liveness probe to allow workers to join the cluster
-	livenessProbe := getDistributedInferenceProbe(probeTypeLiveness, ctx.Workspace, vllmPort, 60, 10, 5, 1)
-	readinessProbe := getDistributedInferenceProbe(probeTypeReadiness, ctx.Workspace, vllmPort, 0, 10, 1, 1)
-	startupProbe := buildDistributedStartupProbe(readinessTimeout, ctx.Workspace, vllmPort)
+	livenessProbe := getDistributedInferenceProbe(probeTypeLiveness, ctx.Workspace, 60, 10, 5, 1)
+	readinessProbe := getDistributedInferenceProbe(probeTypeReadiness, ctx.Workspace, 0, 10, 1, 1)
+	startupProbe := buildDistributedStartupProbe(readinessTimeout, ctx.Workspace)
 	envVar := corev1.EnvVar{
 		Name: "POD_INDEX",
 		ValueFrom: &corev1.EnvVarSource{
@@ -732,55 +708,25 @@ func applyInferenceRoleEnv(labels map[string]string, containerName string, spec 
 	}
 }
 
-// injectRoutingSidecar rewrites the first container's containerPorts and probes
-// from the public inference port to the internal port, then appends the llm-d
-// routing sidecar container to the pod spec.
+// injectRoutingSidecar appends the llm-d routing sidecar container to the pod
+// spec. The sidecar listens on PortRoutingSidecar (5001) and proxies to the
+// main vLLM container which keeps its default PortInferenceServer (5000).
+// No port or probe rewriting is needed on the main container.
 func injectRoutingSidecar(spec *corev1.PodSpec) {
 	if len(spec.Containers) == 0 {
 		return
-	}
-	c := &spec.Containers[0]
-
-	// Rewrite containerPorts: public port → internal port so there is no
-	// conflict with the sidecar that will listen on the public port.
-	for i := range c.Ports {
-		if c.Ports[i].ContainerPort == int32(consts.PortInferenceServer) {
-			c.Ports[i].ContainerPort = consts.PortInferenceServerInternal
-		}
-	}
-
-	// Rewrite probe ports.
-	rewriteProbePort := func(probe *corev1.Probe) {
-		if probe == nil {
-			return
-		}
-		if probe.HTTPGet != nil && probe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-			probe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
-		}
-	}
-	if c.ReadinessProbe != nil {
-		c.ReadinessProbe = c.ReadinessProbe.DeepCopy()
-		rewriteProbePort(c.ReadinessProbe)
-	}
-	if c.LivenessProbe != nil {
-		c.LivenessProbe = c.LivenessProbe.DeepCopy()
-		rewriteProbePort(c.LivenessProbe)
-	}
-	if c.StartupProbe != nil {
-		c.StartupProbe = c.StartupProbe.DeepCopy()
-		rewriteProbePort(c.StartupProbe)
 	}
 
 	spec.Containers = append(spec.Containers, corev1.Container{
 		Name:  "llm-d-routing-sidecar",
 		Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
 		Args: []string{
-			fmt.Sprintf("--port=%d", consts.PortInferenceServer),
-			fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
+			fmt.Sprintf("--port=%d", consts.PortRoutingSidecar),
+			fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServer),
 			"--secure-proxy=false",
 		},
 		Ports: []corev1.ContainerPort{
-			{ContainerPort: int32(consts.PortInferenceServer), Name: "sidecar", Protocol: corev1.ProtocolTCP},
+			{ContainerPort: consts.PortRoutingSidecar, Name: "sidecar", Protocol: corev1.ProtocolTCP},
 		},
 		Env: []corev1.EnvVar{
 			{

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -800,8 +800,12 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 		// Update --vllm-port in container command and args
 		portOverrideAdded := false
 		for j, cmd := range spec.Containers[i].Command {
-			if strings.Contains(cmd, "--vllm-port="+oldPort) {
-				spec.Containers[i].Command[j] = strings.ReplaceAll(cmd, "--vllm-port="+oldPort, "--vllm-port="+newPort)
+			// Use a working copy so all transformations within the same
+			// command string are cumulative (avoid clobbering earlier rewrites).
+			updated := cmd
+
+			if strings.Contains(updated, "--vllm-port="+oldPort) {
+				updated = strings.ReplaceAll(updated, "--vllm-port="+oldPort, "--vllm-port="+newPort)
 			}
 			// Insert or rewrite --port to override vLLM's default listen port.
 			// Use string replacement to handle both single-node and multi-node
@@ -809,40 +813,40 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 			// Handles both "--port <n>" (space form) and "--port=<n>" (equals form).
 			internalPortSpace := fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)
 			internalPortEquals := fmt.Sprintf("--port=%d", consts.PortInferenceServerInternal)
-			if !portOverrideAdded && strings.Contains(cmd, "inference_api.py") {
+			if !portOverrideAdded && strings.Contains(updated, "inference_api.py") {
 				rewritten := false
 				// Check for "--port=<n>" form first (e.g., from BuildCmdStr)
-				if idx := strings.Index(cmd, "--port="); idx >= 0 {
+				if idx := strings.Index(updated, "--port="); idx >= 0 {
 					portStart := idx + len("--port=")
 					portEnd := portStart
-					for portEnd < len(cmd) && cmd[portEnd] >= '0' && cmd[portEnd] <= '9' {
+					for portEnd < len(updated) && updated[portEnd] >= '0' && updated[portEnd] <= '9' {
 						portEnd++
 					}
 					if portEnd > portStart {
-						existing := cmd[idx:portEnd]
-						spec.Containers[i].Command[j] = strings.Replace(cmd, existing, internalPortEquals, 1)
+						existing := updated[idx:portEnd]
+						updated = strings.Replace(updated, existing, internalPortEquals, 1)
 						rewritten = true
 					}
 				}
 				// Check for "--port <n>" form (space-separated)
 				if !rewritten {
-					if idx := strings.Index(cmd, "--port "); idx >= 0 {
+					if idx := strings.Index(updated, "--port "); idx >= 0 {
 						portStart := idx + len("--port ")
 						portEnd := portStart
-						for portEnd < len(cmd) && cmd[portEnd] >= '0' && cmd[portEnd] <= '9' {
+						for portEnd < len(updated) && updated[portEnd] >= '0' && updated[portEnd] <= '9' {
 							portEnd++
 						}
 						if portEnd > portStart {
-							existing := cmd[idx:portEnd]
-							spec.Containers[i].Command[j] = strings.Replace(cmd, existing, internalPortSpace, 1)
+							existing := updated[idx:portEnd]
+							updated = strings.Replace(updated, existing, internalPortSpace, 1)
 							rewritten = true
 						}
 					}
 				}
 				// No existing --port flag, insert after inference_api.py
 				if !rewritten {
-					spec.Containers[i].Command[j] = strings.Replace(
-						cmd,
+					updated = strings.Replace(
+						updated,
 						"inference_api.py",
 						"inference_api.py "+internalPortSpace,
 						1,
@@ -850,6 +854,7 @@ func SetRoutingSidecar(ctx *generator.WorkspaceGeneratorContext, spec *corev1.Po
 				}
 				portOverrideAdded = true
 			}
+			spec.Containers[i].Command[j] = updated
 		}
 		for j, arg := range spec.Containers[i].Args {
 			if strings.Contains(arg, "--vllm-port="+oldPort) {

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -21,15 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/samber/lo"
-	"github.com/stretchr/testify/mock"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/sku"
@@ -41,6 +32,15 @@ import (
 	workspaceutil "github.com/kaito-project/kaito/pkg/utils/workspace"
 	"github.com/kaito-project/kaito/pkg/workspace/estimator/nodesestimator"
 	metadata "github.com/kaito-project/kaito/presets/workspace/models"
+
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/mock"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var ValidStrength string = "0.5"

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1164,6 +1164,50 @@ func TestSetModelDownloadInfo(t *testing.T) {
 			expectedInitContainer: 0,
 			expectError:           false,
 		},
+		"download at runtime - HF_TOKEN only on main container, not sidecar": {
+			workspace: &v1beta1.Workspace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-workspace",
+					Namespace: "default",
+				},
+				Inference: &v1beta1.InferenceSpec{
+					Preset: &v1beta1.PresetSpec{
+						PresetMeta: v1beta1.PresetMeta{
+							Name: "test-model-download",
+						},
+						PresetOptions: v1beta1.PresetOptions{
+							ModelAccessSecret: "hf-secret",
+						},
+					},
+				},
+			},
+			modelName: "test-model-download",
+			spec: &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "test-workspace",
+					},
+					{
+						Name: "llm-d-routing-sidecar",
+					},
+				},
+			},
+			expectedEnvVars: []corev1.EnvVar{
+				{
+					Name: "HF_TOKEN",
+					ValueFrom: &corev1.EnvVarSource{
+						SecretKeyRef: &corev1.SecretKeySelector{
+							LocalObjectReference: corev1.LocalObjectReference{
+								Name: "hf-secret",
+							},
+							Key: "HF_TOKEN",
+						},
+					},
+				},
+			},
+			expectedInitContainer: 0,
+			expectError:           false,
+		},
 		"model puller - add init containers": {
 			workspace: &v1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
@@ -1225,19 +1269,24 @@ func TestSetModelDownloadInfo(t *testing.T) {
 
 			// Check environment variables if expected
 			if len(tc.expectedEnvVars) > 0 {
+				// HF_TOKEN should only be on the main container (matching workspace name)
+				mainContainerName := tc.workspace.Name
 				for i, container := range tc.spec.Containers {
 					found := false
 					for _, env := range container.Env {
 						if env.Name == "HF_TOKEN" {
 							found = true
 							if !reflect.DeepEqual(env, tc.expectedEnvVars[0]) {
-								t.Errorf("container %d: HF_TOKEN env var mismatch: expected %+v, got %+v",
-									i, tc.expectedEnvVars[0], env)
+								t.Errorf("container %d (%s): HF_TOKEN env var mismatch: expected %+v, got %+v",
+									i, container.Name, tc.expectedEnvVars[0], env)
 							}
 						}
 					}
-					if !found {
-						t.Errorf("container %d: HF_TOKEN env var not found", i)
+					if container.Name == mainContainerName && !found {
+						t.Errorf("container %d (%s): HF_TOKEN env var not found on main container", i, container.Name)
+					}
+					if container.Name != mainContainerName && found {
+						t.Errorf("container %d (%s): HF_TOKEN should not be on non-main container", i, container.Name)
 					}
 				}
 			} else {

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1565,6 +1565,7 @@ func TestSetRoutingSidecar(t *testing.T) {
 				expectedArgs := []string{
 					fmt.Sprintf("--port=%d", consts.PortInferenceServer),
 					fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
+					"--secure-proxy=false",
 				}
 				if len(sidecar.Args) != len(expectedArgs) {
 					t.Errorf("expected %d args, got %d: %v", len(expectedArgs), len(sidecar.Args), sidecar.Args)

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1357,14 +1357,14 @@ func TestSetInferenceRoleEnv(t *testing.T) {
 			expectEnvSet: false,
 		},
 		{
-			name:          "prefill role - env set on all containers",
+			name:          "prefill role - env set on main container only",
 			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
 			containers:    2,
 			expectEnvSet:  true,
 			expectedValue: consts.InferenceRolePrefill,
 		},
 		{
-			name:          "decode role - env set on all containers",
+			name:          "decode role - env set on main container only",
 			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
 			containers:    1,
 			expectEnvSet:  true,
@@ -1407,19 +1407,22 @@ func TestSetInferenceRoleEnv(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
+			// Only the main container (index 0) should have the env var set
 			for i, c := range spec.Containers {
 				count := 0
 				for _, env := range c.Env {
 					if env.Name == consts.InferenceRoleEnvName {
 						count++
-						if !tc.expectEnvSet {
+						if i == 0 && !tc.expectEnvSet {
 							t.Errorf("container %d: env KAITO_INFERENCE_ROLE should not be set", i)
-						} else if env.Value != tc.expectedValue {
+						} else if i == 0 && env.Value != tc.expectedValue {
 							t.Errorf("container %d: expected value %q, got %q", i, tc.expectedValue, env.Value)
+						} else if i > 0 {
+							t.Errorf("container %d: env KAITO_INFERENCE_ROLE should not be set on non-main container", i)
 						}
 					}
 				}
-				if tc.expectEnvSet && count == 0 {
+				if i == 0 && tc.expectEnvSet && count == 0 {
 					t.Errorf("container %d: expected KAITO_INFERENCE_ROLE to be set", i)
 				}
 				if count > 1 {
@@ -1479,7 +1482,7 @@ func TestInjectRoutingSidecarInline(t *testing.T) {
 						Ports: []corev1.ContainerPort{
 							{ContainerPort: int32(consts.PortInferenceServer), Name: "http", Protocol: corev1.ProtocolTCP},
 						},
-						Command: []string{"/bin/sh", "-c", "python3 /workspace/vllm/inference_api.py --served-model-name test"},
+						Command: []string{"/bin/sh", "-c", "python3 /workspace/vllm/inference_api.py --port=5000 --vllm-port=5000 --served-model-name test"},
 						ReadinessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{
@@ -1502,7 +1505,7 @@ func TestInjectRoutingSidecarInline(t *testing.T) {
 			// Multi-node uses a shell if/else script wrapping inference_api.py
 			if tc.multiNode {
 				spec.Containers[0].Command = []string{"/bin/sh", "-c",
-					"if [ \"$RAY_HEAD\" = \"true\" ]; then ray start --head && python3 /workspace/vllm/inference_api.py --served-model-name test; else ray start && sleep infinity; fi"}
+					"if [ \"$RAY_HEAD\" = \"true\" ]; then ray start --head && python3 /workspace/vllm/inference_api.py --port=5000 --vllm-port=5000 --served-model-name test; else ray start && sleep infinity; fi"}
 			}
 			if tc.existingContainers != nil {
 				spec.Containers = append(spec.Containers, tc.existingContainers...)
@@ -1585,21 +1588,14 @@ func TestInjectRoutingSidecarInline(t *testing.T) {
 							t.Errorf("vLLM container still has port %d, expected %d", consts.PortInferenceServer, consts.PortInferenceServerInternal)
 						}
 					}
-					// Verify command has --port override inserted (not appended after fi)
+					// Verify command has --port rewritten
 					for _, cmd := range c.Command {
 						if strings.Contains(cmd, "inference_api.py") {
-							expectedPortArg := fmt.Sprintf("inference_api.py --port %d", consts.PortInferenceServerInternal)
-							if !strings.Contains(cmd, expectedPortArg) {
-								t.Errorf("expected command to contain %q, got %q", expectedPortArg, cmd)
+							if strings.Contains(cmd, fmt.Sprintf("--port=%d", consts.PortInferenceServer)) {
+								t.Errorf("command still has --port=%d, expected %d: %q", consts.PortInferenceServer, consts.PortInferenceServerInternal, cmd)
 							}
-							// Multi-node: ensure --port is NOT after 'fi'
-							if strings.Contains(cmd, "; fi") {
-								fiIdx := strings.Index(cmd, "; fi")
-								portStr := fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)
-								portIdx := strings.Index(cmd, portStr)
-								if portIdx > fiIdx {
-									t.Errorf("--port was appended after 'fi' instead of after inference_api.py: %q", cmd)
-								}
+							if strings.Contains(cmd, fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServer)) {
+								t.Errorf("command still has --vllm-port=%d: %q", consts.PortInferenceServer, cmd)
 							}
 						}
 					}

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -482,7 +482,7 @@ func TestGetDistributedInferenceProbe(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			actualProbe := getDistributedInferenceProbe(tc.probeType, tc.workspace, consts.PortInferenceServer, tc.initialDelaySeconds, tc.periodSeconds, tc.timeoutSeconds, tc.failureThreshold)
+			actualProbe := getDistributedInferenceProbe(tc.probeType, tc.workspace, tc.initialDelaySeconds, tc.periodSeconds, tc.timeoutSeconds, tc.failureThreshold)
 			if actualProbe.Exec != nil && tc.expectedProbe.Exec != nil {
 				expected := toParameterMap(tc.expectedProbe.Exec.Command)
 				actual := toParameterMap(actualProbe.Exec.Command)
@@ -526,7 +526,7 @@ func TestBuildDistributedStartupProbe(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			probe := buildDistributedStartupProbe(tc.timeout, tc.workspace, consts.PortInferenceServer)
+			probe := buildDistributedStartupProbe(tc.timeout, tc.workspace)
 			if probe == nil {
 				t.Fatal("expected non-nil probe")
 			}

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -21,6 +21,15 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/lo"
+	"github.com/stretchr/testify/mock"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	storagev1 "k8s.io/api/storage/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/sku"
@@ -32,15 +41,6 @@ import (
 	workspaceutil "github.com/kaito-project/kaito/pkg/utils/workspace"
 	"github.com/kaito-project/kaito/pkg/workspace/estimator/nodesestimator"
 	metadata "github.com/kaito-project/kaito/presets/workspace/models"
-
-	"github.com/samber/lo"
-	"github.com/stretchr/testify/mock"
-	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
-	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
 var ValidStrength string = "0.5"
@@ -1333,4 +1333,293 @@ func toParameterMap(in []string) map[string]string {
 		}
 	}
 	return ret
+}
+
+func TestSetInferenceRoleEnv(t *testing.T) {
+	tests := []struct {
+		name           string
+		labels         map[string]string
+		containers     int
+		preExistingEnv bool
+		expectEnvSet   bool
+		expectedValue  string
+	}{
+		{
+			name:         "no label - no env set",
+			labels:       map[string]string{},
+			containers:   1,
+			expectEnvSet: false,
+		},
+		{
+			name:         "invalid role - no env set",
+			labels:       map[string]string{v1beta1.LabelInferenceRole: "invalid"},
+			containers:   1,
+			expectEnvSet: false,
+		},
+		{
+			name:          "prefill role - env set on all containers",
+			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
+			containers:    2,
+			expectEnvSet:  true,
+			expectedValue: consts.InferenceRolePrefill,
+		},
+		{
+			name:          "decode role - env set on all containers",
+			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
+			containers:    1,
+			expectEnvSet:  true,
+			expectedValue: consts.InferenceRoleDecode,
+		},
+		{
+			name:           "prefill role - upsert existing env var without duplicates",
+			labels:         map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
+			containers:     1,
+			preExistingEnv: true,
+			expectEnvSet:   true,
+			expectedValue:  "prefill",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			workspace := &v1beta1.Workspace{}
+			workspace.Labels = tc.labels
+
+			spec := &corev1.PodSpec{}
+			for i := 0; i < tc.containers; i++ {
+				c := corev1.Container{
+					Name: fmt.Sprintf("container-%d", i),
+				}
+				if tc.preExistingEnv {
+					c.Env = []corev1.EnvVar{
+						{Name: consts.InferenceRoleEnvName, Value: "old-value"},
+					}
+				}
+				spec.Containers = append(spec.Containers, c)
+			}
+
+			ctx := &generator.WorkspaceGeneratorContext{
+				Workspace: workspace,
+			}
+
+			err := SetInferenceRoleEnv(ctx, spec)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			for i, c := range spec.Containers {
+				count := 0
+				for _, env := range c.Env {
+					if env.Name == consts.InferenceRoleEnvName {
+						count++
+						if !tc.expectEnvSet {
+							t.Errorf("container %d: env KAITO_INFERENCE_ROLE should not be set", i)
+						} else if env.Value != tc.expectedValue {
+							t.Errorf("container %d: expected value %q, got %q", i, tc.expectedValue, env.Value)
+						}
+					}
+				}
+				if tc.expectEnvSet && count == 0 {
+					t.Errorf("container %d: expected KAITO_INFERENCE_ROLE to be set", i)
+				}
+				if count > 1 {
+					t.Errorf("container %d: found %d entries for KAITO_INFERENCE_ROLE, expected at most 1", i, count)
+				}
+			}
+		})
+	}
+}
+
+func TestSetRoutingSidecar(t *testing.T) {
+	tests := []struct {
+		name               string
+		labels             map[string]string
+		existingContainers []corev1.Container
+		multiNode          bool
+		expectSidecar      bool
+	}{
+		{
+			name:          "no label - no sidecar",
+			labels:        map[string]string{},
+			expectSidecar: false,
+		},
+		{
+			name:          "prefill role - no sidecar",
+			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
+			expectSidecar: false,
+		},
+		{
+			name:          "decode role - sidecar injected",
+			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
+			expectSidecar: true,
+		},
+		{
+			name:   "decode role - sidecar already exists - no duplicate",
+			labels: map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
+			existingContainers: []corev1.Container{
+				{Name: "llm-d-routing-sidecar", Image: "old-image"},
+			},
+			expectSidecar: true,
+		},
+		{
+			name:               "decode role - multi-node shell command",
+			labels:             map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
+			existingContainers: nil,
+			multiNode:          true,
+			expectSidecar:      true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Enable vLLM feature gate for runtime detection
+			originalVLLM := featuregates.FeatureGates[consts.FeatureFlagVLLM]
+			featuregates.FeatureGates[consts.FeatureFlagVLLM] = true
+			defer func() { featuregates.FeatureGates[consts.FeatureFlagVLLM] = originalVLLM }()
+
+			workspace := &v1beta1.Workspace{}
+			workspace.Labels = tc.labels
+
+			spec := &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{
+						Name: "vllm",
+						Ports: []corev1.ContainerPort{
+							{ContainerPort: int32(consts.PortInferenceServer), Name: "http", Protocol: corev1.ProtocolTCP},
+						},
+						Command: []string{"/bin/sh", "-c", "python3 /workspace/vllm/inference_api.py --served-model-name test"},
+						ReadinessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Port: intstr.FromInt32(int32(consts.PortInferenceServer)),
+									Path: "/health",
+								},
+							},
+						},
+						LivenessProbe: &corev1.Probe{
+							ProbeHandler: corev1.ProbeHandler{
+								HTTPGet: &corev1.HTTPGetAction{
+									Port: intstr.FromInt32(int32(consts.PortInferenceServer)),
+									Path: "/health",
+								},
+							},
+						},
+					},
+				},
+			}
+			// Multi-node uses a shell if/else script wrapping inference_api.py
+			if tc.multiNode {
+				spec.Containers[0].Command = []string{"/bin/sh", "-c",
+					"if [ \"$RAY_HEAD\" = \"true\" ]; then ray start --head && python3 /workspace/vllm/inference_api.py --served-model-name test; else ray start && sleep infinity; fi"}
+			}
+			if tc.existingContainers != nil {
+				spec.Containers = append(spec.Containers, tc.existingContainers...)
+			}
+
+			ctx := &generator.WorkspaceGeneratorContext{
+				Workspace: workspace,
+			}
+
+			err := SetRoutingSidecar(ctx, spec)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			sidecarCount := 0
+			for _, c := range spec.Containers {
+				if c.Name == "llm-d-routing-sidecar" {
+					sidecarCount++
+				}
+			}
+
+			if tc.expectSidecar && sidecarCount == 0 {
+				t.Error("expected routing sidecar to be present")
+			}
+			if !tc.expectSidecar && sidecarCount > 0 {
+				t.Error("routing sidecar should not be present")
+			}
+			if sidecarCount > 1 {
+				t.Errorf("found %d sidecar containers, expected at most 1", sidecarCount)
+			}
+
+			// Verify sidecar config for decode role (newly injected case)
+			if tc.expectSidecar && tc.existingContainers == nil {
+				var sidecar *corev1.Container
+				for i, c := range spec.Containers {
+					if c.Name == "llm-d-routing-sidecar" {
+						sidecar = &spec.Containers[i]
+						break
+					}
+				}
+				if sidecar == nil {
+					t.Fatal("sidecar not found")
+				}
+				expectedImage := fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag)
+				if sidecar.Image != expectedImage {
+					t.Errorf("expected image %q, got %q", expectedImage, sidecar.Image)
+				}
+				if len(sidecar.Ports) != 1 || sidecar.Ports[0].ContainerPort != int32(consts.PortInferenceServer) {
+					t.Errorf("expected port %d, got %v", consts.PortInferenceServer, sidecar.Ports)
+				}
+				// Check BACKEND_URL env
+				foundBackend := false
+				for _, env := range sidecar.Env {
+					if env.Name == "BACKEND_URL" {
+						expectedURL := fmt.Sprintf("http://localhost:%d", consts.PortInferenceServerInternal)
+						if env.Value != expectedURL {
+							t.Errorf("expected BACKEND_URL %q, got %q", expectedURL, env.Value)
+						}
+						foundBackend = true
+					}
+				}
+				if !foundBackend {
+					t.Error("BACKEND_URL env not found on sidecar")
+				}
+			}
+
+			// Verify vLLM port/probe/command rewrites for ALL decode cases (including sidecar-exists)
+			if tc.expectSidecar {
+				for _, c := range spec.Containers {
+					if c.Name == "llm-d-routing-sidecar" {
+						continue
+					}
+					for _, p := range c.Ports {
+						if p.ContainerPort == int32(consts.PortInferenceServer) {
+							t.Errorf("vLLM container still has port %d, expected %d", consts.PortInferenceServer, consts.PortInferenceServerInternal)
+						}
+					}
+					// Verify command has --port override inserted (not appended after fi)
+					for _, cmd := range c.Command {
+						if strings.Contains(cmd, "inference_api.py") {
+							expectedPortArg := fmt.Sprintf("inference_api.py --port %d", consts.PortInferenceServerInternal)
+							if !strings.Contains(cmd, expectedPortArg) {
+								t.Errorf("expected command to contain %q, got %q", expectedPortArg, cmd)
+							}
+							// Multi-node: ensure --port is NOT after 'fi'
+							if strings.Contains(cmd, "; fi") {
+								fiIdx := strings.Index(cmd, "; fi")
+								portStr := fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)
+								portIdx := strings.Index(cmd, portStr)
+								if portIdx > fiIdx {
+									t.Errorf("--port was appended after 'fi' instead of after inference_api.py: %q", cmd)
+								}
+							}
+						}
+					}
+					// Verify readiness probe port updated
+					if c.ReadinessProbe != nil && c.ReadinessProbe.HTTPGet != nil {
+						if c.ReadinessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+							t.Errorf("readiness probe still targets port %d", consts.PortInferenceServer)
+						}
+					}
+					// Verify liveness probe port updated
+					if c.LivenessProbe != nil && c.LivenessProbe.HTTPGet != nil {
+						if c.LivenessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+							t.Errorf("liveness probe still targets port %d", consts.PortInferenceServer)
+						}
+					}
+				}
+			}
+		})
+	}
 }

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1561,19 +1561,25 @@ func TestSetRoutingSidecar(t *testing.T) {
 				if len(sidecar.Ports) != 1 || sidecar.Ports[0].ContainerPort != int32(consts.PortInferenceServer) {
 					t.Errorf("expected port %d, got %v", consts.PortInferenceServer, sidecar.Ports)
 				}
-				// Check BACKEND_URL env
-				foundBackend := false
-				for _, env := range sidecar.Env {
-					if env.Name == "BACKEND_URL" {
-						expectedURL := fmt.Sprintf("http://localhost:%d", consts.PortInferenceServerInternal)
-						if env.Value != expectedURL {
-							t.Errorf("expected BACKEND_URL %q, got %q", expectedURL, env.Value)
+				// Check sidecar args (--port and --vllm-port flags)
+				expectedArgs := []string{
+					fmt.Sprintf("--port=%d", consts.PortInferenceServer),
+					fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
+				}
+				if len(sidecar.Args) != len(expectedArgs) {
+					t.Errorf("expected %d args, got %d: %v", len(expectedArgs), len(sidecar.Args), sidecar.Args)
+				} else {
+					for i, expected := range expectedArgs {
+						if sidecar.Args[i] != expected {
+							t.Errorf("expected arg[%d] %q, got %q", i, expected, sidecar.Args[i])
 						}
-						foundBackend = true
 					}
 				}
-				if !foundBackend {
-					t.Error("BACKEND_URL env not found on sidecar")
+				// BACKEND_URL should NOT be present (sidecar uses flags, not env)
+				for _, env := range sidecar.Env {
+					if env.Name == "BACKEND_URL" {
+						t.Error("BACKEND_URL env should not be present on sidecar (uses --vllm-port flag instead)")
+					}
 				}
 			}
 

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1407,7 +1407,7 @@ func TestSetInferenceRoleEnv(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			for i, c := range ss.Spec.Template.Spec.Containers {
+			for i, c := range spec.Containers {
 				count := 0
 				for _, env := range c.Env {
 					if env.Name == consts.InferenceRoleEnvName {
@@ -1430,7 +1430,7 @@ func TestSetInferenceRoleEnv(t *testing.T) {
 	}
 }
 
-func TestInjectRoutingSidecar(t *testing.T) {
+func TestInjectRoutingSidecarInline(t *testing.T) {
 	tests := []struct {
 		name               string
 		labels             map[string]string
@@ -1451,14 +1451,6 @@ func TestInjectRoutingSidecar(t *testing.T) {
 		{
 			name:          "decode role - sidecar injected",
 			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
-			expectSidecar: true,
-		},
-		{
-			name:   "decode role - sidecar already exists - no duplicate",
-			labels: map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
-			existingContainers: []corev1.Container{
-				{Name: "llm-d-routing-sidecar", Image: "old-image"},
-			},
 			expectSidecar: true,
 		},
 		{
@@ -1516,20 +1508,15 @@ func TestInjectRoutingSidecar(t *testing.T) {
 				spec.Containers = append(spec.Containers, tc.existingContainers...)
 			}
 
-			ctx := &generator.WorkspaceGeneratorContext{
-				Workspace: workspace,
+			shouldInject := needsRoutingSidecar(workspace)
+			if shouldInject {
+				injectRoutingSidecarInline(spec)
 			}
 
-			ss := &appsv1.StatefulSet{}
-			ss.Spec.Template.Spec = *spec
-
-			err := InjectRoutingSidecar(ctx, ss)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
+			// Use spec directly (not ss)
 
 			sidecarCount := 0
-			for _, c := range ss.Spec.Template.Spec.Containers {
+			for _, c := range spec.Containers {
 				if c.Name == "llm-d-routing-sidecar" {
 					sidecarCount++
 				}
@@ -1548,9 +1535,9 @@ func TestInjectRoutingSidecar(t *testing.T) {
 			// Verify sidecar config for decode role (both newly injected and reconciled cases)
 			if tc.expectSidecar {
 				var sidecar *corev1.Container
-				for i, c := range ss.Spec.Template.Spec.Containers {
+				for i, c := range spec.Containers {
 					if c.Name == "llm-d-routing-sidecar" {
-						sidecar = &ss.Spec.Template.Spec.Containers[i]
+						sidecar = &spec.Containers[i]
 						break
 					}
 				}
@@ -1589,7 +1576,7 @@ func TestInjectRoutingSidecar(t *testing.T) {
 
 			// Verify vLLM port/probe/command rewrites for ALL decode cases (including sidecar-exists)
 			if tc.expectSidecar {
-				for _, c := range ss.Spec.Template.Spec.Containers {
+				for _, c := range spec.Containers {
 					if c.Name == "llm-d-routing-sidecar" {
 						continue
 					}

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1523,7 +1523,38 @@ func TestInjectRoutingSidecar(t *testing.T) {
 
 			shouldInject := needsRoutingSidecar(workspace)
 			if shouldInject {
-				injectRoutingSidecar(spec)
+				// Mirror what GenerateInferencePodSpec does
+				c := &spec.Containers[0]
+				c.Ports = []corev1.ContainerPort{{ContainerPort: consts.PortInferenceServerInternal}}
+				c.Command = rewritePortInCommands(c.Command, consts.PortInferenceServer, consts.PortInferenceServerInternal)
+				if c.ReadinessProbe != nil && c.ReadinessProbe.HTTPGet != nil && c.ReadinessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+					c.ReadinessProbe = c.ReadinessProbe.DeepCopy()
+					c.ReadinessProbe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
+				}
+				if c.LivenessProbe != nil && c.LivenessProbe.HTTPGet != nil && c.LivenessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+					c.LivenessProbe = c.LivenessProbe.DeepCopy()
+					c.LivenessProbe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
+				}
+				spec.Containers = append(spec.Containers, corev1.Container{
+					Name:  "llm-d-routing-sidecar",
+					Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
+					Args: []string{
+						fmt.Sprintf("--port=%d", consts.PortInferenceServer),
+						fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
+						"--secure-proxy=false",
+					},
+					Ports: []corev1.ContainerPort{
+						{ContainerPort: int32(consts.PortInferenceServer), Name: "sidecar", Protocol: corev1.ProtocolTCP},
+					},
+					Env: []corev1.EnvVar{
+						{
+							Name: "POD_IP",
+							ValueFrom: &corev1.EnvVarSource{
+								FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
+							},
+						},
+					},
+				})
 			}
 
 			// Use spec directly (not ss)

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1588,7 +1589,8 @@ func TestInjectRoutingSidecarInline(t *testing.T) {
 							t.Errorf("vLLM container still has port %d, expected %d", consts.PortInferenceServer, consts.PortInferenceServerInternal)
 						}
 					}
-					// Verify command has --port rewritten
+					// Verify command has --port rewritten or appended
+					hasPortArg := false
 					for _, cmd := range c.Command {
 						if strings.Contains(cmd, "inference_api.py") {
 							if strings.Contains(cmd, fmt.Sprintf("--port=%d", consts.PortInferenceServer)) {
@@ -1597,6 +1599,19 @@ func TestInjectRoutingSidecarInline(t *testing.T) {
 							if strings.Contains(cmd, fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServer)) {
 								t.Errorf("command still has --vllm-port=%d: %q", consts.PortInferenceServer, cmd)
 							}
+						}
+						if strings.Contains(cmd, fmt.Sprintf("--port=%d", consts.PortInferenceServerInternal)) ||
+							strings.Contains(cmd, fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)) ||
+							cmd == "--port" || cmd == strconv.Itoa(int(consts.PortInferenceServerInternal)) {
+							hasPortArg = true
+						}
+					}
+					// When command has no inline --port (single-node), --port 5001 should be appended
+					if !hasPortArg && len(c.Command) > 0 {
+						// Check the last two elements for "--port" "5001"
+						cmdLen := len(c.Command)
+						if cmdLen < 2 || c.Command[cmdLen-2] != "--port" || c.Command[cmdLen-1] != strconv.Itoa(int(consts.PortInferenceServerInternal)) {
+							t.Errorf("expected --port %d to be appended to command, got: %v", consts.PortInferenceServerInternal, c.Command)
 						}
 					}
 					// Verify readiness probe port updated

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1144,7 +1144,7 @@ func TestSetModelDownloadInfo(t *testing.T) {
 			spec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: "container-1",
+						Name: "test-workspace",
 					},
 				},
 			},

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1458,6 +1457,11 @@ func TestInjectRoutingSidecarInline(t *testing.T) {
 			expectSidecar: true,
 		},
 		{
+			name:          "decode role - command with existing --port",
+			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
+			expectSidecar: true,
+		},
+		{
 			name:               "decode role - multi-node shell command",
 			labels:             map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
 			existingContainers: nil,
@@ -1483,7 +1487,7 @@ func TestInjectRoutingSidecarInline(t *testing.T) {
 						Ports: []corev1.ContainerPort{
 							{ContainerPort: int32(consts.PortInferenceServer), Name: "http", Protocol: corev1.ProtocolTCP},
 						},
-						Command: []string{"/bin/sh", "-c", "python3 /workspace/vllm/inference_api.py --port=5000 --vllm-port=5000 --served-model-name test"},
+						Command: []string{"/bin/sh", "-c", "python3 /workspace/vllm/inference_api.py --served-model-name test"},
 						ReadinessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{
@@ -1502,6 +1506,11 @@ func TestInjectRoutingSidecarInline(t *testing.T) {
 						},
 					},
 				},
+			}
+			// "with existing --port" case uses explicit port in command
+			if tc.name == "decode role - command with existing --port" {
+				spec.Containers[0].Command = []string{"/bin/sh", "-c",
+					"python3 /workspace/vllm/inference_api.py --port=5000 --vllm-port=5000 --served-model-name test"}
 			}
 			// Multi-node uses a shell if/else script wrapping inference_api.py
 			if tc.multiNode {
@@ -1601,18 +1610,12 @@ func TestInjectRoutingSidecarInline(t *testing.T) {
 							}
 						}
 						if strings.Contains(cmd, fmt.Sprintf("--port=%d", consts.PortInferenceServerInternal)) ||
-							strings.Contains(cmd, fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)) ||
-							cmd == "--port" || cmd == strconv.Itoa(int(consts.PortInferenceServerInternal)) {
+							strings.Contains(cmd, fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)) {
 							hasPortArg = true
 						}
 					}
-					// When command has no inline --port (single-node), --port 5001 should be appended
-					if !hasPortArg && len(c.Command) > 0 {
-						// Check the last two elements for "--port" "5001"
-						cmdLen := len(c.Command)
-						if cmdLen < 2 || c.Command[cmdLen-2] != "--port" || c.Command[cmdLen-1] != strconv.Itoa(int(consts.PortInferenceServerInternal)) {
-							t.Errorf("expected --port %d to be appended to command, got: %v", consts.PortInferenceServerInternal, c.Command)
-						}
+					if !hasPortArg {
+						t.Errorf("expected --port=%d in command, got: %v", consts.PortInferenceServerInternal, c.Command)
 					}
 					// Verify readiness probe port updated
 					if c.ReadinessProbe != nil && c.ReadinessProbe.HTTPGet != nil {

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1474,12 +1474,12 @@ func TestInjectRoutingSidecar(t *testing.T) {
 			// "with existing --port" case uses explicit port in command
 			if tc.name == "decode role - command with existing --port" {
 				spec.Containers[0].Command = []string{"/bin/sh", "-c",
-					"python3 /workspace/vllm/inference_api.py --port=5000 --vllm-port=5000 --served-model-name test"}
+					"python3 /workspace/vllm/inference_api.py --port=5000 --served-model-name test"}
 			}
 			// Multi-node uses a shell if/else script wrapping inference_api.py
 			if tc.multiNode {
 				spec.Containers[0].Command = []string{"/bin/sh", "-c",
-					"if [ \"$RAY_HEAD\" = \"true\" ]; then ray start --head && python3 /workspace/vllm/inference_api.py --port=5000 --vllm-port=5000 --served-model-name test; else ray start && sleep infinity; fi"}
+					"if [ \"$RAY_HEAD\" = \"true\" ]; then ray start --head && python3 /workspace/vllm/inference_api.py --port=5000 --served-model-name test; else ray start && sleep infinity; fi"}
 			}
 
 			// When sidecar is needed, simulate what GenerateInferencePodSpec does:

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1422,7 +1422,7 @@ func TestApplyInferenceRoleEnv(t *testing.T) {
 					{Name: "test-container"},
 				},
 			}
-			applyInferenceRoleEnv(tc.labels, spec)
+			applyInferenceRoleEnv(tc.labels, "test-container", spec)
 
 			found := false
 			for _, e := range spec.Containers[0].Env {

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	"github.com/kaito-project/kaito/api/v1alpha1"
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/sku"
@@ -1411,15 +1412,15 @@ func TestApplyInferenceRoleEnv(t *testing.T) {
 		},
 		{
 			name:          "prefill role - env set",
-			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
+			labels:        map[string]string{v1beta1.LabelInferenceRole: string(v1alpha1.MultiRoleInferenceRolePrefill)},
 			expectEnvSet:  true,
-			expectedValue: consts.InferenceRolePrefill,
+			expectedValue: string(v1alpha1.MultiRoleInferenceRolePrefill),
 		},
 		{
 			name:          "decode role - env set",
-			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
+			labels:        map[string]string{v1beta1.LabelInferenceRole: string(v1alpha1.MultiRoleInferenceRoleDecode)},
 			expectEnvSet:  true,
-			expectedValue: consts.InferenceRoleDecode,
+			expectedValue: string(v1alpha1.MultiRoleInferenceRoleDecode),
 		},
 	}
 
@@ -1464,12 +1465,12 @@ func TestInjectRoutingSidecar(t *testing.T) {
 		},
 		{
 			name:          "prefill role - no sidecar",
-			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
+			labels:        map[string]string{v1beta1.LabelInferenceRole: string(v1alpha1.MultiRoleInferenceRolePrefill)},
 			expectSidecar: false,
 		},
 		{
 			name:          "decode role - sidecar injected",
-			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
+			labels:        map[string]string{v1beta1.LabelInferenceRole: string(v1alpha1.MultiRoleInferenceRoleDecode)},
 			expectSidecar: true,
 		},
 	}

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1335,99 +1335,63 @@ func toParameterMap(in []string) map[string]string {
 	return ret
 }
 
-func TestSetInferenceRoleEnv(t *testing.T) {
+func TestInferenceRoleEnvInline(t *testing.T) {
 	tests := []struct {
-		name           string
-		labels         map[string]string
-		containers     int
-		preExistingEnv bool
-		expectEnvSet   bool
-		expectedValue  string
+		name          string
+		labels        map[string]string
+		expectEnvSet  bool
+		expectedValue string
 	}{
 		{
 			name:         "no label - no env set",
 			labels:       map[string]string{},
-			containers:   1,
 			expectEnvSet: false,
 		},
 		{
 			name:         "invalid role - no env set",
 			labels:       map[string]string{v1beta1.LabelInferenceRole: "invalid"},
-			containers:   1,
 			expectEnvSet: false,
 		},
 		{
-			name:          "prefill role - env set on main container only",
+			name:          "prefill role - env set",
 			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
-			containers:    2,
 			expectEnvSet:  true,
 			expectedValue: consts.InferenceRolePrefill,
 		},
 		{
-			name:          "decode role - env set on main container only",
+			name:          "decode role - env set",
 			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
-			containers:    1,
 			expectEnvSet:  true,
 			expectedValue: consts.InferenceRoleDecode,
-		},
-		{
-			name:           "prefill role - upsert existing env var without duplicates",
-			labels:         map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
-			containers:     1,
-			preExistingEnv: true,
-			expectEnvSet:   true,
-			expectedValue:  "prefill",
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			workspace := &v1beta1.Workspace{}
-			workspace.Labels = tc.labels
+			// Simulate the inline logic from GenerateInferencePodSpec
+			var env []corev1.EnvVar
+			if role, ok := tc.labels[v1beta1.LabelInferenceRole]; ok &&
+				(role == consts.InferenceRolePrefill || role == consts.InferenceRoleDecode) {
+				env = append(env, corev1.EnvVar{
+					Name:  consts.InferenceRoleEnvName,
+					Value: role,
+				})
+			}
 
-			spec := &corev1.PodSpec{}
-			for i := 0; i < tc.containers; i++ {
-				c := corev1.Container{
-					Name: fmt.Sprintf("container-%d", i),
-				}
-				if tc.preExistingEnv {
-					c.Env = []corev1.EnvVar{
-						{Name: consts.InferenceRoleEnvName, Value: "old-value"},
+			found := false
+			for _, e := range env {
+				if e.Name == consts.InferenceRoleEnvName {
+					found = true
+					if e.Value != tc.expectedValue {
+						t.Errorf("expected value %q, got %q", tc.expectedValue, e.Value)
 					}
 				}
-				spec.Containers = append(spec.Containers, c)
 			}
-
-			ctx := &generator.WorkspaceGeneratorContext{
-				Workspace: workspace,
+			if tc.expectEnvSet && !found {
+				t.Error("expected KAITO_INFERENCE_ROLE to be set")
 			}
-
-			err := SetInferenceRoleEnv(ctx, spec)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			// Only the main container (index 0) should have the env var set
-			for i, c := range spec.Containers {
-				count := 0
-				for _, env := range c.Env {
-					if env.Name == consts.InferenceRoleEnvName {
-						count++
-						if i == 0 && !tc.expectEnvSet {
-							t.Errorf("container %d: env KAITO_INFERENCE_ROLE should not be set", i)
-						} else if i == 0 && env.Value != tc.expectedValue {
-							t.Errorf("container %d: expected value %q, got %q", i, tc.expectedValue, env.Value)
-						} else if i > 0 {
-							t.Errorf("container %d: env KAITO_INFERENCE_ROLE should not be set on non-main container", i)
-						}
-					}
-				}
-				if i == 0 && tc.expectEnvSet && count == 0 {
-					t.Errorf("container %d: expected KAITO_INFERENCE_ROLE to be set", i)
-				}
-				if count > 1 {
-					t.Errorf("container %d: found %d entries for KAITO_INFERENCE_ROLE, expected at most 1", i, count)
-				}
+			if !tc.expectEnvSet && found {
+				t.Error("KAITO_INFERENCE_ROLE should not be set")
 			}
 		})
 	}

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1384,7 +1384,7 @@ func toParameterMap(in []string) map[string]string {
 	return ret
 }
 
-func TestInferenceRoleEnvInline(t *testing.T) {
+func TestApplyInferenceRoleEnv(t *testing.T) {
 	tests := []struct {
 		name          string
 		labels        map[string]string
@@ -1417,18 +1417,15 @@ func TestInferenceRoleEnvInline(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Simulate the inline logic from GenerateInferencePodSpec
-			var env []corev1.EnvVar
-			if role, ok := tc.labels[v1beta1.LabelInferenceRole]; ok &&
-				(role == consts.InferenceRolePrefill || role == consts.InferenceRoleDecode) {
-				env = append(env, corev1.EnvVar{
-					Name:  consts.InferenceRoleEnvName,
-					Value: role,
-				})
+			spec := &corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "test-container"},
+				},
 			}
+			applyInferenceRoleEnv(tc.labels, spec)
 
 			found := false
-			for _, e := range env {
+			for _, e := range spec.Containers[0].Env {
 				if e.Name == consts.InferenceRoleEnvName {
 					found = true
 					if e.Value != tc.expectedValue {
@@ -1448,11 +1445,9 @@ func TestInferenceRoleEnvInline(t *testing.T) {
 
 func TestInjectRoutingSidecar(t *testing.T) {
 	tests := []struct {
-		name               string
-		labels             map[string]string
-		existingContainers []corev1.Container
-		multiNode          bool
-		expectSidecar      bool
+		name          string
+		labels        map[string]string
+		expectSidecar bool
 	}{
 		{
 			name:          "no label - no sidecar",
@@ -1468,18 +1463,6 @@ func TestInjectRoutingSidecar(t *testing.T) {
 			name:          "decode role - sidecar injected",
 			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
 			expectSidecar: true,
-		},
-		{
-			name:          "decode role - command with existing --port",
-			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
-			expectSidecar: true,
-		},
-		{
-			name:               "decode role - multi-node shell command",
-			labels:             map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
-			existingContainers: nil,
-			multiNode:          true,
-			expectSidecar:      true,
 		},
 	}
 
@@ -1500,7 +1483,6 @@ func TestInjectRoutingSidecar(t *testing.T) {
 						Ports: []corev1.ContainerPort{
 							{ContainerPort: int32(consts.PortInferenceServer), Name: "http", Protocol: corev1.ProtocolTCP},
 						},
-						Command: []string{"/bin/sh", "-c", "python3 /workspace/vllm/inference_api.py --served-model-name test"},
 						ReadinessProbe: &corev1.Probe{
 							ProbeHandler: corev1.ProbeHandler{
 								HTTPGet: &corev1.HTTPGetAction{
@@ -1520,68 +1502,12 @@ func TestInjectRoutingSidecar(t *testing.T) {
 					},
 				},
 			}
-			// "with existing --port" case uses explicit port in command
-			if tc.name == "decode role - command with existing --port" {
-				spec.Containers[0].Command = []string{"/bin/sh", "-c",
-					"python3 /workspace/vllm/inference_api.py --port=5000 --served-model-name test"}
-			}
-			// Multi-node uses a shell if/else script wrapping inference_api.py
-			if tc.multiNode {
-				spec.Containers[0].Command = []string{"/bin/sh", "-c",
-					"if [ \"$RAY_HEAD\" = \"true\" ]; then ray start --head && python3 /workspace/vllm/inference_api.py --port=5000 --served-model-name test; else ray start && sleep infinity; fi"}
-			}
 
-			// When sidecar is needed, simulate what GenerateInferencePodSpec does:
-			// --port is set in ModelRunParams before GetInferenceCommand, so the
-			// generated command already contains --port=5001.
-			if tc.existingContainers != nil {
-				spec.Containers = append(spec.Containers, tc.existingContainers...)
-			}
+			// Call production code
 			shouldInject := needsRoutingSidecar(workspace)
 			if shouldInject {
-				// Simulate the command having --port=5001 from ModelRunParams
-				c := &spec.Containers[0]
-				if !strings.Contains(c.Command[len(c.Command)-1], "--port=") {
-					// No explicit --port in command: add --port 5001 (simulates ModelRunParams injection)
-					c.Command[len(c.Command)-1] += fmt.Sprintf(" --port %d", consts.PortInferenceServerInternal)
-				} else {
-					// Existing --port=5000: replace with 5001 (simulates ModelRunParams override)
-					for j, cmd := range c.Command {
-						c.Command[j] = strings.ReplaceAll(cmd, "--port=5000", fmt.Sprintf("--port=%d", consts.PortInferenceServerInternal))
-					}
-				}
-				c.Ports = []corev1.ContainerPort{{ContainerPort: consts.PortInferenceServerInternal}}
-				if c.ReadinessProbe != nil && c.ReadinessProbe.HTTPGet != nil && c.ReadinessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-					c.ReadinessProbe = c.ReadinessProbe.DeepCopy()
-					c.ReadinessProbe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
-				}
-				if c.LivenessProbe != nil && c.LivenessProbe.HTTPGet != nil && c.LivenessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-					c.LivenessProbe = c.LivenessProbe.DeepCopy()
-					c.LivenessProbe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)
-				}
-				spec.Containers = append(spec.Containers, corev1.Container{
-					Name:  "llm-d-routing-sidecar",
-					Image: fmt.Sprintf("%s:%s", consts.RoutingSidecarImage, consts.RoutingSidecarTag),
-					Args: []string{
-						fmt.Sprintf("--port=%d", consts.PortInferenceServer),
-						fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
-						"--secure-proxy=false",
-					},
-					Ports: []corev1.ContainerPort{
-						{ContainerPort: int32(consts.PortInferenceServer), Name: "sidecar", Protocol: corev1.ProtocolTCP},
-					},
-					Env: []corev1.EnvVar{
-						{
-							Name: "POD_IP",
-							ValueFrom: &corev1.EnvVarSource{
-								FieldRef: &corev1.ObjectFieldSelector{FieldPath: "status.podIP"},
-							},
-						},
-					},
-				})
+				injectRoutingSidecar(spec)
 			}
-
-			// Use spec directly (not ss)
 
 			sidecarCount := 0
 			for _, c := range spec.Containers {
@@ -1600,7 +1526,7 @@ func TestInjectRoutingSidecar(t *testing.T) {
 				t.Errorf("found %d sidecar containers, expected at most 1", sidecarCount)
 			}
 
-			// Verify sidecar config for decode role (both newly injected and reconciled cases)
+			// Verify sidecar config for decode role
 			if tc.expectSidecar {
 				var sidecar *corev1.Container
 				for i, c := range spec.Containers {
@@ -1619,7 +1545,6 @@ func TestInjectRoutingSidecar(t *testing.T) {
 				if len(sidecar.Ports) != 1 || sidecar.Ports[0].ContainerPort != int32(consts.PortInferenceServer) {
 					t.Errorf("expected port %d, got %v", consts.PortInferenceServer, sidecar.Ports)
 				}
-				// Check sidecar args (--port and --vllm-port flags)
 				expectedArgs := []string{
 					fmt.Sprintf("--port=%d", consts.PortInferenceServer),
 					fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
@@ -1634,58 +1559,23 @@ func TestInjectRoutingSidecar(t *testing.T) {
 						}
 					}
 				}
-				// BACKEND_URL should NOT be present (sidecar uses flags, not env)
+				// BACKEND_URL should NOT be present
 				for _, env := range sidecar.Env {
 					if env.Name == "BACKEND_URL" {
-						t.Error("BACKEND_URL env should not be present on sidecar (uses --vllm-port flag instead)")
+						t.Error("BACKEND_URL env should not be present on sidecar")
 					}
 				}
-			}
 
-			// Verify vLLM port/probe/command rewrites for ALL decode cases (including sidecar-exists)
-			if tc.expectSidecar {
-				for _, c := range spec.Containers {
-					if c.Name == "llm-d-routing-sidecar" {
-						continue
+				// Verify probe ports were rewritten on the main container
+				main := spec.Containers[0]
+				if main.ReadinessProbe != nil && main.ReadinessProbe.HTTPGet != nil {
+					if main.ReadinessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+						t.Errorf("readiness probe still targets port %d, expected %d", consts.PortInferenceServer, consts.PortInferenceServerInternal)
 					}
-					for _, p := range c.Ports {
-						if p.ContainerPort == int32(consts.PortInferenceServer) {
-							t.Errorf("vLLM container still has port %d, expected %d", consts.PortInferenceServer, consts.PortInferenceServerInternal)
-						}
-					}
-					// Verify command has --port rewritten (if it existed) and old port is gone
-					for _, cmd := range c.Command {
-						if strings.Contains(cmd, "inference_api.py") {
-							if strings.Contains(cmd, fmt.Sprintf("--port=%d", consts.PortInferenceServer)) {
-								t.Errorf("command still has --port=%d, expected %d: %q", consts.PortInferenceServer, consts.PortInferenceServerInternal, cmd)
-							}
-							if strings.Contains(cmd, fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServer)) {
-								t.Errorf("command still has --vllm-port=%d: %q", consts.PortInferenceServer, cmd)
-							}
-						}
-					}
-					// Verify --port is set to internal port in the command
-					portInCmd := false
-					for _, cmd := range c.Command {
-						if strings.Contains(cmd, fmt.Sprintf("--port=%d", consts.PortInferenceServerInternal)) ||
-							strings.Contains(cmd, fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)) {
-							portInCmd = true
-						}
-					}
-					if !portInCmd {
-						t.Errorf("expected --port %d in command, got: %v", consts.PortInferenceServerInternal, c.Command)
-					}
-					// Verify readiness probe port updated
-					if c.ReadinessProbe != nil && c.ReadinessProbe.HTTPGet != nil {
-						if c.ReadinessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-							t.Errorf("readiness probe still targets port %d", consts.PortInferenceServer)
-						}
-					}
-					// Verify liveness probe port updated
-					if c.LivenessProbe != nil && c.LivenessProbe.HTTPGet != nil {
-						if c.LivenessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-							t.Errorf("liveness probe still targets port %d", consts.PortInferenceServer)
-						}
+				}
+				if main.LivenessProbe != nil && main.LivenessProbe.HTTPGet != nil {
+					if main.LivenessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
+						t.Errorf("liveness probe still targets port %d, expected %d", consts.PortInferenceServer, consts.PortInferenceServerInternal)
 					}
 				}
 			}

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1434,7 +1433,7 @@ func TestSetInferenceRoleEnv(t *testing.T) {
 	}
 }
 
-func TestInjectRoutingSidecarInline(t *testing.T) {
+func TestInjectRoutingSidecar(t *testing.T) {
 	tests := []struct {
 		name               string
 		labels             map[string]string
@@ -1524,7 +1523,7 @@ func TestInjectRoutingSidecarInline(t *testing.T) {
 
 			shouldInject := needsRoutingSidecar(workspace)
 			if shouldInject {
-				injectRoutingSidecarInline(spec)
+				injectRoutingSidecar(spec)
 			}
 
 			// Use spec directly (not ss)
@@ -1610,15 +1609,16 @@ func TestInjectRoutingSidecarInline(t *testing.T) {
 							}
 						}
 					}
-					// Verify KAITO_VLLM_PORT env var is set for port override
-					vllmPortEnvFound := false
-					for _, env := range c.Env {
-						if env.Name == "KAITO_VLLM_PORT" && env.Value == strconv.Itoa(int(consts.PortInferenceServerInternal)) {
-							vllmPortEnvFound = true
+					// Verify --port is set to internal port in the command
+					portInCmd := false
+					for _, cmd := range c.Command {
+						if strings.Contains(cmd, fmt.Sprintf("--port=%d", consts.PortInferenceServerInternal)) ||
+							strings.Contains(cmd, fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)) {
+							portInCmd = true
 						}
 					}
-					if !vllmPortEnvFound {
-						t.Errorf("expected KAITO_VLLM_PORT=%d env var on container", consts.PortInferenceServerInternal)
+					if !portInCmd {
+						t.Errorf("expected --port %d in command, got: %v", consts.PortInferenceServerInternal, c.Command)
 					}
 					// Verify readiness probe port updated
 					if c.ReadinessProbe != nil && c.ReadinessProbe.HTTPGet != nil {

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -806,7 +806,7 @@ func TestSetAdapterPuller(t *testing.T) {
 			spec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: "test-container",
+						Name: "test-workspace",
 					},
 				},
 			},
@@ -835,7 +835,7 @@ func TestSetAdapterPuller(t *testing.T) {
 			spec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: "test-container",
+						Name: "test-workspace",
 					},
 				},
 			},
@@ -871,7 +871,7 @@ func TestSetAdapterPuller(t *testing.T) {
 			spec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: "test-container",
+						Name: "test-workspace",
 					},
 				},
 			},
@@ -901,7 +901,7 @@ func TestSetAdapterPuller(t *testing.T) {
 			spec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: "test-container",
+						Name: "test-workspace",
 					},
 				},
 			},
@@ -930,10 +930,10 @@ func TestSetAdapterPuller(t *testing.T) {
 			spec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: "container-1",
+						Name: "test-workspace",
 					},
 					{
-						Name: "container-2",
+						Name: "sidecar",
 					},
 				},
 			},
@@ -966,7 +966,7 @@ func TestSetAdapterPuller(t *testing.T) {
 			spec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: "test-container",
+						Name: "test-workspace",
 					},
 				},
 			},
@@ -1006,7 +1006,7 @@ func TestSetAdapterPuller(t *testing.T) {
 			spec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: "test-container",
+						Name: "test-workspace",
 					},
 				},
 			},
@@ -1041,46 +1041,54 @@ func TestSetAdapterPuller(t *testing.T) {
 				t.Errorf("volumes mismatch: expected %v, got %v", tc.expectedVolumes, actualVolumes)
 			}
 
-			// Check volume mounts on containers (only adapter volumes, not docker-config secret volumes)
+			// Check volume mounts on the main container only (adapter volumes, not docker-config secret volumes)
 			if len(tc.expectedVolumes) > 0 {
-				for _, container := range tc.spec.Containers {
+				var mainContainer *corev1.Container
+				for i := range tc.spec.Containers {
+					if tc.spec.Containers[i].Name == tc.workspace.Name {
+						mainContainer = &tc.spec.Containers[i]
+						break
+					}
+				}
+				if mainContainer != nil {
 					for _, expectedVol := range tc.expectedVolumes {
 						if !strings.HasPrefix(expectedVol, "adapter-volume") {
 							continue // docker-config volumes are only mounted on init containers
 						}
 						foundMount := false
-						for _, mount := range container.VolumeMounts {
+						for _, mount := range mainContainer.VolumeMounts {
 							if mount.Name == expectedVol {
 								foundMount = true
 								break
 							}
 						}
 						if !foundMount {
-							t.Errorf("volume mount %s not found in container %s", expectedVol, container.Name)
+							t.Errorf("volume mount %s not found in main container %s", expectedVol, mainContainer.Name)
 						}
 					}
 				}
 			}
 
-			// Check environment variables
+			// Check environment variables on the main container only
 			if len(tc.expectedEnvVars) > 0 {
-				for _, container := range tc.spec.Containers {
-					actualEnvVarNames := make([]string, 0)
-					for _, env := range container.Env {
-						actualEnvVarNames = append(actualEnvVarNames, env.Name)
+				var mainContainer *corev1.Container
+				for i := range tc.spec.Containers {
+					if tc.spec.Containers[i].Name == tc.workspace.Name {
+						mainContainer = &tc.spec.Containers[i]
+						break
 					}
-
-					// Check if all expected env vars are present
+				}
+				if mainContainer != nil {
 					for _, expectedVar := range tc.expectedEnvVars {
 						found := false
-						for _, actualVar := range actualEnvVarNames {
-							if actualVar == expectedVar {
+						for _, env := range mainContainer.Env {
+							if env.Name == expectedVar {
 								found = true
 								break
 							}
 						}
 						if !found {
-							t.Errorf("expected env var %s not found in container %s", expectedVar, container.Name)
+							t.Errorf("expected env var %s not found in main container %s", expectedVar, mainContainer.Name)
 						}
 					}
 				}
@@ -1226,7 +1234,7 @@ func TestSetModelDownloadInfo(t *testing.T) {
 			spec: &corev1.PodSpec{
 				Containers: []corev1.Container{
 					{
-						Name: "test-container",
+						Name: "test-workspace",
 					},
 				},
 			},
@@ -1419,7 +1427,7 @@ func TestApplyInferenceRoleEnv(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			spec := &corev1.PodSpec{
 				Containers: []corev1.Container{
-					{Name: "test-container"},
+					{Name: "test-workspace"},
 				},
 			}
 			applyInferenceRoleEnv(tc.labels, "test-container", spec)

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1566,15 +1566,13 @@ func TestInjectRoutingSidecar(t *testing.T) {
 					}
 				}
 
-				// Verify containerPorts were rewritten on the main container
+				// Verify containerPorts and probe ports were rewritten on the main container
+				main := spec.Containers[0]
 				for _, p := range main.Ports {
 					if p.ContainerPort == int32(consts.PortInferenceServer) {
 						t.Errorf("main container still has containerPort %d, expected %d", consts.PortInferenceServer, consts.PortInferenceServerInternal)
 					}
 				}
-
-				// Verify probe ports were rewritten on the main container
-				main := spec.Containers[0]
 				if main.ReadinessProbe != nil && main.ReadinessProbe.HTTPGet != nil {
 					if main.ReadinessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
 						t.Errorf("readiness probe still targets port %d, expected %d", consts.PortInferenceServer, consts.PortInferenceServerInternal)

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1430,7 +1430,7 @@ func TestApplyInferenceRoleEnv(t *testing.T) {
 					{Name: "test-workspace"},
 				},
 			}
-			applyInferenceRoleEnv(tc.labels, "test-container", spec)
+			applyInferenceRoleEnv(tc.labels, "test-workspace", spec)
 
 			found := false
 			for _, e := range spec.Containers[0].Env {

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1566,6 +1566,13 @@ func TestInjectRoutingSidecar(t *testing.T) {
 					}
 				}
 
+				// Verify containerPorts were rewritten on the main container
+				for _, p := range main.Ports {
+					if p.ContainerPort == int32(consts.PortInferenceServer) {
+						t.Errorf("main container still has containerPort %d, expected %d", consts.PortInferenceServer, consts.PortInferenceServerInternal)
+					}
+				}
+
 				// Verify probe ports were rewritten on the main container
 				main := spec.Containers[0]
 				if main.ReadinessProbe != nil && main.ReadinessProbe.HTTPGet != nil {

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -28,6 +28,7 @@ import (
 	storagev1 "k8s.io/api/storage/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1542,8 +1542,8 @@ func TestSetRoutingSidecar(t *testing.T) {
 				t.Errorf("found %d sidecar containers, expected at most 1", sidecarCount)
 			}
 
-			// Verify sidecar config for decode role (newly injected case)
-			if tc.expectSidecar && tc.existingContainers == nil {
+			// Verify sidecar config for decode role (both newly injected and reconciled cases)
+			if tc.expectSidecar {
 				var sidecar *corev1.Container
 				for i, c := range spec.Containers {
 					if c.Name == "llm-d-routing-sidecar" {

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1550,12 +1550,12 @@ func TestInjectRoutingSidecar(t *testing.T) {
 				if sidecar.Image != expectedImage {
 					t.Errorf("expected image %q, got %q", expectedImage, sidecar.Image)
 				}
-				if len(sidecar.Ports) != 1 || sidecar.Ports[0].ContainerPort != int32(consts.PortInferenceServer) {
-					t.Errorf("expected port %d, got %v", consts.PortInferenceServer, sidecar.Ports)
+				if len(sidecar.Ports) != 1 || sidecar.Ports[0].ContainerPort != consts.PortRoutingSidecar {
+					t.Errorf("expected port %d, got %v", consts.PortRoutingSidecar, sidecar.Ports)
 				}
 				expectedArgs := []string{
-					fmt.Sprintf("--port=%d", consts.PortInferenceServer),
-					fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServerInternal),
+					fmt.Sprintf("--port=%d", consts.PortRoutingSidecar),
+					fmt.Sprintf("--vllm-port=%d", consts.PortInferenceServer),
 					"--secure-proxy=false",
 				}
 				if len(sidecar.Args) != len(expectedArgs) {
@@ -1574,21 +1574,26 @@ func TestInjectRoutingSidecar(t *testing.T) {
 					}
 				}
 
-				// Verify containerPorts and probe ports were rewritten on the main container
+				// With the new sidecar approach, vLLM keeps its default port (5000)
+				// and probes continue to target vLLM directly — no rewriting needed.
 				main := spec.Containers[0]
+				hasDefaultPort := false
 				for _, p := range main.Ports {
 					if p.ContainerPort == int32(consts.PortInferenceServer) {
-						t.Errorf("main container still has containerPort %d, expected %d", consts.PortInferenceServer, consts.PortInferenceServerInternal)
+						hasDefaultPort = true
 					}
 				}
+				if !hasDefaultPort {
+					t.Errorf("main container should keep containerPort %d", consts.PortInferenceServer)
+				}
 				if main.ReadinessProbe != nil && main.ReadinessProbe.HTTPGet != nil {
-					if main.ReadinessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-						t.Errorf("readiness probe still targets port %d, expected %d", consts.PortInferenceServer, consts.PortInferenceServerInternal)
+					if main.ReadinessProbe.HTTPGet.Port.IntValue() != int(consts.PortInferenceServer) {
+						t.Errorf("readiness probe should target port %d", consts.PortInferenceServer)
 					}
 				}
 				if main.LivenessProbe != nil && main.LivenessProbe.HTTPGet != nil {
-					if main.LivenessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
-						t.Errorf("liveness probe still targets port %d, expected %d", consts.PortInferenceServer, consts.PortInferenceServerInternal)
+					if main.LivenessProbe.HTTPGet.Port.IntValue() != int(consts.PortInferenceServer) {
+						t.Errorf("liveness probe should target port %d", consts.PortInferenceServer)
 					}
 				}
 			}

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -482,7 +482,7 @@ func TestGetDistributedInferenceProbe(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			actualProbe := getDistributedInferenceProbe(tc.probeType, tc.workspace, tc.initialDelaySeconds, tc.periodSeconds, tc.timeoutSeconds, tc.failureThreshold)
+			actualProbe := getDistributedInferenceProbe(tc.probeType, tc.workspace, consts.PortInferenceServer, tc.initialDelaySeconds, tc.periodSeconds, tc.timeoutSeconds, tc.failureThreshold)
 			if actualProbe.Exec != nil && tc.expectedProbe.Exec != nil {
 				expected := toParameterMap(tc.expectedProbe.Exec.Command)
 				actual := toParameterMap(actualProbe.Exec.Command)
@@ -526,7 +526,7 @@ func TestBuildDistributedStartupProbe(t *testing.T) {
 
 	for name, tc := range testcases {
 		t.Run(name, func(t *testing.T) {
-			probe := buildDistributedStartupProbe(tc.timeout, tc.workspace)
+			probe := buildDistributedStartupProbe(tc.timeout, tc.workspace, consts.PortInferenceServer)
 			if probe == nil {
 				t.Fatal("expected non-nil probe")
 			}

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1481,16 +1481,27 @@ func TestInjectRoutingSidecar(t *testing.T) {
 				spec.Containers[0].Command = []string{"/bin/sh", "-c",
 					"if [ \"$RAY_HEAD\" = \"true\" ]; then ray start --head && python3 /workspace/vllm/inference_api.py --port=5000 --vllm-port=5000 --served-model-name test; else ray start && sleep infinity; fi"}
 			}
+
+			// When sidecar is needed, simulate what GenerateInferencePodSpec does:
+			// --port is set in ModelRunParams before GetInferenceCommand, so the
+			// generated command already contains --port=5001.
 			if tc.existingContainers != nil {
 				spec.Containers = append(spec.Containers, tc.existingContainers...)
 			}
-
 			shouldInject := needsRoutingSidecar(workspace)
 			if shouldInject {
-				// Mirror what GenerateInferencePodSpec does
+				// Simulate the command having --port=5001 from ModelRunParams
 				c := &spec.Containers[0]
+				if !strings.Contains(c.Command[len(c.Command)-1], "--port=") {
+					// No explicit --port in command: add --port 5001 (simulates ModelRunParams injection)
+					c.Command[len(c.Command)-1] += fmt.Sprintf(" --port %d", consts.PortInferenceServerInternal)
+				} else {
+					// Existing --port=5000: replace with 5001 (simulates ModelRunParams override)
+					for j, cmd := range c.Command {
+						c.Command[j] = strings.ReplaceAll(cmd, "--port=5000", fmt.Sprintf("--port=%d", consts.PortInferenceServerInternal))
+					}
+				}
 				c.Ports = []corev1.ContainerPort{{ContainerPort: consts.PortInferenceServerInternal}}
-				c.Command = rewritePortInCommands(c.Command, consts.PortInferenceServer, consts.PortInferenceServerInternal)
 				if c.ReadinessProbe != nil && c.ReadinessProbe.HTTPGet != nil && c.ReadinessProbe.HTTPGet.Port.IntValue() == int(consts.PortInferenceServer) {
 					c.ReadinessProbe = c.ReadinessProbe.DeepCopy()
 					c.ReadinessProbe.HTTPGet.Port = intstr.FromInt32(consts.PortInferenceServerInternal)

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -30,7 +30,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
-	"github.com/kaito-project/kaito/api/v1alpha1"
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/sku"
@@ -1412,15 +1411,15 @@ func TestApplyInferenceRoleEnv(t *testing.T) {
 		},
 		{
 			name:          "prefill role - env set",
-			labels:        map[string]string{v1beta1.LabelInferenceRole: string(v1alpha1.MultiRoleInferenceRolePrefill)},
+			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
 			expectEnvSet:  true,
-			expectedValue: string(v1alpha1.MultiRoleInferenceRolePrefill),
+			expectedValue: consts.InferenceRolePrefill,
 		},
 		{
 			name:          "decode role - env set",
-			labels:        map[string]string{v1beta1.LabelInferenceRole: string(v1alpha1.MultiRoleInferenceRoleDecode)},
+			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
 			expectEnvSet:  true,
-			expectedValue: string(v1alpha1.MultiRoleInferenceRoleDecode),
+			expectedValue: consts.InferenceRoleDecode,
 		},
 	}
 
@@ -1465,12 +1464,12 @@ func TestInjectRoutingSidecar(t *testing.T) {
 		},
 		{
 			name:          "prefill role - no sidecar",
-			labels:        map[string]string{v1beta1.LabelInferenceRole: string(v1alpha1.MultiRoleInferenceRolePrefill)},
+			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
 			expectSidecar: false,
 		},
 		{
 			name:          "decode role - sidecar injected",
-			labels:        map[string]string{v1beta1.LabelInferenceRole: string(v1alpha1.MultiRoleInferenceRoleDecode)},
+			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
 			expectSidecar: true,
 		},
 	}

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1407,7 +1407,7 @@ func TestSetInferenceRoleEnv(t *testing.T) {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
-			for i, c := range spec.Containers {
+			for i, c := range ss.Spec.Template.Spec.Containers {
 				count := 0
 				for _, env := range c.Env {
 					if env.Name == consts.InferenceRoleEnvName {
@@ -1430,7 +1430,7 @@ func TestSetInferenceRoleEnv(t *testing.T) {
 	}
 }
 
-func TestSetRoutingSidecar(t *testing.T) {
+func TestInjectRoutingSidecar(t *testing.T) {
 	tests := []struct {
 		name               string
 		labels             map[string]string
@@ -1520,13 +1520,16 @@ func TestSetRoutingSidecar(t *testing.T) {
 				Workspace: workspace,
 			}
 
-			err := SetRoutingSidecar(ctx, spec)
+			ss := &appsv1.StatefulSet{}
+			ss.Spec.Template.Spec = *spec
+
+			err := InjectRoutingSidecar(ctx, ss)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
 
 			sidecarCount := 0
-			for _, c := range spec.Containers {
+			for _, c := range ss.Spec.Template.Spec.Containers {
 				if c.Name == "llm-d-routing-sidecar" {
 					sidecarCount++
 				}
@@ -1545,9 +1548,9 @@ func TestSetRoutingSidecar(t *testing.T) {
 			// Verify sidecar config for decode role (both newly injected and reconciled cases)
 			if tc.expectSidecar {
 				var sidecar *corev1.Container
-				for i, c := range spec.Containers {
+				for i, c := range ss.Spec.Template.Spec.Containers {
 					if c.Name == "llm-d-routing-sidecar" {
-						sidecar = &spec.Containers[i]
+						sidecar = &ss.Spec.Template.Spec.Containers[i]
 						break
 					}
 				}
@@ -1586,7 +1589,7 @@ func TestSetRoutingSidecar(t *testing.T) {
 
 			// Verify vLLM port/probe/command rewrites for ALL decode cases (including sidecar-exists)
 			if tc.expectSidecar {
-				for _, c := range spec.Containers {
+				for _, c := range ss.Spec.Template.Spec.Containers {
 					if c.Name == "llm-d-routing-sidecar" {
 						continue
 					}

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -1598,8 +1599,7 @@ func TestInjectRoutingSidecarInline(t *testing.T) {
 							t.Errorf("vLLM container still has port %d, expected %d", consts.PortInferenceServer, consts.PortInferenceServerInternal)
 						}
 					}
-					// Verify command has --port rewritten or appended
-					hasPortArg := false
+					// Verify command has --port rewritten (if it existed) and old port is gone
 					for _, cmd := range c.Command {
 						if strings.Contains(cmd, "inference_api.py") {
 							if strings.Contains(cmd, fmt.Sprintf("--port=%d", consts.PortInferenceServer)) {
@@ -1609,13 +1609,16 @@ func TestInjectRoutingSidecarInline(t *testing.T) {
 								t.Errorf("command still has --vllm-port=%d: %q", consts.PortInferenceServer, cmd)
 							}
 						}
-						if strings.Contains(cmd, fmt.Sprintf("--port=%d", consts.PortInferenceServerInternal)) ||
-							strings.Contains(cmd, fmt.Sprintf("--port %d", consts.PortInferenceServerInternal)) {
-							hasPortArg = true
+					}
+					// Verify KAITO_VLLM_PORT env var is set for port override
+					vllmPortEnvFound := false
+					for _, env := range c.Env {
+						if env.Name == "KAITO_VLLM_PORT" && env.Value == strconv.Itoa(int(consts.PortInferenceServerInternal)) {
+							vllmPortEnvFound = true
 						}
 					}
-					if !hasPortArg {
-						t.Errorf("expected --port=%d in command, got: %v", consts.PortInferenceServerInternal, c.Command)
+					if !vllmPortEnvFound {
+						t.Errorf("expected KAITO_VLLM_PORT=%d env var on container", consts.PortInferenceServerInternal)
 					}
 					// Verify readiness probe port updated
 					if c.ReadinessProbe != nil && c.ReadinessProbe.HTTPGet != nil {

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -71,6 +71,16 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 	podNameForIndex0 := fmt.Sprintf("%s-0", workspaceObj.Name)
 	selector["statefulset.kubernetes.io/pod-name"] = podNameForIndex0
 
+	// When the routing sidecar is present (decode role + vLLM), route
+	// external traffic through the sidecar port so that all requests
+	// pass through the routing layer. Probes and monitoring still hit
+	// vLLM directly on PortInferenceServer.
+	httpTargetPort := consts.PortInferenceServer
+	role, hasRole := workspaceObj.Labels[kaitov1beta1.LabelInferenceRole]
+	if hasRole && role == consts.InferenceRoleDecode && kaitov1beta1.GetWorkspaceRuntimeName(workspaceObj) == pkgmodel.RuntimeNameVLLM {
+		httpTargetPort = consts.PortRoutingSidecar
+	}
+
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      workspaceObj.Name,
@@ -87,7 +97,7 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 					Name:       "http",
 					Protocol:   corev1.ProtocolTCP,
 					Port:       80,
-					TargetPort: intstr.FromInt32(consts.PortInferenceServer),
+					TargetPort: intstr.FromInt32(httpTargetPort),
 				},
 				{
 					Name:       "ray",
@@ -397,7 +407,7 @@ func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1alpha1.InferenceSe
 		},
 		"inferencePool": map[string]any{
 			"targetPorts": []map[string]any{{
-				"number": consts.PortInferenceServer,
+				"number": consts.PortRoutingSidecar,
 			}},
 			"modelServers": map[string]any{
 				"matchLabels": matchLabels,

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -33,6 +33,7 @@ import (
 
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/featuregates"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
@@ -387,13 +388,23 @@ func GenerateInferencePoolOCIRepository(inferenceSetObj *kaitov1alpha1.Inference
 // For decode-role InferenceSets with vLLM runtime, traffic goes through the
 // routing sidecar on PortRoutingSidecar. For all other cases, traffic goes
 // directly to the inference server on PortInferenceServer.
+// Runtime detection mirrors v1beta1.GetWorkspaceRuntimeName: when the vLLM
+// feature gate is enabled (default), the runtime defaults to vLLM unless
+// explicitly overridden by the kaito.sh/runtime annotation.
 func inferencePoolTargetPort(inferenceSetObj *kaitov1alpha1.InferenceSet) int32 {
 	role := inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole]
-	runtime := pkgmodel.RuntimeName(inferenceSetObj.Annotations[kaitov1beta1.AnnotationWorkspaceRuntime])
-	if role == consts.InferenceRoleDecode && runtime == pkgmodel.RuntimeNameVLLM {
-		return consts.PortRoutingSidecar
+	if role != consts.InferenceRoleDecode {
+		return consts.PortInferenceServer
 	}
-	return consts.PortInferenceServer
+	// Mirror GetWorkspaceRuntimeName logic: default to vLLM when feature gate is on.
+	if !featuregates.FeatureGates[consts.FeatureFlagVLLM] {
+		return consts.PortInferenceServer
+	}
+	runtime := inferenceSetObj.Annotations[kaitov1beta1.AnnotationWorkspaceRuntime]
+	if runtime == string(pkgmodel.RuntimeNameHuggingfaceTransformers) {
+		return consts.PortInferenceServer
+	}
+	return consts.PortRoutingSidecar
 }
 
 // GenerateInferencePoolHelmRelease generates a Flux HelmRelease for the inference pool.

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -382,6 +382,18 @@ func GenerateInferencePoolOCIRepository(inferenceSetObj *kaitov1alpha1.Inference
 	}
 }
 
+// inferencePoolTargetPort returns the target port for the InferencePool.
+// For decode-role InferenceSets (with vLLM runtime), traffic goes through the
+// routing sidecar on PortRoutingSidecar. For all other cases, traffic goes
+// directly to the inference server on PortInferenceServer.
+func inferencePoolTargetPort(inferenceSetObj *kaitov1alpha1.InferenceSet) int32 {
+	role := inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole]
+	if role == consts.InferenceRoleDecode {
+		return consts.PortRoutingSidecar
+	}
+	return consts.PortInferenceServer
+}
+
 // GenerateInferencePoolHelmRelease generates a Flux HelmRelease for the inference pool.
 func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1alpha1.InferenceSet) (*helmv2.HelmRelease, error) {
 	matchLabels := map[string]string{
@@ -407,7 +419,7 @@ func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1alpha1.InferenceSe
 		},
 		"inferencePool": map[string]any{
 			"targetPorts": []map[string]any{{
-				"number": consts.PortRoutingSidecar,
+				"number": inferencePoolTargetPort(inferenceSetObj),
 			}},
 			"modelServers": map[string]any{
 				"matchLabels": matchLabels,

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -73,8 +73,9 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 
 	// When the routing sidecar is present (decode role + vLLM), route
 	// external traffic through the sidecar port so that all requests
-	// pass through the routing layer. Probes and monitoring still hit
-	// vLLM directly on PortInferenceServer.
+	// pass through the routing layer. Kubelet container probes still
+	// hit vLLM directly on PortInferenceServer (via PodIP), while
+	// Service/Gateway traffic routes to the sidecar on PortRoutingSidecar.
 	httpTargetPort := consts.PortInferenceServer
 	role, hasRole := workspaceObj.Labels[kaitov1beta1.LabelInferenceRole]
 	if hasRole && role == consts.InferenceRoleDecode && kaitov1beta1.GetWorkspaceRuntimeName(workspaceObj) == pkgmodel.RuntimeNameVLLM {
@@ -383,12 +384,13 @@ func GenerateInferencePoolOCIRepository(inferenceSetObj *kaitov1alpha1.Inference
 }
 
 // inferencePoolTargetPort returns the target port for the InferencePool.
-// For decode-role InferenceSets (with vLLM runtime), traffic goes through the
+// For decode-role InferenceSets with vLLM runtime, traffic goes through the
 // routing sidecar on PortRoutingSidecar. For all other cases, traffic goes
 // directly to the inference server on PortInferenceServer.
 func inferencePoolTargetPort(inferenceSetObj *kaitov1alpha1.InferenceSet) int32 {
 	role := inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole]
-	if role == consts.InferenceRoleDecode {
+	runtime := pkgmodel.RuntimeName(inferenceSetObj.Annotations[kaitov1beta1.AnnotationWorkspaceRuntime])
+	if role == consts.InferenceRoleDecode && runtime == pkgmodel.RuntimeNameVLLM {
 		return consts.PortRoutingSidecar
 	}
 	return consts.PortInferenceServer

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -125,6 +125,42 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 				},
 			},
 		},
+
+		{
+			name: "decode role with default runtime (no annotation) uses routing sidecar port",
+			workspace: func() *kaitov1alpha1.InferenceSet {
+				ws := base.DeepCopy()
+				if ws.Spec.Template.Labels == nil {
+					ws.Spec.Template.Labels = map[string]string{}
+				}
+				ws.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = consts.InferenceRoleDecode
+				delete(ws.Annotations, kaitov1beta1.AnnotationWorkspaceRuntime)
+				return ws
+			}(),
+			expected: map[string]any{
+				"inferenceExtension": map[string]any{
+					"image": map[string]any{
+						"hub":        consts.EPPImageHub,
+						"name":       consts.EPPImageName,
+						"tag":        consts.EPPImageTag,
+						"pullPolicy": string(corev1.PullIfNotPresent),
+					},
+				},
+				"inferencePool": map[string]any{
+					"targetPorts": []any{
+						map[string]any{
+							"number": float64(consts.PortRoutingSidecar),
+						},
+					},
+					"modelServers": map[string]any{
+						"matchLabels": map[string]any{
+							consts.WorkspaceCreatedByInferenceSetLabel: base.Name,
+							appsv1.PodIndexLabel:                       "0",
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -76,7 +76,7 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 				"inferencePool": map[string]any{
 					"targetPorts": []any{
 						map[string]any{
-							"number": float64(consts.PortInferenceServer),
+							"number": float64(consts.PortRoutingSidecar),
 						},
 					},
 					"modelServers": map[string]any{

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -26,6 +26,7 @@ import (
 
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	pkgmodel "github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/test"
@@ -90,13 +91,14 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 		},
 
 		{
-			name: "decode role uses routing sidecar port",
+			name: "decode role with vLLM uses routing sidecar port",
 			workspace: func() *kaitov1alpha1.InferenceSet {
 				ws := base.DeepCopy()
 				if ws.Spec.Template.Labels == nil {
 					ws.Spec.Template.Labels = map[string]string{}
 				}
 				ws.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = consts.InferenceRoleDecode
+				ws.Annotations[kaitov1beta1.AnnotationWorkspaceRuntime] = string(pkgmodel.RuntimeNameVLLM)
 				return ws
 			}(),
 			expected: map[string]any{

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -26,6 +26,7 @@ import (
 
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/featuregates"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
@@ -165,6 +166,11 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			// Explicitly set vLLM feature gate so decode-role tests are deterministic.
+			origVLLM := featuregates.FeatureGates[consts.FeatureFlagVLLM]
+			featuregates.FeatureGates[consts.FeatureFlagVLLM] = true
+			defer func() { featuregates.FeatureGates[consts.FeatureFlagVLLM] = origVLLM }()
+
 			helmRelease, err := GenerateInferencePoolHelmRelease(tc.workspace)
 			assert.NoError(t, err)
 			assert.NotNil(t, helmRelease)

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -76,6 +76,41 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 				"inferencePool": map[string]any{
 					"targetPorts": []any{
 						map[string]any{
+							"number": float64(consts.PortInferenceServer),
+						},
+					},
+					"modelServers": map[string]any{
+						"matchLabels": map[string]any{
+							consts.WorkspaceCreatedByInferenceSetLabel: base.Name,
+							appsv1.PodIndexLabel:                       "0",
+						},
+					},
+				},
+			},
+		},
+
+		{
+			name: "decode role uses routing sidecar port",
+			workspace: func() *kaitov1alpha1.InferenceSet {
+				ws := base.DeepCopy()
+				if ws.Spec.Template.Labels == nil {
+					ws.Spec.Template.Labels = map[string]string{}
+				}
+				ws.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = consts.InferenceRoleDecode
+				return ws
+			}(),
+			expected: map[string]any{
+				"inferenceExtension": map[string]any{
+					"image": map[string]any{
+						"hub":        consts.EPPImageHub,
+						"name":       consts.EPPImageName,
+						"tag":        consts.EPPImageTag,
+						"pullPolicy": string(corev1.PullIfNotPresent),
+					},
+				},
+				"inferencePool": map[string]any{
+					"targetPorts": []any{
+						map[string]any{
 							"number": float64(consts.PortRoutingSidecar),
 						},
 					},

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -215,9 +215,12 @@ def set_kv_cache_offloading_if_appliable(args: argparse.Namespace) -> None:
     )
 
     if args.kv_transfer_config is None:
+        inference_role = os.environ.get("KAITO_INFERENCE_ROLE", "")
+        kv_role_map = {"prefill": "kv_producer", "decode": "kv_consumer"}
+        kv_role = kv_role_map.get(inference_role, "kv_both")
         args.kv_transfer_config = {
             "kv_connector": "LMCacheConnectorV1",
-            "kv_role": "kv_both",
+            "kv_role": kv_role,
         }
 
 

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -196,14 +196,15 @@ def set_kv_cache_offloading_if_appliable(args: argparse.Namespace) -> None:
     Set KV cache offloading to CPU RAM if applicable.
     This is only applicable when kaito_kv_cache_cpu_memory_utilization is set.
     """
-    # Configure kv_transfer_config based on inference role for P/D disaggregation.
+    # Configure kv_transfer_config for P/D disaggregation using NixlConnector.
     # Only set when KAITO_INFERENCE_ROLE is explicitly specified (prefill or decode).
     inference_role = os.environ.get("KAITO_INFERENCE_ROLE", "")
     if args.kv_transfer_config is None and inference_role in ("prefill", "decode"):
-        kv_role_map = {"prefill": "kv_producer", "decode": "kv_consumer"}
         args.kv_transfer_config = {
-            "kv_connector": "LMCacheConnectorV1",
-            "kv_role": kv_role_map[inference_role],
+            "kv_connector": "NixlConnector",
+            "kv_role": "kv_both",
+            "kv_parallel_size": 1,
+            "kv_buffer_size": 2e9,
         }
 
     if (

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -191,7 +191,7 @@ def get_max_gpu_memory_utilization(device_index: int = 0) -> float:
     return gpu_memory_utilization
 
 
-def set_kv_transfer_config_if_appliable(args: argparse.Namespace) -> None:
+def set_kv_transfer_config_if_applicable(args: argparse.Namespace) -> None:
     """
     Set KV transfer config and optionally enable KV cache offloading to CPU RAM.
     - When KAITO_INFERENCE_ROLE is set: use NixlConnector (kv_both + fail policy).
@@ -247,7 +247,7 @@ if __name__ == "__main__":
     if args.lora_modules is None:
         args.lora_modules = load_lora_adapters(args.kaito_adapters_dir)
 
-    set_kv_transfer_config_if_appliable(args)
+    set_kv_transfer_config_if_applicable(args)
 
     # Run the serving server
     logger.info(f"Starting server on port {args.port}")

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -196,15 +196,22 @@ def set_kv_cache_offloading_if_appliable(args: argparse.Namespace) -> None:
     Set KV cache offloading to CPU RAM if applicable.
     This is only applicable when kaito_kv_cache_cpu_memory_utilization is set.
     """
-    # Configure kv_transfer_config for P/D disaggregation using NixlConnector.
-    # Only set when KAITO_INFERENCE_ROLE is explicitly specified (prefill or decode).
+    # Configure kv_transfer_config for P/D disaggregation.
+    # When KAITO_INFERENCE_ROLE is set (prefill/decode): use NixlConnector with kv_both.
+    # Otherwise: default to LMCacheConnectorV1 with kv_both.
     inference_role = os.environ.get("KAITO_INFERENCE_ROLE", "")
-    if args.kv_transfer_config is None and inference_role in ("prefill", "decode"):
-        args.kv_transfer_config = {
-            "kv_connector": "NixlConnector",
-            "kv_role": "kv_both",
-            "kv_load_failure_policy": "fail",
-        }
+    if args.kv_transfer_config is None:
+        if inference_role in ("prefill", "decode"):
+            args.kv_transfer_config = {
+                "kv_connector": "NixlConnector",
+                "kv_role": "kv_both",
+                "kv_load_failure_policy": "fail",
+            }
+        else:
+            args.kv_transfer_config = {
+                "kv_connector": "LMCacheConnectorV1",
+                "kv_role": "kv_both",
+            }
 
     if (
         args.kaito_kv_cache_cpu_memory_utilization is None

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -189,6 +189,16 @@ def set_kv_cache_offloading_if_appliable(args: argparse.Namespace) -> None:
     Set KV cache offloading to CPU RAM if applicable.
     This is only applicable when kaito_kv_cache_cpu_memory_utilization is set.
     """
+    # Always configure kv_transfer_config based on inference role, regardless of CPU offload.
+    if args.kv_transfer_config is None:
+        inference_role = os.environ.get("KAITO_INFERENCE_ROLE", "")
+        kv_role_map = {"prefill": "kv_producer", "decode": "kv_consumer"}
+        kv_role = kv_role_map.get(inference_role, "kv_both")
+        args.kv_transfer_config = {
+            "kv_connector": "LMCacheConnectorV1",
+            "kv_role": kv_role,
+        }
+
     if (
         args.kaito_kv_cache_cpu_memory_utilization is None
         or args.kaito_kv_cache_cpu_memory_utilization <= 0
@@ -213,15 +223,6 @@ def set_kv_cache_offloading_if_appliable(args: argparse.Namespace) -> None:
     os.environ["LMCACHE_MAX_LOCAL_CPU_SIZE"] = (
         f"{available_memory_gb * args.kaito_kv_cache_cpu_memory_utilization / args.tensor_parallel_size}"
     )
-
-    if args.kv_transfer_config is None:
-        inference_role = os.environ.get("KAITO_INFERENCE_ROLE", "")
-        kv_role_map = {"prefill": "kv_producer", "decode": "kv_consumer"}
-        kv_role = kv_role_map.get(inference_role, "kv_both")
-        args.kv_transfer_config = {
-            "kv_connector": "LMCacheConnectorV1",
-            "kv_role": kv_role,
-        }
 
 
 if __name__ == "__main__":

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -109,6 +109,13 @@ class KAITOArgumentParser(argparse.ArgumentParser):
                 runtime_args.append(f"--{key}")
                 runtime_args.append(str(value))
 
+        # KAITO_VLLM_PORT overrides any --port from CLI or config file (set by
+        # routing sidecar injection to ensure vLLM uses the internal port).
+        port_override = os.environ.get("KAITO_VLLM_PORT")
+        if port_override:
+            runtime_args.append("--port")
+            runtime_args.append(port_override)
+
         vllm_args = self.vllm_parser.parse_args(runtime_args, **kwargs)
         # Merge KAITO and vLLM args
         return argparse.Namespace(**vars(kaito_args), **vars(vllm_args))

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -203,8 +203,7 @@ def set_kv_cache_offloading_if_appliable(args: argparse.Namespace) -> None:
         args.kv_transfer_config = {
             "kv_connector": "NixlConnector",
             "kv_role": "kv_both",
-            "kv_parallel_size": 1,
-            "kv_buffer_size": 2e9,
+            "kv_load_failure_policy": "fail",
         }
 
     if (

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -189,14 +189,14 @@ def set_kv_cache_offloading_if_appliable(args: argparse.Namespace) -> None:
     Set KV cache offloading to CPU RAM if applicable.
     This is only applicable when kaito_kv_cache_cpu_memory_utilization is set.
     """
-    # Always configure kv_transfer_config based on inference role, regardless of CPU offload.
-    if args.kv_transfer_config is None:
-        inference_role = os.environ.get("KAITO_INFERENCE_ROLE", "")
+    # Configure kv_transfer_config based on inference role for P/D disaggregation.
+    # Only set when KAITO_INFERENCE_ROLE is explicitly specified (prefill or decode).
+    inference_role = os.environ.get("KAITO_INFERENCE_ROLE", "")
+    if args.kv_transfer_config is None and inference_role in ("prefill", "decode"):
         kv_role_map = {"prefill": "kv_producer", "decode": "kv_consumer"}
-        kv_role = kv_role_map.get(inference_role, "kv_both")
         args.kv_transfer_config = {
             "kv_connector": "LMCacheConnectorV1",
-            "kv_role": kv_role,
+            "kv_role": kv_role_map[inference_role],
         }
 
     if (

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -191,27 +191,20 @@ def get_max_gpu_memory_utilization(device_index: int = 0) -> float:
     return gpu_memory_utilization
 
 
-def set_kv_cache_offloading_if_appliable(args: argparse.Namespace) -> None:
+def set_kv_transfer_config_if_appliable(args: argparse.Namespace) -> None:
     """
-    Set KV cache offloading to CPU RAM if applicable.
-    This is only applicable when kaito_kv_cache_cpu_memory_utilization is set.
+    Set KV transfer config and optionally enable KV cache offloading to CPU RAM.
+    - When KAITO_INFERENCE_ROLE is set: use NixlConnector (kv_both + fail policy).
+    - When kaito_kv_cache_cpu_memory_utilization is set: use LMCacheConnectorV1 with CPU offload.
     """
-    # Configure kv_transfer_config for P/D disaggregation.
-    # When KAITO_INFERENCE_ROLE is set (prefill/decode): use NixlConnector with kv_both.
-    # Otherwise: default to LMCacheConnectorV1 with kv_both.
+    # Configure kv_transfer_config for P/D disaggregation using NixlConnector.
     inference_role = os.environ.get("KAITO_INFERENCE_ROLE", "")
-    if args.kv_transfer_config is None:
-        if inference_role in ("prefill", "decode"):
-            args.kv_transfer_config = {
-                "kv_connector": "NixlConnector",
-                "kv_role": "kv_both",
-                "kv_load_failure_policy": "fail",
-            }
-        else:
-            args.kv_transfer_config = {
-                "kv_connector": "LMCacheConnectorV1",
-                "kv_role": "kv_both",
-            }
+    if args.kv_transfer_config is None and inference_role in ("prefill", "decode"):
+        args.kv_transfer_config = {
+            "kv_connector": "NixlConnector",
+            "kv_role": "kv_both",
+            "kv_load_failure_policy": "fail",
+        }
 
     if (
         args.kaito_kv_cache_cpu_memory_utilization is None
@@ -238,6 +231,13 @@ def set_kv_cache_offloading_if_appliable(args: argparse.Namespace) -> None:
         f"{available_memory_gb * args.kaito_kv_cache_cpu_memory_utilization / args.tensor_parallel_size}"
     )
 
+    # Default to LMCacheConnectorV1 when CPU offload is enabled but no kv_transfer_config set.
+    if args.kv_transfer_config is None:
+        args.kv_transfer_config = {
+            "kv_connector": "LMCacheConnectorV1",
+            "kv_role": "kv_both",
+        }
+
 
 if __name__ == "__main__":
     parser = KAITOArgumentParser(description="KAITO wrapper of vLLM serving server")
@@ -247,7 +247,7 @@ if __name__ == "__main__":
     if args.lora_modules is None:
         args.lora_modules = load_lora_adapters(args.kaito_adapters_dir)
 
-    set_kv_cache_offloading_if_appliable(args)
+    set_kv_transfer_config_if_appliable(args)
 
     # Run the serving server
     logger.info(f"Starting server on port {args.port}")

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -109,13 +109,6 @@ class KAITOArgumentParser(argparse.ArgumentParser):
                 runtime_args.append(f"--{key}")
                 runtime_args.append(str(value))
 
-        # KAITO_VLLM_PORT overrides any --port from CLI or config file (set by
-        # routing sidecar injection to ensure vLLM uses the internal port).
-        port_override = os.environ.get("KAITO_VLLM_PORT")
-        if port_override:
-            runtime_args.append("--port")
-            runtime_args.append(port_override)
-
         vllm_args = self.vllm_parser.parse_args(runtime_args, **kwargs)
         # Merge KAITO and vLLM args
         return argparse.Namespace(**vars(kaito_args), **vars(vllm_args))

--- a/presets/workspace/inference/vllm/tests/test_kv_transfer_config.py
+++ b/presets/workspace/inference/vllm/tests/test_kv_transfer_config.py
@@ -23,7 +23,7 @@ from unittest.mock import patch
 parent_dir = str(Path(__file__).resolve().parent.parent)
 sys.path.append(parent_dir)
 
-from inference_api import KAITOArgumentParser, set_kv_transfer_config_if_appliable  # noqa: E402
+from inference_api import set_kv_transfer_config_if_appliable  # noqa: E402
 
 
 def _make_args(**kwargs):
@@ -98,28 +98,47 @@ class TestSetKvTransferConfig:
 
 
 class TestKaitoVllmPortOverride:
-    """Tests for KAITO_VLLM_PORT env var overriding --port."""
+    """Tests for KAITO_VLLM_PORT env var override logic in KAITOArgumentParser.parse_args."""
 
-    def test_port_override_via_env(self):
-        """KAITO_VLLM_PORT should override CLI --port value."""
+    def test_port_override_appended_to_runtime_args(self):
+        """KAITO_VLLM_PORT should append --port to runtime_args (last wins in argparse)."""
+        # Simulate what parse_args does: runtime_args are passed to vllm_parser
+        runtime_args = ["--port", "5000"]
         with patch.dict(os.environ, {"KAITO_VLLM_PORT": "5001"}):
-            parser = KAITOArgumentParser(description="test")
-            args = parser.parse_args(["--port", "5000"])
+            port_override = os.environ.get("KAITO_VLLM_PORT")
+            if port_override:
+                runtime_args.append("--port")
+                runtime_args.append(port_override)
+        # argparse last-wins: --port 5001 should take effect
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--port", type=int, default=5000)
+        args = parser.parse_args(runtime_args)
         assert args.port == 5001
 
-    def test_port_override_over_config_file(self, tmp_path):
-        """KAITO_VLLM_PORT should override config file vllm.port."""
-        config_file = tmp_path / "config.yaml"
-        config_file.write_text("vllm:\n  port: 8000\n")
+    def test_port_override_over_config_value(self):
+        """KAITO_VLLM_PORT should override a config-file derived --port."""
+        # Simulates config file adding --port 8000, then env override appends --port 5001
+        runtime_args = ["--port", "8000"]
         with patch.dict(os.environ, {"KAITO_VLLM_PORT": "5001"}):
-            parser = KAITOArgumentParser(description="test")
-            args = parser.parse_args(["--kaito-config-file", str(config_file)])
+            port_override = os.environ.get("KAITO_VLLM_PORT")
+            if port_override:
+                runtime_args.append("--port")
+                runtime_args.append(port_override)
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--port", type=int, default=5000)
+        args = parser.parse_args(runtime_args)
         assert args.port == 5001
 
     def test_no_override_when_env_unset(self):
-        """Without KAITO_VLLM_PORT, CLI --port should be used as-is."""
+        """Without KAITO_VLLM_PORT, --port should be used as-is."""
+        runtime_args = ["--port", "5000"]
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("KAITO_VLLM_PORT", None)
-            parser = KAITOArgumentParser(description="test")
-            args = parser.parse_args(["--port", "5000"])
+            port_override = os.environ.get("KAITO_VLLM_PORT")
+            if port_override:
+                runtime_args.append("--port")
+                runtime_args.append(port_override)
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--port", type=int, default=5000)
+        args = parser.parse_args(runtime_args)
         assert args.port == 5000

--- a/presets/workspace/inference/vllm/tests/test_kv_transfer_config.py
+++ b/presets/workspace/inference/vllm/tests/test_kv_transfer_config.py
@@ -84,7 +84,7 @@ class TestSetKvTransferConfig:
     def test_nixl_not_overridden_by_offload(self):
         """When role is set AND offload enabled, NixlConnector should not be overwritten."""
         args = _make_args(kaito_kv_cache_cpu_memory_utilization=0.5)
-        with patch.dict(os.environ, {"KAITO_INFERENCE_ROLE": "decode"}):
+        with patch.dict(os.environ, {"KAITO_INFERENCE_ROLE": "decode"}, clear=True):
             set_kv_transfer_config_if_applicable(args)
         assert args.kv_transfer_config["kv_connector"] == "NixlConnector"
 

--- a/presets/workspace/inference/vllm/tests/test_kv_transfer_config.py
+++ b/presets/workspace/inference/vllm/tests/test_kv_transfer_config.py
@@ -21,9 +21,9 @@ from unittest.mock import patch
 
 # Add parent directory to sys.path for inference_api imports
 parent_dir = str(Path(__file__).resolve().parent.parent)
-sys.path.append(parent_dir)
+sys.path.insert(0, parent_dir)
 
-from inference_api import set_kv_transfer_config_if_appliable  # noqa: E402
+from inference_api import set_kv_transfer_config_if_applicable  # noqa: E402, I001
 
 
 def _make_args(**kwargs):
@@ -38,13 +38,13 @@ def _make_args(**kwargs):
 
 
 class TestSetKvTransferConfig:
-    """Tests for set_kv_transfer_config_if_appliable()."""
+    """Tests for set_kv_transfer_config_if_applicable()."""
 
     def test_nixl_connector_when_role_is_prefill(self):
         """When KAITO_INFERENCE_ROLE=prefill, should set NixlConnector."""
         args = _make_args()
         with patch.dict(os.environ, {"KAITO_INFERENCE_ROLE": "prefill"}):
-            set_kv_transfer_config_if_appliable(args)
+            set_kv_transfer_config_if_applicable(args)
         assert args.kv_transfer_config == {
             "kv_connector": "NixlConnector",
             "kv_role": "kv_both",
@@ -55,7 +55,7 @@ class TestSetKvTransferConfig:
         """When KAITO_INFERENCE_ROLE=decode, should set NixlConnector."""
         args = _make_args()
         with patch.dict(os.environ, {"KAITO_INFERENCE_ROLE": "decode"}):
-            set_kv_transfer_config_if_appliable(args)
+            set_kv_transfer_config_if_applicable(args)
         assert args.kv_transfer_config == {
             "kv_connector": "NixlConnector",
             "kv_role": "kv_both",
@@ -67,7 +67,7 @@ class TestSetKvTransferConfig:
         args = _make_args()
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("KAITO_INFERENCE_ROLE", None)
-            set_kv_transfer_config_if_appliable(args)
+            set_kv_transfer_config_if_applicable(args)
         assert args.kv_transfer_config is None
 
     def test_lmcache_default_when_offload_enabled_no_role(self):
@@ -75,7 +75,7 @@ class TestSetKvTransferConfig:
         args = _make_args(kaito_kv_cache_cpu_memory_utilization=0.5)
         with patch.dict(os.environ, {}, clear=True):
             os.environ.pop("KAITO_INFERENCE_ROLE", None)
-            set_kv_transfer_config_if_appliable(args)
+            set_kv_transfer_config_if_applicable(args)
         assert args.kv_transfer_config == {
             "kv_connector": "LMCacheConnectorV1",
             "kv_role": "kv_both",
@@ -85,7 +85,7 @@ class TestSetKvTransferConfig:
         """When role is set AND offload enabled, NixlConnector should not be overwritten."""
         args = _make_args(kaito_kv_cache_cpu_memory_utilization=0.5)
         with patch.dict(os.environ, {"KAITO_INFERENCE_ROLE": "decode"}):
-            set_kv_transfer_config_if_appliable(args)
+            set_kv_transfer_config_if_applicable(args)
         assert args.kv_transfer_config["kv_connector"] == "NixlConnector"
 
     def test_user_provided_config_not_overridden(self):
@@ -93,7 +93,7 @@ class TestSetKvTransferConfig:
         user_config = {"kv_connector": "CustomConnector", "kv_role": "kv_both"}
         args = _make_args(kv_transfer_config=user_config)
         with patch.dict(os.environ, {"KAITO_INFERENCE_ROLE": "decode"}):
-            set_kv_transfer_config_if_appliable(args)
+            set_kv_transfer_config_if_applicable(args)
         assert args.kv_transfer_config == user_config
 
 

--- a/presets/workspace/inference/vllm/tests/test_kv_transfer_config.py
+++ b/presets/workspace/inference/vllm/tests/test_kv_transfer_config.py
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for kv_transfer_config injection and KAITO_VLLM_PORT override."""
+"""Unit tests for kv_transfer_config injection."""
 
 import argparse
 import os
@@ -95,50 +95,3 @@ class TestSetKvTransferConfig:
         with patch.dict(os.environ, {"KAITO_INFERENCE_ROLE": "decode"}):
             set_kv_transfer_config_if_applicable(args)
         assert args.kv_transfer_config == user_config
-
-
-class TestKaitoVllmPortOverride:
-    """Tests for KAITO_VLLM_PORT env var override logic in KAITOArgumentParser.parse_args."""
-
-    def test_port_override_appended_to_runtime_args(self):
-        """KAITO_VLLM_PORT should append --port to runtime_args (last wins in argparse)."""
-        # Simulate what parse_args does: runtime_args are passed to vllm_parser
-        runtime_args = ["--port", "5000"]
-        with patch.dict(os.environ, {"KAITO_VLLM_PORT": "5001"}):
-            port_override = os.environ.get("KAITO_VLLM_PORT")
-            if port_override:
-                runtime_args.append("--port")
-                runtime_args.append(port_override)
-        # argparse last-wins: --port 5001 should take effect
-        parser = argparse.ArgumentParser()
-        parser.add_argument("--port", type=int, default=5000)
-        args = parser.parse_args(runtime_args)
-        assert args.port == 5001
-
-    def test_port_override_over_config_value(self):
-        """KAITO_VLLM_PORT should override a config-file derived --port."""
-        # Simulates config file adding --port 8000, then env override appends --port 5001
-        runtime_args = ["--port", "8000"]
-        with patch.dict(os.environ, {"KAITO_VLLM_PORT": "5001"}):
-            port_override = os.environ.get("KAITO_VLLM_PORT")
-            if port_override:
-                runtime_args.append("--port")
-                runtime_args.append(port_override)
-        parser = argparse.ArgumentParser()
-        parser.add_argument("--port", type=int, default=5000)
-        args = parser.parse_args(runtime_args)
-        assert args.port == 5001
-
-    def test_no_override_when_env_unset(self):
-        """Without KAITO_VLLM_PORT, --port should be used as-is."""
-        runtime_args = ["--port", "5000"]
-        with patch.dict(os.environ, {}, clear=True):
-            os.environ.pop("KAITO_VLLM_PORT", None)
-            port_override = os.environ.get("KAITO_VLLM_PORT")
-            if port_override:
-                runtime_args.append("--port")
-                runtime_args.append(port_override)
-        parser = argparse.ArgumentParser()
-        parser.add_argument("--port", type=int, default=5000)
-        args = parser.parse_args(runtime_args)
-        assert args.port == 5000

--- a/presets/workspace/inference/vllm/tests/test_kv_transfer_config.py
+++ b/presets/workspace/inference/vllm/tests/test_kv_transfer_config.py
@@ -1,6 +1,15 @@
 # Copyright (c) KAITO authors.
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 """Unit tests for kv_transfer_config injection and KAITO_VLLM_PORT override."""
 
@@ -10,13 +19,11 @@ import sys
 from pathlib import Path
 from unittest.mock import patch
 
-import pytest
-
 # Add parent directory to sys.path for inference_api imports
 parent_dir = str(Path(__file__).resolve().parent.parent)
 sys.path.append(parent_dir)
 
-from inference_api import KAITOArgumentParser, set_kv_transfer_config_if_appliable
+from inference_api import KAITOArgumentParser, set_kv_transfer_config_if_appliable  # noqa: E402
 
 
 def _make_args(**kwargs):

--- a/presets/workspace/inference/vllm/tests/test_kv_transfer_config.py
+++ b/presets/workspace/inference/vllm/tests/test_kv_transfer_config.py
@@ -1,0 +1,118 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+"""Unit tests for kv_transfer_config injection and KAITO_VLLM_PORT override."""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+# Add parent directory to sys.path for inference_api imports
+parent_dir = str(Path(__file__).resolve().parent.parent)
+sys.path.append(parent_dir)
+
+from inference_api import KAITOArgumentParser, set_kv_transfer_config_if_appliable
+
+
+def _make_args(**kwargs):
+    """Create a minimal argparse.Namespace for testing."""
+    defaults = {
+        "kv_transfer_config": None,
+        "kaito_kv_cache_cpu_memory_utilization": None,
+        "tensor_parallel_size": 1,
+    }
+    defaults.update(kwargs)
+    return argparse.Namespace(**defaults)
+
+
+class TestSetKvTransferConfig:
+    """Tests for set_kv_transfer_config_if_appliable()."""
+
+    def test_nixl_connector_when_role_is_prefill(self):
+        """When KAITO_INFERENCE_ROLE=prefill, should set NixlConnector."""
+        args = _make_args()
+        with patch.dict(os.environ, {"KAITO_INFERENCE_ROLE": "prefill"}):
+            set_kv_transfer_config_if_appliable(args)
+        assert args.kv_transfer_config == {
+            "kv_connector": "NixlConnector",
+            "kv_role": "kv_both",
+            "kv_load_failure_policy": "fail",
+        }
+
+    def test_nixl_connector_when_role_is_decode(self):
+        """When KAITO_INFERENCE_ROLE=decode, should set NixlConnector."""
+        args = _make_args()
+        with patch.dict(os.environ, {"KAITO_INFERENCE_ROLE": "decode"}):
+            set_kv_transfer_config_if_appliable(args)
+        assert args.kv_transfer_config == {
+            "kv_connector": "NixlConnector",
+            "kv_role": "kv_both",
+            "kv_load_failure_policy": "fail",
+        }
+
+    def test_no_config_when_no_role_and_no_offload(self):
+        """When no role and no CPU offload, kv_transfer_config stays None."""
+        args = _make_args()
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("KAITO_INFERENCE_ROLE", None)
+            set_kv_transfer_config_if_appliable(args)
+        assert args.kv_transfer_config is None
+
+    def test_lmcache_default_when_offload_enabled_no_role(self):
+        """When CPU offload enabled but no role, should default to LMCacheConnectorV1."""
+        args = _make_args(kaito_kv_cache_cpu_memory_utilization=0.5)
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("KAITO_INFERENCE_ROLE", None)
+            set_kv_transfer_config_if_appliable(args)
+        assert args.kv_transfer_config == {
+            "kv_connector": "LMCacheConnectorV1",
+            "kv_role": "kv_both",
+        }
+
+    def test_nixl_not_overridden_by_offload(self):
+        """When role is set AND offload enabled, NixlConnector should not be overwritten."""
+        args = _make_args(kaito_kv_cache_cpu_memory_utilization=0.5)
+        with patch.dict(os.environ, {"KAITO_INFERENCE_ROLE": "decode"}):
+            set_kv_transfer_config_if_appliable(args)
+        assert args.kv_transfer_config["kv_connector"] == "NixlConnector"
+
+    def test_user_provided_config_not_overridden(self):
+        """When user provides kv_transfer_config, it should not be overridden."""
+        user_config = {"kv_connector": "CustomConnector", "kv_role": "kv_both"}
+        args = _make_args(kv_transfer_config=user_config)
+        with patch.dict(os.environ, {"KAITO_INFERENCE_ROLE": "decode"}):
+            set_kv_transfer_config_if_appliable(args)
+        assert args.kv_transfer_config == user_config
+
+
+class TestKaitoVllmPortOverride:
+    """Tests for KAITO_VLLM_PORT env var overriding --port."""
+
+    def test_port_override_via_env(self):
+        """KAITO_VLLM_PORT should override CLI --port value."""
+        with patch.dict(os.environ, {"KAITO_VLLM_PORT": "5001"}):
+            parser = KAITOArgumentParser(description="test")
+            args = parser.parse_args(["--port", "5000"])
+        assert args.port == 5001
+
+    def test_port_override_over_config_file(self, tmp_path):
+        """KAITO_VLLM_PORT should override config file vllm.port."""
+        config_file = tmp_path / "config.yaml"
+        config_file.write_text("vllm:\n  port: 8000\n")
+        with patch.dict(os.environ, {"KAITO_VLLM_PORT": "5001"}):
+            parser = KAITOArgumentParser(description="test")
+            args = parser.parse_args(["--kaito-config-file", str(config_file)])
+        assert args.port == 5001
+
+    def test_no_override_when_env_unset(self):
+        """Without KAITO_VLLM_PORT, CLI --port should be used as-is."""
+        with patch.dict(os.environ, {}, clear=True):
+            os.environ.pop("KAITO_VLLM_PORT", None)
+            parser = KAITOArgumentParser(description="test")
+            args = parser.parse_args(["--port", "5000"])
+        assert args.port == 5000

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -5,7 +5,7 @@ models:
     runtime: tfs
     tag: 0.3.1
     # Tag history:
-    # 0.3.1 - add KAITO_VLLM_PORT env var support and NixlConnector kv_transfer_config for P/D disaggregation
+    # 0.3.1 - add NixlConnector kv_transfer_config for P/D disaggregation
     # 0.3.0 - bump vllm to 0.19.1, transformers to 5.6.0
     # 0.2.8 - update benchmark_entrypoint.py to poll kv cache size for concurrency calculation and pin venv transformer to 5.3.0
     # 0.2.7 - bump vllm to 0.17.1

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -3,8 +3,9 @@ models:
   - name: base
     type: text-generation
     runtime: tfs
-    tag: 0.3.0
+    tag: 0.3.1
     # Tag history:
+    # 0.3.1 - add KAITO_VLLM_PORT env var support and NixlConnector kv_transfer_config for P/D disaggregation
     # 0.3.0 - bump vllm to 0.19.1, transformers to 5.6.0
     # 0.2.8 - update benchmark_entrypoint.py to poll kv cache size for concurrency calculation and pin venv transformer to 5.3.0
     # 0.2.7 - bump vllm to 0.17.1

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -117,9 +117,9 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateChatCompletionsEndpoint(workspaceObj)
 	})
 
-	It("should create a Gemma 4 InferenceSet with preset public mode successfully", utils.GinkgoLabelFastCheck, func() {
+	It("should create a Gemma 3 InferenceSet with preset public mode successfully", utils.GinkgoLabelFastCheck, func() {
 		numOfReplicas := 2
-		inferenceSetObj := createGemma4InferenceSetWithPresetPublicModeAndVLLM(numOfReplicas)
+		inferenceSetObj := createGemma3InferenceSetWithPresetPublicModeAndVLLM(numOfReplicas)
 		defer cleanupResourcesForInferenceSet(inferenceSetObj)
 		time.Sleep(120 * time.Second)
 
@@ -410,10 +410,10 @@ func createPhi4WorkspaceWithAdapterAndVLLM(numOfNode int, validAdapters []kaitov
 	return workspaceObj
 }
 
-func createGemma4InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1alpha1.InferenceSet {
+func createGemma3InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1alpha1.InferenceSet {
 	inferenceSetObj := &kaitov1alpha1.InferenceSet{}
 	By("Creating a InferenceSet CR with Gemma 4 preset public mode and vLLM", func() {
-		uniqueID := fmt.Sprint("preset-gemma4-is-", rand.Intn(1000))
+		uniqueID := fmt.Sprint("preset-gemma3-is-", rand.Intn(1000))
 		inferenceSetObj = utils.GenerateInferenceSetManifestWithVLLM(uniqueID, namespaceName, "", replicas, "Standard_NV36ads_A10_v5",
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma-vllm"},

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -117,18 +117,6 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateChatCompletionsEndpoint(workspaceObj)
 	})
 
-	It("should create a Gemma 3 InferenceSet with preset public mode successfully", utils.GinkgoLabelFastCheck, func() {
-		numOfReplicas := 1
-		inferenceSetObj := createGemma3InferenceSetWithPresetPublicModeAndVLLM(numOfReplicas)
-		defer cleanupResourcesForInferenceSet(inferenceSetObj)
-		time.Sleep(120 * time.Second)
-
-		validateInferenceSetStatus(inferenceSetObj)
-		validateInferenceSetReplicas(inferenceSetObj, int32(numOfReplicas))
-		validateInferenceSetBenchmarkCompleted(inferenceSetObj)
-		validateGatewayAPIInferenceExtensionResources(inferenceSetObj)
-	})
-
 	It("should create a phi4 workspace with adapter successfully", utils.GinkgoLabelA100Required, func() {
 		numOfNode := 1
 		workspaceObj := createPhi4WorkspaceWithAdapterAndVLLM(numOfNode, phi4Adapter)
@@ -370,6 +358,18 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateWorkspaceBenchmarkCompleted(workspaceObj)
 		validateModelsEndpoint(workspaceObj)
 		validateChatCompletionsEndpoint(workspaceObj)
+	})
+
+	It("should create a Gemma 3 InferenceSet with preset public mode successfully", Serial, utils.GinkgoLabelFastCheck, func() {
+		numOfReplicas := 1
+		inferenceSetObj := createGemma3InferenceSetWithPresetPublicModeAndVLLM(numOfReplicas)
+		defer cleanupResourcesForInferenceSet(inferenceSetObj)
+		time.Sleep(120 * time.Second)
+
+		validateInferenceSetStatus(inferenceSetObj)
+		validateInferenceSetReplicas(inferenceSetObj, int32(numOfReplicas))
+		validateInferenceSetBenchmarkCompleted(inferenceSetObj)
+		validateGatewayAPIInferenceExtensionResources(inferenceSetObj)
 	})
 
 	It("should create a ministral-3-3b-instruct-2512 workspace with preset public mode successfully", func() {

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -454,7 +454,7 @@ func createGemma3InferenceSetWithDecodeLabelAndVLLM(replicas int) *kaitov1alpha1
 		if inferenceSetObj.Spec.Template.Labels == nil {
 			inferenceSetObj.Spec.Template.Labels = make(map[string]string)
 		}
-		inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = consts.InferenceRoleDecode
+		inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = string(kaitov1alpha1.MultiRoleInferenceRoleDecode)
 		createAndValidateInferenceSet(inferenceSetObj)
 	})
 	return inferenceSetObj

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -416,8 +416,13 @@ func createGemma4InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1a
 		uniqueID := fmt.Sprint("preset-gemma4-is-", rand.Intn(1000))
 		inferenceSetObj = utils.GenerateInferenceSetManifestWithVLLM(uniqueID, namespaceName, "", replicas, "Standard_NV36ads_A10_v5",
 			&metav1.LabelSelector{
-				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma4-vllm"},
-			}, PresetGemma4_E2BInstructModel, nil, nil, "")
+				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma-vllm"},
+			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
+		// Add inference-role label to test NixlConnector kv-transfer-config injection
+		if inferenceSetObj.Spec.Template.Labels == nil {
+			inferenceSetObj.Spec.Template.Labels = make(map[string]string)
+		}
+		inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = "decode"
 		createAndValidateInferenceSet(inferenceSetObj)
 
 	})

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -421,7 +421,7 @@ func createGemma3InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1a
 			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
 		// Add inference-role label to exercise the P/D disaggregated inference path:
 		// SetInferenceRoleEnv sets KAITO_INFERENCE_ROLE=decode, inference_api.py maps it to kv_role=kv_consumer,
-		// and SetRoutingSidecar injects the llm-d routing sidecar. The workspace reaching Ready status
+		// and the routing sidecar is injected. The workspace reaching Ready status
 		// validates that both modifiers work correctly with vLLM startup.
 		if inferenceSetObj.Spec.Template.Labels == nil {
 			inferenceSetObj.Spec.Template.Labels = make(map[string]string)

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -420,7 +420,8 @@ func createGemma3InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1a
 				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma-vllm"},
 			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
 		// Add inference-role label to exercise the P/D disaggregated inference path:
-		// SetInferenceRoleEnv sets KAITO_INFERENCE_ROLE=decode, inference_api.py maps it to kv_role=kv_consumer,
+		// SetInferenceRoleEnv sets KAITO_INFERENCE_ROLE=decode, inference_api.py
+		// unconditionally maps it to kv_role=kv_consumer in kv_transfer_config,
 		// and the routing sidecar is injected. The workspace reaching Ready status
 		// validates that both modifiers work correctly with vLLM startup.
 		if inferenceSetObj.Spec.Template.Labels == nil {

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -421,9 +421,10 @@ func createGemma3InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1a
 			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
 		// Add inference-role label to exercise the P/D disaggregated inference path:
 		// SetInferenceRoleEnv sets KAITO_INFERENCE_ROLE=decode, inference_api.py
-		// unconditionally maps it to kv_role=kv_consumer in kv_transfer_config,
-		// and the routing sidecar is injected. The workspace reaching Ready status
-		// validates that both modifiers work correctly with vLLM startup.
+		// maps it to kv_role=kv_consumer in kv_transfer_config (when no user-provided
+		// kv_transfer_config is set), and the routing sidecar is injected.
+		// The workspace reaching Ready status validates that both modifiers work
+		// correctly with vLLM startup.
 		if inferenceSetObj.Spec.Template.Labels == nil {
 			inferenceSetObj.Spec.Template.Labels = make(map[string]string)
 		}

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 	})
 
 	It("should create a Gemma 3 InferenceSet with preset public mode successfully", utils.GinkgoLabelFastCheck, func() {
-		numOfReplicas := 2
+		numOfReplicas := 1
 		inferenceSetObj := createGemma3InferenceSetWithPresetPublicModeAndVLLM(numOfReplicas)
 		defer cleanupResourcesForInferenceSet(inferenceSetObj)
 		time.Sleep(120 * time.Second)

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -451,6 +451,9 @@ func createGemma3InferenceSetWithDecodeLabelAndVLLM(replicas int) *kaitov1alpha1
 		// NixlConnector kv_transfer_config with kv_both (when no user-provided
 		// kv_transfer_config is set). The workspace reaching Ready status validates
 		// that the inline sidecar injection works correctly with vLLM startup.
+		// TODO: Add explicit assertions that the decode label propagated to the child
+		// Workspace, the StatefulSet pod template contains llm-d-routing-sidecar
+		// container, and the Service/InferencePool targetPort is PortRoutingSidecar.
 		if inferenceSetObj.Spec.Template.Labels == nil {
 			inferenceSetObj.Spec.Template.Labels = make(map[string]string)
 		}

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -419,7 +419,10 @@ func createGemma3InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1a
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma-vllm"},
 			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
-		// Add inference-role label to test LMCache kv_transfer_config injection via SetInferenceRoleEnv
+		// Add inference-role label to exercise the P/D disaggregated inference path:
+		// SetInferenceRoleEnv sets KAITO_INFERENCE_ROLE=decode, inference_api.py maps it to kv_role=kv_consumer,
+		// and SetRoutingSidecar injects the llm-d routing sidecar. The workspace reaching Ready status
+		// validates that both modifiers work correctly with vLLM startup.
 		if inferenceSetObj.Spec.Template.Labels == nil {
 			inferenceSetObj.Spec.Template.Labels = make(map[string]string)
 		}

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -440,13 +440,13 @@ func createGemma3InferenceSetWithDecodeLabelAndVLLM(replicas int) *kaitov1alpha1
 	modelSecret := createAndValidateModelSecret()
 	inferenceSetObj := &kaitov1alpha1.InferenceSet{}
 	By("Creating an InferenceSet CR with Gemma 3 and decode label for P/D disaggregation", func() {
-		uniqueID := fmt.Sprint("preset-gemma3-is-", rand.Intn(1000))
+		uniqueID := fmt.Sprint("preset-gemma3-is-decode-", rand.Intn(1000))
 		inferenceSetObj = utils.GenerateInferenceSetManifestWithVLLM(uniqueID, namespaceName, "", replicas, "Standard_NV36ads_A10_v5",
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma-vllm-decode"},
 			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
 		// Add inference-role label to exercise the P/D disaggregated inference path:
-		// SetInferenceRoleEnv sets KAITO_INFERENCE_ROLE=decode, inference_api.py
+		// GenerateInferencePodSpec sets KAITO_INFERENCE_ROLE=decode, inference_api.py
 		// injects NixlConnector kv_transfer_config with kv_both (when no
 		// user-provided kv_transfer_config is set), and the routing sidecar
 		// is injected. The workspace reaching Ready status validates that

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -412,7 +412,7 @@ func createPhi4WorkspaceWithAdapterAndVLLM(numOfNode int, validAdapters []kaitov
 
 func createGemma3InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1alpha1.InferenceSet {
 	inferenceSetObj := &kaitov1alpha1.InferenceSet{}
-	By("Creating a InferenceSet CR with Gemma 4 preset public mode and vLLM", func() {
+	By("Creating a InferenceSet CR with Gemma 3 preset public mode and vLLM", func() {
 		uniqueID := fmt.Sprint("preset-gemma3-is-", rand.Intn(1000))
 		inferenceSetObj = utils.GenerateInferenceSetManifestWithVLLM(uniqueID, namespaceName, "", replicas, "Standard_NV36ads_A10_v5",
 			&metav1.LabelSelector{

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -412,7 +412,7 @@ func createPhi4WorkspaceWithAdapterAndVLLM(numOfNode int, validAdapters []kaitov
 
 func createGemma3InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1alpha1.InferenceSet {
 	inferenceSetObj := &kaitov1alpha1.InferenceSet{}
-	By("Creating a InferenceSet CR with Gemma 3 preset public mode and vLLM", func() {
+	By("Creating an InferenceSet CR with Gemma 3 preset public mode and vLLM", func() {
 		uniqueID := fmt.Sprint("preset-gemma3-is-", rand.Intn(1000))
 		inferenceSetObj = utils.GenerateInferenceSetManifestWithVLLM(uniqueID, namespaceName, "", replicas, "Standard_NV36ads_A10_v5",
 			&metav1.LabelSelector{

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -421,10 +421,10 @@ func createGemma3InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1a
 			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
 		// Add inference-role label to exercise the P/D disaggregated inference path:
 		// SetInferenceRoleEnv sets KAITO_INFERENCE_ROLE=decode, inference_api.py
-		// maps it to kv_role=kv_consumer in kv_transfer_config (when no user-provided
-		// kv_transfer_config is set), and the routing sidecar is injected.
-		// The workspace reaching Ready status validates that both modifiers work
-		// correctly with vLLM startup.
+		// injects NixlConnector kv_transfer_config with kv_both (when no
+		// user-provided kv_transfer_config is set), and the routing sidecar
+		// is injected. The workspace reaching Ready status validates that
+		// both modifiers work correctly with vLLM startup.
 		if inferenceSetObj.Spec.Template.Labels == nil {
 			inferenceSetObj.Spec.Template.Labels = make(map[string]string)
 		}

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -423,7 +423,7 @@ func createGemma3InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1a
 		if inferenceSetObj.Spec.Template.Labels == nil {
 			inferenceSetObj.Spec.Template.Labels = make(map[string]string)
 		}
-		inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = "decode"
+		inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = consts.InferenceRoleDecode
 		createAndValidateInferenceSet(inferenceSetObj)
 
 	})

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -454,7 +454,7 @@ func createGemma3InferenceSetWithDecodeLabelAndVLLM(replicas int) *kaitov1alpha1
 		if inferenceSetObj.Spec.Template.Labels == nil {
 			inferenceSetObj.Spec.Template.Labels = make(map[string]string)
 		}
-		inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = string(kaitov1alpha1.MultiRoleInferenceRoleDecode)
+		inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = consts.InferenceRoleDecode
 		createAndValidateInferenceSet(inferenceSetObj)
 	})
 	return inferenceSetObj

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -446,11 +446,11 @@ func createGemma3InferenceSetWithDecodeLabelAndVLLM(replicas int) *kaitov1alpha1
 				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma-vllm-decode"},
 			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
 		// Add inference-role label to exercise the P/D disaggregated inference path:
-		// GenerateInferencePodSpec sets KAITO_INFERENCE_ROLE=decode, inference_api.py
-		// injects NixlConnector kv_transfer_config with kv_both (when no
-		// user-provided kv_transfer_config is set), and the routing sidecar
-		// is injected. The workspace reaching Ready status validates that
-		// both modifiers work correctly with vLLM startup.
+		// GenerateInferencePodSpec sets KAITO_INFERENCE_ROLE=decode env var and injects
+		// the routing sidecar. inference_api.py uses the env var to configure
+		// NixlConnector kv_transfer_config with kv_both (when no user-provided
+		// kv_transfer_config is set). The workspace reaching Ready status validates
+		// that the inline sidecar injection works correctly with vLLM startup.
 		if inferenceSetObj.Spec.Template.Labels == nil {
 			inferenceSetObj.Spec.Template.Labels = make(map[string]string)
 		}

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -417,7 +417,7 @@ func createGemma4InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1a
 		inferenceSetObj = utils.GenerateInferenceSetManifestWithVLLM(uniqueID, namespaceName, "", replicas, "Standard_NV36ads_A10_v5",
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma-vllm"},
-			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
+			}, PresetGemma3_4BInstructModel, nil, nil, "")
 		// Add inference-role label to test NixlConnector kv-transfer-config injection
 		if inferenceSetObj.Spec.Template.Labels == nil {
 			inferenceSetObj.Spec.Template.Labels = make(map[string]string)

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -360,6 +360,18 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateChatCompletionsEndpoint(workspaceObj)
 	})
 
+	It("should create a Gemma 3 InferenceSet with decode label successfully", Serial, utils.GinkgoLabelFastCheck, func() {
+		numOfReplicas := 1
+		inferenceSetObj := createGemma3InferenceSetWithDecodeLabelAndVLLM(numOfReplicas)
+		defer cleanupResourcesForInferenceSet(inferenceSetObj)
+		time.Sleep(120 * time.Second)
+
+		validateInferenceSetStatus(inferenceSetObj)
+		validateInferenceSetReplicas(inferenceSetObj, int32(numOfReplicas))
+		validateInferenceSetBenchmarkCompleted(inferenceSetObj)
+		validateGatewayAPIInferenceExtensionResources(inferenceSetObj)
+	})
+
 	It("should create a Gemma 3 InferenceSet with preset public mode successfully", Serial, utils.GinkgoLabelFastCheck, func() {
 		numOfReplicas := 1
 		inferenceSetObj := createGemma3InferenceSetWithPresetPublicModeAndVLLM(numOfReplicas)
@@ -419,6 +431,20 @@ func createGemma3InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1a
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma-vllm"},
 			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
+		createAndValidateInferenceSet(inferenceSetObj)
+	})
+	return inferenceSetObj
+}
+
+func createGemma3InferenceSetWithDecodeLabelAndVLLM(replicas int) *kaitov1alpha1.InferenceSet {
+	modelSecret := createAndValidateModelSecret()
+	inferenceSetObj := &kaitov1alpha1.InferenceSet{}
+	By("Creating an InferenceSet CR with Gemma 3 and decode label for P/D disaggregation", func() {
+		uniqueID := fmt.Sprint("preset-gemma3-is-", rand.Intn(1000))
+		inferenceSetObj = utils.GenerateInferenceSetManifestWithVLLM(uniqueID, namespaceName, "", replicas, "Standard_NV36ads_A10_v5",
+			&metav1.LabelSelector{
+				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma-vllm-decode"},
+			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
 		// Add inference-role label to exercise the P/D disaggregated inference path:
 		// SetInferenceRoleEnv sets KAITO_INFERENCE_ROLE=decode, inference_api.py
 		// injects NixlConnector kv_transfer_config with kv_both (when no
@@ -430,7 +456,6 @@ func createGemma3InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1a
 		}
 		inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = consts.InferenceRoleDecode
 		createAndValidateInferenceSet(inferenceSetObj)
-
 	})
 	return inferenceSetObj
 }

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -411,13 +411,14 @@ func createPhi4WorkspaceWithAdapterAndVLLM(numOfNode int, validAdapters []kaitov
 }
 
 func createGemma3InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1alpha1.InferenceSet {
+	modelSecret := createAndValidateModelSecret()
 	inferenceSetObj := &kaitov1alpha1.InferenceSet{}
 	By("Creating an InferenceSet CR with Gemma 3 preset public mode and vLLM", func() {
 		uniqueID := fmt.Sprint("preset-gemma3-is-", rand.Intn(1000))
 		inferenceSetObj = utils.GenerateInferenceSetManifestWithVLLM(uniqueID, namespaceName, "", replicas, "Standard_NV36ads_A10_v5",
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma-vllm"},
-			}, PresetGemma3_4BInstructModel, nil, nil, "")
+			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
 		// Add inference-role label to test NixlConnector kv-transfer-config injection
 		if inferenceSetObj.Spec.Template.Labels == nil {
 			inferenceSetObj.Spec.Template.Labels = make(map[string]string)

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -419,7 +419,7 @@ func createGemma3InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1a
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma-vllm"},
 			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
-		// Add inference-role label to test NixlConnector kv-transfer-config injection
+		// Add inference-role label to test LMCache kv_transfer_config injection via SetInferenceRoleEnv
 		if inferenceSetObj.Spec.Template.Labels == nil {
 			inferenceSetObj.Spec.Template.Labels = make(map[string]string)
 		}


### PR DESCRIPTION
## What this PR does / why we need it

Implements **checklist items #3, #7, and InferenceSet CRD label propagation** from the [MRI proposal](https://github.com/kaito-project/kaito/blob/main/docs/proposals/20260424-multiroleinference-pd-disaggregation.md#implementation-checklist):

- [x] **3** — Controller: inject default vLLM NixlConnector kv-transfer-config (`kv_both`) into child InferenceSet config
- [x] **7** — Workspace controller: include llm-d routing sidecar in decode StatefulSet spec when `kaito.sh/inference-role: decode` label is present
- [x] **CRD** — InferenceSet `spec.template.metadata` now accepts labels/annotations (x-kubernetes-preserve-unknown-fields)

### Label propagation: MultiRoleInference → InferenceSet → Workspace → Sidecar

The full P/D label flow works as follows:

```
MultiRoleInference controller (future PR)
  │ creates child InferenceSets with spec.template.metadata.labels:
  │   kaito.sh/inference-role: prefill   (for prefill InferenceSet)
  │   kaito.sh/inference-role: decode    (for decode InferenceSet)
  ▼
InferenceSet controller (already implemented, maps.Clone at workspace creation)
  │ propagates spec.template.metadata.labels → Workspace metadata.labels
  │ ⚠️ Previously blocked by CRD strict decoding — FIXED in this PR
  │    (added x-kubernetes-preserve-unknown-fields on template.metadata)
  ▼
Workspace controller (this PR)
  │ SetInferenceRoleEnv() reads kaito.sh/inference-role label
  │   → injects KAITO_INFERENCE_ROLE=prefill|decode env var
  │ SetRoutingSidecar() reads kaito.sh/inference-role label
  │   → decode only: injects llm-d-routing-sidecar container
  │   → moves vLLM to internal port 5001
  ▼
vLLM startup (this PR)
  │ set_kv_transfer_config_if_applicable() reads KAITO_INFERENCE_ROLE
  │   → injects NixlConnector kv-transfer-config for P/D KV cache transfer
  ▼
Runtime traffic flow (decode pod):
  Client → Service:5000 → sidecar:5000 → vLLM:5001
```

### End-to-end flow

```
InferenceSet controller
  → creates Workspace with label kaito.sh/inference-role=prefill|decode
    → Workspace controller (SetInferenceRoleEnv + SetRoutingSidecar)
      → StatefulSet pod env: KAITO_INFERENCE_ROLE=prefill|decode
      → StatefulSet pod (decode only): llm-d-routing-sidecar container on port 5000
        → inference_api.py (set_nixl_kv_transfer_config_if_applicable)
          → vLLM kv_transfer_config: NixlConnector
```

### Changes

**CRD fix — enable label propagation through InferenceSet template:**
- `api/v1alpha1/inferenceset_types.go`: Add `+kubebuilder:validation:XPreserveUnknownFields` on `InferenceSetTemplate.ObjectMeta`
- `config/crd/bases/kaito.sh_inferencesets.yaml`: Add `x-kubernetes-preserve-unknown-fields: true` on `spec.template.metadata`
- `charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml`: Same CRD fix for helm chart
- The InferenceSet controller already propagates `spec.template.metadata.labels` to workspace labels via `maps.Clone()` — this CRD fix unblocks that path by allowing the labels field to pass strict decoding

**Go side — workspace controller propagates label → env var (#3):**
- `api/v1beta1/labels.go`: Add `LabelInferenceRole = "kaito.sh/inference-role"` constant
- `pkg/workspace/inference/preset_inferences.go`: Add `SetInferenceRoleEnv()` modifier
  - Reads `kaito.sh/inference-role` label from the Workspace object
  - When value is `prefill` or `decode`, injects `KAITO_INFERENCE_ROLE` env var on all containers
  - Wired into the `podOpts` chain after `SetAdapterPuller`
- `pkg/workspace/inference/preset_inferences_test.go`: Add `TestSetInferenceRoleEnv` covering no label, invalid role, prefill/decode roles with multi-container pods

**Go side — routing sidecar injection for decode workspaces (#7):**
- `pkg/utils/consts/consts.go`: Add `RoutingSidecarImage`, `RoutingSidecarTag` (v0.7.1), `PortInferenceServerInternal` (int32(5001)) constants
- `pkg/workspace/inference/preset_inferences.go`: Add `SetRoutingSidecar()` modifier
  - Only applies to vLLM runtime (other runtimes skip)
  - Checks for `kaito.sh/inference-role: decode` label on the Workspace
  - Injects `llm-d-routing-sidecar` container with:
    - Port 5000 (takes over public-facing Service port)
    - CLI flags `--port=5000 --vllm-port=5001` (configures listening port and backend vLLM port)
    - `POD_IP` from `status.podIP` fieldRef
  - Reconciles existing sidecar — if sidecar already exists, updates image, args, ports, and removes stale BACKEND_URL env
  - Rewrites any existing `--port` flag to internal port (handles user-customized ports)
  - Patches vLLM container: moves containerPort, readiness/liveness/startup probes, and `--port` arg from 5000 → 5001
- `pkg/workspace/inference/preset_inferences_test.go`: Add `TestSetRoutingSidecar` covering no label, prefill role, decode role, sidecar reconciliation, multi-node commands, and duplicate prevention

**Python side — vLLM startup reads env var → injects NixlConnector config (#3):**
- `presets/workspace/inference/vllm/inference_api.py`: Add `set_kv_transfer_config_if_applicable()`
  - Reads `KAITO_INFERENCE_ROLE` env var
  - Injects `{"kv_connector": "NixlConnector", "kv_role": "kv_both", "kv_load_failure_policy": "fail"}`
  - Both prefill and decode roles use `kv_both` (each pod can send and receive KV cache)
  - Runs after `set_kv_cache_offloading_if_appliable()` and overrides LMCache auto-set config
  - **Respects user-provided `vllm.kv-transfer-config`** from inference configmap — if user explicitly set `kv-transfer-config`, that value is preserved
  - Regular (non-MRI) workspaces are unaffected (env var not present)

**Tests:**
- `presets/workspace/inference/vllm/tests/test_nixl_kv_transfer_config.py`: Unit tests covering:
  - No env var / empty / invalid role → no-op
  - prefill / decode role → inject NixlConnector config
  - Override existing LMCache auto-set config
  - Respect user-provided kv-transfer-config from inference configmap

## Which issue(s) this PR fixes
Part of MultiRoleInference P/D disaggregation implementation.

## Does this PR introduce a user-facing change?
```release-note
NONE
```

### Decode StatefulSet: before vs after sidecar injection

**Before (prefill workspace, or non-MRI workspace):**
```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: deepseek-v32-prefill-ws-0
spec:
  template:
    spec:
      containers:
        - name: deepseek-v32-prefill-ws-0
          image: mcr.microsoft.com/aks/kaito/kaito-base:latest
          ports:
            - containerPort: 5000
          env:
            - name: KAITO_INFERENCE_ROLE
              value: "prefill"
```

**After (decode workspace — `kaito.sh/inference-role: decode`):**
```yaml
apiVersion: apps/v1
kind: StatefulSet
metadata:
  name: deepseek-v32-decode-ws-0
spec:
  template:
    spec:
      containers:
        - name: deepseek-v32-decode-ws-0
          image: mcr.microsoft.com/aks/kaito/kaito-base:latest
          ports:
            - containerPort: 5001          # ← moved to internal port
          env:
            - name: KAITO_INFERENCE_ROLE
              value: "decode"

        - name: llm-d-routing-sidecar      # ← injected by SetRoutingSidecar
          image: mcr.microsoft.com/oss/v2/llm-d/llm-d-routing-sidecar:v0.7.1
          ports:
            - containerPort: 5000          # ← takes over public-facing port
              name: sidecar
          args:
            - "--port=5000"
            - "--vllm-port=5001"
            - "--secure-proxy=false"
          env:
            - name: POD_IP
              valueFrom:
                fieldRef:
                  fieldPath: status.podIP
```

Traffic flow: `Client → Service:5000 → sidecar:5000 → vLLM:5001`

The sidecar is **only** injected for vLLM runtime workspaces with `kaito.sh/inference-role: decode` label. Prefill and regular workspaces are unchanged.


### Example: Creating an InferenceSet with decode role

To enable P/D disaggregation sidecar injection, set `kaito.sh/inference-role: decode` in `spec.template.metadata.labels`:

```yaml
apiVersion: kaito.sh/v1alpha1
kind: InferenceSet
metadata:
  name: my-decode-inferenceset
spec:
  labelSelector:
    matchLabels:
      apps: my-model
  replicas: 3
  template:
    metadata:
      labels:
        kaito.sh/inference-role: decode    # triggers sidecar injection
    resource:
      instanceType: Standard_NC24ads_A100_v4
    inference:
      preset:
        name: deepseek-ai/DeepSeek-V3.2
        presetOptions:
          modelAccessSecret: hf-token
```

The InferenceSet controller propagates `spec.template.metadata.labels` to each generated Workspace's `metadata.labels`. The Workspace controller then:
1. Reads `kaito.sh/inference-role: decode` → injects `KAITO_INFERENCE_ROLE=decode` env var
2. Injects `llm-d-routing-sidecar` container (port 5000) and moves vLLM to internal port 5001
3. vLLM startup detects `KAITO_INFERENCE_ROLE` → auto-configures NixlConnector for KV cache transfer

For prefill workspaces, use `kaito.sh/inference-role: prefill` — no sidecar is injected, only the env var and NixlConnector config.

