### PR TITLE
feat: support per-scanner guardrails actions

### DIFF
--- a/charts/kaito/ragengine/templates/guardrails-policy-configmap.yaml
+++ b/charts/kaito/ragengine/templates/guardrails-policy-configmap.yaml
@@ -5,10 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
 data:
   guardrails.yaml: |
-    action: block
     blockMessage: The model output was blocked by output guardrails.
     scanners:
       - type: regex
+        action: redact
         patterns:
           - '-----BEGIN (?:[A-Z ]+)?PRIVATE KEY-----'
           - '\bAKIA[0-9A-Z]{16}\b'

--- a/docs/proposals/20260416-ragengine-guardrails-ux-api.md
+++ b/docs/proposals/20260416-ragengine-guardrails-ux-api.md
@@ -71,13 +71,14 @@ metadata:
   name: ragengine-guardrails-policy
 data:
   guardrails.yaml: |
-    action: redact
     blockMessage: The model output was blocked by output guardrails.
     scanners:
       - type: regex
+        action: redact
         patterns:
           - 'https?://\\S+'
       - type: ban_substrings
+        action: block
         substrings:
           - secret
 ```

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -58,9 +58,8 @@ class OutputGuardrails:
 
     def _apply_policy_file(self, policy_path: str) -> "OutputGuardrails":
         if not policy_path:
-            # No policy configured: returns self with empty scanner_configs.
-            # Combined with enabled=True this is effectively fail-open.
-            # TODO(next-PR): ship a default policy or refuse to start.
+            # Guardrails-enabled deployments should provide a policy path.
+            # An empty path currently falls back to fail-open.
             return self
 
         try:

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -79,17 +79,21 @@ class OutputGuardrails:
             logger.warning("output_guardrails_policy_invalid path=%s", policy_path)
             return self
 
+        default_action_on_hit = _normalize_action(
+            policy.get("action"), self.action_on_hit
+        )
         scanner_configs = list(self.scanner_configs)
         if "scanners" in policy:
             scanner_configs = _parse_policy_scanner_configs(
                 policy.get("scanners"),
                 policy_path,
+                default_action_on_hit,
             )
 
         return OutputGuardrails(
             enabled=self.enabled,
             fail_open=self.fail_open,
-            action_on_hit=_normalize_action(policy.get("action"), self.action_on_hit),
+            action_on_hit=default_action_on_hit,
             block_message=_coerce_string(
                 policy.get("blockMessage"), self.block_message
             ),
@@ -105,8 +109,8 @@ class OutputGuardrails:
             return response
 
         try:
-            scanners = self._build_scanners()
-            if not scanners:
+            built_scanners = self._build_scanners_with_configs()
+            if not built_scanners:
                 return response
 
             prompt = self._extract_prompt(request)
@@ -118,25 +122,40 @@ class OutputGuardrails:
                 if message.get("role") != "assistant" or not isinstance(content, str):
                     continue
 
-                sanitized_output, results_valid, results_score = scan_output(
-                    scanners, prompt, content, fail_fast=False
-                )
-                triggered_scanners = {
-                    scanner_name: results_score.get(scanner_name)
-                    for scanner_name, is_valid in results_valid.items()
-                    if not is_valid
-                }
+                sanitized_output = content
+                final_action = None
+                triggered_scanners: list[dict[str, Any]] = []
+                for parsed, scanner in built_scanners:
+                    sanitized_output, results_valid, results_score = scan_output(
+                        [scanner], prompt, sanitized_output, fail_fast=False
+                    )
+                    if all(results_valid.values()):
+                        continue
+
+                    triggered_scanners.append(
+                        {
+                            "type": parsed.type,
+                            "action": parsed.action_on_hit,
+                            "scores": results_score,
+                        }
+                    )
+                    if parsed.action_on_hit == "block":
+                        final_action = "block"
+                        break
+
+                    final_action = "redact"
+
                 if not triggered_scanners:
                     continue
 
-                if self.action_on_hit == "block":
+                if final_action == "block":
                     message["content"] = self.block_message
                 else:
                     message["content"] = sanitized_output
 
                 logger.info(
                     "output_guardrails_triggered action=%s response_id=%s scanners=%s",
-                    self.action_on_hit,
+                    final_action,
                     response.id,
                     triggered_scanners,
                 )
@@ -155,10 +174,16 @@ class OutputGuardrails:
             ) from exc
 
     def _build_scanners(self) -> list[Any]:
+        return [scanner for _, scanner in self._build_scanners_with_configs()]
+
+    def _build_scanners_with_configs(self) -> list[tuple[ParsedScannerConfig, Any]]:
         scanners: list[Any] = []
         for parsed in self.scanner_configs:
             try:
-                scanners.append(parsed.config.build(self.action_on_hit))
+                scanner_action_on_hit = parsed.action_on_hit or self.action_on_hit
+                scanners.append(
+                    (parsed, parsed.config.build(scanner_action_on_hit))
+                )
             except Exception:
                 logger.exception(
                     "output_guardrails_policy_scanner_build_failed type=%s",
@@ -183,7 +208,7 @@ class OutputGuardrails:
 
 
 def _parse_policy_scanner_configs(
-    value: Any, policy_path: str
+    value: Any, policy_path: str, default_action_on_hit: str = DEFAULT_ACTION_ON_HIT
 ) -> list[ParsedScannerConfig]:
     if value is None:
         return []
@@ -207,10 +232,14 @@ def _parse_policy_scanner_configs(
             )
             continue
 
+        scanner_action_on_hit = _normalize_action(
+            raw.get("action"), default_action_on_hit
+        )
+
         normalized_raw = {
             _normalize_scanner_key(str(key)): item
             for key, item in raw.items()
-            if key != "type"
+            if key not in {"type", "action"}
         }
         try:
             cfg = schema_cls.from_dict(normalized_raw)
@@ -222,7 +251,13 @@ def _parse_policy_scanner_configs(
             )
             continue
 
-        parsed_configs.append(ParsedScannerConfig(type=scanner_type, config=cfg))
+        parsed_configs.append(
+            ParsedScannerConfig(
+                type=scanner_type,
+                action_on_hit=scanner_action_on_hit,
+                config=cfg,
+            )
+        )
 
     return parsed_configs
 

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -125,6 +125,7 @@ class OutputGuardrails:
                 final_action = None
                 triggered_scanners: list[dict[str, Any]] = []
                 for parsed, scanner in built_scanners:
+                    scanner_action_on_hit = parsed.action_on_hit or self.action_on_hit
                     sanitized_output, results_valid, results_score = scan_output(
                         [scanner], prompt, sanitized_output, fail_fast=False
                     )
@@ -134,11 +135,11 @@ class OutputGuardrails:
                     triggered_scanners.append(
                         {
                             "type": parsed.type,
-                            "action": parsed.action_on_hit,
+                            "action": scanner_action_on_hit,
                             "scores": results_score,
                         }
                     )
-                    if parsed.action_on_hit == "block":
+                    if scanner_action_on_hit == "block":
                         final_action = "block"
                         break
 

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -181,9 +181,7 @@ class OutputGuardrails:
         for parsed in self.scanner_configs:
             try:
                 scanner_action_on_hit = parsed.action_on_hit or self.action_on_hit
-                scanners.append(
-                    (parsed, parsed.config.build(scanner_action_on_hit))
-                )
+                scanners.append((parsed, parsed.config.build(scanner_action_on_hit)))
             except Exception:
                 logger.exception(
                     "output_guardrails_policy_scanner_build_failed type=%s",

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -141,6 +141,7 @@ class ParsedScannerConfig:
 
     type: str
     config: Any
+    action_on_hit: str | None = None
 
 
 def _coerce_string_list(value: Any) -> list[str]:

--- a/presets/ragengine/tests/api/test_chat_completions.py
+++ b/presets/ragengine/tests/api/test_chat_completions.py
@@ -507,7 +507,7 @@ async def test_chat_completions_output_guardrails_fail_closed(
     )
     monkeypatch.setattr(
         guardrails,
-        "_build_scanners",
+        "_build_scanners_with_configs",
         lambda: (_ for _ in ()).throw(RuntimeError("scanner init failed")),
     )
 

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -661,7 +661,7 @@ def test_guard_response_applies_action(
         enabled=True,
         action_on_hit=action,
         block_message=block_message,
-            scanner_configs=[_regex_cfg(patterns=[r"\S+"], action_on_hit=action)],
+        scanner_configs=[_regex_cfg(patterns=[r"\S+"], action_on_hit=action)],
     )
 
     out = guardrails.guard_response(_make_response("dirty"), {"messages": []})

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -48,16 +48,20 @@ def _write_policy(tmp_path, monkeypatch, yaml_content: str, *, enabled: bool = T
     return policy_path
 
 
-def _regex_cfg(patterns=("a",), **kw) -> ParsedScannerConfig:
+def _regex_cfg(patterns=("a",), action_on_hit="redact", **kw) -> ParsedScannerConfig:
     return ParsedScannerConfig(
         type="regex",
+        action_on_hit=action_on_hit,
         config=RegexConfig(patterns=list(patterns), **kw),
     )
 
 
-def _ban_subs_cfg(substrings=("secret",), **kw) -> ParsedScannerConfig:
+def _ban_subs_cfg(
+    substrings=("secret",), action_on_hit="redact", **kw
+) -> ParsedScannerConfig:
     return ParsedScannerConfig(
         type="ban_substrings",
+        action_on_hit=action_on_hit,
         config=BanSubstringsConfig(substrings=list(substrings), **kw),
     )
 
@@ -183,8 +187,8 @@ def test_from_config_loads_yaml_policy(tmp_path, monkeypatch):
     assert guardrails.action_on_hit == "block"
     assert guardrails.block_message == "blocked-by-policy"
     assert guardrails.scanner_configs == [
-        _regex_cfg(patterns=[r"https?://\S+"]),
-        _ban_subs_cfg(substrings=["secret"]),
+        _regex_cfg(patterns=[r"https?://\S+"], action_on_hit="block"),
+        _ban_subs_cfg(substrings=["secret"], action_on_hit="block"),
     ]
 
 
@@ -218,7 +222,9 @@ def test_from_config_replaces_scanners_with_policy_values(tmp_path, monkeypatch)
     guardrails = OutputGuardrails.from_config()
 
     assert guardrails.action_on_hit == "block"
-    assert guardrails.scanner_configs == [_ban_subs_cfg(substrings=["yaml-only"])]
+    assert guardrails.scanner_configs == [
+        _ban_subs_cfg(substrings=["yaml-only"], action_on_hit="block")
+    ]
 
 
 def test_from_config_invalid_action_falls_back_to_default(tmp_path, monkeypatch):
@@ -237,7 +243,9 @@ def test_from_config_invalid_action_falls_back_to_default(tmp_path, monkeypatch)
     guardrails = OutputGuardrails.from_config()
 
     assert guardrails.action_on_hit == "redact"
-    assert guardrails.scanner_configs == [_regex_cfg(patterns=[r"https?://\S+"])]
+    assert guardrails.scanner_configs == [
+        _regex_cfg(patterns=[r"https?://\S+"], action_on_hit="redact")
+    ]
 
 
 def test_from_config_returns_empty_scanners_when_policy_scanners_is_not_a_list(
@@ -257,6 +265,32 @@ def test_from_config_returns_empty_scanners_when_policy_scanners_is_not_a_list(
 
     assert guardrails.action_on_hit == "block"
     assert guardrails.scanner_configs == []
+
+
+def test_from_config_scanner_action_overrides_top_level_action(tmp_path, monkeypatch):
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: block
+        scanners:
+          - type: regex
+            action: redact
+            patterns:
+              - https?://\\S+
+          - type: ban_substrings
+            substrings:
+              - secret
+        """,
+    )
+
+    guardrails = OutputGuardrails.from_config()
+
+    assert guardrails.action_on_hit == "block"
+    assert guardrails.scanner_configs == [
+        _regex_cfg(patterns=[r"https?://\S+"], action_on_hit="redact"),
+        _ban_subs_cfg(substrings=["secret"], action_on_hit="block"),
+    ]
 
 
 def test_from_config_skips_invalid_scanners_and_filters_non_string_values(
@@ -477,6 +511,24 @@ def test_build_scanners_supports_normalized_ban_substrings_type(
     assert scanners[0].redact is True
 
 
+def test_build_scanners_uses_per_scanner_action(fake_llm_guard_scanners):
+    parsed = [
+        _regex_cfg(patterns=["a"], action_on_hit="redact"),
+        _ban_subs_cfg(substrings=["secret"], action_on_hit="block"),
+    ]
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        action_on_hit="redact",
+        scanner_configs=parsed,
+    )
+
+    scanners = guardrails._build_scanners()
+
+    assert scanners[0].redact is True
+    assert scanners[1].redact is False
+
+
 def test_build_scanners_skips_configs_whose_build_raises(monkeypatch):
     sentinel = object()
     call_count = {"n": 0}
@@ -609,11 +661,67 @@ def test_guard_response_applies_action(
         enabled=True,
         action_on_hit=action,
         block_message=block_message,
-        scanner_configs=[_regex_cfg(patterns=[r"\S+"])],
+            scanner_configs=[_regex_cfg(patterns=[r"\S+"], action_on_hit=action)],
     )
 
     out = guardrails.guard_response(_make_response("dirty"), {"messages": []})
     assert out.choices[0].message.content == expected_content
+
+
+def test_guard_response_applies_mixed_scanner_actions_in_order(monkeypatch):
+    call_outputs = iter(
+        [
+            ("REDACTED-CONTENT", {"regex": False}, {"regex": 0.9}),
+            (
+                "REDACTED-CONTENT",
+                {"ban_substrings": True},
+                {"ban_substrings": 0.0},
+            ),
+        ]
+    )
+
+    def _scan_output(scanners, prompt, output, fail_fast):
+        return next(call_outputs)
+
+    _patch_scan_output(monkeypatch, _scan_output)
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        block_message="blocked!",
+        scanner_configs=[
+            _regex_cfg(patterns=[r"\S+"], action_on_hit="redact"),
+            _ban_subs_cfg(substrings=["secret"], action_on_hit="block"),
+        ],
+    )
+
+    out = guardrails.guard_response(_make_response("dirty"), {"messages": []})
+    assert out.choices[0].message.content == "REDACTED-CONTENT"
+
+
+def test_guard_response_block_wins_when_block_scanner_triggers(monkeypatch):
+    call_outputs = iter(
+        [
+            ("REDACTED-CONTENT", {"regex": False}, {"regex": 0.9}),
+            ("ignored-after-block", {"ban_substrings": False}, {"ban_substrings": 0.7}),
+        ]
+    )
+
+    def _scan_output(scanners, prompt, output, fail_fast):
+        return next(call_outputs)
+
+    _patch_scan_output(monkeypatch, _scan_output)
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        block_message="blocked!",
+        scanner_configs=[
+            _regex_cfg(patterns=[r"\S+"], action_on_hit="redact"),
+            _ban_subs_cfg(substrings=["secret"], action_on_hit="block"),
+        ],
+    )
+
+    out = guardrails.guard_response(_make_response("dirty"), {"messages": []})
+    assert out.choices[0].message.content == "blocked!"
 
 
 # ---------------------------------------------------------------------------

--- a/presets/ragengine/tests/test_default_guardrails_policy.py
+++ b/presets/ragengine/tests/test_default_guardrails_policy.py
@@ -64,3 +64,4 @@ def test_default_guardrails_policy_template_has_non_empty_scanners():
     parsed = _parse_policy_scanner_configs(scanners, str(CHART_TEMPLATE))
     assert parsed
     assert [scanner.type for scanner in parsed] == ["regex"]
+    assert [scanner.action_on_hit for scanner in parsed] == ["redact"]


### PR DESCRIPTION
**Reason for Change**:
Support per-scanner `action` in the guardrails policy so operators can mix `redact` and `block` behavior within one policy. This also updates the default guardrails template to redact regex hits instead of blocking the whole response.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
- Top-level `action` remains supported as the default for scanners that do not set their own `action`.
- Runtime execution now applies scanners one by one so mixed `redact`/`block` policies behave deterministically.
- The default ConfigMap template now marks the baseline regex scanner as `action: redact`.
- Validated with:
  - `./.venv/bin/python -m pytest presets/ragengine/tests/guardrails/test_output_guardrails.py presets/ragengine/tests/test_default_guardrails_policy.py`
  - `./.venv/bin/python -m pytest presets/ragengine/tests/api/test_chat_completions.py -k output_guardrails_policy_file`