### PR TITLE
fix: reinstall nixl-cu12 to fix vLLM 0.19.1 libcudart.so.13 import error

### DIFF
--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -37,7 +37,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 # with CUDA 12. Reinstall nixl-cu12 to replace the bundled nixl_ep with a CUDA 12
 # compatible version, fixing: ImportError: libcudart.so.13: cannot open shared object file
 # See: https://github.com/vllm-project/vllm/issues/42525
-RUN pip3 install --no-cache-dir --force-reinstall --no-deps nixl-cu12
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install --force-reinstall --no-deps nixl-cu12==1.1.0
 
 # 1. Huggingface transformers
 COPY presets/workspace/inference/${MODEL_TYPE}/inference_api.py \

--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -33,6 +33,12 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     uv pip install --system -q -r /workspace/requirements.txt && \
     pip3 uninstall -y uv
 
+# Fix: vLLM >= 0.19.0 bundles nixl_ep compiled against CUDA 13, but torch ships
+# with CUDA 12. Reinstall nixl-cu12 to replace the bundled nixl_ep with a CUDA 12
+# compatible version, fixing: ImportError: libcudart.so.13: cannot open shared object file
+# See: https://github.com/vllm-project/vllm/issues/42525
+RUN pip3 install --no-cache-dir --force-reinstall --no-deps nixl-cu12
+
 # 1. Huggingface transformers
 COPY presets/workspace/inference/${MODEL_TYPE}/inference_api.py \
     presets/workspace/tuning/${MODEL_TYPE}/cli.py \


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

vLLM >= 0.19.0 bundles `nixl_ep` compiled against CUDA 13, but KAITO's base image uses `torch==2.10.0` with CUDA 12. The `nixl_ep` module is unconditionally imported at startup (via `all2all_utils.py` → `nixl_ep_prepare_finalize.py`), causing vLLM EngineCore to crash:

```
(EngineCore pid=222) ImportError: libcudart.so.13: cannot open shared object file: No such file or directory
```

**Import chain** (unconditional — triggers even for single-node non-MoE models like llama-3.1-8b):
```
worker_base.init_worker → resolve_obj_by_qualname → import vllm.v1.worker.gpu_worker
→ kernel_warmup → deep_gemm_warmup → fp8 → fused_moe/oracle/fp8
→ all2all_utils → nixl_ep_prepare_finalize → import nixl_ep
→ nixl_ep_cpp → libcudart.so.13 not found
```

**Upstream vLLM issue**: https://github.com/vllm-project/vllm/issues/42525
- This is a known regression in vLLM 0.19.x where the `nixl_ep` CUDA version mismatches the rest of the stack
- The upstream issue is still **open** with no merged fix
- Community workaround: `pip install --force-reinstall --no-deps nixl-cu12` to replace the bundled CUDA 13 `nixl_ep` with a CUDA 12 compatible version

**Fix**: After installing vLLM from requirements, reinstall `nixl-cu12` to replace the bundled `nixl_ep` (CUDA 13) with a CUDA 12 compatible version that matches `torch==2.10.0`.

**Which issue(s) this PR fixes**:
Fixes vLLM 0.19.1 preset workspaces (e.g., llama-3.1-8b-instruct) failing to start on GPU nodes.

**Does this PR introduce a user-facing change?**
```release-note
Fix vLLM preset workspaces failing to start with "libcudart.so.13 not found" error after vLLM 0.19.1 upgrade.
```
