### PR TITLE
fix: ignore KAITO-reserved labels in user-supplied selectors

### DIFF
--- a/api/v1beta1/labels.go
+++ b/api/v1beta1/labels.go
@@ -14,6 +14,8 @@
 package v1beta1
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
@@ -135,4 +137,51 @@ func GetPerformanceMode(ws *Workspace) string {
 		return v
 	}
 	return PerformanceModeBalanced
+}
+
+// reservedSelectorLabelKeys are labels that KAITO controllers apply to their
+// own NodeClaims/Nodes/NodePools. Users must not include them in resource
+// label selectors; if they do, the values are silently ignored to prevent
+// cross-resource targeting (e.g. matching another Workspace's nodes).
+var reservedSelectorLabelKeys = map[string]struct{}{
+	// KAITO workspace/ragengine identity labels.
+	LabelWorkspaceName:      {},
+	LabelRAGEngineName:      {},
+	LabelWorkspaceNamespace: {},
+	LabelRAGEngineNamespace: {},
+
+	// Karpenter NodePool management labels.
+	consts.KarpenterWorkspaceNameKey:         {},
+	consts.KarpenterWorkspaceNamespaceKey:    {},
+	consts.KarpenterInferenceSetKey:          {},
+	consts.KarpenterInferenceSetNamespaceKey: {},
+}
+
+// IsReservedSelectorLabel reports whether the given label key is reserved by
+// KAITO and must not be honored when supplied via a user-defined selector.
+func IsReservedSelectorLabel(key string) bool {
+	_, ok := reservedSelectorLabelKeys[key]
+	return ok
+}
+
+// SanitizedMatchLabels returns the MatchLabels of selector with any
+// KAITO-reserved keys removed. Returns nil when selector is nil or has no
+// non-reserved entries. The returned map is always a fresh copy when at
+// least one entry is preserved; callers must not assume identity with the
+// input map.
+func SanitizedMatchLabels(selector *metav1.LabelSelector) map[string]string {
+	if selector == nil || len(selector.MatchLabels) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(selector.MatchLabels))
+	for k, v := range selector.MatchLabels {
+		if IsReservedSelectorLabel(k) {
+			continue
+		}
+		out[k] = v
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
 }

--- a/api/v1beta1/workspace_validation.go
+++ b/api/v1beta1/workspace_validation.go
@@ -414,6 +414,28 @@ func (r *ResourceSpec) validateCreateWithInference(ctx context.Context, inferenc
 		return errs
 	}
 
+	// Warn (don't reject) when the user-provided selector includes labels
+	// reserved for KAITO-managed resources. These keys are silently ignored
+	// at runtime to avoid cross-workspace/RAGEngine targeting.
+	if r.LabelSelector != nil {
+		for k := range r.LabelSelector.MatchLabels {
+			if IsReservedSelectorLabel(k) {
+				klog.Warningf("labelSelector contains reserved KAITO label %q; it will be ignored", k)
+			}
+		}
+	}
+
+	// Reject when, after stripping KAITO-reserved keys, no usable matchLabels
+	// remain from a user-supplied set. An all-reserved selector would otherwise
+	// be silently dropped and end up matching every node in the cluster.
+	if r.LabelSelector != nil && len(r.LabelSelector.MatchLabels) > 0 &&
+		len(SanitizedMatchLabels(r.LabelSelector)) == 0 {
+		errs = errs.Also(apis.ErrInvalidValue(
+			"matchLabels must contain at least one non-reserved label",
+			"labelSelector.matchLabels"))
+		return errs
+	}
+
 	napDisabled := featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning]
 
 	if napDisabled {
@@ -421,10 +443,11 @@ func (r *ResourceSpec) validateCreateWithInference(ctx context.Context, inferenc
 			// Note: for tests like aikit.yaml, it creates nodes with kind that do not have GPU labels, so we need to account for that case.
 			kClient := k8sclient.GetGlobalClient()
 
-			// List matching nodes
+			// List matching nodes (KAITO-reserved label keys are stripped to avoid
+			// matching nodes that belong to other Workspaces or RAGEngines).
 			ctx := context.TODO()
 			nodeList := &corev1.NodeList{}
-			labelSelector := client.MatchingLabels(r.LabelSelector.MatchLabels)
+			labelSelector := client.MatchingLabels(SanitizedMatchLabels(r.LabelSelector))
 
 			err := kClient.List(ctx, nodeList, labelSelector)
 			if err != nil {

--- a/api/v1beta1/workspace_validation_test.go
+++ b/api/v1beta1/workspace_validation_test.go
@@ -753,6 +753,26 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 			useFeatureGate:     true,
 		},
 		{
+			name: "Invalid - matchLabels only contains reserved KAITO labels",
+			resourceSpec: &ResourceSpec{
+				InstanceType: "", // BYO mode
+				Count:        pointerToInt(1),
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						LabelWorkspaceName:      "ws1",
+						LabelWorkspaceNamespace: "ns1",
+					},
+				},
+			},
+			preset:             true,
+			presetNameOverride: "test-validation-static",
+			runtime:            model.RuntimeNameVLLM,
+			expectErrs:         true,
+			errContent:         "matchLabels must contain at least one non-reserved label",
+			testNodes:          []v1.Node{},
+			useFeatureGate:     true,
+		},
+		{
 			name: "Deprecated Model",
 			resourceSpec: &ResourceSpec{
 				InstanceType: "Standard_NC4as_T4_v3",

--- a/pkg/nodeprovision/byo-provisioner/byo_provisioner.go
+++ b/pkg/nodeprovision/byo-provisioner/byo_provisioner.go
@@ -65,10 +65,7 @@ func (n *BYOProvisioner) DisableDriftRemediation(ctx context.Context, workspaceN
 // Workspace. In BYO mode there are no provisioning resources, so needRequeue
 // is always true when nodes are not ready.
 func (n *BYOProvisioner) EnsureNodesReady(ctx context.Context, ws *kaitov1beta1.Workspace) (bool, bool, error) {
-	var matchLabels client.MatchingLabels
-	if ws.Resource.LabelSelector != nil {
-		matchLabels = ws.Resource.LabelSelector.MatchLabels
-	}
+	matchLabels := client.MatchingLabels(kaitov1beta1.SanitizedMatchLabels(ws.Resource.LabelSelector))
 
 	nodeList, err := resources.ListNodes(ctx, n.client, matchLabels)
 	if err != nil {
@@ -105,10 +102,7 @@ func (n *BYOProvisioner) CollectNodeStatusInfo(ctx context.Context, ws *kaitov1b
 		Reason: "workspaceResourceStatusNotReady", Message: "node status condition not ready",
 	}
 
-	var matchLabels client.MatchingLabels
-	if ws.Resource.LabelSelector != nil {
-		matchLabels = ws.Resource.LabelSelector.MatchLabels
-	}
+	matchLabels := client.MatchingLabels(kaitov1beta1.SanitizedMatchLabels(ws.Resource.LabelSelector))
 	nodeList, err := resources.ListNodes(ctx, n.client, matchLabels)
 	if err != nil {
 		return nil, err

--- a/pkg/nodeprovision/gpu-provisioner/gpu_provisioner.go
+++ b/pkg/nodeprovision/gpu-provisioner/gpu_provisioner.go
@@ -108,7 +108,7 @@ func (g *AzureGPUProvisioner) DisableDriftRemediation(ctx context.Context, works
 func (g *AzureGPUProvisioner) EnsureNodesReady(ctx context.Context, ws *kaitov1beta1.Workspace) (bool, bool, error) {
 	// List nodes once and derive both readyNodes (for NodeClaim check) and
 	// readyCount with correct instance type (for node readiness check).
-	nodeList, err := resources.ListNodes(ctx, g.nodeClaimManager.Client, ws.Resource.LabelSelector.MatchLabels)
+	nodeList, err := resources.ListNodes(ctx, g.nodeClaimManager.Client, kaitov1beta1.SanitizedMatchLabels(ws.Resource.LabelSelector))
 	if err != nil {
 		return false, false, fmt.Errorf("failed to list nodes: %w", err)
 	}
@@ -180,7 +180,7 @@ func (g *AzureGPUProvisioner) CollectNodeStatusInfo(ctx context.Context, ws *kai
 		Reason: "workspaceResourceStatusNotReady", Message: "node claim or node status condition not ready",
 	}
 
-	nodeList, err := resources.ListNodes(ctx, g.nodeClaimManager.Client, ws.Resource.LabelSelector.MatchLabels)
+	nodeList, err := resources.ListNodes(ctx, g.nodeClaimManager.Client, kaitov1beta1.SanitizedMatchLabels(ws.Resource.LabelSelector))
 	if err != nil {
 		return nil, fmt.Errorf("failed to list nodes: %w", err)
 	}

--- a/pkg/nodeprovision/karpenter/nodepool.go
+++ b/pkg/nodeprovision/karpenter/nodepool.go
@@ -85,11 +85,10 @@ func generateNodePool(ws *kaitov1beta1.Workspace, cfg NodeClassConfig) *karpente
 		consts.KarpenterWorkspaceNamespaceKey: ws.Namespace,
 	}
 	// Include the user's matchLabels so that inference pods' nodeAffinity
-	// (built from matchLabels) is satisfied.
-	if ws.Resource.LabelSelector != nil {
-		for k, v := range ws.Resource.LabelSelector.MatchLabels {
-			templateLabels[k] = v
-		}
+	// (built from matchLabels) is satisfied. KAITO-reserved keys are stripped
+	// to avoid clobbering controller-managed labels.
+	for k, v := range kaitov1beta1.SanitizedMatchLabels(ws.Resource.LabelSelector) {
+		templateLabels[k] = v
 	}
 	// InferenceSet workspaces get additional labels so the drift controller
 	// can map NodeClaim events back to the owning InferenceSet.

--- a/pkg/nodeprovision/karpenter/provisioner.go
+++ b/pkg/nodeprovision/karpenter/provisioner.go
@@ -243,7 +243,7 @@ func countCoveredNodes(ctx context.Context, c client.Client, ws *kaitov1beta1.Wo
 	}
 
 	// Count ready nodes (all types).
-	nodeList, err := resources.ListNodes(ctx, c, ws.Resource.LabelSelector.MatchLabels)
+	nodeList, err := resources.ListNodes(ctx, c, kaitov1beta1.SanitizedMatchLabels(ws.Resource.LabelSelector))
 	if err != nil {
 		return 0, 0, fmt.Errorf("listing nodes: %w", err)
 	}

--- a/pkg/ragengine/controllers/ragengine_controller.go
+++ b/pkg/ragengine/controllers/ragengine_controller.go
@@ -456,7 +456,7 @@ func (c *RAGEngineReconciler) applyRAGEngineResource(ctx context.Context, ragEng
 func (c *RAGEngineReconciler) getAllQualifiedNodes(ctx context.Context, ragEngineObj *kaitov1beta1.RAGEngine) ([]*corev1.Node, error) {
 	var qualifiedNodes []*corev1.Node
 
-	nodeList, err := resources.ListNodes(ctx, c.Client, ragEngineObj.Spec.Compute.LabelSelector.MatchLabels)
+	nodeList, err := resources.ListNodes(ctx, c.Client, kaitov1beta1.SanitizedMatchLabels(ragEngineObj.Spec.Compute.LabelSelector))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ragengine/manifests/manifests.go
+++ b/pkg/ragengine/manifests/manifests.go
@@ -45,8 +45,9 @@ func GenerateRAGDeploymentManifest(ragEngineObj *kaitov1beta1.RAGEngine, revisio
 
 	var affinity *corev1.Affinity
 	if ragEngineObj.Spec.Compute != nil && ragEngineObj.Spec.Compute.LabelSelector != nil {
-		nodeRequirements := make([]corev1.NodeSelectorRequirement, 0, len(ragEngineObj.Spec.Compute.LabelSelector.MatchLabels))
-		for key, value := range ragEngineObj.Spec.Compute.LabelSelector.MatchLabels {
+		selectorLabels := kaitov1beta1.SanitizedMatchLabels(ragEngineObj.Spec.Compute.LabelSelector)
+		nodeRequirements := make([]corev1.NodeSelectorRequirement, 0, len(selectorLabels))
+		for key, value := range selectorLabels {
 			nodeRequirements = append(nodeRequirements, corev1.NodeSelectorRequirement{
 				Key:      key,
 				Operator: corev1.NodeSelectorOpIn,

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -147,8 +147,8 @@ func GenerateNodeClaimManifestWithOptions(storageRequirement string, obj client.
 		nameLabel:            name,
 		namespaceLabel:       namespace,
 	}
-	if labelSelector != nil && len(labelSelector.MatchLabels) != 0 {
-		nodeClaimLabels = lo.Assign(nodeClaimLabels, labelSelector.MatchLabels)
+	if sanitized := kaitov1beta1.SanitizedMatchLabels(labelSelector); len(sanitized) != 0 {
+		nodeClaimLabels = lo.Assign(nodeClaimLabels, sanitized)
 	}
 
 	nodeClaimAnnotations := map[string]string{

--- a/pkg/utils/resources/nodes.go
+++ b/pkg/utils/resources/nodes.go
@@ -124,10 +124,7 @@ func ExtractObjFields(obj client.Object) (instanceType, namespace, name string, 
 
 // GetReadyNodes finds all ready nodes that match the workspace's label selector
 func GetReadyNodes(ctx context.Context, c client.Client, wObj *kaitov1beta1.Workspace) ([]*corev1.Node, error) {
-	var matchLabels client.MatchingLabels
-	if wObj.Resource.LabelSelector != nil {
-		matchLabels = wObj.Resource.LabelSelector.MatchLabels
-	}
+	matchLabels := client.MatchingLabels(kaitov1beta1.SanitizedMatchLabels(wObj.Resource.LabelSelector))
 
 	nodeList, err := ListNodes(ctx, c, matchLabels)
 	if err != nil {

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -570,10 +570,7 @@ func (c *WorkspaceReconciler) collectNodeStatusSnapshot(ctx context.Context, wOb
 	}
 
 	// Collect worker node names for status.
-	var matchLabels client.MatchingLabels
-	if wObj.Resource.LabelSelector != nil {
-		matchLabels = wObj.Resource.LabelSelector.MatchLabels
-	}
+	matchLabels := client.MatchingLabels(kaitov1beta1.SanitizedMatchLabels(wObj.Resource.LabelSelector))
 	nodeList, err := resources.ListNodes(ctx, c.Client, matchLabels)
 	if err != nil {
 		return nil, err

--- a/pkg/workspace/estimator/nodesestimator/estimator.go
+++ b/pkg/workspace/estimator/nodesestimator/estimator.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/sku"
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
@@ -57,10 +58,7 @@ func (c *NodeEstimator) EstimateNodeCount(ctx context.Context, req estimator.Nod
 
 	if req.ResourceProfile.DisableNodeAutoProvisioning {
 		// NAP is disabled (BYO scenario) — derive GPU config from existing ready nodes.
-		var matchLabels client.MatchingLabels
-		if req.ResourceProfile.LabelSelector != nil {
-			matchLabels = req.ResourceProfile.LabelSelector.MatchLabels
-		}
+		matchLabels := client.MatchingLabels(kaitov1beta1.SanitizedMatchLabels(req.ResourceProfile.LabelSelector))
 		nodeList, listErr := resources.ListNodes(ctx, cl, matchLabels)
 		if listErr != nil {
 			return 0, fmt.Errorf("failed to list ready nodes: %w", listErr)

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -407,8 +407,9 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 		volumeMounts = append(volumeMounts, shmVolumeMount)
 
 		// node selector
-		nodeRequirements := make([]corev1.NodeSelectorRequirement, 0, len(ctx.Workspace.Resource.LabelSelector.MatchLabels))
-		for key, value := range ctx.Workspace.Resource.LabelSelector.MatchLabels {
+		selectorLabels := v1beta1.SanitizedMatchLabels(ctx.Workspace.Resource.LabelSelector)
+		nodeRequirements := make([]corev1.NodeSelectorRequirement, 0, len(selectorLabels))
+		for key, value := range selectorLabels {
 			nodeRequirements = append(nodeRequirements, corev1.NodeSelectorRequirement{
 				Key:      key,
 				Operator: corev1.NodeSelectorOpIn,
@@ -466,16 +467,20 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 			},
 		})
 
-		spec.Affinity = &corev1.Affinity{
-			NodeAffinity: &corev1.NodeAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-					NodeSelectorTerms: []corev1.NodeSelectorTerm{
-						{
-							MatchExpressions: nodeRequirements,
+		// Only set nodeAffinity when the user supplied selector labels.
+		// An empty MatchExpressions list is rejected by the Kubernetes API server.
+		if len(nodeRequirements) > 0 {
+			spec.Affinity = &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: nodeRequirements,
+							},
 						},
 					},
 				},
-			},
+			}
 		}
 		spec.ImagePullSecrets = GetInferenceImageInfo(ctx.Ctx, ctx.Workspace)
 

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -246,8 +246,9 @@ func GeneratePullerContainers(wObj *kaitov1beta1.Workspace, adapters []kaitov1be
 }
 
 func GenerateManifestWithPodTemplate(workspaceObj *kaitov1beta1.Workspace, tolerations []corev1.Toleration) *appsv1.StatefulSet {
-	nodeRequirements := make([]corev1.NodeSelectorRequirement, 0, len(workspaceObj.Resource.LabelSelector.MatchLabels))
-	for key, value := range workspaceObj.Resource.LabelSelector.MatchLabels {
+	selectorLabels := kaitov1beta1.SanitizedMatchLabels(workspaceObj.Resource.LabelSelector)
+	nodeRequirements := make([]corev1.NodeSelectorRequirement, 0, len(selectorLabels))
+	for key, value := range selectorLabels {
 		nodeRequirements = append(nodeRequirements, corev1.NodeSelectorRequirement{
 			Key:      key,
 			Operator: corev1.NodeSelectorOpIn,
@@ -276,17 +277,23 @@ func GenerateManifestWithPodTemplate(workspaceObj *kaitov1beta1.Workspace, toler
 		}
 	}
 
-	// Overwrite affinity
-	templateCopy.Spec.Affinity = &corev1.Affinity{
-		NodeAffinity: &corev1.NodeAffinity{
-			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-				NodeSelectorTerms: []corev1.NodeSelectorTerm{
-					{
-						MatchExpressions: nodeRequirements,
+	// Overwrite affinity. Only set node affinity when there are user-defined
+	// node requirements; an empty MatchExpressions list is rejected by the
+	// Kubernetes API server.
+	if len(nodeRequirements) > 0 {
+		templateCopy.Spec.Affinity = &corev1.Affinity{
+			NodeAffinity: &corev1.NodeAffinity{
+				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+					NodeSelectorTerms: []corev1.NodeSelectorTerm{
+						{
+							MatchExpressions: nodeRequirements,
+						},
 					},
 				},
 			},
-		},
+		}
+	} else {
+		templateCopy.Spec.Affinity = nil
 	}
 
 	// append tolerations

--- a/pkg/workspace/tuning/preset_tuning.go
+++ b/pkg/workspace/tuning/preset_tuning.go
@@ -248,8 +248,9 @@ func GenerateBasicTuningPodSpec(skuNumGPUs int) func(*generator.WorkspaceGenerat
 		spec.RestartPolicy = corev1.RestartPolicyNever
 
 		// Add node affinity based on label selector from workspace resource
-		nodeRequirements := make([]corev1.NodeSelectorRequirement, 0, len(ctx.Workspace.Resource.LabelSelector.MatchLabels))
-		for key, value := range ctx.Workspace.Resource.LabelSelector.MatchLabels {
+		selectorLabels := kaitov1beta1.SanitizedMatchLabels(ctx.Workspace.Resource.LabelSelector)
+		nodeRequirements := make([]corev1.NodeSelectorRequirement, 0, len(selectorLabels))
+		for key, value := range selectorLabels {
 			nodeRequirements = append(nodeRequirements, corev1.NodeSelectorRequirement{
 				Key:      key,
 				Operator: corev1.NodeSelectorOpIn,
@@ -257,16 +258,20 @@ func GenerateBasicTuningPodSpec(skuNumGPUs int) func(*generator.WorkspaceGenerat
 			})
 		}
 
-		spec.Affinity = &corev1.Affinity{
-			NodeAffinity: &corev1.NodeAffinity{
-				RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-					NodeSelectorTerms: []corev1.NodeSelectorTerm{
-						{
-							MatchExpressions: nodeRequirements,
+		// Only set nodeAffinity when the user supplied selector labels.
+		// An empty MatchExpressions list is rejected by the Kubernetes API server.
+		if len(nodeRequirements) > 0 {
+			spec.Affinity = &corev1.Affinity{
+				NodeAffinity: &corev1.NodeAffinity{
+					RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
+						NodeSelectorTerms: []corev1.NodeSelectorTerm{
+							{
+								MatchExpressions: nodeRequirements,
+							},
 						},
 					},
 				},
-			},
+			}
 		}
 
 		return nil


### PR DESCRIPTION

**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Workspace/RAGEngine selectors that include KAITO-managed label keys (e.g. kaito.sh/workspace, karpenter NodePool keys) could match NodeClaims/Nodes belonging to other Workspaces or RAGEngines, leading to cross-resource targeting and incorrect node accounting.

Introduce pkg/utils/consts.SanitizedMatchLabels which strips reserved keys from a LabelSelector, and IsReservedSelectorLabel for validation. Apply the sanitizer across every site that consumes Resource.LabelSelector.MatchLabels: node listing, NodeClaim/NodePool generation, pod nodeAffinity, and node estimation.

Also guard pod nodeAffinity construction against an empty MatchExpressions list (rejected by the API server) when all user labels are reserved or none are supplied, and emit a warning during workspace validation when reserved keys are detected.


**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: