### PR TITLE
fix: benchmark timeout on models with hybrid architecture

### DIFF
--- a/presets/workspace/inference/vllm/benchmark_entrypoint.py
+++ b/presets/workspace/inference/vllm/benchmark_entrypoint.py
@@ -314,7 +314,7 @@ def _run_benchmark() -> tuple:
     _log(f"processor_resolved PROCESSOR={processor or '<auto>'}")
     _log(f"benchmark_start epoch={t0_epoch:.1f} t0_gen={t0_gen} t0_prompt={t0_prompt}")
 
-    max_concurrency = _compute_max_concurrency()
+    max_concurrency = min(_compute_max_concurrency(), 1024)
     _log(
         f'{{"duration_sec":{BENCHMARK_DURATION},"input_tokens":{BENCHMARK_INPUT_LEN},'
         f'"output_tokens":{BENCHMARK_OUTPUT_LEN},"max_concurrency":{max_concurrency}}}',

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -3,8 +3,9 @@ models:
   - name: base
     type: text-generation
     runtime: tfs
-    tag: 0.3.1
+    tag: 0.3.2
     # Tag history:
+    # 0.3.2 - cap benchmark max_concurrency at 1024 to prevent drain timeout on hybrid architectures
     # 0.3.1 - add NixlConnector kv_transfer_config for P/D disaggregation
     # 0.3.0 - bump vllm to 0.19.1, transformers to 5.6.0
     # 0.2.8 - update benchmark_entrypoint.py to poll kv cache size for concurrency calculation and pin venv transformer to 5.3.0


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
On hybrid Mamba+Attention models (e.g. Nemotron-120B-A12B), vLLM's page-size unification inflates the block_size reported in cache_config_info to 8320 to equalize page sizes across Mamba state and attention KV cache groups. Our concurrency formula (num_gpu_blocks × block_size / seq_len) interprets block_size as tokens-per-block, which leads to a huge concurrency number and leads to drain timeouts. After researching, it is hard to have a formula that estimates the concurrency for models with this architecture, and there could be other scenarios where the formula doesn't fit. Capping at 1024 (vLLM's max_num_seqs) keeps drain under ~3 minutes on the worst-case model I tested.
**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Fixes #2044
**Notes for Reviewers**: