### PR TITLE
fix: missing webhook infrastructure and add e2e test for MultiRoleInference 

### DIFF
--- a/charts/kaito/workspace/templates/inferenceset_clusterrole.yaml
+++ b/charts/kaito/workspace/templates/inferenceset_clusterrole.yaml
@@ -37,7 +37,7 @@ rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
     verbs: ["update"]
-    resourceNames: ["validation.inferenceset.kaito.sh"]
+    resourceNames: ["validation.inferenceset.kaito.sh", "validation.multiroleinference.kaito.sh"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch", "update"]

--- a/charts/kaito/workspace/templates/inferenceset_clusterrole.yaml
+++ b/charts/kaito/workspace/templates/inferenceset_clusterrole.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.featureGates.enableInferenceSetController -}}
+{{- if or .Values.featureGates.enableInferenceSetController .Values.featureGates.enableMultiRoleInferenceController -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/charts/kaito/workspace/templates/inferenceset_clusterrole.yaml
+++ b/charts/kaito/workspace/templates/inferenceset_clusterrole.yaml
@@ -37,7 +37,7 @@ rules:
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
     verbs: ["update"]
-    resourceNames: ["validation.inferenceset.kaito.sh", "validation.multiroleinference.kaito.sh"]
+    resourceNames: ["validation.inferenceset.kaito.sh"{{- if .Values.featureGates.enableMultiRoleInferenceController }}, "validation.multiroleinference.kaito.sh"{{- end }}]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch", "update"]

--- a/charts/kaito/workspace/templates/inferenceset_clusterrole_binding.yaml
+++ b/charts/kaito/workspace/templates/inferenceset_clusterrole_binding.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.featureGates.enableInferenceSetController -}}
+{{- if or .Values.featureGates.enableInferenceSetController .Values.featureGates.enableMultiRoleInferenceController -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/kaito/workspace/templates/multiroleinference_clusterrole.yaml
+++ b/charts/kaito/workspace/templates/multiroleinference_clusterrole.yaml
@@ -1,34 +1,34 @@
-{{- if .Values.featureGates.enableInferenceSetController -}}
+{{- if .Values.featureGates.enableMultiRoleInferenceController -}}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "kaito.inferenceSetClusterRoleName" . }}
+  name: {{ include "kaito.fullname" . }}-multiroleinference
   labels:
     {{- include "kaito.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["kaito.sh"]
-    resources: ["workspaces"]
+    resources: ["multiroleinferences"]
     verbs: ["update", "patch","get","list","watch", "create", "delete"]
   - apiGroups: ["kaito.sh"]
-    resources: ["workspaces/status"]
+    resources: ["multiroleinferences/status"]
     verbs: ["update", "patch","get","list","watch"]
+  - apiGroups: ["kaito.sh"]
+    resources: ["multiroleinferences/finalizers"]
+    verbs: ["update", "patch"]
   - apiGroups: ["kaito.sh"]
     resources: ["inferencesets"]
     verbs: ["update", "patch","get","list","watch","create","delete"]
   - apiGroups: ["kaito.sh"]
     resources: ["inferencesets/status"]
-    verbs: ["update", "patch","get","list","watch"]
-  - apiGroups: [ "apps" ]
-    resources: ["controllerrevisions" ]
-    verbs: [ "get","list","watch","create", "delete","update", "patch"]
+    verbs: ["get","list","watch"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
     verbs: ["get","list","watch"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
     verbs: ["update"]
-    resourceNames: ["validation.inferenceset.kaito.sh"]
+    resourceNames: ["validation.multiroleinference.kaito.sh"]
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch", "update"]

--- a/charts/kaito/workspace/templates/multiroleinference_clusterrole_binding.yaml
+++ b/charts/kaito/workspace/templates/multiroleinference_clusterrole_binding.yaml
@@ -1,14 +1,14 @@
-{{- if .Values.featureGates.enableInferenceSetController -}}
+{{- if .Values.featureGates.enableMultiRoleInferenceController -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "kaito.inferenceSetClusterRoleBindingName" . }}
+  name: {{ include "kaito.fullname" . }}-multiroleinference
   labels:
    {{- include "kaito.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "kaito.inferenceSetClusterRoleName" . }}
+  name: {{ include "kaito.fullname" . }}-multiroleinference
 subjects:
 - kind: ServiceAccount
   name: {{ include "kaito.serviceAccountName" . }}

--- a/charts/kaito/workspace/templates/webhooks.yaml
+++ b/charts/kaito/workspace/templates/webhooks.yaml
@@ -54,7 +54,7 @@ webhooks:
           - CREATE
           - UPDATE
 {{- end }}
-{{- if .Values.featureGates.enableInferenceSetController }}
+{{- if .Values.featureGates.enableMultiRoleInferenceController }}
 ---
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration

--- a/charts/kaito/workspace/templates/webhooks.yaml
+++ b/charts/kaito/workspace/templates/webhooks.yaml
@@ -53,4 +53,33 @@ webhooks:
         operations:
           - CREATE
           - UPDATE
+{{- end }}
+{{- if .Values.featureGates.enableInferenceSetController }}
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+metadata:
+  name: validation.multiroleinference.kaito.sh
+  labels:
+    {{- include "kaito.labels" . | nindent 4 }}
+webhooks:
+  - name: validation.multiroleinference.kaito.sh
+    admissionReviewVersions: ["v1"]
+    clientConfig:
+      service:
+        name: {{ include "kaito.serviceName" . }}
+        namespace: {{ .Release.Namespace }}
+        port: {{ .Values.webhook.port }}
+    failurePolicy: Fail
+    sideEffects: None
+    rules:
+      - apiGroups:
+          - kaito.sh
+        apiVersions:
+          - v1alpha1
+        resources:
+          - multiroleinferences
+        operations:
+          - CREATE
+          - UPDATE
 {{- end -}}

--- a/cmd/workspace/main.go
+++ b/cmd/workspace/main.go
@@ -295,10 +295,8 @@ func main() {
 		}
 	}
 
-	// MultiRoleInference controller — requires enableMultiRoleInferenceController, InferenceSet controller, and GAIE.
-	if featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] &&
-		featuregates.FeatureGates[consts.FeatureFlagEnableInferenceSetController] &&
-		featuregates.FeatureGates[consts.FeatureFlagGatewayAPIInferenceExtension] {
+	// MultiRoleInference controller — requires enableMultiRoleInferenceController.
+	if featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] {
 		mriReconciler := multiroleinference.NewMultiRoleInferenceReconciler(
 			kClient,
 			mgr.GetScheme(),

--- a/pkg/workspace/webhooks/webhooks.go
+++ b/pkg/workspace/webhooks/webhooks.go
@@ -38,10 +38,7 @@ func NewControllerWebhooks() []knativeinjection.ControllerConstructor {
 
 	if featuregates.FeatureGates[consts.FeatureFlagEnableInferenceSetController] {
 		constructor = append(constructor, NewInferenceSetCRDValidationWebhook)
-		// MRI webhook requires GAIE — MRI creates InferencePool + EPP.
-		if featuregates.FeatureGates[consts.FeatureFlagGatewayAPIInferenceExtension] {
-			constructor = append(constructor, NewMultiRoleInferenceCRDValidationWebhook)
-		}
+		constructor = append(constructor, NewMultiRoleInferenceCRDValidationWebhook)
 	}
 
 	return constructor

--- a/pkg/workspace/webhooks/webhooks.go
+++ b/pkg/workspace/webhooks/webhooks.go
@@ -38,6 +38,8 @@ func NewControllerWebhooks() []knativeinjection.ControllerConstructor {
 
 	if featuregates.FeatureGates[consts.FeatureFlagEnableInferenceSetController] {
 		constructor = append(constructor, NewInferenceSetCRDValidationWebhook)
+	}
+	if featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] {
 		constructor = append(constructor, NewMultiRoleInferenceCRDValidationWebhook)
 	}
 

--- a/pkg/workspace/webhooks/webhooks_test.go
+++ b/pkg/workspace/webhooks/webhooks_test.go
@@ -28,25 +28,25 @@ func TestNewControllerWebhooks(t *testing.T) {
 	tests := []struct {
 		name                     string
 		enableInferenceSet       bool
-		enableGAIE               bool
+		enableMRI                bool
 		expectedConstructorCount int
 	}{
 		{
 			name:                     "InferenceSet controller disabled",
 			enableInferenceSet:       false,
-			enableGAIE:               false,
+			enableMRI:                false,
 			expectedConstructorCount: 2,
 		},
 		{
-			name:                     "InferenceSet controller enabled without GAIE",
+			name:                     "InferenceSet controller enabled without MRI",
 			enableInferenceSet:       true,
-			enableGAIE:               false,
+			enableMRI:                false,
 			expectedConstructorCount: 3, // certificates + workspace + inferenceset
 		},
 		{
-			name:                     "InferenceSet controller enabled with GAIE",
+			name:                     "InferenceSet and MRI controllers enabled",
 			enableInferenceSet:       true,
-			enableGAIE:               true,
+			enableMRI:                true,
 			expectedConstructorCount: 4, // certificates + workspace + inferenceset + MRI
 		},
 	}
@@ -55,15 +55,15 @@ func TestNewControllerWebhooks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			// Save original feature gate state
 			originalIS := featuregates.FeatureGates[consts.FeatureFlagEnableInferenceSetController]
-			originalGAIE := featuregates.FeatureGates[consts.FeatureFlagGatewayAPIInferenceExtension]
+			originalMRI := featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController]
 			defer func() {
 				featuregates.FeatureGates[consts.FeatureFlagEnableInferenceSetController] = originalIS
-				featuregates.FeatureGates[consts.FeatureFlagGatewayAPIInferenceExtension] = originalGAIE
+				featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = originalMRI
 			}()
 
 			// Set feature gates for test
 			featuregates.FeatureGates[consts.FeatureFlagEnableInferenceSetController] = tt.enableInferenceSet
-			featuregates.FeatureGates[consts.FeatureFlagGatewayAPIInferenceExtension] = tt.enableGAIE
+			featuregates.FeatureGates[consts.FeatureFlagEnableMultiRoleInferenceController] = tt.enableMRI
 
 			// Call the function
 			constructors := NewControllerWebhooks()

--- a/pkg/workspace/webhooks/webhooks_test.go
+++ b/pkg/workspace/webhooks/webhooks_test.go
@@ -49,6 +49,12 @@ func TestNewControllerWebhooks(t *testing.T) {
 			enableMRI:                true,
 			expectedConstructorCount: 4, // certificates + workspace + inferenceset + MRI
 		},
+		{
+			name:                     "MRI controller enabled without InferenceSet",
+			enableInferenceSet:       false,
+			enableMRI:                true,
+			expectedConstructorCount: 3, // certificates + workspace + MRI
+		},
 	}
 
 	for _, tt := range tests {

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -433,33 +433,6 @@ func createGemma3InferenceSetWithPresetPublicModeAndVLLM(replicas int) *kaitov1a
 	return inferenceSetObj
 }
 
-func createGemma3InferenceSetWithDecodeLabelAndVLLM(replicas int) *kaitov1alpha1.InferenceSet {
-	modelSecret := createAndValidateModelSecret()
-	inferenceSetObj := &kaitov1alpha1.InferenceSet{}
-	By("Creating an InferenceSet CR with Gemma 3 and decode label for P/D disaggregation", func() {
-		uniqueID := fmt.Sprint("preset-gemma3-is-decode-", rand.Intn(1000))
-		inferenceSetObj = utils.GenerateInferenceSetManifestWithVLLM(uniqueID, namespaceName, "", replicas, "Standard_NV36ads_A10_v5",
-			&metav1.LabelSelector{
-				MatchLabels: map[string]string{"kaito-workspace": "public-preset-is-e2e-test-gemma-vllm-decode"},
-			}, PresetGemma3_4BInstructModel, nil, nil, modelSecret.Name)
-		// Add inference-role label to exercise the P/D disaggregated inference path:
-		// GenerateInferencePodSpec sets KAITO_INFERENCE_ROLE=decode env var and injects
-		// the routing sidecar. inference_api.py uses the env var to configure
-		// NixlConnector kv_transfer_config with kv_both (when no user-provided
-		// kv_transfer_config is set). The workspace reaching Ready status validates
-		// that the inline sidecar injection works correctly with vLLM startup.
-		// TODO: Add explicit assertions that the decode label propagated to the child
-		// Workspace, the StatefulSet pod template contains llm-d-routing-sidecar
-		// container, and the Service/InferencePool targetPort is PortRoutingSidecar.
-		if inferenceSetObj.Spec.Template.Labels == nil {
-			inferenceSetObj.Spec.Template.Labels = make(map[string]string)
-		}
-		inferenceSetObj.Spec.Template.Labels[kaitov1beta1.LabelInferenceRole] = string(kaitov1alpha1.MultiRoleInferenceRoleDecode)
-		createAndValidateInferenceSet(inferenceSetObj)
-	})
-	return inferenceSetObj
-}
-
 func createGemma3MultiRoleInference() *kaitov1alpha1.MultiRoleInference {
 	modelSecret := createAndValidateModelSecret()
 	mriObj := &kaitov1alpha1.MultiRoleInference{}
@@ -735,7 +708,7 @@ func validateGatewayAPIInferenceExtensionResources(iObj *kaitov1alpha1.Inference
 	By("Checking Flux OCIRepository is Ready", func() {
 		Eventually(func() bool {
 			ociRepository := &sourcev1.OCIRepository{}
-			err := utils.utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+			err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
 				Namespace: iObj.Namespace,
 				Name:      kaitoutils.InferencePoolName(iObj.Name),
 			}, ociRepository, &client.GetOptions{})
@@ -754,7 +727,7 @@ func validateGatewayAPIInferenceExtensionResources(iObj *kaitov1alpha1.Inference
 	By("Checking Flux HelmRelease is Ready", func() {
 		Eventually(func() bool {
 			helmRelease := &helmv2.HelmRelease{}
-			err := utils.utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+			err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
 				Namespace: iObj.Namespace,
 				Name:      kaitoutils.InferencePoolName(iObj.Name),
 			}, helmRelease, &client.GetOptions{})
@@ -778,7 +751,7 @@ func validateGatewayAPIInferenceExtensionResources(iObj *kaitov1alpha1.Inference
 func validateWorkspaceBenchmarkCompleted(workspaceObj *kaitov1beta1.Workspace) {
 	By("Validating workspace benchmark completed and performance is set", func() {
 		Eventually(func() bool {
-			err := utils.utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+			err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
 				Name:      workspaceObj.Name,
 				Namespace: workspaceObj.Namespace,
 			}, workspaceObj)
@@ -867,7 +840,7 @@ func logBenchmarkPhaseElapsed(coreClient *kubernetes.Clientset, wsName, wsNamesp
 func validateInferenceSetBenchmarkCompleted(inferenceSetObj *kaitov1alpha1.InferenceSet) {
 	By("Validating inferenceset aggregated performance is set", func() {
 		Eventually(func() bool {
-			err := utils.utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+			err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
 				Name:      inferenceSetObj.Name,
 				Namespace: inferenceSetObj.Namespace,
 			}, inferenceSetObj)
@@ -893,7 +866,7 @@ func validateInferenceSetBenchmarkCompleted(inferenceSetObj *kaitov1alpha1.Infer
 	By("Validating all child workspace benchmarks completed", func() {
 		wsList := &kaitov1beta1.WorkspaceList{}
 		Eventually(func() bool {
-			err := utils.utils.TestingCluster.KubeClient.List(ctx, wsList,
+			err := utils.TestingCluster.KubeClient.List(ctx, wsList,
 				client.InNamespace(inferenceSetObj.Namespace),
 				client.MatchingLabels{consts.WorkspaceCreatedByInferenceSetLabel: inferenceSetObj.Name},
 			)
@@ -925,7 +898,7 @@ func validateInferenceSetBenchmarkCompleted(inferenceSetObj *kaitov1alpha1.Infer
 			return
 		}
 		wsList := &kaitov1beta1.WorkspaceList{}
-		if err := utils.utils.TestingCluster.KubeClient.List(ctx, wsList,
+		if err := utils.TestingCluster.KubeClient.List(ctx, wsList,
 			client.InNamespace(inferenceSetObj.Namespace),
 			client.MatchingLabels{consts.WorkspaceCreatedByInferenceSetLabel: inferenceSetObj.Name},
 		); err != nil {

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -499,7 +499,7 @@ func createGemma3MultiRoleInference() *kaitov1alpha1.MultiRoleInference {
 
 		By("Creating MultiRoleInference", func() {
 			Eventually(func() error {
-				return TestingCluster.KubeClient.Create(ctx, mriObj, &client.CreateOptions{})
+				return utils.TestingCluster.KubeClient.Create(ctx, mriObj, &client.CreateOptions{})
 			}, utils.PollTimeout, utils.PollInterval).
 				Should(Succeed(), "Failed to create MultiRoleInference")
 		})
@@ -509,7 +509,7 @@ func createGemma3MultiRoleInference() *kaitov1alpha1.MultiRoleInference {
 
 func cleanupResourcesForMultiRoleInference(mriObj *kaitov1alpha1.MultiRoleInference) {
 	By("Cleaning up MultiRoleInference", func() {
-		err := TestingCluster.KubeClient.Delete(ctx, mriObj, &client.DeleteOptions{})
+		err := utils.TestingCluster.KubeClient.Delete(ctx, mriObj, &client.DeleteOptions{})
 		if err != nil {
 			GinkgoWriter.Printf("Failed to delete MultiRoleInference %s: %v\n", mriObj.Name, err)
 		}
@@ -520,7 +520,7 @@ func validateMultiRoleInferenceChildInferenceSets(mriObj *kaitov1alpha1.MultiRol
 	By("Validating child InferenceSets are created for each role", func() {
 		Eventually(func() bool {
 			isList := &kaitov1alpha1.InferenceSetList{}
-			err := TestingCluster.KubeClient.List(ctx, isList,
+			err := utils.TestingCluster.KubeClient.List(ctx, isList,
 				client.InNamespace(mriObj.Namespace),
 				client.MatchingLabels{kaitov1alpha1.LabelMultiRoleInferenceParent: mriObj.Name})
 			if err != nil {
@@ -549,7 +549,7 @@ func validateMultiRoleInferenceChildInferenceSets(mriObj *kaitov1alpha1.MultiRol
 func validateMultiRoleInferenceStatus(mriObj *kaitov1alpha1.MultiRoleInference) {
 	By("Validating MultiRoleInference status conditions", func() {
 		Eventually(func() bool {
-			err := TestingCluster.KubeClient.Get(ctx, client.ObjectKeyFromObject(mriObj), mriObj)
+			err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKeyFromObject(mriObj), mriObj)
 			if err != nil {
 				return false
 			}
@@ -735,7 +735,7 @@ func validateGatewayAPIInferenceExtensionResources(iObj *kaitov1alpha1.Inference
 	By("Checking Flux OCIRepository is Ready", func() {
 		Eventually(func() bool {
 			ociRepository := &sourcev1.OCIRepository{}
-			err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+			err := utils.utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
 				Namespace: iObj.Namespace,
 				Name:      kaitoutils.InferencePoolName(iObj.Name),
 			}, ociRepository, &client.GetOptions{})
@@ -754,7 +754,7 @@ func validateGatewayAPIInferenceExtensionResources(iObj *kaitov1alpha1.Inference
 	By("Checking Flux HelmRelease is Ready", func() {
 		Eventually(func() bool {
 			helmRelease := &helmv2.HelmRelease{}
-			err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+			err := utils.utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
 				Namespace: iObj.Namespace,
 				Name:      kaitoutils.InferencePoolName(iObj.Name),
 			}, helmRelease, &client.GetOptions{})
@@ -778,7 +778,7 @@ func validateGatewayAPIInferenceExtensionResources(iObj *kaitov1alpha1.Inference
 func validateWorkspaceBenchmarkCompleted(workspaceObj *kaitov1beta1.Workspace) {
 	By("Validating workspace benchmark completed and performance is set", func() {
 		Eventually(func() bool {
-			err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+			err := utils.utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
 				Name:      workspaceObj.Name,
 				Namespace: workspaceObj.Namespace,
 			}, workspaceObj)
@@ -867,7 +867,7 @@ func logBenchmarkPhaseElapsed(coreClient *kubernetes.Clientset, wsName, wsNamesp
 func validateInferenceSetBenchmarkCompleted(inferenceSetObj *kaitov1alpha1.InferenceSet) {
 	By("Validating inferenceset aggregated performance is set", func() {
 		Eventually(func() bool {
-			err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+			err := utils.utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
 				Name:      inferenceSetObj.Name,
 				Namespace: inferenceSetObj.Namespace,
 			}, inferenceSetObj)
@@ -893,7 +893,7 @@ func validateInferenceSetBenchmarkCompleted(inferenceSetObj *kaitov1alpha1.Infer
 	By("Validating all child workspace benchmarks completed", func() {
 		wsList := &kaitov1beta1.WorkspaceList{}
 		Eventually(func() bool {
-			err := utils.TestingCluster.KubeClient.List(ctx, wsList,
+			err := utils.utils.TestingCluster.KubeClient.List(ctx, wsList,
 				client.InNamespace(inferenceSetObj.Namespace),
 				client.MatchingLabels{consts.WorkspaceCreatedByInferenceSetLabel: inferenceSetObj.Name},
 			)
@@ -925,7 +925,7 @@ func validateInferenceSetBenchmarkCompleted(inferenceSetObj *kaitov1alpha1.Infer
 			return
 		}
 		wsList := &kaitov1beta1.WorkspaceList{}
-		if err := utils.TestingCluster.KubeClient.List(ctx, wsList,
+		if err := utils.utils.TestingCluster.KubeClient.List(ctx, wsList,
 			client.InNamespace(inferenceSetObj.Namespace),
 			client.MatchingLabels{consts.WorkspaceCreatedByInferenceSetLabel: inferenceSetObj.Name},
 		); err != nil {

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -516,6 +516,11 @@ func validateMultiRoleInferenceChildInferenceSets(mriObj *kaitov1alpha1.MultiRol
 				if roleLabel != templateRoleLabel {
 					return false
 				}
+				// Verify the parent label is also on template labels
+				templateParentLabel := is.Spec.Template.Labels[kaitov1alpha1.LabelMultiRoleInferenceParent]
+				if templateParentLabel != mriObj.Name {
+					return false
+				}
 				if roleLabel == string(kaitov1alpha1.MultiRoleInferenceRolePrefill) {
 					foundPrefill = true
 				}

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -443,9 +443,6 @@ func createGemma3MultiRoleInference() *kaitov1alpha1.MultiRoleInference {
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      uniqueID,
 				Namespace: namespaceName,
-				Annotations: map[string]string{
-					kaitov1beta1.AnnotationWorkspaceRuntime: "vllm",
-				},
 			},
 			Spec: kaitov1alpha1.MultiRoleInferenceSpec{
 				LabelSelector: &metav1.LabelSelector{
@@ -482,9 +479,16 @@ func createGemma3MultiRoleInference() *kaitov1alpha1.MultiRoleInference {
 
 func cleanupResourcesForMultiRoleInference(mriObj *kaitov1alpha1.MultiRoleInference) {
 	By("Cleaning up MultiRoleInference", func() {
-		err := utils.TestingCluster.KubeClient.Delete(ctx, mriObj, &client.DeleteOptions{})
-		if err != nil {
-			GinkgoWriter.Printf("Failed to delete MultiRoleInference %s: %v\n", mriObj.Name, err)
+		if !CurrentSpecReport().Failed() {
+			Eventually(func() error {
+				err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKeyFromObject(mriObj), mriObj)
+				if err != nil {
+					return client.IgnoreNotFound(err)
+				}
+				return utils.TestingCluster.KubeClient.Delete(ctx, mriObj, &client.DeleteOptions{})
+			}, utils.PollTimeout, utils.PollInterval).Should(Succeed(), "Failed to delete MultiRoleInference")
+		} else {
+			GinkgoWriter.Printf("test failed, keep %s\n", mriObj.Name)
 		}
 	})
 }
@@ -526,17 +530,17 @@ func validateMultiRoleInferenceStatus(mriObj *kaitov1alpha1.MultiRoleInference) 
 			if err != nil {
 				return false
 			}
-			// Check that PrefillReady and DecodeReady conditions exist
-			hasPrefillCond, hasDecodeCond := false, false
+			// Check that PrefillReady and DecodeReady conditions are True
+			prefillReady, decodeReady := false, false
 			for _, cond := range mriObj.Status.Conditions {
-				if cond.Type == string(kaitov1alpha1.MultiRoleInferenceConditionTypePrefillReady) {
-					hasPrefillCond = true
+				if cond.Type == string(kaitov1alpha1.MultiRoleInferenceConditionTypePrefillReady) && cond.Status == metav1.ConditionTrue {
+					prefillReady = true
 				}
-				if cond.Type == string(kaitov1alpha1.MultiRoleInferenceConditionTypeDecodeReady) {
-					hasDecodeCond = true
+				if cond.Type == string(kaitov1alpha1.MultiRoleInferenceConditionTypeDecodeReady) && cond.Status == metav1.ConditionTrue {
+					decodeReady = true
 				}
 			}
-			return hasPrefillCond && hasDecodeCond
+			return prefillReady && decodeReady
 		}, utils.PollTimeout, utils.PollInterval).Should(BeTrue(),
 			"Expected PrefillReady and DecodeReady conditions on MultiRoleInference %s", mriObj.Name)
 	})

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -506,10 +506,16 @@ func validateMultiRoleInferenceChildInferenceSets(mriObj *kaitov1alpha1.MultiRol
 			if len(isList.Items) != 2 {
 				return false
 			}
-			// Verify both roles exist
+			// Verify both roles exist in metadata labels and template labels
 			foundPrefill, foundDecode := false, false
 			for _, is := range isList.Items {
 				roleLabel := is.Labels[kaitov1alpha1.LabelInferenceRole]
+				// Also verify the role label is propagated to Spec.Template.Labels
+				// so that downstream pods get the correct role for P/D disaggregation
+				templateRoleLabel := is.Spec.Template.Labels[kaitov1alpha1.LabelInferenceRole]
+				if roleLabel != templateRoleLabel {
+					return false
+				}
 				if roleLabel == string(kaitov1alpha1.MultiRoleInferenceRolePrefill) {
 					foundPrefill = true
 				}

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -363,7 +363,6 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 	It("should create a MultiRoleInference with prefill and decode roles successfully", Serial, utils.GinkgoLabelFastCheck, func() {
 		mriObj := createGemma3MultiRoleInference()
 		defer cleanupResourcesForMultiRoleInference(mriObj)
-		time.Sleep(120 * time.Second)
 
 		validateMultiRoleInferenceChildInferenceSets(mriObj)
 		validateMultiRoleInferenceStatus(mriObj)
@@ -529,7 +528,7 @@ func validateMultiRoleInferenceChildInferenceSets(mriObj *kaitov1alpha1.MultiRol
 				}
 			}
 			return foundPrefill && foundDecode
-		}, utils.PollTimeout, utils.PollInterval).Should(BeTrue(),
+		}, 20*time.Minute, utils.PollInterval).Should(BeTrue(),
 			"Expected 2 child InferenceSets (prefill + decode) for MultiRoleInference %s", mriObj.Name)
 	})
 }
@@ -552,7 +551,7 @@ func validateMultiRoleInferenceStatus(mriObj *kaitov1alpha1.MultiRoleInference) 
 				}
 			}
 			return prefillReady && decodeReady
-		}, utils.PollTimeout, utils.PollInterval).Should(BeTrue(),
+		}, 20*time.Minute, utils.PollInterval).Should(BeTrue(),
 			"Expected PrefillReady and DecodeReady conditions on MultiRoleInference %s", mriObj.Name)
 	})
 }

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -360,16 +360,13 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateChatCompletionsEndpoint(workspaceObj)
 	})
 
-	It("should create a Gemma 3 InferenceSet with decode label successfully", Serial, utils.GinkgoLabelFastCheck, func() {
-		numOfReplicas := 1
-		inferenceSetObj := createGemma3InferenceSetWithDecodeLabelAndVLLM(numOfReplicas)
-		defer cleanupResourcesForInferenceSet(inferenceSetObj)
+	It("should create a MultiRoleInference with prefill and decode roles successfully", Serial, utils.GinkgoLabelFastCheck, func() {
+		mriObj := createGemma3MultiRoleInference()
+		defer cleanupResourcesForMultiRoleInference(mriObj)
 		time.Sleep(120 * time.Second)
 
-		validateInferenceSetStatus(inferenceSetObj)
-		validateInferenceSetReplicas(inferenceSetObj, int32(numOfReplicas))
-		validateInferenceSetBenchmarkCompleted(inferenceSetObj)
-		validateGatewayAPIInferenceExtensionResources(inferenceSetObj)
+		validateMultiRoleInferenceChildInferenceSets(mriObj)
+		validateMultiRoleInferenceStatus(mriObj)
 	})
 
 	It("should create a Gemma 3 InferenceSet with preset public mode successfully", Serial, utils.GinkgoLabelFastCheck, func() {
@@ -461,6 +458,115 @@ func createGemma3InferenceSetWithDecodeLabelAndVLLM(replicas int) *kaitov1alpha1
 		createAndValidateInferenceSet(inferenceSetObj)
 	})
 	return inferenceSetObj
+}
+
+func createGemma3MultiRoleInference() *kaitov1alpha1.MultiRoleInference {
+	modelSecret := createAndValidateModelSecret()
+	mriObj := &kaitov1alpha1.MultiRoleInference{}
+	By("Creating a MultiRoleInference CR with Gemma 3 prefill and decode roles", func() {
+		uniqueID := fmt.Sprint("mri-gemma3-pd-", rand.Intn(1000))
+		replicas := int32(1)
+		mriObj = &kaitov1alpha1.MultiRoleInference{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      uniqueID,
+				Namespace: namespaceName,
+				Annotations: map[string]string{
+					kaitov1beta1.AnnotationWorkspaceRuntime: "vllm",
+				},
+			},
+			Spec: kaitov1alpha1.MultiRoleInferenceSpec{
+				LabelSelector: &metav1.LabelSelector{
+					MatchLabels: map[string]string{"kaito-mri": uniqueID},
+				},
+				Model: kaitov1alpha1.MultiRoleInferenceModelSpec{
+					Name:              string(PresetGemma3_4BInstructModel),
+					ModelAccessSecret: modelSecret.Name,
+				},
+				Roles: []kaitov1alpha1.MultiRoleInferenceRoleSpec{
+					{
+						Type:         kaitov1alpha1.MultiRoleInferenceRolePrefill,
+						Replicas:     &replicas,
+						InstanceType: "Standard_NV36ads_A10_v5",
+					},
+					{
+						Type:         kaitov1alpha1.MultiRoleInferenceRoleDecode,
+						Replicas:     &replicas,
+						InstanceType: "Standard_NV36ads_A10_v5",
+					},
+				},
+			},
+		}
+
+		By("Creating MultiRoleInference", func() {
+			Eventually(func() error {
+				return TestingCluster.KubeClient.Create(ctx, mriObj, &client.CreateOptions{})
+			}, utils.PollTimeout, utils.PollInterval).
+				Should(Succeed(), "Failed to create MultiRoleInference")
+		})
+	})
+	return mriObj
+}
+
+func cleanupResourcesForMultiRoleInference(mriObj *kaitov1alpha1.MultiRoleInference) {
+	By("Cleaning up MultiRoleInference", func() {
+		err := TestingCluster.KubeClient.Delete(ctx, mriObj, &client.DeleteOptions{})
+		if err != nil {
+			GinkgoWriter.Printf("Failed to delete MultiRoleInference %s: %v\n", mriObj.Name, err)
+		}
+	})
+}
+
+func validateMultiRoleInferenceChildInferenceSets(mriObj *kaitov1alpha1.MultiRoleInference) {
+	By("Validating child InferenceSets are created for each role", func() {
+		Eventually(func() bool {
+			isList := &kaitov1alpha1.InferenceSetList{}
+			err := TestingCluster.KubeClient.List(ctx, isList,
+				client.InNamespace(mriObj.Namespace),
+				client.MatchingLabels{kaitov1alpha1.LabelMultiRoleInferenceParent: mriObj.Name})
+			if err != nil {
+				return false
+			}
+			if len(isList.Items) != 2 {
+				return false
+			}
+			// Verify both roles exist
+			foundPrefill, foundDecode := false, false
+			for _, is := range isList.Items {
+				roleLabel := is.Labels[kaitov1alpha1.LabelInferenceRole]
+				if roleLabel == string(kaitov1alpha1.MultiRoleInferenceRolePrefill) {
+					foundPrefill = true
+				}
+				if roleLabel == string(kaitov1alpha1.MultiRoleInferenceRoleDecode) {
+					foundDecode = true
+				}
+			}
+			return foundPrefill && foundDecode
+		}, utils.PollTimeout, utils.PollInterval).Should(BeTrue(),
+			"Expected 2 child InferenceSets (prefill + decode) for MultiRoleInference %s", mriObj.Name)
+	})
+}
+
+func validateMultiRoleInferenceStatus(mriObj *kaitov1alpha1.MultiRoleInference) {
+	By("Validating MultiRoleInference status conditions", func() {
+		Eventually(func() bool {
+			err := TestingCluster.KubeClient.Get(ctx, client.ObjectKeyFromObject(mriObj), mriObj)
+			if err != nil {
+				return false
+			}
+			// Check that PrefillReady and DecodeReady conditions exist
+			hasPrefillCond, hasDecodeCond := false, false
+			for _, cond := range mriObj.Status.Conditions {
+				if cond.Type == string(kaitov1alpha1.MultiRoleInferenceConditionTypePrefillReady) {
+					hasPrefillCond = true
+				}
+				if cond.Type == string(kaitov1alpha1.MultiRoleInferenceConditionTypeDecodeReady) {
+					hasDecodeCond = true
+				}
+			}
+			return hasPrefillCond && hasDecodeCond
+		}, utils.PollTimeout, utils.PollInterval).Should(BeTrue(),
+			"Expected PrefillReady and DecodeReady conditions on MultiRoleInference %s", mriObj.Name)
+	})
 }
 
 func createLlama3_1_8BInstructWorkspaceWithPresetPublicModeAndVLLM(numOfNode int, instanceType string) *kaitov1beta1.Workspace {


### PR DESCRIPTION
## What this PR does

Replaces the existing InferenceSet decode-label test with a full MultiRoleInference (MRI) e2e test that exercises the P/D disaggregated inference lifecycle. Also fixes missing MRI webhook infrastructure.

### Test flow
1. Create a `MultiRoleInference` CR with Gemma 3 model, prefill and decode roles (1 replica each)
2. Validate that the MRI controller creates 2 child `InferenceSet` objects with correct labels on both metadata and template:
   - `kaito.sh/inference-role: prefill` / `decode`
   - `multiroleinference.kaito.sh/created-by: <mri-name>`
3. Validate that MRI status has `PrefillReady` and `DecodeReady` conditions with `Status=True`

### New helpers
- `createGemma3MultiRoleInference()` — creates MRI CR
- `cleanupResourcesForMultiRoleInference()` — deletes MRI on test teardown (skips on failure for debugging)
- `validateMultiRoleInferenceChildInferenceSets()` — verifies 2 child InferenceSets with role and parent labels on both metadata and template
- `validateMultiRoleInferenceStatus()` — verifies PrefillReady/DecodeReady conditions are True

### Bug fixes included
- **Add missing `ValidatingWebhookConfiguration` for MRI** — the Go code registered `validation.multiroleinference.kaito.sh` but the Helm chart had no corresponding VWC manifest, causing cert controller errors
- **Gate MRI webhook on `enableMultiRoleInferenceController`** — previously gated on `enableInferenceSetController`/`gatewayAPIInferenceExtension`, now correctly uses the same feature gate as the MRI CRD and controller
- **Add MRI webhook to RBAC** — added `validation.multiroleinference.kaito.sh` to `resourceNames` in `inferenceset_clusterrole.yaml` (conditional on `enableMultiRoleInferenceController`)
- **Fix webhook unit test** — updated `webhooks_test.go` to test `enableMultiRoleInferenceController` gate instead of `gatewayAPIInferenceExtension`

### E2E improvements
- Removed unnecessary `time.Sleep(120s)` — rely on `Eventually` polling instead
- Increased MRI validation timeout to 20 minutes (MRI needs 2 GPU nodes, each takes ~5-10 min to provision)
