### PR TITLE
chore: use CRD API enum for inference role constants instead of consts package

### DIFF
--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -124,8 +124,6 @@ const (
 
 	// Inference role constants for P/D disaggregated serving.
 	InferenceRoleEnvName = "KAITO_INFERENCE_ROLE"
-	InferenceRolePrefill = "prefill"
-	InferenceRoleDecode  = "decode"
 
 	// ConditionReady is the condition type for a ready condition.
 	ConditionReady = "Ready"

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -122,7 +122,8 @@ const (
 	// through the routing layer. vLLM keeps its default port (5000).
 	PortRoutingSidecar = int32(5001)
 
-	// Inference role constants for P/D disaggregated serving.
+	// InferenceRoleEnvName is the environment variable name used to pass the
+	// inference role (prefill/decode) to the model container in P/D disaggregated serving.
 	InferenceRoleEnvName = "KAITO_INFERENCE_ROLE"
 
 	// ConditionReady is the condition type for a ready condition.

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -30,8 +30,8 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/kaito-project/kaito/api/v1beta1"
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
+	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/sku"

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kaito-project/kaito/api/v1beta1"
+	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	pkgmodel "github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/sku"
@@ -694,7 +695,7 @@ func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec
 // env var; sidecar containers do not use it.
 func applyInferenceRoleEnv(labels map[string]string, containerName string, spec *corev1.PodSpec) {
 	role, ok := labels[v1beta1.LabelInferenceRole]
-	if !ok || (role != consts.InferenceRolePrefill && role != consts.InferenceRoleDecode) {
+	if !ok || (role != string(kaitov1alpha1.MultiRoleInferenceRolePrefill) && role != string(kaitov1alpha1.MultiRoleInferenceRoleDecode)) {
 		return
 	}
 	for i := range spec.Containers {
@@ -742,7 +743,7 @@ func injectRoutingSidecar(spec *corev1.PodSpec) {
 // needsRoutingSidecar returns true if the workspace requires the llm-d routing sidecar.
 func needsRoutingSidecar(ws *v1beta1.Workspace) bool {
 	role, ok := ws.Labels[v1beta1.LabelInferenceRole]
-	if !ok || role != consts.InferenceRoleDecode {
+	if !ok || role != string(kaitov1alpha1.MultiRoleInferenceRoleDecode) {
 		return false
 	}
 	return v1beta1.GetWorkspaceRuntimeName(ws) == pkgmodel.RuntimeNameVLLM

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/sku"
@@ -1411,15 +1412,15 @@ func TestApplyInferenceRoleEnv(t *testing.T) {
 		},
 		{
 			name:          "prefill role - env set",
-			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
+			labels:        map[string]string{v1beta1.LabelInferenceRole: string(kaitov1alpha1.MultiRoleInferenceRolePrefill)},
 			expectEnvSet:  true,
-			expectedValue: consts.InferenceRolePrefill,
+			expectedValue: string(kaitov1alpha1.MultiRoleInferenceRolePrefill),
 		},
 		{
 			name:          "decode role - env set",
-			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
+			labels:        map[string]string{v1beta1.LabelInferenceRole: string(kaitov1alpha1.MultiRoleInferenceRoleDecode)},
 			expectEnvSet:  true,
-			expectedValue: consts.InferenceRoleDecode,
+			expectedValue: string(kaitov1alpha1.MultiRoleInferenceRoleDecode),
 		},
 	}
 
@@ -1464,12 +1465,12 @@ func TestInjectRoutingSidecar(t *testing.T) {
 		},
 		{
 			name:          "prefill role - no sidecar",
-			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRolePrefill},
+			labels:        map[string]string{v1beta1.LabelInferenceRole: string(kaitov1alpha1.MultiRoleInferenceRolePrefill)},
 			expectSidecar: false,
 		},
 		{
 			name:          "decode role - sidecar injected",
-			labels:        map[string]string{v1beta1.LabelInferenceRole: consts.InferenceRoleDecode},
+			labels:        map[string]string{v1beta1.LabelInferenceRole: string(kaitov1alpha1.MultiRoleInferenceRoleDecode)},
 			expectSidecar: true,
 		},
 	}

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -79,7 +79,7 @@ func GenerateServiceManifest(workspaceObj *kaitov1beta1.Workspace, serviceType c
 	// Service/Gateway traffic routes to the sidecar on PortRoutingSidecar.
 	httpTargetPort := consts.PortInferenceServer
 	role, hasRole := workspaceObj.Labels[kaitov1beta1.LabelInferenceRole]
-	if hasRole && role == consts.InferenceRoleDecode && kaitov1beta1.GetWorkspaceRuntimeName(workspaceObj) == pkgmodel.RuntimeNameVLLM {
+	if hasRole && role == string(kaitov1alpha1.MultiRoleInferenceRoleDecode) && kaitov1beta1.GetWorkspaceRuntimeName(workspaceObj) == pkgmodel.RuntimeNameVLLM {
 		httpTargetPort = consts.PortRoutingSidecar
 	}
 
@@ -393,7 +393,7 @@ func GenerateInferencePoolOCIRepository(inferenceSetObj *kaitov1alpha1.Inference
 // explicitly overridden by the kaito.sh/runtime annotation.
 func inferencePoolTargetPort(inferenceSetObj *kaitov1alpha1.InferenceSet) int32 {
 	role := inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole]
-	if role != consts.InferenceRoleDecode {
+	if role != string(kaitov1alpha1.MultiRoleInferenceRoleDecode) {
 		return consts.PortInferenceServer
 	}
 	// Mirror GetWorkspaceRuntimeName logic: default to vLLM when feature gate is on.

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -98,7 +98,7 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 				if ws.Spec.Template.Labels == nil {
 					ws.Spec.Template.Labels = map[string]string{}
 				}
-				ws.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = consts.InferenceRoleDecode
+				ws.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = string(kaitov1alpha1.MultiRoleInferenceRoleDecode)
 				ws.Annotations[kaitov1beta1.AnnotationWorkspaceRuntime] = string(pkgmodel.RuntimeNameVLLM)
 				return ws
 			}(),
@@ -134,7 +134,7 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 				if ws.Spec.Template.Labels == nil {
 					ws.Spec.Template.Labels = map[string]string{}
 				}
-				ws.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = consts.InferenceRoleDecode
+				ws.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = string(kaitov1alpha1.MultiRoleInferenceRoleDecode)
 				delete(ws.Annotations, kaitov1beta1.AnnotationWorkspaceRuntime)
 				return ws
 			}(),

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -457,7 +457,7 @@ func createGemma3InferenceSetWithDecodeLabelAndVLLM(replicas int) *kaitov1alpha1
 		if inferenceSetObj.Spec.Template.Labels == nil {
 			inferenceSetObj.Spec.Template.Labels = make(map[string]string)
 		}
-		inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = consts.InferenceRoleDecode
+		inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = string(kaitov1alpha1.MultiRoleInferenceRoleDecode)
 		createAndValidateInferenceSet(inferenceSetObj)
 	})
 	return inferenceSetObj


### PR DESCRIPTION
## What this PR does

Replaces `consts.InferenceRolePrefill` (`"prefill"`) and `consts.InferenceRoleDecode` (`"decode"`) with the CRD API enum types `kaitov1alpha1.MultiRoleInferenceRolePrefill` and `kaitov1alpha1.MultiRoleInferenceRoleDecode` from `api/v1alpha1/multiroleinference_types.go`.

This avoids duplicate string definitions and uses the CRD-defined enum as the single source of truth for inference role values.

### Changes
- Remove `InferenceRolePrefill` and `InferenceRoleDecode` from `pkg/utils/consts/consts.go`
- Replace all usages across `manifests.go`, `preset_inferences.go`, and their tests with `string(kaitov1alpha1.MultiRoleInferenceRole{Prefill,Decode})`
- Keep `InferenceRoleEnvName` in consts (not part of the CRD enum)

### Related
- Addresses review comment from @Fei-Guo in #2027
