### PR TITLE
feat: onboard kimi and minimax models to model catalog

### DIFF
--- a/benchmarks/mt_bench/mt_bench_eval.py
+++ b/benchmarks/mt_bench/mt_bench_eval.py
@@ -31,7 +31,10 @@ Environment Variables:
   AZURE_OPENAI_API_VERSION API version (required when JUDGE_SOURCE=MICROSOFT_AI_FOUNDRY)
   PARALLEL                Concurrent judge API calls (default: 2)
   MAX_TOKENS              Max tokens for model responses (default: 1024)
-  TEMPERATURE             Model temperature (default: 0.0)
+  TEMPERATURE             Model temperature (default: 1.0)
+  ENABLE_THINKING         Enable thinking mode for model (default: false)
+  VERBOSE                 Log response content, reasoning, and judge explanations (default: false)
+  CATEGORIES              Comma-separated list of categories to run (default: all)
   DRY_RUN                 If "true", skip judging stage (default: false)
   RESULTS_DIR             Directory for detailed output files (default: /results)
 
@@ -246,7 +249,10 @@ def load_config() -> dict:
         "judge_api_key": _env("JUDGE_API_KEY", required=True),
         "parallel": int(_env("PARALLEL", "2")),
         "max_tokens": int(_env("MAX_TOKENS", "1024")),
-        "temperature": float(_env("TEMPERATURE", "0.0")),
+        "temperature": float(_env("TEMPERATURE", "1.0")),
+        "enable_thinking": _env("ENABLE_THINKING", "false").lower() == "true",
+        "verbose": _env("VERBOSE", "false").lower() == "true",
+        "categories": _env("CATEGORIES", ""),
         "dry_run": _env("DRY_RUN", "false").lower() == "true",
         "results_dir": Path(_env("RESULTS_DIR", "/results")),
     }
@@ -300,6 +306,8 @@ def generate_answers(
     model_name: str,
     max_tokens: int,
     temperature: float,
+    enable_thinking: bool = False,
+    verbose: bool = False,
 ) -> list[dict]:
     """Call the Kaito workspace for each MT-Bench question (2 turns each)."""
     client = OpenAI(
@@ -323,9 +331,35 @@ def generate_answers(
                     messages=messages,
                     max_completion_tokens=max_tokens,
                     temperature=temperature,
-                    extra_body={"chat_template_kwargs": {"enable_thinking": False}},
+                    extra_body={"chat_template_kwargs": {"enable_thinking": enable_thinking, "thinking": enable_thinking}},
                 )
-                answer_text = resp.choices[0].message.content or ""
+                msg = resp.choices[0].message
+                answer_text = msg.content or ""
+                reasoning = (
+                    getattr(msg, "reasoning_content", None)
+                    or getattr(msg, "reasoning", None)
+                    or ""
+                )
+                finish = resp.choices[0].finish_reason or "unknown"
+                # Due to the limit on max_completion_tokens, the model may use all tokens for reasoning and return an empty answer.
+                # In that case, we send the reasoning part to the judge as a workaround.
+                if not answer_text and reasoning:
+                    log.info(
+                        "q%d turn %d content empty, using reasoning (%d chars) as answer",
+                        qid, turn_idx + 1, len(reasoning),
+                    )
+                    answer_text = reasoning
+                if verbose:
+                    if not answer_text:
+                        log.warning(
+                            "q%d turn %d EMPTY content. finish_reason=%s, "
+                            "reasoning_len=%d, raw_message=%s",
+                            qid,
+                            turn_idx + 1,
+                            finish,
+                            len(reasoning),
+                            str(msg),
+                        )
             except Exception as e:
                 log.warning(
                     "Failed to get answer for q%d turn %d: %s", qid, turn_idx + 1, e
@@ -334,6 +368,14 @@ def generate_answers(
 
             model_answers.append(answer_text)
             messages.append({"role": "assistant", "content": answer_text})
+            if verbose:
+                log.info(
+                    "q%d turn %d response (len=%d): %s",
+                    qid,
+                    turn_idx + 1,
+                    len(answer_text),
+                    answer_text,
+                )
 
         record = {
             "question_id": qid,
@@ -466,6 +508,7 @@ def judge_answers(
     azure_deployment: str,
     azure_api_version: str,
     parallel: int,
+    verbose: bool = False,
 ) -> list[dict]:
     """Judge all answers using a strong model."""
     if judge_source == "MICROSOFT_AI_FOUNDRY":
@@ -506,12 +549,14 @@ def judge_answers(
         for future in concurrent.futures.as_completed(futures):
             result = future.result()
             judgments.append(result)
-            log.info(
-                "Judged q%d turn %d: score=%d",
-                result["question_id"],
-                result["turn"],
-                result["score"],
-            )
+            if verbose:
+                log.info(
+                    "Judged q%d turn %d: score=%d | %s",
+                    result["question_id"],
+                    result["turn"],
+                    result["score"],
+                    result["judgment"],
+                )
 
     judgments.sort(key=lambda j: (j["question_id"], j["turn"]))
     return judgments
@@ -664,6 +709,13 @@ def main() -> None:
     judge_prompts = JUDGE_PROMPTS
     log.info("Using %d hardcoded judge prompt templates", len(judge_prompts))
 
+    # ── Filter categories if specified ───────────────────────────────
+    cat_filter = None
+    if cfg["categories"]:
+        cat_filter = {c.strip() for c in cfg["categories"].split(",")}
+        questions = [q for q in questions if q["category"] in cat_filter]
+        log.info("Filtered to %d questions in categories: %s", len(questions), cat_filter)
+
     # ── Stage 1: Generate answers ────────────────────────────────────────
     log.info(
         "Stage 1: Generating answers from %s (model=%s)",
@@ -677,6 +729,8 @@ def main() -> None:
         cfg["model_name"],
         cfg["max_tokens"],
         cfg["temperature"],
+        cfg["enable_thinking"],
+        cfg["verbose"],
     )
     t1 = time.time()
     log.info("Stage 1 complete: %d answers in %.1fs", len(answers), t1 - t0)
@@ -714,6 +768,7 @@ def main() -> None:
             cfg["azure_deployment"],
             cfg["azure_api_version"],
             cfg["parallel"],
+            cfg["verbose"],
         )
         t3 = time.time()
         log.info("Stage 2 complete: %d judgments in %.1fs", len(judgments), t3 - t2)

--- a/benchmarks/mt_bench/mt_bench_eval.py
+++ b/benchmarks/mt_bench/mt_bench_eval.py
@@ -326,12 +326,16 @@ def generate_answers(
         for turn_idx, turn_text in enumerate(turns):
             messages.append({"role": "user", "content": turn_text})
             try:
+                # Mistral tokenizer mode does not support chat_template_kwargs
+                extra = {}
+                if not model_name.lower().startswith("mistral"):
+                    extra["chat_template_kwargs"] = {"enable_thinking": enable_thinking, "thinking": enable_thinking}
                 resp = client.chat.completions.create(
                     model=model_name,
                     messages=messages,
                     max_completion_tokens=max_tokens,
                     temperature=temperature,
-                    extra_body={"chat_template_kwargs": {"enable_thinking": enable_thinking, "thinking": enable_thinking}},
+                    extra_body=extra,
                 )
                 msg = resp.choices[0].message
                 answer_text = msg.content or ""

--- a/benchmarks/mt_bench/mt_bench_eval.py
+++ b/benchmarks/mt_bench/mt_bench_eval.py
@@ -329,7 +329,10 @@ def generate_answers(
                 # Mistral tokenizer mode does not support chat_template_kwargs
                 extra = {}
                 if not model_name.lower().startswith("mistral"):
-                    extra["chat_template_kwargs"] = {"enable_thinking": enable_thinking, "thinking": enable_thinking}
+                    extra["chat_template_kwargs"] = {
+                        "enable_thinking": enable_thinking,
+                        "thinking": enable_thinking,
+                    }
                 resp = client.chat.completions.create(
                     model=model_name,
                     messages=messages,
@@ -350,20 +353,21 @@ def generate_answers(
                 if not answer_text and reasoning:
                     log.info(
                         "q%d turn %d content empty, using reasoning (%d chars) as answer",
-                        qid, turn_idx + 1, len(reasoning),
+                        qid,
+                        turn_idx + 1,
+                        len(reasoning),
                     )
                     answer_text = reasoning
-                if verbose:
-                    if not answer_text:
-                        log.warning(
-                            "q%d turn %d EMPTY content. finish_reason=%s, "
-                            "reasoning_len=%d, raw_message=%s",
-                            qid,
-                            turn_idx + 1,
-                            finish,
-                            len(reasoning),
-                            str(msg),
-                        )
+                if verbose and not answer_text:
+                    log.warning(
+                        "q%d turn %d EMPTY content. finish_reason=%s, "
+                        "reasoning_len=%d, raw_message=%s",
+                        qid,
+                        turn_idx + 1,
+                        finish,
+                        len(reasoning),
+                        str(msg),
+                    )
             except Exception as e:
                 log.warning(
                     "Failed to get answer for q%d turn %d: %s", qid, turn_idx + 1, e
@@ -718,7 +722,9 @@ def main() -> None:
     if cfg["categories"]:
         cat_filter = {c.strip() for c in cfg["categories"].split(",")}
         questions = [q for q in questions if q["category"] in cat_filter]
-        log.info("Filtered to %d questions in categories: %s", len(questions), cat_filter)
+        log.info(
+            "Filtered to %d questions in categories: %s", len(questions), cat_filter
+        )
 
     # ── Stage 1: Generate answers ────────────────────────────────────────
     log.info(

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -195,6 +195,8 @@ var (
 		// JIT compilation with CUDA dev headers (nvcc, cublasLt, nvrtc).
 		// Pin to triton backend to avoid the JIT dependency for now.
 		"mistral-small-4-119b-2603": "triton",
+		// MiniMax-M2.7 FP8 MoE also defaults to FlashInfer CUTLASS which needs nvcc.
+		"minimax-m2.7": "triton",
 	}
 
 	// vllmGdnPrefillBackendPrefixMap maps model name prefixes to their vLLM GDN prefill backend.
@@ -204,6 +206,15 @@ var (
 	vllmGdnPrefillBackendPrefixMap = map[string]string{
 		"qwen3.5": "triton",
 		"qwen3.6": "triton",
+	}
+
+	// vllmExpertParallelEnabled maps model name prefixes to enable expert parallelism.
+	// Expert parallelism distributes MoE experts across TP ranks, which can avoid
+	// FP8 block quantization issues when expert weight dimensions are not divisible
+	// by the quantization block size.
+	// source: https://docs.vllm.ai/en/latest/configuration/engine_args/#-enable-expert-parallel
+	vllmExpertParallelEnabled = map[string]bool{
+		"minimax-m2": true,
 	}
 
 	// catalogOverrides provides hardcoded values for models whose HuggingFace
@@ -664,6 +675,14 @@ func (g *Generator) FinalizeParams() {
 	for prefix, backend := range vllmGdnPrefillBackendPrefixMap {
 		if strings.HasPrefix(g.Param.Metadata.Name, prefix) {
 			g.Param.VLLM.ModelRunParams["gdn-prefill-backend"] = backend
+			break
+		}
+	}
+
+	// Enable expert parallelism based on model name prefix
+	for prefix, enabled := range vllmExpertParallelEnabled {
+		if strings.HasPrefix(g.Param.Metadata.Name, prefix) && enabled {
+			g.Param.VLLM.ModelRunParams["enable-expert-parallel"] = ""
 			break
 		}
 	}

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -69,6 +69,7 @@ var (
 		"HunYuanMoEV1ForCausalLM":                "hunyuan_a13b",
 		"GraniteForCausalLM":                     "granite",
 		"KimiK2ForCausalLM":                      "kimi_k2",
+		"KimiK25ForConditionalGeneration":        "kimi_k2",
 		"MiniMaxM2ForCausalLM":                   "minimax_m2_append_think",
 		"Mistral3ForConditionalGeneration":       "mistral",
 		"MistralForCausalLM":                     "mistral",
@@ -164,6 +165,7 @@ var (
 		"NemotronH_Nano_VL_V2":                   "qwen3_coder",
 		"Phi4MiniForCausalLM":                    "phi4_mini_json",
 		"KimiK2ForCausalLM":                      "kimi_k2",
+		"KimiK25ForConditionalGeneration":        "kimi_k2",
 		"GigaChat3ForCausalLM":                   "gigachat3",
 	}
 

--- a/presets/workspace/models/model_catalog.yaml
+++ b/presets/workspace/models/model_catalog.yaml
@@ -708,3 +708,18 @@ models:
   numKeyValueHeads: 8
   headDim: 128
   quantMethod: fp8
+- name: mistralai/Mistral-Medium-3.5-128B
+  description: https://huggingface.co/mistralai/Mistral-Medium-3.5-128B
+  license: other
+  modelFileSize: 124.43Gi
+  architectures:
+  - Mistral3ForConditionalGeneration
+  modelTokenLimit: 262144
+  hiddenSize: 12288
+  numHiddenLayers: 88
+  numAttentionHeads: 96
+  numKeyValueHeads: 8
+  loadFormat: mistral
+  configFormat: mistral
+  tokenizerMode: mistral
+  quantMethod: fp8

--- a/presets/workspace/models/model_catalog.yaml
+++ b/presets/workspace/models/model_catalog.yaml
@@ -694,3 +694,17 @@ models:
   kvLoraRank: 512
   qkRopeHeadDim: 64
   quantMethod: pack-quantized
+- name: MiniMaxAI/MiniMax-M2.7
+  description: https://huggingface.co/MiniMaxAI/MiniMax-M2.7
+  license: other
+  pipelineTag: text-generation
+  modelFileSize: 214.34Gi
+  architectures:
+  - MiniMaxM2ForCausalLM
+  modelTokenLimit: 204800
+  hiddenSize: 3072
+  numHiddenLayers: 62
+  numAttentionHeads: 48
+  numKeyValueHeads: 8
+  headDim: 128
+  quantMethod: fp8

--- a/presets/workspace/models/model_catalog.yaml
+++ b/presets/workspace/models/model_catalog.yaml
@@ -679,3 +679,18 @@ models:
   headDim: 256
   quantMethod: gptq
   quantBits: 4
+- name: moonshotai/Kimi-K2.5
+  description: https://huggingface.co/moonshotai/Kimi-K2.5
+  license: modified-mit
+  pipelineTag: image-text-to-text
+  modelFileSize: 554.32Gi
+  architectures:
+  - KimiK25ForConditionalGeneration
+  modelTokenLimit: 262144
+  hiddenSize: 7168
+  numHiddenLayers: 61
+  numAttentionHeads: 64
+  numKeyValueHeads: 64
+  kvLoraRank: 512
+  qkRopeHeadDim: 64
+  quantMethod: pack-quantized

--- a/presets/workspace/models/model_catalog.yaml
+++ b/presets/workspace/models/model_catalog.yaml
@@ -694,6 +694,21 @@ models:
   kvLoraRank: 512
   qkRopeHeadDim: 64
   quantMethod: pack-quantized
+- name: moonshotai/Kimi-K2.6
+  description: https://huggingface.co/moonshotai/Kimi-K2.6
+  license: modified-mit
+  pipelineTag: image-text-to-text
+  modelFileSize: 554.32Gi
+  architectures:
+  - KimiK25ForConditionalGeneration
+  modelTokenLimit: 262144
+  hiddenSize: 7168
+  numHiddenLayers: 61
+  numAttentionHeads: 64
+  numKeyValueHeads: 64
+  kvLoraRank: 512
+  qkRopeHeadDim: 64
+  quantMethod: pack-quantized
 - name: MiniMaxAI/MiniMax-M2.7
   description: https://huggingface.co/MiniMaxAI/MiniMax-M2.7
   license: other

--- a/presets/workspace/models/model_catalog_mtbench_scores.md
+++ b/presets/workspace/models/model_catalog_mtbench_scores.md
@@ -57,3 +57,4 @@ All models were deployed as KAITO Workspace CRs on AKS and evaluated using the v
 | Qwen/Qwen3.6-35B-A3B | vllm | 8.17 | 7.85 | 8.05 | 8.55 | 9.90 | 8.00 | 8.40 | 7.30 | 7.30 | 2026-05-07 |
 | Qwen/Qwen3.6-27B | vllm | 8.12 | 8.35 | 8.05 | 8.80 | 9.85 | 7.70 | 8.00 | 7.10 | 7.15 | 2026-05-07 |
 | Qwen/Qwen3.5-397B-A17B-GPTQ-Int4 | vllm | 8.53 | 8.25 | 8.35 | 8.80 | 9.95 | 8.75 | 8.55 | 8.00 | 7.60 | 2026-05-07 |
+| moonshotai/Kimi-K2.5 | vllm | 7.64 | 6.45 | 7.75 | 8.35 | 9.40 | 6.05 | 7.85 | 7.65 | 7.65 | 2026-05-12 |

--- a/presets/workspace/models/model_catalog_mtbench_scores.md
+++ b/presets/workspace/models/model_catalog_mtbench_scores.md
@@ -59,3 +59,4 @@ All models were deployed as KAITO Workspace CRs on AKS and evaluated using the v
 | Qwen/Qwen3.5-397B-A17B-GPTQ-Int4 | vllm | 8.53 | 8.25 | 8.35 | 8.80 | 9.95 | 8.75 | 8.55 | 8.00 | 7.60 | 2026-05-07 |
 | moonshotai/Kimi-K2.5 | vllm | 7.64 | 6.45 | 7.75 | 8.35 | 9.40 | 6.05 | 7.85 | 7.65 | 7.65 | 2026-05-12 |
 | MiniMaxAI/MiniMax-M2.7 | vllm | 7.16 | 7.15 | 6.90 | 7.29 | 8.72 | 6.90 | 6.95 | 6.25 | 7.15 | 2026-05-13 |
+| mistralai/Mistral-Medium-3.5-128B | vllm | 8.18 | 8.05 | 8.10 | 8.15 | 9.55 | 7.40 | 8.60 | 7.60 | 8.00 | 2026-05-14 |

--- a/presets/workspace/models/model_catalog_mtbench_scores.md
+++ b/presets/workspace/models/model_catalog_mtbench_scores.md
@@ -58,3 +58,4 @@ All models were deployed as KAITO Workspace CRs on AKS and evaluated using the v
 | Qwen/Qwen3.6-27B | vllm | 8.12 | 8.35 | 8.05 | 8.80 | 9.85 | 7.70 | 8.00 | 7.10 | 7.15 | 2026-05-07 |
 | Qwen/Qwen3.5-397B-A17B-GPTQ-Int4 | vllm | 8.53 | 8.25 | 8.35 | 8.80 | 9.95 | 8.75 | 8.55 | 8.00 | 7.60 | 2026-05-07 |
 | moonshotai/Kimi-K2.5 | vllm | 7.64 | 6.45 | 7.75 | 8.35 | 9.40 | 6.05 | 7.85 | 7.65 | 7.65 | 2026-05-12 |
+| MiniMaxAI/MiniMax-M2.7 | vllm | 7.16 | 7.15 | 6.90 | 7.29 | 8.72 | 6.90 | 6.95 | 6.25 | 7.15 | 2026-05-13 |

--- a/presets/workspace/models/model_catalog_mtbench_scores.md
+++ b/presets/workspace/models/model_catalog_mtbench_scores.md
@@ -60,3 +60,4 @@ All models were deployed as KAITO Workspace CRs on AKS and evaluated using the v
 | moonshotai/Kimi-K2.5 | vllm | 7.64 | 6.45 | 7.75 | 8.35 | 9.40 | 6.05 | 7.85 | 7.65 | 7.65 | 2026-05-12 |
 | MiniMaxAI/MiniMax-M2.7 | vllm | 7.16 | 7.15 | 6.90 | 7.29 | 8.72 | 6.90 | 6.95 | 6.25 | 7.15 | 2026-05-13 |
 | mistralai/Mistral-Medium-3.5-128B | vllm | 8.18 | 8.05 | 8.10 | 8.15 | 9.55 | 7.40 | 8.60 | 7.60 | 8.00 | 2026-05-14 |
+| moonshotai/Kimi-K2.6 | vllm | 8.44 | 8.40 | 8.55 | 8.95 | 9.95 | 6.95 | 8.35 | 7.80 | 8.55 | 2026-05-14 |


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
This PR onboards the following models to Kaito's model catalog:
- moonshotai/Kimi-K2.5 
- moonshotai/Kimi-K2.6
- MiniMaxAI/MiniMax-M2.7
- mistralai/Mistral-Medium-3.5-128B

NOTE:
- Kimi models don't work with dtype=float16. Today Kaito will set dtype=float16 if CUDA compute capability < 8.0. So CUDA compute capability >= 8.0 is required for Kimi model deployments.
- MiniMax-M2.7 failed with https://github.com/vllm-project/vllm/issues/17569 when deployed without the `enable-expert-parallel` flag.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).
- [x] deployed new models to an AKS cluster and ran mt-bench evaluation. **NOTE: models were tested with annotation `kaito.sh/disable-benchmark: "true"`**. Some models failed to become InferenceReady due to a bug in the benchmark: https://github.com/kaito-project/kaito/issues/2044.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: