### PR TITLE
fix: Deepseek r1/v3 models tokenization issue

### DIFF
--- a/benchmarks/mt_bench/mt_bench_eval.py
+++ b/benchmarks/mt_bench/mt_bench_eval.py
@@ -76,6 +76,14 @@ DATA_DIR = Path(os.environ.get("DATA_DIR", "/app/data"))
 
 # ── Judge prompt templates ────────
 
+TOKENIZATION_PENALTY = (
+    "IMPORTANT: If the response contains garbled text caused by tokenization "
+    "issues, such as the characters \u0120 (used in place of spaces), "
+    "\u010a (used in place of newlines), or similar byte-level BPE artifacts "
+    "that make the text unreadable, you MUST give a score of 1 regardless "
+    "of other qualities."
+)
+
 JUDGE_PROMPTS: dict[str, dict] = {
     "single-v1": {
         "name": "single-v1",
@@ -91,6 +99,8 @@ JUDGE_PROMPTS: dict[str, dict] = {
             "objective as possible. After providing your explanation, you must rate "
             "the response on a scale of 1 to 10 by strictly following this format: "
             '"[[rating]]", for example: "Rating: [[5]]".\n'
+            "\n"
+            f"{TOKENIZATION_PENALTY}\n"
             "\n"
             "[Question]\n"
             "{question}\n"
@@ -116,6 +126,8 @@ JUDGE_PROMPTS: dict[str, dict] = {
             "After providing your explanation, you must rate the response on a scale "
             'of 1 to 10 by strictly following this format: "[[rating]]", for '
             'example: "Rating: [[5]]".\n'
+            "\n"
+            f"{TOKENIZATION_PENALTY}\n"
             "\n"
             "[Question]\n"
             "{question}\n"
@@ -144,6 +156,7 @@ JUDGE_PROMPTS: dict[str, dict] = {
             "explanation, you must rate the response on a scale of 1 to 10 by "
             'strictly following this format: "[[rating]]", for example: '
             '"Rating: [[5]]".\n\n'
+            f"{TOKENIZATION_PENALTY}\n\n"
         ),
         "prompt_template": (
             "<|The Start of Assistant A's Conversation with User|>\n"
@@ -178,6 +191,7 @@ JUDGE_PROMPTS: dict[str, dict] = {
             "After providing your explanation, you must rate the response on a scale "
             'of 1 to 10 by strictly following this format: "[[rating]]", for '
             'example: "Rating: [[5]]".\n\n'
+            f"{TOKENIZATION_PENALTY}\n\n"
         ),
         "prompt_template": (
             "<|The Start of Reference Answer|>\n"

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -180,6 +180,14 @@ var (
 		"qwen2.5":     "tool-chat-hermes.jinja",
 	}
 
+	// tokenizerModePrefixMap maps model name prefixes to their vLLM tokenizer mode.
+	tokenizerModePrefixMap = map[string]string{
+		// Use deepseek_v32 tokenizer mode for both DeepSeek R1 and V3 models to avoid special token decoding issues:
+		// https://github.com/kaito-project/kaito/issues/1976
+		"deepseek-r1": "deepseek_v32",
+		"deepseek-v3": "deepseek_v32",
+	}
+
 	// vllmAttentionBackendPrefixMap maps model name prefixes to their vLLM attention backend.
 	// source: https://docs.vllm.ai/en/latest/design/attention_backends/
 	vllmAttentionBackendPrefixMap = map[string]string{
@@ -657,6 +665,14 @@ func (g *Generator) FinalizeParams() {
 	g.Param.VLLM.ModelRunParams["load_format"] = g.LoadFormat
 	g.Param.VLLM.ModelRunParams["config_format"] = g.ConfigFormat
 	g.Param.VLLM.ModelRunParams["tokenizer_mode"] = g.TokenizerMode
+
+	// Override tokenizer mode based on model name prefix
+	for prefix, mode := range tokenizerModePrefixMap {
+		if strings.HasPrefix(g.Param.Metadata.Name, prefix) {
+			g.Param.VLLM.ModelRunParams["tokenizer_mode"] = mode
+			break
+		}
+	}
 
 	// Set attention backend based on model name prefix
 	for prefix, backend := range vllmAttentionBackendPrefixMap {

--- a/presets/workspace/models/model_catalog_mtbench_scores.md
+++ b/presets/workspace/models/model_catalog_mtbench_scores.md
@@ -16,7 +16,7 @@ All models were deployed as KAITO Workspace CRs on AKS and evaluated using the v
 | microsoft/Phi-3-medium-128k-instruct | vllm | 6.58 | 7.15 | 6.45 | 6.35 | 7.20 | 5.55 | 7.55 | 6.20 | 6.15 | 2026-04-20 |
 | microsoft/Phi-3.5-mini-instruct | vllm | 6.24 | 7.25 | 6.15 | 5.65 | 6.45 | 5.20 | 6.45 | 6.25 | 6.55 | 2026-04-20 |
 | meta-llama/Llama-3.1-8B-Instruct | vllm | 6.03 | 7.10 | 6.00 | 3.80 | 7.05 | 5.30 | 6.85 | 5.55 | 6.60 | 2026-04-20 |
-| deepseek-ai/DeepSeek-R1-Distill-Llama-8B | vllm | 4.60 | 5.30 | 4.45 | 5.30 | 5.40 | 2.05 | 6.50 | 3.95 | 3.85 | 2026-04-20 |
+| deepseek-ai/DeepSeek-R1-Distill-Llama-8B | vllm | 5.28 | 6.35 | 4.90 | 5.20 | 6.50 | 3.15 | 6.75 | 4.80 | 4.55 | 2026-05-14 |
 | deepseek-ai/DeepSeek-R1-Distill-Qwen-14B | vllm | 5.36 | 5.95 | 5.55 | 7.20 | 4.85 | 3.80 | 6.80 | 4.85 | 3.90 | 2026-04-20 |
 | Qwen/Qwen2.5-Coder-7B-Instruct | vllm | 4.81 | 5.70 | 3.50 | 2.80 | 6.45 | 5.40 | 5.60 | 5.00 | 4.00 | 2026-04-20 |
 | Qwen/Qwen2.5-Coder-32B-Instruct | vllm | 5.85 | 5.60 | 5.75 | 5.30 | 5.80 | 7.30 | 5.40 | 6.15 | 5.50 | 2026-04-20 |
@@ -32,7 +32,7 @@ All models were deployed as KAITO Workspace CRs on AKS and evaluated using the v
 | mistralai/Ministral-3-8B-Instruct-2512 | vllm | 7.29 | 7.95 | 7.30 | 6.75 | 9.15 | 6.25 | 7.95 | 6.60 | 6.35 | 2026-04-20 |
 | mistralai/Ministral-3-14B-Instruct-2512 | vllm | 7.34 | 8.15 | 7.35 | 6.05 | 9.70 | 6.15 | 8.15 | 6.45 | 6.70 | 2026-04-20 |
 | mistralai/Mistral-7B-v0.3 | vllm | 2.01 | 2.55 | 1.50 | 1.50 | 1.65 | 1.70 | 2.30 | 3.00 | 1.85 | 2026-04-20 |
-| deepseek-ai/DeepSeek-R1-0528 | vllm | 5.06 | 7.90 | 7.30 | 3.85 | 2.65 | 1.65 | 5.55 | 5.55 | 6.05 | 2026-04-17 |
+| deepseek-ai/DeepSeek-R1-0528 | vllm | 6.61 | 8.25 | 7.20 | 6.25 | 8.45 | 5.30 | 5.95 | 6.05 | 5.45 | 2026-05-18 |
 | deepseek-ai/DeepSeek-V3-0324 | vllm | 8.07 | 8.20 | 7.95 | 7.35 | 9.50 | 8.20 | 8.30 | 7.00 | 8.05 | 2026-04-17 |
 | mistralai/Mistral-Large-3-675B-Instruct-2512 | vllm | 7.86 | 8.05 | 7.65 | 7.75 | 9.05 | 7.90 | 8.50 | 7.25 | 6.70 | 2026-04-17 |
 | nvidia/NVIDIA-Nemotron-3-Nano-4B-BF16 | vllm | 6.37 | 6.35 | 5.65 | 6.65 | 9.10 | 5.85 | 7.05 | 6.10 | 4.20 | 2026-04-29 |


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
We observed garbled outputs with tokenization issues in special characters in all DeepSeek models in the model catalog:
```
ĊHereâĢĻsĠyourĠHawaiâĢĻiĠtravelĠblogĠrebootâĢĶeveryĠsentenceĠstartsĠwithĠA!ĠAloha!ĠĠĊĊ---ĊĊ**Aloha,ĠadventurousĠsouls!ĠĠĊAchingĠforĠmoreĠthanĠbeaches?ĠAbsolutely!ĠAfterĠmyĠjourneyĠthroughĠHawaiâĢĻi,ĠIâĢĻmĠaglowĠwithĠaloha.ĠAllowĠmeĠtoĠshareĠtheĠmagic.ĠĠĊĊArrivingĠfirstĠonĠOâĢĻahu:ĠĠĊAlwaysĠbeginĠwithĠreverenceĠatĠPearlĠHarbor.ĠAmidstĠhallowedĠwaters,ĠtheĠUSSĠArizonaĠMemorialĠanchorsĠhistory.ĠAllowĠhoursĠforĠreflection.ĠĠĊAdvanceĠtoĠvibrantĠWaikÄ«kÄ«Ġafterward.ĠAttendĠfreeĠlei
```
This PR fixes this issue by pinning the tokenization model to `deepseek_v32` for these models and enhance mt-bench to detect such tokenization issue.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).
- [x] verified the tokenization issue no longer existed after the fix.
- [x] verified enhanced mt-bench was able to detect such tokenization issus:
<img width="1106" height="255" alt="Screenshot 2026-05-18 at 1 59 42 PM" src="https://github.com/user-attachments/assets/6119f393-af89-4ecc-8d84-91925e4bc490" />
  
**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Fixes #1976

**Notes for Reviewers**: