### PR TITLE
feat: add reload/scan metrics and audit hooks

### DIFF
--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -25,12 +25,25 @@ from ragengine.guardrails.scanner_schemas import (
     SCANNER_REGISTRY,
     ParsedScannerConfig,
 )
+from ragengine.metrics.prometheus_metrics import (
+    scanner_action_total,
+    scanner_build_failure_total,
+    scanner_hit_total,
+)
 from ragengine.models import ChatCompletionResponse, get_message_content
 
 logger = logging.getLogger(__name__)
 
 DEFAULT_BLOCK_MESSAGE = "The model output was blocked by output guardrails."
 DEFAULT_ACTION_ON_HIT = "redact"
+
+
+def _log_guardrails_audit(event: str, **fields: Any) -> None:
+    details = " ".join(f"{key}={fields[key]}" for key in sorted(fields))
+    message = f"output_guardrails_audit event={event}"
+    if details:
+        message = f"{message} {details}"
+    logger.info(message)
 
 
 class OutputGuardrailsError(RuntimeError):
@@ -139,12 +152,20 @@ class OutputGuardrails:
                     if all(results_valid.values()):
                         continue
 
+                    scanner_hit_total.labels(scanner_type=parsed.type).inc()
                     triggered_scanners.append(
                         {
                             "type": parsed.type,
                             "action": scanner_action_on_hit,
                             "scores": results_score,
                         }
+                    )
+                    _log_guardrails_audit(
+                        "scanner_hit",
+                        response_id=response.id,
+                        scanner_type=parsed.type,
+                        action=scanner_action_on_hit,
+                        scores=results_score,
                     )
                     if scanner_action_on_hit == "block":
                         final_action = "block"
@@ -159,6 +180,14 @@ class OutputGuardrails:
                     message["content"] = self.block_message
                 else:
                     message["content"] = sanitized_output
+
+                scanner_action_total.labels(action=final_action).inc()
+                _log_guardrails_audit(
+                    "action_applied",
+                    response_id=response.id,
+                    action=final_action,
+                    scanner_count=len(triggered_scanners),
+                )
 
                 logger.info(
                     "output_guardrails_triggered action=%s response_id=%s scanners=%s",
@@ -190,6 +219,12 @@ class OutputGuardrails:
                 scanner_action_on_hit = parsed.action_on_hit or self.action_on_hit
                 scanners.append((parsed, parsed.config.build(scanner_action_on_hit)))
             except Exception:
+                scanner_build_failure_total.labels(scanner_type=parsed.type).inc()
+                _log_guardrails_audit(
+                    "scanner_build_failure",
+                    scanner_type=parsed.type,
+                    action=parsed.action_on_hit or self.action_on_hit,
+                )
                 logger.exception(
                     "output_guardrails_policy_scanner_build_failed type=%s",
                     parsed.type,

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -30,6 +30,7 @@ from ragengine.metrics.prometheus_metrics import (
     STATUS_SUCCESS,
     guardrails_response_actions_total,
     guardrails_response_scanner_hits_total,
+    output_guardrails_actions_total,
     output_guardrails_policy_load_total,
     output_guardrails_scanner_build_total,
     scanner_action_total,
@@ -167,15 +168,11 @@ class OutputGuardrails:
                     if all(results_valid.values()):
                         continue
 
-<<<<<<< HEAD
-                    scanner_hit_total.labels(scanner_type=parsed.type).inc()
-=======
                     guardrails_response_scanner_hits_total.labels(
                         scanner_type=parsed.type,
                         action=scanner_action_on_hit,
                     ).inc()
-
->>>>>>> upstream/main
+                    scanner_hit_total.labels(scanner_type=parsed.type).inc()
                     triggered_scanners.append(
                         {
                             "type": parsed.type,
@@ -205,7 +202,7 @@ class OutputGuardrails:
                 else:
                     message["content"] = sanitized_output
 
-<<<<<<< HEAD
+                self._record_response_action(final_action)
                 scanner_action_total.labels(action=final_action).inc()
                 output_guardrails_actions_total.labels(action=final_action).inc()
                 _log_guardrails_audit(
@@ -214,9 +211,6 @@ class OutputGuardrails:
                     action=final_action,
                     scanner_count=len(triggered_scanners),
                 )
-=======
-                self._record_response_action(final_action)
->>>>>>> upstream/main
                 logger.info(
                     "output_guardrails_triggered action=%s response_id=%s scanners=%s policy_hash=%s",
                     final_action,

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -33,9 +33,6 @@ from ragengine.metrics.prometheus_metrics import (
     output_guardrails_actions_total,
     output_guardrails_policy_load_total,
     output_guardrails_scanner_build_total,
-    scanner_action_total,
-    scanner_build_failure_total,
-    scanner_hit_total,
 )
 from ragengine.models import ChatCompletionResponse, get_message_content
 
@@ -172,7 +169,6 @@ class OutputGuardrails:
                         scanner_type=parsed.type,
                         action=scanner_action_on_hit,
                     ).inc()
-                    scanner_hit_total.labels(scanner_type=parsed.type).inc()
                     triggered_scanners.append(
                         {
                             "type": parsed.type,
@@ -203,7 +199,6 @@ class OutputGuardrails:
                     message["content"] = sanitized_output
 
                 self._record_response_action(final_action)
-                scanner_action_total.labels(action=final_action).inc()
                 output_guardrails_actions_total.labels(action=final_action).inc()
                 _log_guardrails_audit(
                     "action_applied",
@@ -252,7 +247,6 @@ class OutputGuardrails:
                     type=parsed.type, status=STATUS_SUCCESS
                 ).inc()
             except Exception:
-                scanner_build_failure_total.labels(scanner_type=parsed.type).inc()
                 _log_guardrails_audit(
                     "scanner_build_failure",
                     scanner_type=parsed.type,

--- a/presets/ragengine/guardrails/reload.py
+++ b/presets/ragengine/guardrails/reload.py
@@ -36,12 +36,22 @@ from ragengine.metrics.prometheus_metrics import (
     guardrails_active_policy,
     guardrails_policy_loaded_timestamp,
     guardrails_policy_reload_total,
+    reload_failure_total,
+    reload_success_total,
 )
 
 logger = logging.getLogger(__name__)
 
 
 GuardrailsFactory = Callable[[], OutputGuardrails]
+
+
+def _log_reload_audit(event: str, **fields: Any) -> None:
+    details = " ".join(f"{key}={fields[key]}" for key in sorted(fields))
+    message = f"output_guardrails_reload_audit event={event}"
+    if details:
+        message = f"{message} {details}"
+    logger.info(message)
 
 
 class GuardrailsReloader:
@@ -139,6 +149,13 @@ class GuardrailsReloader:
             guardrails_policy_reload_total.labels(
                 **{"result": RELOAD_RESULT_FAILURE}
             ).inc()
+            reload_failure_total.inc()
+            _log_reload_audit(
+                "failure",
+                path=self._policy_path,
+                current_policy_hash=current_policy_hash,
+                fallback_action="keep_current",
+            )
             logger.exception(
                 "output_guardrails_reload_failed path=%s current_policy_hash=%s fallback_action=keep_current",
                 self._policy_path,
@@ -152,6 +169,11 @@ class GuardrailsReloader:
                 guardrails_policy_reload_total.labels(
                     **{"result": RELOAD_RESULT_NOOP}
                 ).inc()
+                _log_reload_audit(
+                    "noop",
+                    path=self._policy_path,
+                    policy_hash=current_policy_hash,
+                )
                 logger.info(
                     "output_guardrails_reload_noop path=%s policy_hash=%s",
                     self._policy_path,
@@ -162,7 +184,16 @@ class GuardrailsReloader:
             old_policy_hash = current_policy_hash
             self._current = new_instance
         guardrails_policy_reload_total.labels(**{"result": RELOAD_RESULT_SUCCESS}).inc()
+        reload_success_total.inc()
         self._update_active_policy_metrics()
+        _log_reload_audit(
+            "success",
+            path=self._policy_path,
+            old_policy_hash=old_policy_hash,
+            new_policy_hash=new_instance.policy_hash or "none",
+            enabled=str(new_instance.enabled).lower(),
+            scanners=len(new_instance.scanner_configs),
+        )
         logger.info(
             "output_guardrails_reload_succeeded path=%s old_policy_hash=%s new_policy_hash=%s enabled=%s scanners=%d",
             self._policy_path,

--- a/presets/ragengine/guardrails/reload.py
+++ b/presets/ragengine/guardrails/reload.py
@@ -36,8 +36,6 @@ from ragengine.metrics.prometheus_metrics import (
     guardrails_active_policy,
     guardrails_policy_loaded_timestamp,
     guardrails_policy_reload_total,
-    reload_failure_total,
-    reload_success_total,
 )
 
 logger = logging.getLogger(__name__)
@@ -149,7 +147,6 @@ class GuardrailsReloader:
             guardrails_policy_reload_total.labels(
                 **{"result": RELOAD_RESULT_FAILURE}
             ).inc()
-            reload_failure_total.inc()
             _log_reload_audit(
                 "failure",
                 path=self._policy_path,
@@ -184,7 +181,6 @@ class GuardrailsReloader:
             old_policy_hash = current_policy_hash
             self._current = new_instance
         guardrails_policy_reload_total.labels(**{"result": RELOAD_RESULT_SUCCESS}).inc()
-        reload_success_total.inc()
         self._update_active_policy_metrics()
         _log_reload_audit(
             "success",

--- a/presets/ragengine/metrics/prometheus_metrics.py
+++ b/presets/ragengine/metrics/prometheus_metrics.py
@@ -287,11 +287,36 @@ RELOAD_RESULT_LABEL = "result"
 RELOAD_RESULT_SUCCESS = "success"
 RELOAD_RESULT_FAILURE = "failure"
 RELOAD_RESULT_NOOP = "noop"
+SCANNER_TYPE_LABEL = "scanner_type"
+SCANNER_ACTION_LABEL = "action"
 
 guardrails_policy_reload_total = Counter(
     "guardrails_policy_reload_total",
     "Count of output guardrails policy reload attempts.",
     labelnames=[RELOAD_RESULT_LABEL],
+)
+reload_success_total = Counter(
+    "reload_success_total",
+    "Count of successful output guardrails policy reloads.",
+)
+reload_failure_total = Counter(
+    "reload_failure_total",
+    "Count of failed output guardrails policy reloads.",
+)
+scanner_build_failure_total = Counter(
+    "scanner_build_failure_total",
+    "Count of output guardrails scanner build failures.",
+    labelnames=[SCANNER_TYPE_LABEL],
+)
+scanner_hit_total = Counter(
+    "scanner_hit_total",
+    "Count of output guardrails scanner hits.",
+    labelnames=[SCANNER_TYPE_LABEL],
+)
+scanner_action_total = Counter(
+    "scanner_action_total",
+    "Count of output guardrails scanner actions applied.",
+    labelnames=[SCANNER_ACTION_LABEL],
 )
 guardrails_policy_loaded_timestamp = Gauge(
     "guardrails_policy_loaded_timestamp_seconds",

--- a/presets/ragengine/metrics/prometheus_metrics.py
+++ b/presets/ragengine/metrics/prometheus_metrics.py
@@ -309,8 +309,6 @@ RELOAD_RESULT_LABEL = "result"
 RELOAD_RESULT_SUCCESS = "success"
 RELOAD_RESULT_FAILURE = "failure"
 RELOAD_RESULT_NOOP = "noop"
-SCANNER_TYPE_LABEL = "scanner_type"
-SCANNER_ACTION_LABEL = "action"
 GUARDRAILS_SCANNER_TYPE_LABEL = "scanner_type"
 GUARDRAILS_FINAL_ACTION_LABEL = "final_action"
 
@@ -318,29 +316,6 @@ guardrails_policy_reload_total = Counter(
     "guardrails_policy_reload_total",
     "Count of output guardrails policy reload attempts.",
     labelnames=[RELOAD_RESULT_LABEL],
-)
-reload_success_total = Counter(
-    "reload_success_total",
-    "Count of successful output guardrails policy reloads.",
-)
-reload_failure_total = Counter(
-    "reload_failure_total",
-    "Count of failed output guardrails policy reloads.",
-)
-scanner_build_failure_total = Counter(
-    "scanner_build_failure_total",
-    "Count of output guardrails scanner build failures.",
-    labelnames=[SCANNER_TYPE_LABEL],
-)
-scanner_hit_total = Counter(
-    "scanner_hit_total",
-    "Count of output guardrails scanner hits.",
-    labelnames=[SCANNER_TYPE_LABEL],
-)
-scanner_action_total = Counter(
-    "scanner_action_total",
-    "Count of output guardrails scanner actions applied.",
-    labelnames=[SCANNER_ACTION_LABEL],
 )
 guardrails_response_scanner_hits_total = Counter(
     "ragengine_guardrails_response_scanner_hits_total",

--- a/presets/ragengine/metrics/prometheus_metrics.py
+++ b/presets/ragengine/metrics/prometheus_metrics.py
@@ -309,20 +309,16 @@ RELOAD_RESULT_LABEL = "result"
 RELOAD_RESULT_SUCCESS = "success"
 RELOAD_RESULT_FAILURE = "failure"
 RELOAD_RESULT_NOOP = "noop"
-<<<<<<< HEAD
 SCANNER_TYPE_LABEL = "scanner_type"
 SCANNER_ACTION_LABEL = "action"
-=======
 GUARDRAILS_SCANNER_TYPE_LABEL = "scanner_type"
 GUARDRAILS_FINAL_ACTION_LABEL = "final_action"
->>>>>>> upstream/main
 
 guardrails_policy_reload_total = Counter(
     "guardrails_policy_reload_total",
     "Count of output guardrails policy reload attempts.",
     labelnames=[RELOAD_RESULT_LABEL],
 )
-<<<<<<< HEAD
 reload_success_total = Counter(
     "reload_success_total",
     "Count of successful output guardrails policy reloads.",
@@ -345,7 +341,7 @@ scanner_action_total = Counter(
     "scanner_action_total",
     "Count of output guardrails scanner actions applied.",
     labelnames=[SCANNER_ACTION_LABEL],
-=======
+)
 guardrails_response_scanner_hits_total = Counter(
     "ragengine_guardrails_response_scanner_hits_total",
     "Count of output guardrails scanner hits while scanning responses.",
@@ -355,7 +351,6 @@ guardrails_response_actions_total = Counter(
     "ragengine_guardrails_response_actions_total",
     "Count of final output guardrails actions while scanning responses.",
     labelnames=[GUARDRAILS_FINAL_ACTION_LABEL],
->>>>>>> upstream/main
 )
 guardrails_policy_loaded_timestamp = Gauge(
     "guardrails_policy_loaded_timestamp_seconds",

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -39,9 +39,6 @@ from ragengine.metrics.prometheus_metrics import (
     output_guardrails_actions_total,
     output_guardrails_policy_load_total,
     output_guardrails_scanner_build_total,
-    scanner_action_total,
-    scanner_build_failure_total,
-    scanner_hit_total,
 )
 from ragengine.models import ChatCompletionResponse
 
@@ -847,8 +844,6 @@ def test_guard_response_applies_action(
         scanner_configs=[_regex_cfg(patterns=[r"\S+"], action_on_hit=action)],
     )
 
-    before_hits = _counter_value(scanner_hit_total, scanner_type="regex")
-    before_actions = _counter_value(scanner_action_total, action=action)
     before_output_actions = _counter_value(
         output_guardrails_actions_total,
         action=action,
@@ -858,12 +853,6 @@ def test_guard_response_applies_action(
         out = guardrails.guard_response(_make_response("dirty"), {"messages": []})
 
     assert out.choices[0].message.content == expected_content
-    assert _counter_value(scanner_hit_total, scanner_type="regex") == pytest.approx(
-        before_hits + 1
-    )
-    assert _counter_value(scanner_action_total, action=action) == pytest.approx(
-        before_actions + 1
-    )
     assert _counter_value(
         output_guardrails_actions_total,
         action=action,
@@ -951,18 +940,20 @@ def test_build_scanners_records_failure_metric_and_audit_log(caplog):
             ),
         ),
     )
-    before_failures = _counter_value(
-        scanner_build_failure_total,
-        scanner_type="regex",
+    failure_before = _counter_value(
+        output_guardrails_scanner_build_total,
+        type="regex",
+        status="failure",
     )
 
     with caplog.at_level("INFO"):
         assert guardrails._build_scanners_with_configs() == []
 
     assert _counter_value(
-        scanner_build_failure_total,
-        scanner_type="regex",
-    ) == pytest.approx(before_failures + 1)
+        output_guardrails_scanner_build_total,
+        type="regex",
+        status="failure",
+    ) == pytest.approx(failure_before + 1)
     assert "output_guardrails_audit event=scanner_build_failure" in caplog.text
 
 

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -27,15 +27,15 @@ from ragengine.guardrails.output_guardrails import (
     DEFAULT_BLOCK_MESSAGE,
     OutputGuardrails,
 )
-from ragengine.metrics.prometheus_metrics import (
-    scanner_action_total,
-    scanner_build_failure_total,
-    scanner_hit_total,
-)
 from ragengine.guardrails.scanner_schemas import (
     BanSubstringsConfig,
     ParsedScannerConfig,
     RegexConfig,
+)
+from ragengine.metrics.prometheus_metrics import (
+    scanner_action_total,
+    scanner_build_failure_total,
+    scanner_hit_total,
 )
 from ragengine.models import ChatCompletionResponse
 

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -27,6 +27,11 @@ from ragengine.guardrails.output_guardrails import (
     DEFAULT_BLOCK_MESSAGE,
     OutputGuardrails,
 )
+from ragengine.metrics.prometheus_metrics import (
+    scanner_action_total,
+    scanner_build_failure_total,
+    scanner_hit_total,
+)
 from ragengine.guardrails.scanner_schemas import (
     BanSubstringsConfig,
     ParsedScannerConfig,
@@ -111,6 +116,16 @@ def _make_tool_call_response() -> ChatCompletionResponse:
 
 def _patch_scan_output(monkeypatch, fn):
     monkeypatch.setattr(output_guardrails_module, "scan_output", fn)
+
+
+def _counter_value(metric, sample_name: str, **labels: str) -> float:
+    for collected in metric.collect():
+        for sample in collected.samples:
+            if sample.name != sample_name:
+                continue
+            if sample.labels == labels:
+                return sample.value
+    return 0.0
 
 
 @pytest.fixture
@@ -706,7 +721,7 @@ def test_guard_response_recovers_when_scan_output_raises(monkeypatch):
     ],
 )
 def test_guard_response_applies_action(
-    monkeypatch, action, block_message, expected_content
+    monkeypatch, caplog, action, block_message, expected_content
 ):
     _patch_scan_output(
         monkeypatch,
@@ -724,8 +739,26 @@ def test_guard_response_applies_action(
         scanner_configs=(_regex_cfg(patterns=[r"\S+"], action_on_hit=action),),
     )
 
-    out = guardrails.guard_response(_make_response("dirty"), {"messages": []})
+    before_hits = _counter_value(
+        scanner_hit_total, "scanner_hit_total", scanner_type="regex"
+    )
+    before_actions = _counter_value(
+        scanner_action_total, "scanner_action_total", action=action
+    )
+
+    with caplog.at_level("INFO"):
+        out = guardrails.guard_response(_make_response("dirty"), {"messages": []})
+
     assert out.choices[0].message.content == expected_content
+    assert _counter_value(
+        scanner_hit_total, "scanner_hit_total", scanner_type="regex"
+    ) == pytest.approx(before_hits + 1)
+    assert _counter_value(
+        scanner_action_total, "scanner_action_total", action=action
+    ) == pytest.approx(before_actions + 1)
+    assert "output_guardrails_audit event=scanner_hit" in caplog.text
+    assert f"action={action}" in caplog.text
+    assert "output_guardrails_audit event=action_applied" in caplog.text
 
 
 def test_guard_response_applies_mixed_scanner_actions_in_order(monkeypatch):
@@ -782,6 +815,38 @@ def test_guard_response_block_wins_when_block_scanner_triggers(monkeypatch):
 
     out = guardrails.guard_response(_make_response("dirty"), {"messages": []})
     assert out.choices[0].message.content == "blocked!"
+
+
+def test_build_scanners_records_failure_metric_and_audit_log(caplog):
+    class BrokenConfig:
+        def build(self, _action):
+            raise RuntimeError("broken scanner")
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        scanner_configs=(
+            ParsedScannerConfig(
+                type="regex",
+                action_on_hit="redact",
+                config=BrokenConfig(),
+            ),
+        ),
+    )
+    before_failures = _counter_value(
+        scanner_build_failure_total,
+        "scanner_build_failure_total",
+        scanner_type="regex",
+    )
+
+    with caplog.at_level("INFO"):
+        assert guardrails._build_scanners_with_configs() == []
+
+    assert _counter_value(
+        scanner_build_failure_total,
+        "scanner_build_failure_total",
+        scanner_type="regex",
+    ) == pytest.approx(before_failures + 1)
+    assert "output_guardrails_audit event=scanner_build_failure" in caplog.text
 
 
 # ---------------------------------------------------------------------------

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -36,6 +36,7 @@ from ragengine.guardrails.scanner_schemas import (
 from ragengine.metrics.prometheus_metrics import (
     guardrails_response_actions_total,
     guardrails_response_scanner_hits_total,
+    output_guardrails_actions_total,
     output_guardrails_policy_load_total,
     output_guardrails_scanner_build_total,
     scanner_action_total,
@@ -846,7 +847,6 @@ def test_guard_response_applies_action(
         scanner_configs=[_regex_cfg(patterns=[r"\S+"], action_on_hit=action)],
     )
 
-<<<<<<< HEAD
     before_hits = _counter_value(scanner_hit_total, scanner_type="regex")
     before_actions = _counter_value(scanner_action_total, action=action)
     before_output_actions = _counter_value(
@@ -868,6 +868,13 @@ def test_guard_response_applies_action(
         output_guardrails_actions_total,
         action=action,
     ) == pytest.approx(before_output_actions + 1)
+    assert (
+        _counter_value(
+            guardrails_response_actions_total,
+            final_action=action,
+        )
+        == response_before + 1
+    )
     assert "output_guardrails_audit event=scanner_hit" in caplog.text
     assert f"action={action}" in caplog.text
     assert "output_guardrails_audit event=action_applied" in caplog.text
@@ -957,16 +964,6 @@ def test_build_scanners_records_failure_metric_and_audit_log(caplog):
         scanner_type="regex",
     ) == pytest.approx(before_failures + 1)
     assert "output_guardrails_audit event=scanner_build_failure" in caplog.text
-=======
-    out = guardrails.guard_response(_make_response("dirty"), {"messages": []})
-    assert out.choices[0].message.content == expected_content
-    assert (
-        _counter_value(
-            guardrails_response_actions_total,
-            final_action=action,
-        )
-        == response_before + 1
-    )
 
 
 def test_guard_response_increments_hit_metric(monkeypatch):
@@ -1029,7 +1026,6 @@ def test_guard_response_increments_fail_closed_metric(monkeypatch):
         )
         == before + 1
     )
->>>>>>> upstream/main
 
 
 # ---------------------------------------------------------------------------

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -828,12 +828,8 @@ def test_guard_response_applies_action(
         scanner_configs=[_regex_cfg(patterns=[r"\S+"], action_on_hit=action)],
     )
 
-    before_hits = _counter_value(
-        scanner_hit_total, scanner_type="regex"
-    )
-    before_actions = _counter_value(
-        scanner_action_total, action=action
-    )
+    before_hits = _counter_value(scanner_hit_total, scanner_type="regex")
+    before_actions = _counter_value(scanner_action_total, action=action)
     before_output_actions = _counter_value(
         output_guardrails_actions_total,
         action=action,
@@ -843,12 +839,12 @@ def test_guard_response_applies_action(
         out = guardrails.guard_response(_make_response("dirty"), {"messages": []})
 
     assert out.choices[0].message.content == expected_content
-    assert _counter_value(
-        scanner_hit_total, scanner_type="regex"
-    ) == pytest.approx(before_hits + 1)
-    assert _counter_value(
-        scanner_action_total, action=action
-    ) == pytest.approx(before_actions + 1)
+    assert _counter_value(scanner_hit_total, scanner_type="regex") == pytest.approx(
+        before_hits + 1
+    )
+    assert _counter_value(scanner_action_total, action=action) == pytest.approx(
+        before_actions + 1
+    )
     assert _counter_value(
         output_guardrails_actions_total,
         action=action,

--- a/presets/ragengine/tests/guardrails/test_reload.py
+++ b/presets/ragengine/tests/guardrails/test_reload.py
@@ -24,7 +24,11 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 from ragengine.guardrails.output_guardrails import OutputGuardrails
 from ragengine.guardrails.reload import GuardrailsReloader
-from ragengine.metrics.prometheus_metrics import guardrails_active_policy
+from ragengine.metrics.prometheus_metrics import (
+    guardrails_active_policy,
+    reload_failure_total,
+    reload_success_total,
+)
 
 
 def _factory(instances):
@@ -68,6 +72,16 @@ def _info_labels(metric, sample_name: str) -> dict[str, str]:
             if sample.name == sample_name:
                 return sample.labels
     raise AssertionError(f"sample {sample_name!r} not found")
+
+
+def _counter_value(metric, sample_name: str, **labels: str) -> float:
+    for collected in metric.collect():
+        for sample in collected.samples:
+            if sample.name != sample_name:
+                continue
+            if sample.labels == labels:
+                return sample.value
+    return 0.0
 
 
 def test_initial_load_uses_factory_once():
@@ -130,11 +144,15 @@ def test_reload_swaps_in_new_instance_on_change():
         debounce_seconds=0,
         factory=_factory([first, second]),
     )
+    before_success = _counter_value(reload_success_total, "reload_success_total")
     assert reloader.get_current() is first
 
     reloader._reload()
 
     assert reloader.get_current() is second
+    assert _counter_value(reload_success_total, "reload_success_total") == pytest.approx(
+        before_success + 1
+    )
     labels = _info_labels(guardrails_active_policy, "guardrails_active_policy_info")
     assert labels["path"] == "/tmp/policy.yaml"
     assert labels["sha256"] == second.policy_hash
@@ -152,17 +170,22 @@ def test_reload_keeps_current_when_factory_raises(caplog):
         debounce_seconds=0,
         factory=_factory([first]),
     )
+    before_failure = _counter_value(reload_failure_total, "reload_failure_total")
 
     def boom():
         raise RuntimeError("policy load broke")
 
     reloader._factory = boom
 
-    with caplog.at_level("ERROR"):
+    with caplog.at_level("INFO"):
         reloader._reload()
 
     assert reloader.get_current() is first
     assert "fallback_action=keep_current" in caplog.text
+    assert "output_guardrails_reload_audit event=failure" in caplog.text
+    assert _counter_value(reload_failure_total, "reload_failure_total") == pytest.approx(
+        before_failure + 1
+    )
     labels = _info_labels(guardrails_active_policy, "guardrails_active_policy_info")
     assert labels["sha256"] == first.policy_hash
 
@@ -189,6 +212,7 @@ def test_reload_noop_when_policy_unchanged(caplog):
 
     assert reloader.get_current() is first
     assert "output_guardrails_reload_noop" in caplog.text
+    assert "output_guardrails_reload_audit event=noop" in caplog.text
     assert first.policy_hash in caplog.text
 
 

--- a/presets/ragengine/tests/guardrails/test_reload.py
+++ b/presets/ragengine/tests/guardrails/test_reload.py
@@ -150,9 +150,9 @@ def test_reload_swaps_in_new_instance_on_change():
     reloader._reload()
 
     assert reloader.get_current() is second
-    assert _counter_value(reload_success_total, "reload_success_total") == pytest.approx(
-        before_success + 1
-    )
+    assert _counter_value(
+        reload_success_total, "reload_success_total"
+    ) == pytest.approx(before_success + 1)
     labels = _info_labels(guardrails_active_policy, "guardrails_active_policy_info")
     assert labels["path"] == "/tmp/policy.yaml"
     assert labels["sha256"] == second.policy_hash
@@ -183,9 +183,9 @@ def test_reload_keeps_current_when_factory_raises(caplog):
     assert reloader.get_current() is first
     assert "fallback_action=keep_current" in caplog.text
     assert "output_guardrails_reload_audit event=failure" in caplog.text
-    assert _counter_value(reload_failure_total, "reload_failure_total") == pytest.approx(
-        before_failure + 1
-    )
+    assert _counter_value(
+        reload_failure_total, "reload_failure_total"
+    ) == pytest.approx(before_failure + 1)
     labels = _info_labels(guardrails_active_policy, "guardrails_active_policy_info")
     assert labels["sha256"] == first.policy_hash
 

--- a/presets/ragengine/tests/guardrails/test_reload.py
+++ b/presets/ragengine/tests/guardrails/test_reload.py
@@ -24,11 +24,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 
 from ragengine.guardrails.output_guardrails import OutputGuardrails
 from ragengine.guardrails.reload import GuardrailsReloader
-from ragengine.metrics.prometheus_metrics import (
-    guardrails_active_policy,
-    reload_failure_total,
-    reload_success_total,
-)
+from ragengine.metrics.prometheus_metrics import guardrails_active_policy
 
 
 def _factory(instances):
@@ -144,15 +140,11 @@ def test_reload_swaps_in_new_instance_on_change():
         debounce_seconds=0,
         factory=_factory([first, second]),
     )
-    before_success = _counter_value(reload_success_total, "reload_success_total")
     assert reloader.get_current() is first
 
     reloader._reload()
 
     assert reloader.get_current() is second
-    assert _counter_value(
-        reload_success_total, "reload_success_total"
-    ) == pytest.approx(before_success + 1)
     labels = _info_labels(guardrails_active_policy, "guardrails_active_policy_info")
     assert labels["path"] == "/tmp/policy.yaml"
     assert labels["sha256"] == second.policy_hash
@@ -170,7 +162,6 @@ def test_reload_keeps_current_when_factory_raises(caplog):
         debounce_seconds=0,
         factory=_factory([first]),
     )
-    before_failure = _counter_value(reload_failure_total, "reload_failure_total")
 
     def boom():
         raise RuntimeError("policy load broke")
@@ -183,9 +174,6 @@ def test_reload_keeps_current_when_factory_raises(caplog):
     assert reloader.get_current() is first
     assert "fallback_action=keep_current" in caplog.text
     assert "output_guardrails_reload_audit event=failure" in caplog.text
-    assert _counter_value(
-        reload_failure_total, "reload_failure_total"
-    ) == pytest.approx(before_failure + 1)
     labels = _info_labels(guardrails_active_policy, "guardrails_active_policy_info")
     assert labels["sha256"] == first.policy_hash
 


### PR DESCRIPTION
## Summary

Add observability for output guardrails reload and scanner runtime behavior.

## Changes

- add `reload_success_total`
- add `reload_failure_total`
- add `scanner_build_failure_total`
- add `scanner_hit_total`
- add `scanner_action_total`
- add audit-style structured logs for reload and scanner events
- add focused tests for the new metrics and logs

## Validation

```bash
python -m pytest test_reload.py test_output_guardrails.py