### PR TITLE
chore: bump go version from 1.26.2 to 1.26.3

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -17,7 +17,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.26.2'
+  GO_VERSION: '1.26.3'
 
 jobs:
   create-release:

--- a/.github/workflows/e2e-workflow.yaml
+++ b/.github/workflows/e2e-workflow.yaml
@@ -42,7 +42,7 @@ jobs:
 
     env:
       TEST_SUITE: ${{ inputs.node_provisioner }}
-      GO_VERSION: "1.26.2"
+      GO_VERSION: "1.26.3"
       KARPENTER_NAMESPACE: "karpenter"
       GPU_PROVISIONER_NAMESPACE: "gpu-provisioner"
 

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  GO_VERSION: '1.26.2'
+  GO_VERSION: '1.26.3'
 
 permissions:
   contents: read

--- a/.github/workflows/publish-rag-controller-gh-image.yaml
+++ b/.github/workflows/publish-rag-controller-gh-image.yaml
@@ -12,7 +12,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.26.2'
+  GO_VERSION: '1.26.3'
   IMAGE_NAME: 'ragengine'
   REGISTRY: ghcr.io
 

--- a/.github/workflows/publish-rag-controller-mcr-image.yaml
+++ b/.github/workflows/publish-rag-controller-mcr-image.yaml
@@ -13,7 +13,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.26.2'
+  GO_VERSION: '1.26.3'
   IMAGE_NAME: 'ragengine'
 
 jobs:

--- a/.github/workflows/publish-rag-service-gh-image.yaml
+++ b/.github/workflows/publish-rag-service-gh-image.yaml
@@ -12,7 +12,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.26.2'
+  GO_VERSION: '1.26.3'
   IMAGE_NAME: 'kaito-rag-service'
   REGISTRY: ghcr.io
 

--- a/.github/workflows/publish-rag-service-mcr-image.yaml
+++ b/.github/workflows/publish-rag-service-mcr-image.yaml
@@ -13,7 +13,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.26.2'
+  GO_VERSION: '1.26.3'
   IMAGE_NAME: 'kaito-rag-service'
 
 jobs:

--- a/.github/workflows/publish-runtime-mcr-image.yaml
+++ b/.github/workflows/publish-runtime-mcr-image.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-    GO_VERSION: "1.26.2"
+    GO_VERSION: "1.26.3"
     BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 permissions:

--- a/.github/workflows/publish-workspace-gh-image.yaml
+++ b/.github/workflows/publish-workspace-gh-image.yaml
@@ -12,7 +12,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.26.2'
+  GO_VERSION: '1.26.3'
   IMAGE_NAME: 'workspace'
   REGISTRY: ghcr.io
 

--- a/.github/workflows/publish-workspace-mcr-image.yaml
+++ b/.github/workflows/publish-workspace-mcr-image.yaml
@@ -13,7 +13,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.26.2'
+  GO_VERSION: '1.26.3'
   IMAGE_NAME: 'workspace'
 
 jobs:

--- a/.github/workflows/ragengine-e2e-workflow.yaml
+++ b/.github/workflows/ragengine-e2e-workflow.yaml
@@ -35,7 +35,7 @@ jobs:
 
     env:
       TEST_SUITE: ${{ inputs.node_provisioner }}
-      GO_VERSION: "1.26.2"
+      GO_VERSION: "1.26.3"
       KARPENTER_NAMESPACE: "karpenter"
       GPU_PROVISIONER_NAMESPACE: "gpu-provisioner"
 

--- a/.github/workflows/ragengine-e2e.yaml
+++ b/.github/workflows/ragengine-e2e.yaml
@@ -13,7 +13,7 @@ on:
       - 'presets/ragengine/**'
 
 env:
-  GO_VERSION: "1.26.2"
+  GO_VERSION: "1.26.3"
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/unit-tests-ragengine.yaml
+++ b/.github/workflows/unit-tests-ragengine.yaml
@@ -17,7 +17,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: "1.26.2"
+  GO_VERSION: "1.26.3"
 
 jobs:
   unit-tests:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -13,7 +13,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: "1.26.2"
+  GO_VERSION: "1.26.3"
 
 jobs:
   unit-tests:

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   OLD_CHART_VERSION: ${{ github.event.inputs.old_chart_version || '0.7.1' }}
-  GO_VERSION: "1.26.2"
+  GO_VERSION: "1.26.3"
 
 jobs:
   chart-upgrade-test:

--- a/.github/workflows/workspace-e2e.yaml
+++ b/.github/workflows/workspace-e2e.yaml
@@ -21,7 +21,7 @@ on:
         default: "swedencentral"
 
 env:
-  GO_VERSION: "1.26.2"
+  GO_VERSION: "1.26.3"
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kaito-project/kaito
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/Azure/karpenter-provider-azure v1.10.2
@@ -29,6 +29,7 @@ require (
 	sigs.k8s.io/controller-runtime v0.22.4
 	sigs.k8s.io/gateway-api-inference-extension v1.3.1
 	sigs.k8s.io/karpenter v1.10.0
+	sigs.k8s.io/yaml v1.6.0
 )
 
 require (
@@ -131,7 +132,6 @@ require (
 	sigs.k8s.io/json v0.0.0-20250730193827-2d320260d730 // indirect
 	sigs.k8s.io/randfill v1.0.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v6 v6.3.1 // indirect
-	sigs.k8s.io/yaml v1.6.0 // indirect
 )
 
 replace (


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
To fix CVEs in stdlib: https://github.com/kaito-project/kaito/actions/runs/25540233952/job/74964356273#step:4:238

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: