### PR TITLE
fix: benchmark: sum vLLM metrics across engine shards

### DIFF
--- a/presets/workspace/inference/vllm/benchmark_entrypoint.py
+++ b/presets/workspace/inference/vllm/benchmark_entrypoint.py
@@ -89,11 +89,33 @@ def _health_check() -> bool:
         return False
 
 
-def _read_counter(metric: str) -> int:
-    """Parse a Prometheus counter value from vLLM /metrics.
+def _sum_counter_metric(metric: str) -> int:
+    """Sum all samples for an additive Prometheus metric from vLLM /metrics.
 
-    Handles both labelled (``metric{...} value``) and bare (``metric value``) forms.
-    Returns 0 if the metric is absent or the endpoint is unreachable.
+    Aggregates across label sets (e.g. multiple ``engine`` shards in a
+    tensor/pipeline-parallel deployment).  Returns 0 if the metric is absent
+    or the endpoint is unreachable.
+
+    Intended for **additive** metric types only:
+
+      * counters (``..._total``) — summing yields the total count
+      * gauges where summing is meaningful (e.g. ``vllm:num_requests_running``
+        — total in-flight requests across shards)
+
+    NOT suitable for:
+
+      * histograms / summaries (exposed as ``_bucket`` / ``_sum`` / ``_count``
+        — this function will return 0 for the bare metric name)
+      * non-additive gauges such as utilization percentages
+      * info metrics (label-only; value is always 1)
+
+    Example /metrics output (multi-engine deployment)::
+
+        vllm:generation_tokens_total{engine="0",model_name="gemma-4-e4b-it"} 408832.0
+        vllm:generation_tokens_total{engine="1",model_name="gemma-4-e4b-it"} 407040.0
+
+    For ``metric="vllm:generation_tokens_total"`` this returns ``815872``
+    (408832 + 407040).
     """
     try:
         data = (
@@ -103,13 +125,20 @@ def _read_counter(metric: str) -> int:
         )
     except Exception:
         return 0
-    for line in data.splitlines():
-        if line.startswith(f"{metric}{{") or line.startswith(f"{metric} "):
-            try:
-                return int(float(line.split()[-1]))
-            except (ValueError, IndexError):
-                return 0
-    return 0
+    total = 0.0
+    found = False
+    for family in text_string_to_metric_families(data):
+        for sample in family.samples:
+            # The prometheus_client parser strips the ``_total`` suffix from
+            # counter family names (e.g. family ``vllm:generation_tokens`` for
+            # metric ``vllm:generation_tokens_total``), so match on the raw
+            # ``sample.name`` instead.  This also naturally skips the synthetic
+            # ``_created`` timestamp samples.
+            if sample.name != metric:
+                continue
+            found = True
+            total += sample.value
+    return int(total) if found else 0
 
 
 # ── Benchmark configuration ───────────────────────────────────────────────────
@@ -277,12 +306,13 @@ def _run_benchmark() -> tuple:
     Raises ``RuntimeError`` on any failure so the caller can log it and fall back
     to the sentinel result.
     """
-    t0_gen = _read_counter("vllm:generation_tokens_total")
-    t0_prompt = _read_counter("vllm:prompt_tokens_total")
+    t0_gen = _sum_counter_metric("vllm:generation_tokens_total")
+    t0_prompt = _sum_counter_metric("vllm:prompt_tokens_total")
     t0_epoch = time.time()
 
     processor = _resolve_processor()
     _log(f"processor_resolved PROCESSOR={processor or '<auto>'}")
+    _log(f"benchmark_start epoch={t0_epoch:.1f} t0_gen={t0_gen} t0_prompt={t0_prompt}")
 
     max_concurrency = _compute_max_concurrency()
     _log(
@@ -298,8 +328,9 @@ def _run_benchmark() -> tuple:
     ttft_ms, tpot_ms = _extract_guidellm_metrics(report)
 
     t1_epoch = time.time()
-    t1_gen = _read_counter("vllm:generation_tokens_total")
-    t1_prompt = _read_counter("vllm:prompt_tokens_total")
+    t1_gen = _sum_counter_metric("vllm:generation_tokens_total")
+    t1_prompt = _sum_counter_metric("vllm:prompt_tokens_total")
+    _log(f"benchmark_end epoch={t1_epoch:.1f} t1_gen={t1_gen} t1_prompt={t1_prompt}")
 
     delta_gen = t1_gen - t0_gen
     # Require at least one generated token.  Zero generation means the load did not
@@ -327,7 +358,7 @@ def _drain(timeout: float = 300.0) -> None:
     _log("drain_start")
     deadline = time.monotonic() + timeout
     while True:
-        if _read_counter("vllm:num_requests_running") == 0:
+        if _sum_counter_metric("vllm:num_requests_running") == 0:
             break
         if time.monotonic() >= deadline:
             raise TimeoutError(f"_drain timed out after {timeout}s")

--- a/presets/workspace/inference/vllm/tests/test_benchmark_entrypoint.py
+++ b/presets/workspace/inference/vllm/tests/test_benchmark_entrypoint.py
@@ -78,7 +78,7 @@ def test_log_exits_1_on_write_failure():
     assert exc_info.value.code == 1
 
 
-# ── _read_counter ─────────────────────────────────────────────────────────────
+# ── _sum_counter_metric ───────────────────────────────────────────────────────
 
 _METRICS_BODY = b"""\
 # HELP vllm:generation_tokens_total Number of generation tokens processed.
@@ -90,32 +90,62 @@ vllm:prompt_tokens_total{engine="0",model_name="phi-4"} 12345.0
 # HELP vllm:num_requests_running Number of requests in model execution batches.
 # TYPE vllm:num_requests_running gauge
 vllm:num_requests_running{engine="0",model_name="phi-4"} 3.0
+# HELP process_open_fds Number of open file descriptors.
+# TYPE process_open_fds gauge
 process_open_fds 47.0
 """
 
+# Multi-engine deployment (e.g. data-parallel): vLLM emits one series per engine.
+_MULTI_ENGINE_METRICS_BODY = b"""\
+# HELP vllm:generation_tokens_total Number of generation tokens processed.
+# TYPE vllm:generation_tokens_total counter
+vllm:generation_tokens_total{engine="0",model_name="gemma-4-e4b-it"} 408832.0
+vllm:generation_tokens_total{engine="1",model_name="gemma-4-e4b-it"} 407040.0
+# HELP vllm:num_requests_running Number of requests in model execution batches.
+# TYPE vllm:num_requests_running gauge
+vllm:num_requests_running{engine="0",model_name="gemma-4-e4b-it"} 2.0
+vllm:num_requests_running{engine="1",model_name="gemma-4-e4b-it"} 5.0
+"""
 
-def test_read_counter_labelled():
+
+def test_sum_counter_metric_labelled():
     resp = _make_urlopen_response(200, _METRICS_BODY)
     with patch("urllib.request.urlopen", return_value=resp):
-        assert bm._read_counter("vllm:generation_tokens_total") == 987654
+        assert bm._sum_counter_metric("vllm:generation_tokens_total") == 987654
 
 
-def test_read_counter_bare():
+def test_sum_counter_metric_bare():
     """process_open_fds is a real bare (no-label) metric in vLLM's /metrics output."""
     resp = _make_urlopen_response(200, _METRICS_BODY)
     with patch("urllib.request.urlopen", return_value=resp):
-        assert bm._read_counter("process_open_fds") == 47
+        assert bm._sum_counter_metric("process_open_fds") == 47
 
 
-def test_read_counter_not_found():
+def test_sum_counter_metric_aggregates_across_engines():
+    """Multi-engine series for the same metric must be summed (e.g. DP shards)."""
+    resp = _make_urlopen_response(200, _MULTI_ENGINE_METRICS_BODY)
+    with patch("urllib.request.urlopen", return_value=resp):
+        # 408832 + 407040 = 815872
+        assert bm._sum_counter_metric("vllm:generation_tokens_total") == 815872
+
+
+def test_sum_counter_metric_aggregates_gauge_across_engines():
+    """Additive gauges (in-flight request counts) are also summed across shards."""
+    resp = _make_urlopen_response(200, _MULTI_ENGINE_METRICS_BODY)
+    with patch("urllib.request.urlopen", return_value=resp):
+        # 2 + 5 = 7
+        assert bm._sum_counter_metric("vllm:num_requests_running") == 7
+
+
+def test_sum_counter_metric_not_found():
     resp = _make_urlopen_response(200, _METRICS_BODY)
     with patch("urllib.request.urlopen", return_value=resp):
-        assert bm._read_counter("vllm:nonexistent_metric") == 0
+        assert bm._sum_counter_metric("vllm:nonexistent_metric") == 0
 
 
-def test_read_counter_network_error():
+def test_sum_counter_metric_network_error():
     with patch("urllib.request.urlopen", side_effect=OSError("timeout")):
-        assert bm._read_counter("vllm:generation_tokens_total") == 0
+        assert bm._sum_counter_metric("vllm:generation_tokens_total") == 0
 
 
 # ── _compute_max_concurrency ──────────────────────────────────────────────────
@@ -332,7 +362,7 @@ def test_run_benchmark_success(monkeypatch):
 
     mock_report = _mock_report(ttft_mean=42.123, tpot_mean=3.456)
     with (
-        patch.object(bm, "_read_counter", side_effect=read_counter),
+        patch.object(bm, "_sum_counter_metric", side_effect=read_counter),
         patch.object(bm, "_resolve_processor", return_value="mymodel"),
         patch.object(bm, "_compute_max_concurrency", return_value=128),
         patch.object(bm, "_run_guidellm", return_value=mock_report),
@@ -354,7 +384,7 @@ def test_run_benchmark_success(monkeypatch):
 def test_run_benchmark_no_generation():
     mock_report = _mock_report()
     with (
-        patch.object(bm, "_read_counter", return_value=0),
+        patch.object(bm, "_sum_counter_metric", return_value=0),
         patch.object(bm, "_resolve_processor", return_value=""),
         patch.object(bm, "_compute_max_concurrency", return_value=128),
         patch.object(bm, "_run_guidellm", return_value=mock_report),
@@ -367,7 +397,7 @@ def test_run_benchmark_no_generation():
 
 def test_run_benchmark_guidellm_fails():
     with (
-        patch.object(bm, "_read_counter", return_value=0),
+        patch.object(bm, "_sum_counter_metric", return_value=0),
         patch.object(bm, "_resolve_processor", return_value=""),
         patch.object(bm, "_compute_max_concurrency", return_value=128),
         patch.object(bm, "_run_guidellm", return_value=None),
@@ -383,7 +413,7 @@ def test_run_benchmark_guidellm_fails():
 
 def test_drain_already_zero():
     with (
-        patch.object(bm, "_read_counter", return_value=0),
+        patch.object(bm, "_sum_counter_metric", return_value=0),
         patch.object(bm, "_log"),
         patch("time.sleep") as mock_sleep,
     ):
@@ -395,7 +425,7 @@ def test_drain_polls_until_zero():
     # Returns 3, 3, 0 on successive calls
     counter_calls = [3, 3, 0]
     with (
-        patch.object(bm, "_read_counter", side_effect=counter_calls),
+        patch.object(bm, "_sum_counter_metric", side_effect=counter_calls),
         patch.object(bm, "_log"),
         patch("time.sleep") as mock_sleep,
     ):
@@ -409,7 +439,7 @@ def test_drain_timeout():
     # monotonic() returns: initial call (deadline set), then past-deadline on second call
     mono_values = [0.0, 301.0]
     with (
-        patch.object(bm, "_read_counter", return_value=1),
+        patch.object(bm, "_sum_counter_metric", return_value=1),
         patch.object(bm, "_log"),
         patch("time.sleep"),
         patch("time.monotonic", side_effect=mono_values),


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Multi-engine deployments(DP) emit one series per engine (e.g. engine=0, engine=1). The old line-prefix reader picked only the first match, undercounting TPM and letting _drain() exit while other shards still had in-flight requests.

Use prometheus_client.parser and sum all samples matching the metric name.

TPM benchmark results (gemma4-e4b-it):
- TP1 with single A100: 780185
- TP2 with two A100: 1121435
- DP2 with two A100: 1538991

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: