### PR TITLE
feat: ragengine guardrails reload observability

### DIFF
--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -13,6 +13,7 @@
 
 import logging
 import re
+from hashlib import sha256
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -43,6 +44,8 @@ class OutputGuardrails:
     action_on_hit: str = DEFAULT_ACTION_ON_HIT
     block_message: str = DEFAULT_BLOCK_MESSAGE
     scanner_configs: tuple[ParsedScannerConfig, ...] = field(default_factory=tuple)
+    policy_hash: str = ""
+    policy_path: str = ""
 
     @classmethod
     def from_config(cls) -> "OutputGuardrails":
@@ -63,8 +66,9 @@ class OutputGuardrails:
             return self
 
         try:
-            with open(policy_path, encoding="utf-8") as policy_file:
-                policy = yaml.safe_load(policy_file) or {}
+            with open(policy_path, "rb") as policy_file:
+                policy_bytes = policy_file.read()
+            policy = yaml.safe_load(policy_bytes.decode("utf-8")) or {}
         except FileNotFoundError:
             logger.warning("output_guardrails_policy_missing path=%s", policy_path)
             return self
@@ -81,6 +85,7 @@ class OutputGuardrails:
         default_action_on_hit = _normalize_action(
             policy.get("action"), self.action_on_hit
         )
+        policy_hash = sha256(policy_bytes).hexdigest()
         scanner_configs = self.scanner_configs
         if "scanners" in policy:
             scanner_configs = _parse_policy_scanner_configs(
@@ -97,6 +102,8 @@ class OutputGuardrails:
                 policy.get("blockMessage"), self.block_message
             ),
             scanner_configs=scanner_configs,
+            policy_hash=policy_hash,
+            policy_path=policy_path,
         )
 
     def guard_response(

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -13,8 +13,8 @@
 
 import logging
 import re
-from hashlib import sha256
 from dataclasses import dataclass, field
+from hashlib import sha256
 from typing import Any
 
 import yaml

--- a/presets/ragengine/guardrails/reload.py
+++ b/presets/ragengine/guardrails/reload.py
@@ -33,6 +33,7 @@ from ragengine.metrics.prometheus_metrics import (
     RELOAD_RESULT_FAILURE,
     RELOAD_RESULT_NOOP,
     RELOAD_RESULT_SUCCESS,
+    guardrails_active_policy,
     guardrails_policy_loaded_timestamp,
     guardrails_policy_reload_total,
 )
@@ -61,7 +62,7 @@ class GuardrailsReloader:
         self._watcher_factory = watcher
         self._current_lock = threading.Lock()
         self._current = factory()
-        guardrails_policy_loaded_timestamp.set(time.time())
+        self._update_active_policy_metrics()
         self._task: asyncio.Task[None] | None = None
         self._stop_event: asyncio.Event | None = None
 
@@ -129,28 +130,53 @@ class GuardrailsReloader:
         try:
             new_instance = self._factory()
         except Exception:
+            current_policy_hash = self.get_current().policy_hash or "none"
             guardrails_policy_reload_total.labels(
                 **{"result": RELOAD_RESULT_FAILURE}
             ).inc()
             logger.exception(
-                "output_guardrails_policy_reload_failed path=%s", self._policy_path
+                "output_guardrails_reload_failed path=%s current_policy_hash=%s fallback_action=keep_current",
+                self._policy_path,
+                current_policy_hash,
             )
             return
 
         with self._current_lock:
+            current_policy_hash = self._current.policy_hash or "none"
             if new_instance == self._current:
                 guardrails_policy_reload_total.labels(
                     **{"result": RELOAD_RESULT_NOOP}
                 ).inc()
+                logger.info(
+                    "output_guardrails_reload_noop path=%s policy_hash=%s",
+                    self._policy_path,
+                    current_policy_hash,
+                )
                 return
 
+            old_policy_hash = current_policy_hash
             self._current = new_instance
-
         guardrails_policy_reload_total.labels(**{"result": RELOAD_RESULT_SUCCESS}).inc()
-        guardrails_policy_loaded_timestamp.set(time.time())
+        self._update_active_policy_metrics()
         logger.info(
-            "output_guardrails_policy_reloaded path=%s enabled=%s scanners=%d",
+            "output_guardrails_reload_succeeded path=%s old_policy_hash=%s new_policy_hash=%s enabled=%s scanners=%d",
             self._policy_path,
+            old_policy_hash,
+            new_instance.policy_hash or "none",
             new_instance.enabled,
             len(new_instance.scanner_configs),
+        )
+
+    def _update_active_policy_metrics(self) -> None:
+        with self._current_lock:
+            current = self._current
+
+        guardrails_policy_loaded_timestamp.set(time.time())
+        guardrails_active_policy.info(
+            {
+                "path": current.policy_path or self._policy_path or "",
+                "sha256": current.policy_hash or "none",
+                "enabled": str(current.enabled).lower(),
+                "scanner_count": str(len(current.scanner_configs)),
+            }
         )

--- a/presets/ragengine/metrics/prometheus_metrics.py
+++ b/presets/ragengine/metrics/prometheus_metrics.py
@@ -12,7 +12,7 @@
 # limitations under the License.
 
 
-from prometheus_client import Counter, Gauge, Histogram
+from prometheus_client import Counter, Gauge, Histogram, Info
 
 STATUS_LABEL = "status"
 MODE_LABEL = "mode"
@@ -296,4 +296,8 @@ guardrails_policy_reload_total = Counter(
 guardrails_policy_loaded_timestamp = Gauge(
     "guardrails_policy_loaded_timestamp_seconds",
     "Unix timestamp of the most recent successful output guardrails policy load.",
+)
+guardrails_active_policy = Info(
+    "guardrails_active_policy",
+    "Metadata for the currently active output guardrails policy.",
 )

--- a/presets/ragengine/tests/guardrails/test_reload.py
+++ b/presets/ragengine/tests/guardrails/test_reload.py
@@ -14,6 +14,8 @@
 import asyncio
 import os
 import sys
+from dataclasses import replace
+from hashlib import sha256
 import threading
 
 import pytest
@@ -22,6 +24,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 from ragengine.guardrails.output_guardrails import OutputGuardrails
 from ragengine.guardrails.reload import GuardrailsReloader
+from ragengine.metrics.prometheus_metrics import guardrails_active_policy
 
 
 def _factory(instances):
@@ -48,14 +51,40 @@ def _enabled(block_message: str = "blocked") -> OutputGuardrails:
     return OutputGuardrails(enabled=True, block_message=block_message)
 
 
+def _with_policy_meta(
+    guardrails: OutputGuardrails, *, policy_path: str, content: str, scanners: int = 0
+) -> OutputGuardrails:
+    return replace(
+        guardrails,
+        policy_path=policy_path,
+        policy_hash=sha256(content.encode("utf-8")).hexdigest(),
+        scanner_configs=tuple(object() for _ in range(scanners)),
+    )
+
+
+def _info_labels(metric, sample_name: str) -> dict[str, str]:
+    for collected in metric.collect():
+        for sample in collected.samples:
+            if sample.name == sample_name:
+                return sample.labels
+    raise AssertionError(f"sample {sample_name!r} not found")
+
+
 def test_initial_load_uses_factory_once():
-    initial = _disabled()
+    initial = _with_policy_meta(
+        _disabled(),
+        policy_path="/tmp/does-not-matter",
+        content="enabled: false\n",
+    )
     reloader = GuardrailsReloader(
         policy_path="/tmp/does-not-matter",
         debounce_seconds=0,
         factory=_factory([initial]),
     )
     assert reloader.get_current() is initial
+    labels = _info_labels(guardrails_active_policy, "guardrails_active_policy_info")
+    assert labels["path"] == "/tmp/does-not-matter"
+    assert labels["sha256"] == initial.policy_hash
 
 
 def test_start_is_noop_when_policy_path_is_empty():
@@ -84,8 +113,18 @@ def test_default_debounce_is_short_for_runtime_reload():
 
 
 def test_reload_swaps_in_new_instance_on_change():
-    first = _enabled("first")
-    second = _enabled("second")
+    first = _with_policy_meta(
+        _enabled("first"),
+        policy_path="/tmp/policy.yaml",
+        content="blockMessage: first\n",
+        scanners=1,
+    )
+    second = _with_policy_meta(
+        _enabled("second"),
+        policy_path="/tmp/policy.yaml",
+        content="blockMessage: second\n",
+        scanners=2,
+    )
     reloader = GuardrailsReloader(
         policy_path="/tmp/policy.yaml",
         debounce_seconds=0,
@@ -96,10 +135,18 @@ def test_reload_swaps_in_new_instance_on_change():
     reloader._reload()
 
     assert reloader.get_current() is second
+    labels = _info_labels(guardrails_active_policy, "guardrails_active_policy_info")
+    assert labels["path"] == "/tmp/policy.yaml"
+    assert labels["sha256"] == second.policy_hash
+    assert labels["scanner_count"] == "2"
 
 
-def test_reload_keeps_current_when_factory_raises():
-    first = _enabled("first")
+def test_reload_keeps_current_when_factory_raises(caplog):
+    first = _with_policy_meta(
+        _enabled("first"),
+        policy_path="/tmp/policy.yaml",
+        content="blockMessage: first\n",
+    )
     reloader = GuardrailsReloader(
         policy_path="/tmp/policy.yaml",
         debounce_seconds=0,
@@ -112,26 +159,41 @@ def test_reload_keeps_current_when_factory_raises():
     # Swap factory in-place so the next call to ``_reload`` raises.
     reloader._factory = boom
 
-    reloader._reload()
+    with caplog.at_level("ERROR"):
+        reloader._reload()
 
     assert reloader.get_current() is first
+    assert "fallback_action=keep_current" in caplog.text
+    labels = _info_labels(guardrails_active_policy, "guardrails_active_policy_info")
+    assert labels["sha256"] == first.policy_hash
 
 
-def test_reload_noop_when_policy_unchanged():
-    first = _enabled("same")
-    duplicate = _enabled("same")
+def test_reload_noop_when_policy_unchanged(caplog):
+    first = _with_policy_meta(
+        _enabled("same"),
+        policy_path="/tmp/policy.yaml",
+        content="blockMessage: same\n",
+    )
+    duplicate = _with_policy_meta(
+        _enabled("same"),
+        policy_path="/tmp/policy.yaml",
+        content="blockMessage: same\n",
+    )
     reloader = GuardrailsReloader(
         policy_path="/tmp/policy.yaml",
         debounce_seconds=0,
         factory=_factory([first, duplicate]),
     )
 
-    reloader._reload()
+    with caplog.at_level("INFO"):
+        reloader._reload()
 
     # The reloader keeps the original reference (not the duplicate) when the
     # new policy compares equal -- this avoids churning scanner objects that
     # request handlers may already be holding.
     assert reloader.get_current() is first
+    assert "output_guardrails_reload_noop" in caplog.text
+    assert first.policy_hash in caplog.text
 
 
 def test_get_current_returns_snapshot_while_reload_builds_new_instance():

--- a/presets/ragengine/tests/guardrails/test_reload.py
+++ b/presets/ragengine/tests/guardrails/test_reload.py
@@ -14,9 +14,9 @@
 import asyncio
 import os
 import sys
+import threading
 from dataclasses import replace
 from hashlib import sha256
-import threading
 
 import pytest
 


### PR DESCRIPTION
## What this PR does

This PR adds observability on top of the existing guardrails hot reload flow.

It is a stacked PR on top of the hot reload branch and focuses on making reload behavior easier to inspect and debug, without changing the watcher model or the core reload lifecycle.

Specifically, this PR adds:

- stable policy metadata on `OutputGuardrails`
- active policy metadata export for the currently live policy
- structured reload logs for success / failure / noop cases
- explicit fallback logging when reload fails and the previous policy is kept
- focused tests for active policy metadata and reload logging behavior
