### PR TITLE
feat: MRI controller creates InferencePool + EPP plugins config (basic functionalities)

### DIFF
--- a/api/v1alpha1/multiroleinference_types.go
+++ b/api/v1alpha1/multiroleinference_types.go
@@ -83,7 +83,9 @@ type MultiRoleInferenceSpec struct {
 
 	// EPPPluginsConfig references a ConfigMap containing custom EPP plugins configuration.
 	// If not set, the controller auto-generates a standard P/D disaggregation plugin config
-	// with prefill-filter, decode-filter, precise-prefix-cache-scorer, and load-aware-scorer.
+	// with prefill-filter, decode-filter, and load-aware-scorer.
+	// To enable precise-prefix-cache-scorer (which requires a tokenizer sidecar),
+	// provide a custom EPP plugins config via this field.
 	// +optional
 	EPPPluginsConfig string `json:"eppPluginsConfig,omitempty"`
 

--- a/charts/kaito/workspace/templates/multiroleinference_clusterrole.yaml
+++ b/charts/kaito/workspace/templates/multiroleinference_clusterrole.yaml
@@ -32,4 +32,13 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["source.toolkit.fluxcd.io"]
+    resources: ["ocirepositories"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["helm.toolkit.fluxcd.io"]
+    resources: ["helmreleases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 {{- end -}}

--- a/cmd/workspace/main.go
+++ b/cmd/workspace/main.go
@@ -290,6 +290,7 @@ func main() {
 			mgr.GetScheme(),
 			log.Log.WithName("controllers").WithName("MultiRoleInference"),
 			mgr.GetEventRecorderFor("KAITO-MultiRoleInference-controller"),
+			featuregates.FeatureGates[consts.FeatureFlagGatewayAPIInferenceExtension],
 		)
 		if err = mriReconciler.SetupWithManager(mgr); err != nil {
 			klog.ErrorS(err, "unable to create controller", "controller", "MultiRoleInference")

--- a/examples/inference/kaito_multiroleinference_phi4_4.yaml
+++ b/examples/inference/kaito_multiroleinference_phi4_4.yaml
@@ -1,0 +1,19 @@
+---
+apiVersion: kaito.sh/v1alpha1
+kind: MultiRoleInference
+metadata:
+  name: phi-4-mini
+  namespace: default
+spec:
+  labelSelector:
+    matchLabels:
+      apps: phi-4-mini
+  model:
+    name: phi-4-mini-instruct
+  roles:
+    - type: prefill
+      replicas: 1
+      instanceType: Standard_NC24ads_A100_v4
+    - type: decode
+      replicas: 1
+      instanceType: Standard_NC24ads_A100_v4

--- a/pkg/controllers/multiroleinference/controller.go
+++ b/pkg/controllers/multiroleinference/controller.go
@@ -555,8 +555,9 @@ func defaultPDPluginsConfig() string {
 }
 
 // inferencePoolName returns the name of the InferencePool resources for the MRI.
+// Delegates to the shared utils.InferencePoolName helper.
 func inferencePoolName(mriName string) string {
-	return fmt.Sprintf("%s-inferencepool", mriName)
+	return utils.InferencePoolName(mriName)
 }
 
 // reconcileInferencePool creates or updates the Flux OCIRepository and HelmRelease
@@ -693,7 +694,11 @@ func (r *MultiRoleInferenceReconciler) reconcileInferencePool(
 }
 
 // isInferencePoolReady checks if the InferencePool HelmRelease is ready.
+// When Gateway API Inference Extension is disabled, no pool is reconciled so we return true.
 func (r *MultiRoleInferenceReconciler) isInferencePoolReady(ctx context.Context, mri *kaitov1alpha1.MultiRoleInference) bool {
+	if !r.EnableGatewayAPIInferenceExt {
+		return true
+	}
 	poolName := inferencePoolName(mri.Name)
 	hr := &helmv2.HelmRelease{}
 	if err := r.Get(ctx, client.ObjectKey{Name: poolName, Namespace: mri.Namespace}, hr); err != nil {

--- a/pkg/controllers/multiroleinference/controller.go
+++ b/pkg/controllers/multiroleinference/controller.go
@@ -550,7 +550,7 @@ schedulingProfiles:
 // Note: precise-prefix-cache-scorer is omitted because it requires a tokenizer
 // sidecar (UDS socket) that is not yet deployed by KAITO. Once tokenizer sidecar
 // support is added, this config should be updated to include it.
-func defaultPDPluginsConfig(modelName string) string {
+func defaultPDPluginsConfig() string {
 	return defaultPDPluginsConfigTemplate
 }
 
@@ -619,7 +619,7 @@ func (r *MultiRoleInferenceReconciler) reconcileInferencePool(
 	}
 
 	// Load plugins config: either from user-provided ConfigMap or auto-generated default.
-	pluginsYAML := defaultPDPluginsConfig(mri.Spec.Model.Name)
+	pluginsYAML := defaultPDPluginsConfig()
 	if mri.Spec.EPPPluginsConfig != "" {
 		cm := &corev1.ConfigMap{}
 		if err := r.Get(ctx, client.ObjectKey{Name: mri.Spec.EPPPluginsConfig, Namespace: mri.Namespace}, cm); err != nil {

--- a/pkg/controllers/multiroleinference/controller.go
+++ b/pkg/controllers/multiroleinference/controller.go
@@ -15,23 +15,34 @@ package multiroleinference
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"time"
 
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	gaiev1 "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+	gaiev1alpha2 "sigs.k8s.io/gateway-api-inference-extension/apix/v1alpha2"
 
 	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/utils"
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 const (
@@ -45,18 +56,20 @@ const (
 // MultiRoleInferenceReconciler reconciles a MultiRoleInference object.
 type MultiRoleInferenceReconciler struct {
 	client.Client
-	Log      logr.Logger
-	Scheme   *runtime.Scheme
-	Recorder record.EventRecorder
+	Log                          logr.Logger
+	Scheme                       *runtime.Scheme
+	Recorder                     record.EventRecorder
+	EnableGatewayAPIInferenceExt bool
 }
 
 // NewMultiRoleInferenceReconciler creates a new reconciler.
-func NewMultiRoleInferenceReconciler(client client.Client, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder) *MultiRoleInferenceReconciler {
+func NewMultiRoleInferenceReconciler(client client.Client, scheme *runtime.Scheme, log logr.Logger, recorder record.EventRecorder, enableGWIE bool) *MultiRoleInferenceReconciler {
 	return &MultiRoleInferenceReconciler{
-		Client:   client,
-		Scheme:   scheme,
-		Log:      log,
-		Recorder: recorder,
+		Client:                       client,
+		Scheme:                       scheme,
+		Log:                          log,
+		Recorder:                     recorder,
+		EnableGatewayAPIInferenceExt: enableGWIE,
 	}
 }
 
@@ -64,6 +77,9 @@ func NewMultiRoleInferenceReconciler(client client.Client, scheme *runtime.Schem
 // +kubebuilder:rbac:groups=kaito.sh,resources=multiroleinferences/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=kaito.sh,resources=multiroleinferences/finalizers,verbs=update
 // +kubebuilder:rbac:groups=kaito.sh,resources=inferencesets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch
+// +kubebuilder:rbac:groups=source.toolkit.fluxcd.io,resources=ocirepositories,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=helm.toolkit.fluxcd.io,resources=helmreleases,verbs=get;list;watch;create;update;patch;delete
 
 func (r *MultiRoleInferenceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("multiroleinference", req.NamespacedName)
@@ -125,7 +141,8 @@ func (r *MultiRoleInferenceReconciler) deleteMultiRoleInference(ctx context.Cont
 	return r.garbageCollectMultiRoleInference(ctx, log, mri)
 }
 
-// garbageCollectMultiRoleInference deletes all child InferenceSets and removes the finalizer.
+// garbageCollectMultiRoleInference deletes all child InferenceSets and removes
+// the finalizer. OCIRepository and HelmRelease are GC'd via ownerReferences.
 func (r *MultiRoleInferenceReconciler) garbageCollectMultiRoleInference(ctx context.Context, log logr.Logger, mri *kaitov1alpha1.MultiRoleInference) (ctrl.Result, error) {
 	// List all child InferenceSets owned by this MRI.
 	isList := &kaitov1alpha1.InferenceSetList{}
@@ -202,6 +219,28 @@ func (r *MultiRoleInferenceReconciler) addOrUpdateMultiRoleInference(ctx context
 		return ctrl.Result{}, err
 	}
 
+	// Reconcile InferencePool via Flux OCIRepository + HelmRelease — only when GWIE is enabled.
+	// EPP plugins config is passed inline through Helm values (pluginsCustomConfig),
+	// so no separate ConfigMap reconciliation is needed.
+	if r.EnableGatewayAPIInferenceExt {
+		if err := r.reconcileInferencePool(ctx, mri); err != nil {
+			log.Error(err, "Failed to reconcile InferencePool")
+			r.Recorder.Eventf(mri, "Warning", "ReconcileFailed",
+				"Failed to reconcile InferencePool: %v", err)
+			meta.SetStatusCondition(&mri.Status.Conditions, metav1.Condition{
+				Type:               string(kaitov1alpha1.MultiRoleInferenceConditionTypeReady),
+				Status:             metav1.ConditionFalse,
+				Reason:             "ReconcileFailed",
+				Message:            fmt.Sprintf("Failed to reconcile InferencePool: %v", err),
+				ObservedGeneration: mri.Generation,
+			})
+			if statusErr := r.Status().Update(ctx, mri); statusErr != nil {
+				log.Error(statusErr, "Failed to update status")
+			}
+			return ctrl.Result{}, err
+		}
+	}
+
 	// Aggregate status from child InferenceSets.
 	if err := r.aggregateStatus(ctx, log, mri); err != nil {
 		log.Error(err, "Failed to aggregate status")
@@ -235,9 +274,7 @@ func (r *MultiRoleInferenceReconciler) aggregateStatus(ctx context.Context, log 
 	prefillReady := r.isInferenceSetReady(roleISMap[string(kaitov1alpha1.MultiRoleInferenceRolePrefill)])
 	decodeReady := r.isInferenceSetReady(roleISMap[string(kaitov1alpha1.MultiRoleInferenceRoleDecode)])
 
-	// TODO: include inferencePoolReady once InferencePool creation is implemented (Step 4).
-	// For now, InferencePool is always not ready.
-	inferencePoolReady := false
+	inferencePoolReady := r.isInferencePoolReady(ctx, mri)
 	allReady := prefillReady && decodeReady && inferencePoolReady
 
 	// Set prefill condition.
@@ -284,13 +321,20 @@ func (r *MultiRoleInferenceReconciler) aggregateStatus(ctx context.Context, log 
 		ObservedGeneration: mri.Generation,
 	})
 
-	// TODO: Check InferencePool readiness (Step 4 — InferencePool not yet created by this controller).
-	// For now, mark InferencePoolReady as False with reason "NotImplemented".
+	// Check InferencePool readiness.
+	condStatus = metav1.ConditionFalse
+	reason = "InferencePoolNotReady"
+	message = "InferencePool is not ready"
+	if inferencePoolReady {
+		condStatus = metav1.ConditionTrue
+		reason = "InferencePoolReady"
+		message = "InferencePool is ready"
+	}
 	meta.SetStatusCondition(&mri.Status.Conditions, metav1.Condition{
 		Type:               string(kaitov1alpha1.MultiRoleInferenceConditionTypeInferencePoolReady),
-		Status:             metav1.ConditionFalse,
-		Reason:             "NotImplemented",
-		Message:            "InferencePool creation is not yet implemented",
+		Status:             condStatus,
+		Reason:             reason,
+		Message:            message,
 		ObservedGeneration: mri.Generation,
 	})
 
@@ -454,11 +498,246 @@ func (r *MultiRoleInferenceReconciler) reconcileInferenceSet(
 	return nil
 }
 
+const (
+	// eppPluginsConfigKey is the filename key for EPP plugins config,
+	// used both as the ConfigMap data key and the Helm pluginsConfigFile name.
+	eppPluginsConfigKey = "config.yaml"
+)
+
+// defaultPDPluginsConfigTemplate is the default EPP plugins YAML template for P/D disaggregated serving.
+// Uses the llm-d EndpointPickerConfig format with schedulingProfiles for prefill and decode.
+const defaultPDPluginsConfigTemplate = `apiVersion: inference.networking.x-k8s.io/v1alpha1
+kind: EndpointPickerConfig
+plugins:
+  - type: disagg-headers-handler
+  - type: prefix-based-pd-decider
+    parameters:
+      nonCachedTokens: 4
+  - type: disagg-profile-handler
+    parameters:
+      deciders:
+        prefill: prefix-based-pd-decider
+  - type: by-label-selector
+    name: prefill-filter
+    parameters:
+      matchLabels:
+        kaito.sh/inference-role: prefill
+  - type: by-label-selector
+    name: decode-filter
+    parameters:
+      matchLabels:
+        kaito.sh/inference-role: decode
+  - type: load-aware-scorer
+    parameters:
+      threshold: 10
+  - type: max-score-picker
+schedulingProfiles:
+  - name: prefill
+    plugins:
+      - pluginRef: prefill-filter
+      - pluginRef: load-aware-scorer
+        weight: 10
+      - pluginRef: max-score-picker
+  - name: decode
+    plugins:
+      - pluginRef: decode-filter
+      - pluginRef: load-aware-scorer
+        weight: 10
+      - pluginRef: max-score-picker
+`
+
+// defaultPDPluginsConfig returns the default P/D plugins config.
+// Note: precise-prefix-cache-scorer is omitted because it requires a tokenizer
+// sidecar (UDS socket) that is not yet deployed by KAITO. Once tokenizer sidecar
+// support is added, this config should be updated to include it.
+func defaultPDPluginsConfig(modelName string) string {
+	return defaultPDPluginsConfigTemplate
+}
+
+// inferencePoolName returns the name of the InferencePool resources for the MRI.
+func inferencePoolName(mriName string) string {
+	return fmt.Sprintf("%s-inferencepool", mriName)
+}
+
+// reconcileInferencePool creates or updates the Flux OCIRepository and HelmRelease
+// that render an InferencePool CR + EPP deployment, owned by the MRI.
+func (r *MultiRoleInferenceReconciler) reconcileInferencePool(
+	ctx context.Context,
+	mri *kaitov1alpha1.MultiRoleInference,
+) error {
+	poolName := inferencePoolName(mri.Name)
+
+	// --- OCIRepository ---
+	ociRepo := &sourcev1.OCIRepository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolName,
+			Namespace: mri.Namespace,
+		},
+	}
+
+	ociResult, err := controllerutil.CreateOrUpdate(ctx, r.Client, ociRepo, func() error {
+		if err := controllerutil.SetControllerReference(mri, ociRepo, r.Scheme); err != nil {
+			return err
+		}
+		ociRepo.Spec = sourcev1.OCIRepositorySpec{
+			URL:      consts.InferencePoolChartURL,
+			Interval: metav1.Duration{Duration: 10 * time.Minute},
+			Reference: &sourcev1.OCIRepositoryRef{
+				Tag: consts.InferencePoolChartVersion,
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("CreateOrUpdate OCIRepository %s: %w", poolName, err)
+	}
+	klog.V(2).InfoS("Reconciled InferencePool OCIRepository",
+		"name", poolName,
+		"result", ociResult,
+	)
+
+	// --- HelmRelease ---
+	// InferencePool selects ALL MRI pods (prefill + decode). EPP's internal
+	// prefill-filter / decode-filter plugins handle role-based selection.
+	// targetPort=5001 (sidecar) is only used by Envoy for user-facing traffic;
+	// EPP routes user requests exclusively to decode pods via decode-filter.
+	// Prefill communication is initiated by the decode sidecar directly to
+	// prefill pod:5000, bypassing InferencePool/Envoy entirely.
+	matchLabels := map[string]string{
+		kaitov1alpha1.LabelMultiRoleInferenceParent: mri.Name,
+		appsv1.PodIndexLabel:                        "0", // Only leader pod (ordinal 0) serves inference traffic
+	}
+
+	// Build EPP extension values with llm-d image and P/D plugins config.
+	eppValues := map[string]any{
+		"image": map[string]string{
+			"hub":        consts.EPPImageHub,
+			"name":       consts.EPPImageName,
+			"tag":        consts.EPPImageTag,
+			"pullPolicy": string(corev1.PullIfNotPresent),
+		},
+	}
+
+	// Load plugins config: either from user-provided ConfigMap or auto-generated default.
+	pluginsYAML := defaultPDPluginsConfig(mri.Spec.Model.Name)
+	if mri.Spec.EPPPluginsConfig != "" {
+		cm := &corev1.ConfigMap{}
+		if err := r.Get(ctx, client.ObjectKey{Name: mri.Spec.EPPPluginsConfig, Namespace: mri.Namespace}, cm); err != nil {
+			return fmt.Errorf("get user-provided EPP plugins ConfigMap %s: %w", mri.Spec.EPPPluginsConfig, err)
+		}
+		if data, ok := cm.Data[eppPluginsConfigKey]; ok {
+			pluginsYAML = data
+		} else {
+			return fmt.Errorf("EPP plugins ConfigMap %s missing key %s", mri.Spec.EPPPluginsConfig, eppPluginsConfigKey)
+		}
+	}
+	eppValues["pluginsConfigFile"] = eppPluginsConfigKey
+	eppValues["pluginsCustomConfig"] = map[string]string{
+		eppPluginsConfigKey: pluginsYAML,
+	}
+	// Disable EPP secure-serving (self-signed TLS) — MRI pools run plaintext
+	// behind the mesh, matching standalone InferenceSet behavior.
+	eppValues["flags"] = map[string]string{
+		"secure-serving": "false",
+	}
+
+	helmValues := map[string]any{
+		"inferenceExtension": eppValues,
+		"inferencePool": map[string]any{
+			"targetPorts": []map[string]any{
+				{"number": consts.PortRoutingSidecar}, // routing sidecar port; GWIE CRD allows only one targetPort (maxItems: 1)
+			},
+			"modelServers": map[string]any{
+				"matchLabels": matchLabels,
+			},
+		},
+	}
+	rawHelmValues, err := json.Marshal(helmValues)
+	if err != nil {
+		return fmt.Errorf("marshal HelmRelease values: %w", err)
+	}
+
+	helmRelease := &helmv2.HelmRelease{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      poolName,
+			Namespace: mri.Namespace,
+		},
+	}
+
+	helmResult, err := controllerutil.CreateOrUpdate(ctx, r.Client, helmRelease, func() error {
+		if err := controllerutil.SetControllerReference(mri, helmRelease, r.Scheme); err != nil {
+			return err
+		}
+		helmRelease.Spec = helmv2.HelmReleaseSpec{
+			Interval: metav1.Duration{Duration: 10 * time.Minute},
+			ChartRef: &helmv2.CrossNamespaceSourceReference{
+				Kind:      sourcev1.OCIRepositoryKind,
+				Namespace: mri.Namespace,
+				Name:      poolName,
+			},
+			Values: &apiextensionsv1.JSON{
+				Raw: rawHelmValues,
+			},
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("CreateOrUpdate HelmRelease %s: %w", poolName, err)
+	}
+	klog.V(2).InfoS("Reconciled InferencePool HelmRelease",
+		"name", poolName,
+		"result", helmResult,
+	)
+
+	return nil
+}
+
+// isInferencePoolReady checks if the InferencePool HelmRelease is ready.
+func (r *MultiRoleInferenceReconciler) isInferencePoolReady(ctx context.Context, mri *kaitov1alpha1.MultiRoleInference) bool {
+	poolName := inferencePoolName(mri.Name)
+	hr := &helmv2.HelmRelease{}
+	if err := r.Get(ctx, client.ObjectKey{Name: poolName, Namespace: mri.Namespace}, hr); err != nil {
+		return false
+	}
+	for _, cond := range hr.Status.Conditions {
+		if cond.Type == "Ready" && cond.Status == metav1.ConditionTrue &&
+			hr.Status.ObservedGeneration >= hr.Generation {
+			return true
+		}
+	}
+	return false
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *MultiRoleInferenceReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).
+	builder := ctrl.NewControllerManagedBy(mgr).
 		For(&kaitov1alpha1.MultiRoleInference{}).
-		Owns(&kaitov1alpha1.InferenceSet{}).
+		Owns(&kaitov1alpha1.InferenceSet{})
+
+	// Only watch Flux resources when Gateway API Inference Extension is enabled,
+	// because the Flux CRDs are only installed under that feature gate.
+	if r.EnableGatewayAPIInferenceExt {
+		// Verify prerequisite CRDs exist before configuring watches.
+		for _, gvk := range []schema.GroupVersionKind{
+			helmv2.GroupVersion.WithKind(helmv2.HelmReleaseKind),
+			sourcev1.GroupVersion.WithKind(sourcev1.OCIRepositoryKind),
+			gaiev1.SchemeGroupVersion.WithKind("InferencePool"),
+			gaiev1alpha2.SchemeGroupVersion.WithKind("InferenceObjective"),
+		} {
+			found, err := utils.EnsureKindExists(mgr.GetConfig(), gvk)
+			if err != nil {
+				return fmt.Errorf("failed to ensure kind %s exists: %w", gvk.Kind, err)
+			}
+			if !found {
+				return fmt.Errorf("%s not found in the cluster, please ensure the Gateway API Inference Extension and Flux are installed", gvk.String())
+			}
+		}
+		builder = builder.
+			Owns(&sourcev1.OCIRepository{}).
+			Owns(&helmv2.HelmRelease{})
+	}
+
+	return builder.
 		WithOptions(controller.Options{MaxConcurrentReconciles: 3}).
 		Complete(r)
 }

--- a/pkg/controllers/multiroleinference/controller.go
+++ b/pkg/controllers/multiroleinference/controller.go
@@ -705,7 +705,7 @@ func (r *MultiRoleInferenceReconciler) isInferencePoolReady(ctx context.Context,
 		return false
 	}
 	for _, cond := range hr.Status.Conditions {
-		if cond.Type == "Ready" && cond.Status == metav1.ConditionTrue &&
+		if cond.Type == consts.ConditionReady && cond.Status == metav1.ConditionTrue &&
 			hr.Status.ObservedGeneration >= hr.Generation {
 			return true
 		}

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -279,6 +279,14 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 			if workspaceLabels == nil {
 				workspaceLabels = make(map[string]string)
 			}
+			// Also propagate select labels from the InferenceSet's own metadata,
+			// in case template.metadata.labels was pruned by the API server.
+			if role, ok := iObj.Labels[kaitov1alpha1.LabelInferenceRole]; ok {
+				workspaceLabels[kaitov1alpha1.LabelInferenceRole] = role
+			}
+			if mriParent, ok := iObj.Labels[kaitov1alpha1.LabelMultiRoleInferenceParent]; ok {
+				workspaceLabels[kaitov1alpha1.LabelMultiRoleInferenceParent] = mriParent
+			}
 			workspaceLabels[consts.WorkspaceCreatedByInferenceSetLabel] = iObj.Name
 			workspaceObj.Labels = workspaceLabels
 
@@ -306,6 +314,43 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 			if err := c.Client.Create(ctx, workspaceObj); err != nil {
 				klog.ErrorS(err, "failed to create workspace", "workspace", workspaceObj.Name)
 				return reconcile.Result{}, err
+			}
+		}
+	}
+
+	// Reconcile labels on existing workspaces to match template labels and InferenceSet metadata labels.
+	// This ensures label changes (e.g., adding kaito.sh/inference-role) propagate
+	// to workspaces that were created before the label was set.
+	desiredLabels := make(map[string]string)
+	for k, v := range iObj.Spec.Template.Labels {
+		desiredLabels[k] = v
+	}
+	// Propagate inference-role from InferenceSet metadata (reliable even if template labels are pruned).
+	if role, ok := iObj.Labels[kaitov1alpha1.LabelInferenceRole]; ok {
+		desiredLabels[kaitov1alpha1.LabelInferenceRole] = role
+	}
+	if mriParent, ok := iObj.Labels[kaitov1alpha1.LabelMultiRoleInferenceParent]; ok {
+		desiredLabels[kaitov1alpha1.LabelMultiRoleInferenceParent] = mriParent
+	}
+	if len(desiredLabels) > 0 {
+		for i := range wsList.Items {
+			ws := &wsList.Items[i]
+			needsUpdate := false
+			if ws.Labels == nil {
+				ws.Labels = make(map[string]string)
+			}
+			for k, v := range desiredLabels {
+				if ws.Labels[k] != v {
+					ws.Labels[k] = v
+					needsUpdate = true
+				}
+			}
+			if needsUpdate {
+				klog.InfoS("Reconciling workspace labels", "workspace", klog.KObj(ws))
+				if err := c.Client.Update(ctx, ws); err != nil {
+					klog.ErrorS(err, "failed to update workspace labels", "workspace", klog.KObj(ws))
+					return ctrl.Result{}, err
+				}
 			}
 		}
 	}
@@ -415,6 +460,19 @@ func (c *InferenceSetReconciler) ensureGatewayAPIInferenceExtension(ctx context.
 	if iObj == nil {
 		return fmt.Errorf("InferenceSet object is nil")
 	}
+
+	// Skip GWIE for child InferenceSets managed by MultiRoleInference.
+	// The MRI controller creates a shared InferencePool + EPP for all child InferenceSets.
+	// Use OwnerReferences (controller-managed) instead of labels (easily user-modifiable)
+	// to prevent accidental GWIE bypass on standalone InferenceSets.
+	for _, owner := range iObj.OwnerReferences {
+		if owner.Controller != nil && *owner.Controller &&
+			owner.Kind == "MultiRoleInference" &&
+			owner.APIVersion == kaitov1alpha1.GroupVersion.String() {
+			return nil
+		}
+	}
+
 	runtimeName := kaitov1alpha1.GetInferenceSetRuntimeName(iObj)
 	isPresetInference := iObj.Spec.Template.Inference.Preset != nil
 

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -318,7 +318,9 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 		}
 	}
 
-	// Reconcile labels on existing workspaces to match template labels and InferenceSet metadata labels.
+	// Reconcile labels on existing workspaces by additively propagating InferenceSet metadata labels.
+	// Note: this only adds/updates desired labels; it does not remove stale labels to avoid
+	// conflicting with labels managed by other controllers.
 	// This ensures label changes (e.g., adding kaito.sh/inference-role) propagate
 	// to workspaces that were created before the label was set.
 	desiredLabels := make(map[string]string)

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -344,12 +344,11 @@ func (p *PresetParam) buildHuggingfaceInferenceCommand() []string {
 }
 
 func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
-	// If the Workspace was created by an InferenceSet, expose the InferenceSet
-	// name as the served model name so all replicas behind the InferenceSet
-	// share a single, stable model identifier in the OpenAI-compatible API.
-	// Standalone Workspaces keep the model's default served name.
-	if isName, ok := rc.WorkspaceMetadata.Labels[consts.WorkspaceCreatedByInferenceSetLabel]; ok && isName != "" {
-		p.VLLM.ModelRunParams["served-model-name"] = isName
+	// For InferenceSet-managed workspaces (both MRI and standalone), use the model name
+	// as served-model-name so all roles share a single model identifier for EPP routing.
+	// p.VLLM.ModelName is derived from the workspace's inference.preset.name field.
+	if _, ok := rc.WorkspaceMetadata.Labels[consts.WorkspaceCreatedByInferenceSetLabel]; ok && p.VLLM.ModelName != "" {
+		p.VLLM.ModelRunParams["served-model-name"] = p.VLLM.ModelName
 	} else if p.VLLM.ModelName != "" {
 		p.VLLM.ModelRunParams["served-model-name"] = p.VLLM.ModelName
 	}

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -351,6 +351,8 @@ func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
 	//   so EPP routes requests by InferenceSet identity.
 	// - Fallback: use VLLM.ModelName if available.
 	if isName, ok := rc.WorkspaceMetadata.Labels[consts.WorkspaceCreatedByInferenceSetLabel]; ok && isName != "" {
+		// Note: string literal used to avoid import cycle with api/v1alpha1 package.
+		// Matches v1alpha1.LabelMultiRoleInferenceParent.
 		if _, isMRI := rc.WorkspaceMetadata.Labels["multiroleinference.kaito.sh/created-by"]; isMRI && p.VLLM.ModelName != "" {
 			p.VLLM.ModelRunParams["served-model-name"] = p.VLLM.ModelName
 		} else {

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -344,11 +344,18 @@ func (p *PresetParam) buildHuggingfaceInferenceCommand() []string {
 }
 
 func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
-	// For InferenceSet-managed workspaces (both MRI and standalone), use the model name
-	// as served-model-name so all roles share a single model identifier for EPP routing.
-	// p.VLLM.ModelName is derived from the workspace's inference.preset.name field.
-	if _, ok := rc.WorkspaceMetadata.Labels[consts.WorkspaceCreatedByInferenceSetLabel]; ok && p.VLLM.ModelName != "" {
-		p.VLLM.ModelRunParams["served-model-name"] = p.VLLM.ModelName
+	// For InferenceSet-managed workspaces, determine the served-model-name:
+	// - MRI workspaces (have multiroleinference.kaito.sh/created-by label): use VLLM.ModelName
+	//   so all roles share a single model identifier for EPP routing.
+	// - Standalone InferenceSet workspaces: use the InferenceSet name (label value)
+	//   so EPP routes requests by InferenceSet identity.
+	// - Fallback: use VLLM.ModelName if available.
+	if isName, ok := rc.WorkspaceMetadata.Labels[consts.WorkspaceCreatedByInferenceSetLabel]; ok && isName != "" {
+		if _, isMRI := rc.WorkspaceMetadata.Labels["multiroleinference.kaito.sh/created-by"]; isMRI && p.VLLM.ModelName != "" {
+			p.VLLM.ModelRunParams["served-model-name"] = p.VLLM.ModelName
+		} else {
+			p.VLLM.ModelRunParams["served-model-name"] = isName
+		}
 	} else if p.VLLM.ModelName != "" {
 		p.VLLM.ModelRunParams["served-model-name"] = p.VLLM.ModelName
 	}

--- a/pkg/model/interface_test.go
+++ b/pkg/model/interface_test.go
@@ -240,6 +240,16 @@ func TestGetInferenceCommandVLLMServedModelName(t *testing.T) {
 			expectedServed: "served-model-name=my-inferenceset",
 		},
 		{
+			name:          "MRI workspace uses model name over InferenceSet name",
+			vllmModelName: "phi-4-mini-instruct",
+			workspaceLabels: map[string]string{
+				consts.WorkspaceCreatedByInferenceSetLabel: "phi-4-decode",
+				"multiroleinference.kaito.sh/created-by":   "phi-4",
+			},
+			expectedServed:    "served-model-name=phi-4-mini-instruct",
+			notExpectedServed: "served-model-name=phi-4-decode",
+		},
+		{
 			name:          "InferenceSet label with empty value falls back to VLLM.ModelName",
 			vllmModelName: "default-model",
 			workspaceLabels: map[string]string{

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -105,7 +105,7 @@ const (
 	// See: https://github.com/llm-d/llm-d-inference-scheduler
 	EPPImageHub  = "mcr.microsoft.com/oss/v2/llm-d"
 	EPPImageName = "llm-d-inference-scheduler"
-	EPPImageTag  = "v0.7.1"
+	EPPImageTag  = "v0.8.0"
 
 	// Routing sidecar for P/D disaggregation on decode workspaces.
 	// The sidecar listens on port 5001 (PortRoutingSidecar) and forwards
@@ -113,7 +113,7 @@ const (
 	// is set to 5001 so external traffic flows through the routing layer.
 	// See: https://github.com/llm-d/llm-d-routing-sidecar
 	RoutingSidecarImage = "mcr.microsoft.com/oss/v2/llm-d/llm-d-routing-sidecar"
-	RoutingSidecarTag   = "v0.7.1"
+	RoutingSidecarTag   = "v0.8.0"
 
 	// PortRoutingSidecar is the port the routing sidecar listens on.
 	// When the sidecar is present, the Service targetPort points here

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -133,6 +133,13 @@ func GenerateStatefulSetManifest(revisionNum string, replicas int) func(*generat
 				klog.Infof("Adding label %s=%s to statefulset selector", consts.WorkspaceCreatedByInferenceSetLabel, createdBy)
 				selector[consts.WorkspaceCreatedByInferenceSetLabel] = createdBy
 			}
+			// Propagate MRI parent and inference-role labels to pod templates for InferencePool endpoint selection.
+			if parent, exists := ctx.Workspace.Labels[kaitov1alpha1.LabelMultiRoleInferenceParent]; exists {
+				selector[kaitov1alpha1.LabelMultiRoleInferenceParent] = parent
+			}
+			if role, exists := ctx.Workspace.Labels[kaitov1alpha1.LabelInferenceRole]; exists {
+				selector[kaitov1alpha1.LabelInferenceRole] = role
+			}
 		}
 		labelselector := &metav1.LabelSelector{
 			MatchLabels: selector,
@@ -286,6 +293,15 @@ func GenerateManifestWithPodTemplate(workspaceObj *kaitov1beta1.Workspace, toler
 			klog.Infof("Adding label %s=%s to statefulset selector", consts.WorkspaceCreatedByInferenceSetLabel, createdBy)
 			templateCopy.ObjectMeta.Labels[consts.WorkspaceCreatedByInferenceSetLabel] = createdBy
 			labelselector.MatchLabels[consts.WorkspaceCreatedByInferenceSetLabel] = createdBy
+		}
+		// Propagate MRI parent and inference-role labels to pod templates for InferencePool endpoint selection.
+		if parent, exists := workspaceObj.Labels[kaitov1alpha1.LabelMultiRoleInferenceParent]; exists {
+			templateCopy.ObjectMeta.Labels[kaitov1alpha1.LabelMultiRoleInferenceParent] = parent
+			labelselector.MatchLabels[kaitov1alpha1.LabelMultiRoleInferenceParent] = parent
+		}
+		if role, exists := workspaceObj.Labels[kaitov1alpha1.LabelInferenceRole]; exists {
+			templateCopy.ObjectMeta.Labels[kaitov1alpha1.LabelInferenceRole] = role
+			labelselector.MatchLabels[kaitov1alpha1.LabelInferenceRole] = role
 		}
 	}
 

--- a/presets/workspace/inference/vllm/tests/conftest.py
+++ b/presets/workspace/inference/vllm/tests/conftest.py
@@ -26,7 +26,7 @@ from unittest.mock import MagicMock
 
 def _install_mock_module(name: str) -> None:
     """Install a MagicMock as a top-level module if it is not already importable."""
-    if name not in sys.modules:
+    if name not in sys.modules or not hasattr(sys.modules[name], "__file__"):
         sys.modules[name] = MagicMock()
 
 

--- a/presets/workspace/inference/vllm/tests/conftest.py
+++ b/presets/workspace/inference/vllm/tests/conftest.py
@@ -1,0 +1,75 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Shared test configuration and heavy-dependency mocking for vLLM inference tests.
+
+vllm and its transitive dependencies (transformers, huggingface-hub, torch, etc.)
+have strict version constraints that may conflict in CI's lightweight pip environment.
+This conftest installs lightweight stubs for modules that are not exercised by
+unit tests, allowing inference_api to be imported without the full vllm stack.
+"""
+
+import sys
+import types
+from unittest.mock import MagicMock
+
+
+def _install_mock_module(name: str) -> None:
+    """Install a MagicMock as a top-level module if it is not already importable."""
+    if name not in sys.modules:
+        sys.modules[name] = MagicMock()
+
+
+def _install_mock_tree(root: str, children: list[str]) -> None:
+    """Install a mock module tree (root + root.child1 + root.child1.child2 ...)."""
+    _install_mock_module(root)
+    for child in children:
+        full = f"{root}.{child}"
+        parts = full.split(".")
+        for i in range(1, len(parts) + 1):
+            _install_mock_module(".".join(parts[:i]))
+
+
+# Only mock if vllm is not genuinely installed (i.e., CI lightweight environment).
+try:
+    import vllm  # noqa: F401
+except (ImportError, Exception):
+    # Mock the vllm module tree that inference_api.py touches at import time.
+    _install_mock_tree(
+        "vllm",
+        [
+            "entrypoints",
+            "entrypoints.openai",
+            "entrypoints.openai.api_server",
+            "entrypoints.openai.models",
+            "entrypoints.openai.models.protocol",
+            "utils",
+            "utils.argparse_utils",
+        ],
+    )
+
+    # Mock other heavy deps that inference_api imports at module level.
+    for mod in ("pynvml", "uvloop", "psutil"):
+        _install_mock_module(mod)
+
+    # Provide a minimal FlexibleArgumentParser stub so inference_api can subclass it.
+    import argparse
+
+    fap_mod = types.ModuleType("vllm.utils.argparse_utils")
+    fap_mod.FlexibleArgumentParser = argparse.ArgumentParser
+    sys.modules["vllm.utils.argparse_utils"] = fap_mod
+
+    # Provide LoRAModulePath stub.
+    protocol_mod = types.ModuleType("vllm.entrypoints.openai.models.protocol")
+    protocol_mod.LoRAModulePath = MagicMock()
+    sys.modules["vllm.entrypoints.openai.models.protocol"] = protocol_mod

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -68,9 +68,10 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 			validateInferenceSetStatus(is)
 			// Match replicas by role label instead of assuming all roles have the same count
 			roleName := is.Labels[kaitov1alpha1.LabelInferenceRole]
-			if expectedReplicas, ok := roleReplicas[roleName]; ok {
-				validateInferenceSetReplicas(is, expectedReplicas)
-			}
+			Expect(roleName).NotTo(BeEmpty(), "InferenceSet %s missing required %s label", is.Name, kaitov1alpha1.LabelInferenceRole)
+			expectedReplicas, ok := roleReplicas[roleName]
+			Expect(ok).To(BeTrue(), "InferenceSet %s has unexpected role label %q", is.Name, roleName)
+			validateInferenceSetReplicas(is, expectedReplicas)
 			validateInferenceSetBenchmarkCompleted(is)
 		}
 

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -713,10 +713,10 @@ func validateMultiRoleInferenceChatCompletions(mriObj *kaitov1alpha1.MultiRoleIn
 			expectedCompletion := `"object":"chat.completion`
 			execOption := corev1.PodExecOptions{
 				Command: []string{"bash", "-c", fmt.Sprintf(
-					`apt-get update -qq && apt-get install -y -qq curl > /dev/null 2>&1; `+
+					`command -v curl > /dev/null 2>&1 || (apt-get update -qq > /dev/null 2>&1 && apt-get install -y -qq curl > /dev/null 2>&1); `+
 						`curl -s --max-time 30 -X POST -H "Content-Type: application/json" `+
 						`-d '{"model":"%s","messages":[{"role":"user","content":"What is Kubernetes?"}],"max_tokens":7,"temperature":0}' `+
-						`%s | tee /dev/stderr | grep -q '%s'`,
+						`%s | grep -q '%s'`,
 					modelName, svcEndpoint, expectedCompletion)},
 				Container: decodeWS.Name,
 				Stdout:    true,

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -70,8 +70,6 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 			roleName := is.Labels[kaitov1alpha1.LabelInferenceRole]
 			if expectedReplicas, ok := roleReplicas[roleName]; ok {
 				validateInferenceSetReplicas(is, expectedReplicas)
-			} else {
-				validateInferenceSetReplicas(is, *mriObj.Spec.Roles[0].Replicas)
 			}
 			validateInferenceSetBenchmarkCompleted(is)
 		}

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -712,7 +712,7 @@ func validateMultiRoleInferenceChatCompletions(mriObj *kaitov1alpha1.MultiRoleIn
 
 			expectedCompletion := `"object":"chat.completion`
 			execOption := corev1.PodExecOptions{
-				Command: []string{"bash", "-c", fmt.Sprintf(
+				Command: []string{"sh", "-c", fmt.Sprintf(
 					`command -v curl > /dev/null 2>&1 || (apt-get update -qq > /dev/null 2>&1 && apt-get install -y -qq curl > /dev/null 2>&1); `+
 						`curl -s --max-time 30 -X POST -H "Content-Type: application/json" `+
 						`-d '{"model":"%s","messages":[{"role":"user","content":"What is Kubernetes?"}],"max_tokens":7,"temperature":0}' `+

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -14,6 +14,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math/rand"
@@ -43,6 +44,43 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 	BeforeEach(func() {
 		loadTestEnvVars()
 		loadModelVersions()
+	})
+
+	// MRI and InferenceSet tests run first so they are not interrupted by
+	// slow/flaky GPU-provisioning timeouts in the preset workspace tests below.
+	It("should create a MultiRoleInference with prefill and decode roles successfully", Serial, utils.GinkgoLabelFastCheck, func() {
+		mriObj := createGemma3MultiRoleInference()
+		defer cleanupResourcesForMultiRoleInference(mriObj)
+
+		validateMultiRoleInferenceChildInferenceSets(mriObj)
+
+		// Validate each child InferenceSet's status, replicas, benchmark, and GWIE resources
+		childInferenceSets := getMultiRoleInferenceChildInferenceSets(mriObj)
+		for i := range childInferenceSets {
+			is := &childInferenceSets[i]
+			validateInferenceSetStatus(is)
+			validateInferenceSetReplicas(is, *mriObj.Spec.Roles[0].Replicas)
+			validateInferenceSetBenchmarkCompleted(is)
+		}
+
+		// Validate MRI-owned InferencePool and GWIE resources (shared across all roles)
+		validateMultiRoleInferenceGWIEResources(mriObj)
+		validateMultiRoleInferenceStatus(mriObj)
+
+		// Validate chat completions endpoint via a decode pod
+		validateMultiRoleInferenceChatCompletions(mriObj)
+	})
+
+	It("should create a Gemma 3 InferenceSet with preset public mode successfully", Serial, utils.GinkgoLabelFastCheck, func() {
+		numOfReplicas := 1
+		inferenceSetObj := createGemma3InferenceSetWithPresetPublicModeAndVLLM(numOfReplicas)
+		defer cleanupResourcesForInferenceSet(inferenceSetObj)
+		time.Sleep(120 * time.Second)
+
+		validateInferenceSetStatus(inferenceSetObj)
+		validateInferenceSetReplicas(inferenceSetObj, int32(numOfReplicas))
+		validateInferenceSetBenchmarkCompleted(inferenceSetObj)
+		validateGatewayAPIInferenceExtensionResources(inferenceSetObj)
 	})
 
 	It("should create a qwen3-coder-30b-a3b-instruct two-node workspace with preset public mode successfully", utils.GinkgoLabelFastCheck, func() {
@@ -491,7 +529,7 @@ func cleanupResourcesForMultiRoleInference(mriObj *kaitov1alpha1.MultiRoleInfere
 					return client.IgnoreNotFound(err)
 				}
 				return utils.TestingCluster.KubeClient.Delete(ctx, mriObj, &client.DeleteOptions{})
-			}, utils.PollTimeout, utils.PollInterval).Should(Succeed(), "Failed to delete MultiRoleInference")
+			}, 5*time.Minute, utils.PollInterval).Should(Succeed(), "Failed to delete MultiRoleInference")
 		} else {
 			GinkgoWriter.Printf("test failed, keep %s\n", mriObj.Name)
 		}
@@ -559,6 +597,130 @@ func validateMultiRoleInferenceStatus(mriObj *kaitov1alpha1.MultiRoleInference) 
 			return prefillReady && decodeReady
 		}, 20*time.Minute, utils.PollInterval).Should(BeTrue(),
 			"Expected PrefillReady and DecodeReady conditions on MultiRoleInference %s", mriObj.Name)
+	})
+}
+
+// getMultiRoleInferenceChildInferenceSets returns the child InferenceSets for an MRI.
+func getMultiRoleInferenceChildInferenceSets(mriObj *kaitov1alpha1.MultiRoleInference) []kaitov1alpha1.InferenceSet {
+	var children []kaitov1alpha1.InferenceSet
+	Eventually(func() bool {
+		isList := &kaitov1alpha1.InferenceSetList{}
+		err := utils.TestingCluster.KubeClient.List(ctx, isList,
+			client.InNamespace(mriObj.Namespace),
+			client.MatchingLabels{kaitov1alpha1.LabelMultiRoleInferenceParent: mriObj.Name})
+		if err != nil {
+			return false
+		}
+		if len(isList.Items) != len(mriObj.Spec.Roles) {
+			return false
+		}
+		children = isList.Items
+		return true
+	}, 20*time.Minute, utils.PollInterval).Should(BeTrue(),
+		"Expected %d child InferenceSets for MultiRoleInference %s", len(mriObj.Spec.Roles), mriObj.Name)
+	return children
+}
+
+// validateMultiRoleInferenceGWIEResources validates the MRI-owned InferencePool
+// Flux resources (OCIRepository + HelmRelease) are ready.
+func validateMultiRoleInferenceGWIEResources(mriObj *kaitov1alpha1.MultiRoleInference) {
+	poolName := kaitoutils.InferencePoolName(mriObj.Name)
+
+	By("Checking MRI-owned Flux OCIRepository is Ready", func() {
+		Eventually(func() bool {
+			ociRepository := &sourcev1.OCIRepository{}
+			err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+				Namespace: mriObj.Namespace,
+				Name:      poolName,
+			}, ociRepository, &client.GetOptions{})
+			if err != nil {
+				return false
+			}
+			for _, cond := range ociRepository.Status.Conditions {
+				if cond.Type == consts.ConditionReady && cond.Status == metav1.ConditionTrue {
+					return true
+				}
+			}
+			return false
+		}, 10*time.Minute, utils.PollInterval).Should(BeTrue(),
+			"Failed to validate MRI Flux OCIRepository is Ready for %s", mriObj.Name)
+	})
+
+	By("Checking MRI-owned Flux HelmRelease is Ready", func() {
+		Eventually(func() bool {
+			helmRelease := &helmv2.HelmRelease{}
+			err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+				Namespace: mriObj.Namespace,
+				Name:      poolName,
+			}, helmRelease, &client.GetOptions{})
+			if err != nil {
+				return false
+			}
+			for _, cond := range helmRelease.Status.Conditions {
+				if cond.Type == consts.ConditionReady && cond.Status == metav1.ConditionTrue {
+					return true
+				}
+			}
+			return false
+		}, 10*time.Minute, utils.PollInterval).Should(BeTrue(),
+			"Failed to validate MRI Flux HelmRelease is Ready for %s", mriObj.Name)
+	})
+}
+
+// validateMultiRoleInferenceChatCompletions validates the /v1/chat/completions
+// endpoint by exec-ing curl into a decode pod.
+func validateMultiRoleInferenceChatCompletions(mriObj *kaitov1alpha1.MultiRoleInference) {
+	modelName := getModelName(mriObj.Spec.Model.Name)
+
+	By("Validating /v1/chat/completions via decode pod", func() {
+		coreClient, err := utils.GetK8sClientset()
+		Expect(err).NotTo(HaveOccurred(), "Failed to create core client")
+
+		k8sConfig, err := utils.GetK8sConfig()
+		Expect(err).NotTo(HaveOccurred(), "Failed to get k8s config")
+
+		Eventually(func() bool {
+			// Find the decode Workspace to get the service name and pod name
+			wsList := &kaitov1beta1.WorkspaceList{}
+			err = utils.TestingCluster.KubeClient.List(ctx, wsList,
+				client.InNamespace(namespaceName),
+				client.MatchingLabels{
+					kaitov1alpha1.LabelMultiRoleInferenceParent: mriObj.Name,
+					kaitov1alpha1.LabelInferenceRole:            string(kaitov1alpha1.MultiRoleInferenceRoleDecode),
+				})
+			if err != nil || len(wsList.Items) == 0 {
+				GinkgoWriter.Printf("Failed to find decode Workspace: %v\n", err)
+				return false
+			}
+			decodeWS := &wsList.Items[0]
+
+			// StatefulSet pod name is <workspace.Name>-0
+			podName := decodeWS.Name + "-0"
+			// Decode workspace service name matches workspace name, exposed on port 80
+			svcEndpoint := fmt.Sprintf("http://%s.%s.svc.cluster.local:80/v1/chat/completions", decodeWS.Name, mriObj.Namespace)
+
+			expectedCompletion := `"object":"chat.completion`
+			execOption := corev1.PodExecOptions{
+				Command: []string{"bash", "-c", fmt.Sprintf(
+					`curl -s --max-time 30 -X POST -H "Content-Type: application/json" `+
+						`-d '{"model":"%s","messages":[{"role":"user","content":"What is Kubernetes?"}],"max_tokens":7,"temperature":0}' `+
+						`%s | tee /dev/stderr | grep -q '%s'`,
+					modelName, svcEndpoint, expectedCompletion)},
+				Container: decodeWS.Name,
+				Stdout:    true,
+				Stderr:    true,
+			}
+
+			execCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			defer cancel()
+			stdout, err := utils.ExecSync(execCtx, k8sConfig, coreClient, mriObj.Namespace, podName, execOption)
+			if err != nil {
+				GinkgoWriter.Printf("validate chat completions fails: %v, stdout: %s\n", err, stdout)
+				return false
+			}
+			return true
+		}, 5*time.Minute, utils.PollInterval).Should(BeTrue(),
+			"Failed to validate /v1/chat/completions endpoint on MRI decode pod")
 	})
 }
 
@@ -846,6 +1008,7 @@ func logBenchmarkPhaseElapsed(coreClient *kubernetes.Clientset, wsName, wsNamesp
 	podName := wsName + "-0"
 	req := coreClient.CoreV1().Pods(wsNamespace).GetLogs(podName, &corev1.PodLogOptions{
 		TailLines: &tailLines,
+		Container: wsName, // specify container name to handle multi-container pods (e.g., with routing sidecar)
 	})
 	stream, err := req.Stream(ctx)
 	if err != nil {

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -56,10 +56,23 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 
 		// Validate each child InferenceSet's status, replicas, benchmark, and GWIE resources
 		childInferenceSets := getMultiRoleInferenceChildInferenceSets(mriObj)
+		// Build a map of role name -> expected replicas for accurate validation
+		roleReplicas := map[string]int32{}
+		for _, role := range mriObj.Spec.Roles {
+			if role.Replicas != nil {
+				roleReplicas[string(role.Type)] = *role.Replicas
+			}
+		}
 		for i := range childInferenceSets {
 			is := &childInferenceSets[i]
 			validateInferenceSetStatus(is)
-			validateInferenceSetReplicas(is, *mriObj.Spec.Roles[0].Replicas)
+			// Match replicas by role label instead of assuming all roles have the same count
+			roleName := is.Labels[kaitov1alpha1.LabelInferenceRole]
+			if expectedReplicas, ok := roleReplicas[roleName]; ok {
+				validateInferenceSetReplicas(is, expectedReplicas)
+			} else {
+				validateInferenceSetReplicas(is, *mriObj.Spec.Roles[0].Replicas)
+			}
 			validateInferenceSetBenchmarkCompleted(is)
 		}
 
@@ -702,7 +715,8 @@ func validateMultiRoleInferenceChatCompletions(mriObj *kaitov1alpha1.MultiRoleIn
 			expectedCompletion := `"object":"chat.completion`
 			execOption := corev1.PodExecOptions{
 				Command: []string{"bash", "-c", fmt.Sprintf(
-					`curl -s --max-time 30 -X POST -H "Content-Type: application/json" `+
+					`apt-get update -qq && apt-get install -y -qq curl > /dev/null 2>&1; `+
+						`curl -s --max-time 30 -X POST -H "Content-Type: application/json" `+
 						`-d '{"model":"%s","messages":[{"role":"user","content":"What is Kubernetes?"}],"max_tokens":7,"temperature":0}' `+
 						`%s | tee /dev/stderr | grep -q '%s'`,
 					modelName, svcEndpoint, expectedCompletion)},

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -694,7 +694,7 @@ func validateMultiRoleInferenceChatCompletions(mriObj *kaitov1alpha1.MultiRoleIn
 			// Find the decode Workspace to get the service name and pod name
 			wsList := &kaitov1beta1.WorkspaceList{}
 			err = utils.TestingCluster.KubeClient.List(ctx, wsList,
-				client.InNamespace(namespaceName),
+				client.InNamespace(mriObj.Namespace),
 				client.MatchingLabels{
 					kaitov1alpha1.LabelMultiRoleInferenceParent: mriObj.Name,
 					kaitov1alpha1.LabelInferenceRole:            string(kaitov1alpha1.MultiRoleInferenceRoleDecode),


### PR DESCRIPTION
## What type of PR is this?
/kind feature

## What this PR does / why we need it
Implements **Steps 4, 5, 8, 10, and 12** from the [P/D Disaggregation Implementation Checklist](https://github.com/kaito-project/kaito/blob/main/docs/proposals/20260424-multiroleinference-pd-disaggregation.md#implementation-checklist), adding InferencePool and EPP (Endpoint Picker Plugin) support to the MultiRoleInference (MRI) controller for P/D disaggregated serving.

### Implementation Checklist Coverage

| Step | Description | Status |
|------|-------------|--------|
| 1 | MultiRoleInference CRD types | ✅ Done (prior PRs) |
| 2 | Controller: create prefill/decode child InferenceSets | ✅ Done (prior PRs) |
| 3 | Controller: inject NixlConnector kv-transfer-config | ✅ Done (prior PRs) |
| **4** | **Controller: create OCIRepository + HelmRelease for InferencePool + EPP** | ✅ **This PR** |
| **5** | **Controller: auto-generate P/D EPP plugin config** | ✅ **This PR** |
| 6 | Controller: create DestinationRule (TLS bypass) | Skipped (#1983 merged) |
| 7 | Workspace controller: llm-d routing sidecar in decode pods | ✅ Done (prior PRs) |
| **8** | **Controller: status aggregation (InferenceSets + InferencePool → MRI)** | ✅ **This PR** |
| 9 | Webhook: validation + defaulting | ✅ Done (prior PRs) |
| **10** | **Support custom `eppPluginsConfig` ConfigMap override** | ✅ **This PR** |
| 11 | Support MRI `roles[].replicas` sync | ✅ Done (prior PRs) |
| **12** | **E2E tests** | ✅ **This PR** |
| 13 | Controller: propagate KEDA annotations | TODO (Phase 3) |
| 14 | keda-kaito-scaler: role-specific metrics | TODO (Phase 3) |

### MRI Controller Changes (Steps 4, 5, 8, 10)
1. **InferencePool via Flux** (Step 4): MRI controller creates OCIRepository + HelmRelease to deploy InferencePool + EPP. InferencePool selector uses `apps.kubernetes.io/pod-index: "0"` for Ray cluster leader pod routing. Single targetPort 5001 (routing sidecar) — GWIE CRD enforces `maxItems: 1`
2. **EPP plugins config** (Step 5): Auto-generates P/D scheduling profiles (prefill-filter, decode-filter, load-aware-scorer) using `EndpointPickerConfig` format, passed inline via Helm values
3. **Custom EPP plugins** (Step 10): Supports user-provided ConfigMap override via `spec.eppPluginsConfig`
4. **Status aggregation** (Step 8): `isInferencePoolReady()` checks HelmRelease Ready condition; `aggregateStatus()` now includes InferencePool readiness in the overall MRI Ready condition
5. **GWIE feature gate**: InferencePool/EPP reconciliation gated by `EnableGatewayAPIInferenceExt`; Flux CRD watches only registered when feature gate is enabled
6. **CRD existence checks**: Validates InferencePool, InferenceObjective, OCIRepository, HelmRelease CRDs exist at controller startup
7. **Skip child GWIE**: Child InferenceSets owned by MRI (detected via OwnerReferences) skip per-InferenceSet InferencePool creation — MRI creates a shared pool
8. **Label propagation**: `kaito.sh/inference-role` and `multiroleinference.kaito.sh/created-by` labels propagated from Workspace to StatefulSet pod templates for InferencePool endpoint selection

### E2E Tests (Step 12)
- MRI test validates: child InferenceSet status/replicas/benchmark, Flux OCIRepository + HelmRelease Ready, `/v1/chat/completions` via decode pod
- InferenceSet standalone test validates GWIE resources
- Tests moved to top of file to avoid GPU provisioner timeout interference
- Mock vllm imports in CI to fix huggingface-hub version conflict
- Container name specified in `GetLogs` for multi-container pod support

### Helm Chart
- MRI ClusterRole updated with ConfigMaps (get/list/watch), OCIRepositories, HelmReleases permissions

## TODO (follow-up PRs)
- [ ] EPP tokenizer support (tokenizer-based request cost estimation)
- [ ] Additional EPP plugin configurations (e.g., queue-depth scorer, priority-based routing)
- [ ] Configurable InferencePool Helm chart version/registry
- [ ] MRI controller: propagate KEDA annotations for auto-scaling (Step 13)
- [ ] keda-kaito-scaler: role-specific metrics integration (Step 14)
- [ ] InferencePool health monitoring and auto-recovery

## How to test
1. Enable feature gates: `enableMultiRoleInferenceController=true`, `gatewayAPIInferenceExtension=true`
2. Deploy a MultiRoleInference CR with prefill and decode roles
3. Verify:
   - Child InferenceSets created with correct role labels
   - InferencePool + EPP deployed via Flux HelmRelease
   - Pods have `kaito.sh/inference-role` and MRI parent labels
   - Chat completions endpoint responds on decode pods

## Which issue(s) this PR fixes
Related: https://github.com/kaito-project/kaito/blob/main/docs/proposals/20260424-multiroleinference-pd-disaggregation.md
