### PR TITLE
feat: add secrets and sensitive scanners

### DIFF
--- a/charts/kaito/ragengine/templates/guardrails-policy-configmap.yaml
+++ b/charts/kaito/ragengine/templates/guardrails-policy-configmap.yaml
@@ -16,3 +16,13 @@ data:
           - '\bgh[pousr]_[A-Za-z0-9_]{20,}\b'
           - '(?i)\bsk-[A-Za-z0-9]{20,}\b'
           - '(?i)\bbearer\s+[A-Za-z0-9._\-]{20,}\b'
+      - type: secrets
+        action: redact
+        redactMode: partial
+      - type: sensitive
+        action: redact
+        detectors:
+          - email
+          - phone
+          - credit_card
+          - ip_address

--- a/docs/proposals/20260416-ragengine-guardrails-ux-api.md
+++ b/docs/proposals/20260416-ragengine-guardrails-ux-api.md
@@ -100,8 +100,14 @@ it into the Pod.
 - User-provided ConfigMaps are not modified or owned by the controller.
 - Hot reload is not part of this PR.
 
-The default template provides a conservative baseline of regex scanners for
-obvious credential leakage, including:
+The default template provides a conservative deterministic baseline for
+credential and lightweight PII leakage. It combines:
+
+- regex scanners for a few high-signal token formats
+- a `secrets` scanner backed by `detect-secrets`
+- a lightweight `sensitive` scanner for common PII patterns
+
+The built-in regex baseline still covers obvious credential leakage, including:
 
 - PEM private key headers
 - AWS access key IDs (`AKIA...`)
@@ -109,6 +115,13 @@ obvious credential leakage, including:
 - GitHub tokens (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`)
 - `sk-...` style API keys
 - `Bearer ...` authorization tokens
+
+The lightweight `sensitive` scanner covers:
+
+- email addresses
+- phone numbers
+- credit card-like numbers (Luhn-validated)
+- IPv4 addresses
 
 This is baseline protection, not a complete content-safety policy. Broader
 scanners can still be added via a custom ConfigMap.

--- a/docs/proposals/20260416-ragengine-guardrails-ux-api.md
+++ b/docs/proposals/20260416-ragengine-guardrails-ux-api.md
@@ -101,13 +101,13 @@ it into the Pod.
 - Hot reload is not part of this PR.
 
 The default template provides a conservative deterministic baseline for
-credential and lightweight PII leakage. It combines:
+credential and lightweight PII leakage:
 
-- regex scanners for a few high-signal token formats
+- a regex scanner for a few high-signal token formats
 - a `secrets` scanner backed by `detect-secrets`
 - a lightweight `sensitive` scanner for common PII patterns
 
-The built-in regex baseline still covers obvious credential leakage, including:
+The regex scanner covers obvious credential leakage, including:
 
 - PEM private key headers
 - AWS access key IDs (`AKIA...`)
@@ -116,14 +116,14 @@ The built-in regex baseline still covers obvious credential leakage, including:
 - `sk-...` style API keys
 - `Bearer ...` authorization tokens
 
-The lightweight `sensitive` scanner covers:
+The `sensitive` scanner covers:
 
 - email addresses
 - phone numbers
 - credit card-like numbers (Luhn-validated)
 - IPv4 addresses
 
-This is baseline protection, not a complete content-safety policy. Broader
+This is baseline protection, not a complete content-safety policy. Additional
 scanners can still be added via a custom ConfigMap.
 
 ### Runtime Failure Semantics

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -50,9 +50,7 @@ _REGEX_MATCH_TYPES = frozenset(m.value for m in RegexMatchType)
 _SECRETS_REDACT_MODES = frozenset({"all", "partial", "hash"})
 _DEFAULT_SENSITIVE_DETECTORS = ("email", "phone", "credit_card", "ip_address")
 _SENSITIVE_DETECTORS = frozenset(_DEFAULT_SENSITIVE_DETECTORS)
-_EMAIL_PATTERN = re.compile(
-    r"\b[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[A-Za-z]{2,}\b"
-)
+_EMAIL_PATTERN = re.compile(r"\b[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[A-Za-z]{2,}\b")
 _PHONE_PATTERN = re.compile(r"(?<!\w)(?:\+?\d[\d().\- ]{8,}\d)(?!\w)")
 _CREDIT_CARD_PATTERN = re.compile(r"(?<!\d)(?:\d[ -]?){12,18}\d(?!\d)")
 _IPV4_PATTERN = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
@@ -277,7 +275,9 @@ def _dedupe_strings(values: list[str]) -> list[str]:
     return deduped
 
 
-def _collect_sensitive_matches(text: str, detectors: list[str]) -> list[_SensitiveMatch]:
+def _collect_sensitive_matches(
+    text: str, detectors: list[str]
+) -> list[_SensitiveMatch]:
     matches: list[_SensitiveMatch] = []
     for detector in detectors:
         if detector == "email":
@@ -317,8 +317,13 @@ def _collect_sensitive_matches(text: str, detectors: list[str]) -> list[_Sensiti
 
 def _dedupe_matches(matches: list[_SensitiveMatch]) -> list[_SensitiveMatch]:
     deduped: list[_SensitiveMatch] = []
-    for match in sorted(matches, key=lambda item: (item.start, -(item.end - item.start))):
-        if any(match.start < existing.end and existing.start < match.end for existing in deduped):
+    for match in sorted(
+        matches, key=lambda item: (item.start, -(item.end - item.start))
+    ):
+        if any(
+            match.start < existing.end and existing.start < match.end
+            for existing in deduped
+        ):
             continue
         deduped.append(match)
     return deduped

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -22,12 +22,6 @@ NOTE: Validation here is the runtime safety net for cases the
 admission webhook cannot cover (failurePolicy=Ignore, pre-existing
 CRs, ConfigMap-mounted policies, version skew). Bad configs are
 logged and skipped so the rest of the chain still runs.
-
-TODO: Many llm_guard scanners (e.g. Toxicity, Bias, Language) do not
-support redaction; pairing them with action=redact would be a no-op.
-When adding such scanners, declare a per-schema `supports_redact` flag
-and reject the (action=redact + non-redact scanner) combination at parse
-time, instead of trying to fix it at runtime.
 """
 
 import ipaddress
@@ -121,7 +115,7 @@ class SensitiveConfig:
 
     @classmethod
     def from_dict(cls, raw: dict) -> "SensitiveConfig":
-        detectors_value = raw.get("detectors", raw.get("entity_types"))
+        detectors_value = raw.get("detectors")
         if detectors_value is None:
             return cls(detectors=list(_DEFAULT_SENSITIVE_DETECTORS))
 
@@ -238,7 +232,6 @@ SCANNER_REGISTRY: dict[str, type] = {
     "regex": RegexConfig,
     "secrets": SecretsConfig,
     "sensitive": SensitiveConfig,
-    "pii": SensitiveConfig,
 }
 
 

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -30,10 +30,12 @@ and reject the (action=redact + non-redact scanner) combination at parse
 time, instead of trying to fix it at runtime.
 """
 
+import ipaddress
 import re
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
+import llm_guard.input_scanners as llm_guard_input_scanners
 import llm_guard.output_scanners as llm_guard_output_scanners
 from llm_guard.input_scanners.ban_substrings import (
     MatchType as BanSubstringsMatchType,
@@ -45,6 +47,108 @@ from llm_guard.input_scanners.regex import MatchType as RegexMatchType
 # letting the error surface only when the scanner is built.
 _BAN_SUBSTRINGS_MATCH_TYPES = frozenset(m.value for m in BanSubstringsMatchType)
 _REGEX_MATCH_TYPES = frozenset(m.value for m in RegexMatchType)
+_SECRETS_REDACT_MODES = frozenset({"all", "partial", "hash"})
+_DEFAULT_SENSITIVE_DETECTORS = ("email", "phone", "credit_card", "ip_address")
+_SENSITIVE_DETECTORS = frozenset(_DEFAULT_SENSITIVE_DETECTORS)
+_EMAIL_PATTERN = re.compile(
+    r"\b[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[A-Za-z]{2,}\b"
+)
+_PHONE_PATTERN = re.compile(r"(?<!\w)(?:\+?\d[\d().\- ]{8,}\d)(?!\w)")
+_CREDIT_CARD_PATTERN = re.compile(r"(?<!\d)(?:\d[ -]?){12,18}\d(?!\d)")
+_IPV4_PATTERN = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+
+
+@dataclass(frozen=True)
+class _SensitiveMatch:
+    start: int
+    end: int
+    detector: str
+
+
+class _OutputSecretsScanner:
+    def __init__(self, scanner: Any) -> None:
+        self._scanner = scanner
+
+    def scan(self, prompt: str, output: str) -> tuple[str, bool, float]:
+        del prompt
+        return self._scanner.scan(output)
+
+
+class _DeterministicSensitiveScanner:
+    def __init__(self, *, detectors: list[str], redact: bool) -> None:
+        self._detectors = list(detectors)
+        self._redact = redact
+
+    def scan(self, prompt: str, output: str) -> tuple[str, bool, float]:
+        del prompt
+        if output.strip() == "":
+            return output, True, -1.0
+
+        matches = _collect_sensitive_matches(output, self._detectors)
+        if not matches:
+            return output, True, -1.0
+
+        sanitized_output = output
+        if self._redact:
+            sanitized_output = _redact_sensitive_matches(output, matches)
+
+        return sanitized_output, False, 1.0
+
+
+@dataclass
+class SecretsConfig:
+    supports_redact: ClassVar[bool] = True
+    redact_mode: str = "all"
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "SecretsConfig":
+        redact_mode = str(raw.get("redact_mode", "all")).lower()
+        if redact_mode not in _SECRETS_REDACT_MODES:
+            raise ValueError(
+                f"secrets 'redact_mode' must be one of "
+                f"{sorted(_SECRETS_REDACT_MODES)}, got {redact_mode!r}"
+            )
+        return cls(redact_mode=redact_mode)
+
+    def build(self, action_on_hit: str) -> Any:
+        return _OutputSecretsScanner(
+            llm_guard_input_scanners.Secrets(redact_mode=self.redact_mode)
+        )
+
+
+@dataclass
+class SensitiveConfig:
+    supports_redact: ClassVar[bool] = True
+    detectors: list[str]
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "SensitiveConfig":
+        detectors_value = raw.get("detectors", raw.get("entity_types"))
+        if detectors_value is None:
+            return cls(detectors=list(_DEFAULT_SENSITIVE_DETECTORS))
+
+        detectors = [item.lower() for item in _coerce_string_list(detectors_value)]
+        if not detectors:
+            raise ValueError(
+                "sensitive requires 'detectors' to be a non-empty list of strings"
+            )
+
+        invalid_detectors = [
+            detector for detector in detectors if detector not in _SENSITIVE_DETECTORS
+        ]
+        if invalid_detectors:
+            raise ValueError(
+                f"sensitive 'detectors' must be drawn from "
+                f"{sorted(_SENSITIVE_DETECTORS)}, got {invalid_detectors!r}"
+            )
+
+        return cls(detectors=_dedupe_strings(detectors))
+
+    def build(self, action_on_hit: str) -> Any:
+        return _DeterministicSensitiveScanner(
+            detectors=self.detectors,
+            redact=(action_on_hit == "redact"),
+        )
 
 
 @dataclass
@@ -134,6 +238,9 @@ class RegexConfig:
 SCANNER_REGISTRY: dict[str, type] = {
     "ban_substrings": BanSubstringsConfig,
     "regex": RegexConfig,
+    "secrets": SecretsConfig,
+    "sensitive": SensitiveConfig,
+    "pii": SensitiveConfig,
 }
 
 
@@ -160,3 +267,79 @@ def _coerce_bool(value: Any, fallback: bool, *, field: str) -> bool:
     if isinstance(value, bool):
         return value
     raise ValueError(f"{field!r} must be a boolean (true/false), got {value!r}")
+
+
+def _dedupe_strings(values: list[str]) -> list[str]:
+    deduped: list[str] = []
+    for value in values:
+        if value not in deduped:
+            deduped.append(value)
+    return deduped
+
+
+def _collect_sensitive_matches(text: str, detectors: list[str]) -> list[_SensitiveMatch]:
+    matches: list[_SensitiveMatch] = []
+    for detector in detectors:
+        if detector == "email":
+            matches.extend(
+                _SensitiveMatch(match.start(), match.end(), detector)
+                for match in _EMAIL_PATTERN.finditer(text)
+            )
+        elif detector == "phone":
+            for match in _PHONE_PATTERN.finditer(text):
+                candidate = match.group(0)
+                digits = re.sub(r"\D", "", candidate)
+                if len(digits) < 10 or len(digits) > 15:
+                    continue
+                if not any(separator in candidate for separator in " +-.()"):
+                    continue
+                matches.append(_SensitiveMatch(match.start(), match.end(), detector))
+        elif detector == "credit_card":
+            for match in _CREDIT_CARD_PATTERN.finditer(text):
+                digits = re.sub(r"\D", "", match.group(0))
+                if len(digits) < 13 or len(digits) > 19:
+                    continue
+                if not _passes_luhn_check(digits):
+                    continue
+                matches.append(_SensitiveMatch(match.start(), match.end(), detector))
+        elif detector == "ip_address":
+            for match in _IPV4_PATTERN.finditer(text):
+                try:
+                    ip = ipaddress.ip_address(match.group(0))
+                except ValueError:
+                    continue
+                if ip.version != 4:
+                    continue
+                matches.append(_SensitiveMatch(match.start(), match.end(), detector))
+
+    return _dedupe_matches(matches)
+
+
+def _dedupe_matches(matches: list[_SensitiveMatch]) -> list[_SensitiveMatch]:
+    deduped: list[_SensitiveMatch] = []
+    for match in sorted(matches, key=lambda item: (item.start, -(item.end - item.start))):
+        if any(match.start < existing.end and existing.start < match.end for existing in deduped):
+            continue
+        deduped.append(match)
+    return deduped
+
+
+def _redact_sensitive_matches(text: str, matches: list[_SensitiveMatch]) -> str:
+    redacted = text
+    for match in sorted(matches, key=lambda item: item.start, reverse=True):
+        replacement = f"<{match.detector.upper()}>"
+        redacted = redacted[: match.start] + replacement + redacted[match.end :]
+    return redacted
+
+
+def _passes_luhn_check(value: str) -> bool:
+    total = 0
+    reverse_digits = value[::-1]
+    for index, digit_char in enumerate(reverse_digits):
+        digit = int(digit_char)
+        if index % 2 == 1:
+            digit *= 2
+            if digit > 9:
+                digit -= 9
+        total += digit
+    return total % 10 == 0

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -72,7 +72,7 @@ class _OutputSecretsScanner:
         return self._scanner.scan(output)
 
 
-class _DeterministicSensitiveScanner:
+class _PatternPIIScanner:
     def __init__(self, *, detectors: list[str], redact: bool) -> None:
         self._detectors = list(detectors)
         self._redact = redact
@@ -143,7 +143,7 @@ class SensitiveConfig:
         return cls(detectors=_dedupe_strings(detectors))
 
     def build(self, action_on_hit: str) -> Any:
-        return _DeterministicSensitiveScanner(
+        return _PatternPIIScanner(
             detectors=self.detectors,
             redact=(action_on_hit == "redact"),
         )

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -722,7 +722,9 @@ def test_guard_response_redacts_sensitive_entities_end_to_end():
     )
 
     out = guardrails.guard_response(
-        _make_response("Email alice@example.com or call +1 (206) 555-0100 from 10.0.0.1"),
+        _make_response(
+            "Email alice@example.com or call +1 (206) 555-0100 from 10.0.0.1"
+        ),
         {"messages": []},
     )
 

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -616,11 +616,11 @@ def test_parse_policy_scanner_configs_rejects_non_bool_flags():
     assert parsed == (_ban_subs_cfg(substrings=["a"], case_sensitive=True),)
 
 
-def test_parse_policy_scanner_configs_accepts_secrets_and_sensitive_aliases():
+def test_parse_policy_scanner_configs_accepts_secrets_and_sensitive():
     parsed = output_guardrails_module._parse_policy_scanner_configs(
         [
             {"type": "secrets", "redact_mode": "partial"},
-            {"type": "pii", "detectors": ["email", "credit_card"]},
+            {"type": "sensitive", "detectors": ["email", "credit_card"]},
         ],
         "guardrails.yaml",
     )
@@ -628,7 +628,7 @@ def test_parse_policy_scanner_configs_accepts_secrets_and_sensitive_aliases():
     assert parsed == (
         _secrets_cfg(redact_mode="partial"),
         ParsedScannerConfig(
-            type="pii",
+            type="sensitive",
             action_on_hit="redact",
             config=SensitiveConfig(detectors=["email", "credit_card"]),
         ),

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -18,6 +18,7 @@ import textwrap
 import time
 
 import pytest
+from llm_guard import scan_output
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
 
@@ -771,6 +772,22 @@ def test_build_scanners_supports_secrets_type(monkeypatch):
         False,
         1.0,
     )
+
+
+def test_secrets_config_build_works_with_scan_output_end_to_end():
+    scanner = SecretsConfig(redact_mode="partial").build("redact")
+    original_output = "Contact me at AKIA1234567890ABCDEF for access."
+
+    sanitized_output, results_valid, results_score = scan_output(
+        [scanner],
+        "ignored prompt",
+        original_output,
+        fail_fast=False,
+    )
+
+    assert sanitized_output != original_output
+    assert any(valid is False for valid in results_valid.values())
+    assert results_score
 
 
 def test_sensitive_config_build_redacts_requested_detectors_only():

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -31,6 +31,8 @@ from ragengine.guardrails.scanner_schemas import (
     BanSubstringsConfig,
     ParsedScannerConfig,
     RegexConfig,
+    SecretsConfig,
+    SensitiveConfig,
 )
 from ragengine.models import ChatCompletionResponse
 
@@ -63,6 +65,26 @@ def _ban_subs_cfg(
         type="ban_substrings",
         action_on_hit=action_on_hit,
         config=BanSubstringsConfig(substrings=list(substrings), **kw),
+    )
+
+
+def _secrets_cfg(action_on_hit="redact", **kw) -> ParsedScannerConfig:
+    return ParsedScannerConfig(
+        type="secrets",
+        action_on_hit=action_on_hit,
+        config=SecretsConfig(**kw),
+    )
+
+
+def _sensitive_cfg(
+    detectors=("email", "phone", "credit_card", "ip_address"),
+    action_on_hit="redact",
+    **kw,
+) -> ParsedScannerConfig:
+    return ParsedScannerConfig(
+        type="sensitive",
+        action_on_hit=action_on_hit,
+        config=SensitiveConfig(detectors=list(detectors), **kw),
     )
 
 
@@ -189,6 +211,32 @@ def test_from_config_loads_yaml_policy(tmp_path, monkeypatch):
     assert guardrails.scanner_configs == (
         _regex_cfg(patterns=[r"https?://\S+"], action_on_hit="block"),
         _ban_subs_cfg(substrings=["secret"], action_on_hit="block"),
+    )
+
+
+def test_from_config_loads_yaml_policy_with_secrets_and_sensitive(
+    tmp_path, monkeypatch
+):
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: redact
+        scanners:
+          - type: secrets
+            redactMode: partial
+          - type: sensitive
+            detectors:
+              - email
+              - ip_address
+        """,
+    )
+
+    guardrails = OutputGuardrails.from_config()
+
+    assert guardrails.scanner_configs == (
+        _secrets_cfg(redact_mode="partial"),
+        _sensitive_cfg(detectors=["email", "ip_address"]),
     )
 
 
@@ -405,6 +453,8 @@ def test_parse_policy_scanner_configs_skips_unknown_and_invalid_schema():
             {"type": "unknown_scanner"},
             {"type": "regex"},  # missing required 'patterns'
             {"type": "ban_substrings"},  # missing required 'substrings'
+            {"type": "secrets", "redact_mode": "bogus"},
+            {"type": "sensitive", "detectors": ["email", "bogus"]},
             {"type": "regex", "patterns": ["a"]},
         ],
         "guardrails.yaml",
@@ -479,6 +529,25 @@ def test_parse_policy_scanner_configs_rejects_non_bool_flags():
     )
 
     assert parsed == (_ban_subs_cfg(substrings=["a"], case_sensitive=True),)
+
+
+def test_parse_policy_scanner_configs_accepts_secrets_and_sensitive_aliases():
+    parsed = output_guardrails_module._parse_policy_scanner_configs(
+        [
+            {"type": "secrets", "redact_mode": "partial"},
+            {"type": "pii", "detectors": ["email", "credit_card"]},
+        ],
+        "guardrails.yaml",
+    )
+
+    assert parsed == (
+        _secrets_cfg(redact_mode="partial"),
+        ParsedScannerConfig(
+            type="pii",
+            action_on_hit="redact",
+            config=SensitiveConfig(detectors=["email", "credit_card"]),
+        ),
+    )
 
 
 def test_parse_policy_scanner_configs_skips_redact_incompatible_scanners(
@@ -587,6 +656,79 @@ def test_build_scanners_uses_per_scanner_action(fake_llm_guard_scanners):
 
     assert scanners[0].redact is True
     assert scanners[1].redact is False
+
+
+def test_build_scanners_supports_secrets_type(monkeypatch):
+    class FakeSecrets:
+        def __init__(self, *, redact_mode="all"):
+            self.redact_mode = redact_mode
+
+        def scan(self, output):
+            return f"{self.redact_mode}:{output}", False, 1.0
+
+    monkeypatch.setattr(
+        scanner_schemas_module.llm_guard_input_scanners,
+        "Secrets",
+        FakeSecrets,
+        raising=False,
+    )
+
+    parsed = output_guardrails_module._parse_policy_scanner_configs(
+        [{"type": "secrets", "redactMode": "partial"}],
+        "guardrails.yaml",
+    )
+    guardrails = OutputGuardrails(enabled=True, scanner_configs=parsed)
+
+    scanners = guardrails._build_scanners()
+
+    assert parsed == (_secrets_cfg(redact_mode="partial"),)
+    assert scanners[0].scan("ignored", "secret-value") == (
+        "partial:secret-value",
+        False,
+        1.0,
+    )
+
+
+def test_sensitive_config_build_redacts_requested_detectors_only():
+    scanner = SensitiveConfig(detectors=["email", "ip_address"]).build("redact")
+
+    sanitized, is_valid, risk_score = scanner.scan(
+        "",
+        "Email alice@example.com from 10.0.0.1 but keep 4111 1111 1111 1111",
+    )
+
+    assert sanitized == "Email <EMAIL> from <IP_ADDRESS> but keep 4111 1111 1111 1111"
+    assert is_valid is False
+    assert risk_score == 1.0
+
+
+def test_sensitive_config_detects_luhn_valid_credit_cards_only():
+    scanner = SensitiveConfig(detectors=["credit_card"]).build("redact")
+
+    sanitized, is_valid, risk_score = scanner.scan(
+        "",
+        "good 4111 1111 1111 1111 bad 4111 1111 1111 1112",
+    )
+
+    assert sanitized == "good <CREDIT_CARD> bad 4111 1111 1111 1112"
+    assert is_valid is False
+    assert risk_score == 1.0
+
+
+def test_guard_response_redacts_sensitive_entities_end_to_end():
+    guardrails = OutputGuardrails(
+        enabled=True,
+        scanner_configs=(_sensitive_cfg(detectors=["email", "phone", "ip_address"]),),
+    )
+
+    out = guardrails.guard_response(
+        _make_response("Email alice@example.com or call +1 (206) 555-0100 from 10.0.0.1"),
+        {"messages": []},
+    )
+
+    assert out.choices[0].message.content == (
+        "Email <EMAIL> or call <PHONE> from <IP_ADDRESS>"
+    )
 
 
 def test_build_scanners_skips_configs_whose_build_raises(monkeypatch):

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -225,6 +225,8 @@ def test_from_config_loads_yaml_policy(tmp_path, monkeypatch):
         _regex_cfg(patterns=[r"https?://\S+"], action_on_hit="block"),
         _ban_subs_cfg(substrings=["secret"], action_on_hit="block"),
     )
+
+
 def test_from_config_records_policy_load_metrics(tmp_path, monkeypatch):
     _write_policy(
         tmp_path,
@@ -720,6 +722,7 @@ def test_build_scanners_supports_normalized_ban_substrings_type(
     assert isinstance(scanners[0], FakeBanSubstrings)
     assert scanners[0].substrings == ["secret"]
     assert scanners[0].redact is True
+
 
 def test_build_scanners_uses_per_scanner_action(fake_llm_guard_scanners):
     parsed = (

--- a/presets/ragengine/tests/test_default_guardrails_policy.py
+++ b/presets/ragengine/tests/test_default_guardrails_policy.py
@@ -63,5 +63,9 @@ def test_default_guardrails_policy_template_has_non_empty_scanners():
 
     parsed = _parse_policy_scanner_configs(scanners, str(CHART_TEMPLATE))
     assert parsed
-    assert [scanner.type for scanner in parsed] == ["regex"]
-    assert [scanner.action_on_hit for scanner in parsed] == ["redact"]
+    assert [scanner.type for scanner in parsed] == ["regex", "secrets", "sensitive"]
+    assert [scanner.action_on_hit for scanner in parsed] == [
+        "redact",
+        "redact",
+        "redact",
+    ]


### PR DESCRIPTION
## Summary

Add Scanner Pack 2 for output guardrails to reduce data leakage risk.

This PR introduces:
- `secrets` scanner support backed by `detect-secrets`
- lightweight deterministic `sensitive` / `pii (Personally Identifiable Information)` scanning for:
  - email
  - phone
  - credit card-like values
  - IPv4 addresses

## Changes

- add YAML schema and registry support for `secrets`, `sensitive`, and `pii`
- add redact/block runtime support through the existing guardrails scanner pipeline
- keep the scope deterministic and lightweight
- update the default guardrails policy template
- add golden tests, unit tests, and failure behavior coverage

## Notes

- `secrets` is implemented for output scanning with a thin adapter over llm-guard's detect-secrets scanner
- `sensitive` / `pii` intentionally avoids heavy NER / Presidio-style runtime dependencies in this first version
- person-name detection is intentionally out of scope

## Validation

```bash
python -m pytest test_output_guardrails.py test_default_guardrails_policy.py