### PR TITLE
feat: scanner pack 3 json reading time length limit

### DIFF
--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -252,10 +252,10 @@ class JSONConfig:
 
 
 @dataclass
-# Enforces a maximum reading-time budget for the output using llm_guard's
-# average reading-speed heuristic (about 200 words per minute). Configure
-# max_time in minutes, and use truncate to shorten outputs that exceed the
-# budget instead of rejecting them outright.
+# Enforces a reading-time limit for the output using llm_guard's average
+# reading-speed heuristic (about 200 words per minute). max_time is expressed
+# in minutes. If truncate is true, outputs that exceed the limit are shortened
+# to fit; otherwise they are marked invalid.
 class ReadingTimeConfig:
     supports_redact: ClassVar[bool] = True
     # Maximum allowed reading time, expressed in fractional minutes. For

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -252,10 +252,13 @@ class JSONConfig:
 
 
 @dataclass
-# Enforces a maximum estimated reading time for the output and can truncate
-# responses that exceed the configured limit.
+# Enforces a maximum estimated reading time for the output using llm_guard's
+# average reading speed heuristic (about 200 words per minute). max_time is
+# expressed in minutes, and truncate controls whether over-budget responses are
+# shortened to fit within that limit.
 class ReadingTimeConfig:
     supports_redact: ClassVar[bool] = True
+    # Maximum allowed reading time in minutes; 0.25 means 15 seconds.
     max_time: float
     truncate: bool = False
 

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -228,6 +228,7 @@ class RegexConfig:
 
 
 @dataclass
+# Validates that the output is parseable JSON.
 class JSONConfig:
     supports_redact: ClassVar[bool] = True
     required_elements: int = 0
@@ -249,6 +250,8 @@ class JSONConfig:
 
 
 @dataclass
+# Enforces a maximum estimated reading time for the output and can truncate
+# responses that exceed the configured limit.
 class ReadingTimeConfig:
     supports_redact: ClassVar[bool] = True
     max_time: float

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -252,14 +252,14 @@ class JSONConfig:
 
 
 @dataclass
-# Enforces a maximum estimated reading time for the output using llm_guard's
-# average reading speed heuristic (about 200 words per minute). max_time is
-# expressed in minutes, and truncate controls whether over-budget responses are
-# shortened to fit within that limit.
+# Enforces a maximum reading-time budget for the output using llm_guard's
+# average reading-speed heuristic (about 200 words per minute). Configure
+# max_time in minutes, and use truncate to shorten outputs that exceed the
+# budget instead of rejecting them outright.
 class ReadingTimeConfig:
     supports_redact: ClassVar[bool] = True
-    # Maximum allowed reading time in minutes. Values are fractional minutes;
-    # for example, 0.25 means one quarter of a minute (15 seconds).
+    # Maximum allowed reading time, expressed in fractional minutes. For
+    # example, 0.25 means one quarter of a minute (15 seconds).
     max_time: float
     truncate: bool = False
 

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -131,9 +131,54 @@ class RegexConfig:
         )
 
 
+
+@dataclass
+class JSONConfig:
+    supports_redact: ClassVar[bool] = True
+    required_elements: int = 0
+    repair: bool = True
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "JSONConfig":
+        required_elements = raw.get("required_elements", 0)
+        if not isinstance(required_elements, int) or required_elements < 0:
+            raise ValueError("json 'required_elements' must be a non-negative integer")
+        repair = _coerce_bool(raw.get("repair"), True, field="repair")
+        return cls(required_elements=required_elements, repair=repair)
+
+    def build(self, action_on_hit: str) -> Any:
+        return llm_guard_output_scanners.JSON(
+            required_elements=self.required_elements,
+            repair=self.repair,
+        )
+
+
+@dataclass
+class ReadingTimeConfig:
+    supports_redact: ClassVar[bool] = True
+    max_time: float
+    truncate: bool = False
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "ReadingTimeConfig":
+        max_time = raw.get("max_time")
+        if not (isinstance(max_time, (int, float)) and max_time > 0):
+            raise ValueError("reading_time 'max_time' must be a positive number (minutes)")
+        truncate = _coerce_bool(raw.get("truncate"), False, field="truncate")
+        return cls(max_time=float(max_time), truncate=truncate)
+
+    def build(self, action_on_hit: str) -> Any:
+        return llm_guard_output_scanners.ReadingTime(
+            max_time=self.max_time,
+            truncate=self.truncate,
+        )
+
+
 SCANNER_REGISTRY: dict[str, type] = {
     "ban_substrings": BanSubstringsConfig,
     "regex": RegexConfig,
+    "json": JSONConfig,
+    "reading_time": ReadingTimeConfig,
 }
 
 

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -131,7 +131,6 @@ class RegexConfig:
         )
 
 
-
 @dataclass
 class JSONConfig:
     supports_redact: ClassVar[bool] = True
@@ -163,7 +162,9 @@ class ReadingTimeConfig:
     def from_dict(cls, raw: dict) -> "ReadingTimeConfig":
         max_time = raw.get("max_time")
         if not (isinstance(max_time, (int, float)) and max_time > 0):
-            raise ValueError("reading_time 'max_time' must be a positive number (minutes)")
+            raise ValueError(
+                "reading_time 'max_time' must be a positive number (minutes)"
+            )
         truncate = _coerce_bool(raw.get("truncate"), False, field="truncate")
         return cls(max_time=float(max_time), truncate=truncate)
 

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -258,7 +258,8 @@ class JSONConfig:
 # shortened to fit within that limit.
 class ReadingTimeConfig:
     supports_redact: ClassVar[bool] = True
-    # Maximum allowed reading time in minutes; 0.25 means 15 seconds.
+    # Maximum allowed reading time in minutes. Values are fractional minutes;
+    # for example, 0.25 means one quarter of a minute (15 seconds).
     max_time: float
     truncate: bool = False
 

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -109,6 +109,8 @@ class SecretsConfig:
 
 
 @dataclass
+# Detects common sensitive data such as email addresses, phone numbers,
+# credit cards, and IP addresses.
 class SensitiveConfig:
     supports_redact: ClassVar[bool] = True
     detectors: list[str]

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -507,26 +507,30 @@ def test_from_config_skips_invalid_scanners_and_filters_non_string_values(
 
 
 def test_from_config_loads_json_and_reading_time_scanners(tmp_path, monkeypatch):
+    # ReadingTime expects minutes, so 0.25 means 15 seconds.
+    fifteen_seconds_in_minutes = 0.25
+    policy = """
+    action: redact
+    scanners:
+      - type: json
+        required_elements: 1
+        repair: false
+      - type: reading_time
+        max_time: 0.25
+        truncate: true
+    """
+
     _write_policy(
         tmp_path,
         monkeypatch,
-        """
-        action: redact
-        scanners:
-          - type: json
-            required_elements: 1
-            repair: false
-          - type: reading_time
-            max_time: 0.25
-            truncate: true
-        """,
+        policy,
     )
 
     guardrails = OutputGuardrails.from_config()
 
     assert guardrails.scanner_configs == (
         _json_cfg(required_elements=1, repair=False),
-        _reading_time_cfg(max_time=0.25, truncate=True),
+                _reading_time_cfg(max_time=fifteen_seconds_in_minutes, truncate=True),
     )
 
 

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -1185,6 +1185,55 @@ def test_guard_response_with_real_json_scanner_blocks_invalid_output(
     assert out.choices[0].message.content == "invalid-json"
 
 
+def test_guard_response_with_real_json_scanner_allows_valid_output(
+    tmp_path, monkeypatch
+):
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: block
+        blockMessage: invalid-json
+        scanners:
+          - type: json
+            required_elements: 1
+            repair: false
+        """,
+    )
+
+    guardrails = OutputGuardrails.from_config()
+
+    out = guardrails.guard_response(
+        _make_response('{"a": 1, "b": [true, false], "c": "ok"}'),
+        {"messages": []},
+    )
+
+    assert out.choices[0].message.content == '{"a": 1, "b": [true, false], "c": "ok"}'
+
+
+def test_guard_response_with_real_json_scanner_repair_true_keeps_simple_malformed_json(
+    tmp_path, monkeypatch
+):
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: block
+        blockMessage: invalid-json
+        scanners:
+          - type: json
+                        required_elements: 0
+            repair: true
+        """,
+    )
+
+    guardrails = OutputGuardrails.from_config()
+
+    out = guardrails.guard_response(_make_response('{"a": 1, "b": 2'), {"messages": []})
+
+    assert out.choices[0].message.content == '{"a": 1, "b": 2'
+
+
 def test_guard_response_with_real_reading_time_scanner_truncates_output(
     tmp_path, monkeypatch
 ):
@@ -1207,6 +1256,32 @@ def test_guard_response_with_real_reading_time_scanner_truncates_output(
     )
 
     assert out.choices[0].message.content == "one two"
+
+
+def test_guard_response_with_real_reading_time_scanner_allows_exact_threshold_output(
+    tmp_path, monkeypatch
+):
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: block
+        blockMessage: too-long
+        scanners:
+          - type: reading_time
+            max_time: 0.05
+            truncate: false
+        """,
+    )
+
+    guardrails = OutputGuardrails.from_config()
+
+    out = guardrails.guard_response(
+        _make_response("One two three four five six seven eight nine ten."),
+        {"messages": []},
+    )
+
+    assert out.choices[0].message.content == "One two three four five six seven eight nine ten."
 
 
 def test_guard_response_applies_mixed_scanner_actions_in_order(monkeypatch):

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -1281,7 +1281,10 @@ def test_guard_response_with_real_reading_time_scanner_allows_exact_threshold_ou
         {"messages": []},
     )
 
-    assert out.choices[0].message.content == "One two three four five six seven eight nine ten."
+    assert (
+        out.choices[0].message.content
+        == "One two three four five six seven eight nine ten."
+    )
 
 
 def test_guard_response_applies_mixed_scanner_actions_in_order(monkeypatch):

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -530,7 +530,7 @@ def test_from_config_loads_json_and_reading_time_scanners(tmp_path, monkeypatch)
 
     assert guardrails.scanner_configs == (
         _json_cfg(required_elements=1, repair=False),
-                _reading_time_cfg(max_time=fifteen_seconds_in_minutes, truncate=True),
+        _reading_time_cfg(max_time=fifteen_seconds_in_minutes, truncate=True),
     )
 
 

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -29,7 +29,9 @@ from ragengine.guardrails.output_guardrails import (
 )
 from ragengine.guardrails.scanner_schemas import (
     BanSubstringsConfig,
+    JSONConfig,
     ParsedScannerConfig,
+    ReadingTimeConfig,
     RegexConfig,
 )
 from ragengine.models import ChatCompletionResponse
@@ -63,6 +65,24 @@ def _ban_subs_cfg(
         type="ban_substrings",
         action_on_hit=action_on_hit,
         config=BanSubstringsConfig(substrings=list(substrings), **kw),
+    )
+
+
+def _json_cfg(required_elements=0, action_on_hit="redact", **kw) -> ParsedScannerConfig:
+    return ParsedScannerConfig(
+        type="json",
+        action_on_hit=action_on_hit,
+        config=JSONConfig(required_elements=required_elements, **kw),
+    )
+
+
+def _reading_time_cfg(
+    max_time=0.5, action_on_hit="redact", **kw
+) -> ParsedScannerConfig:
+    return ParsedScannerConfig(
+        type="reading_time",
+        action_on_hit=action_on_hit,
+        config=ReadingTimeConfig(max_time=max_time, **kw),
     )
 
 
@@ -144,6 +164,16 @@ def fake_llm_guard_scanners(monkeypatch):
             self.contains_all = contains_all
             self.redact = redact
 
+    class FakeJSON:
+        def __init__(self, *, required_elements=0, repair=True):
+            self.required_elements = required_elements
+            self.repair = repair
+
+    class FakeReadingTime:
+        def __init__(self, max_time, *, truncate=False):
+            self.max_time = max_time
+            self.truncate = truncate
+
     monkeypatch.setattr(
         scanner_schemas_module.llm_guard_output_scanners,
         "Regex",
@@ -156,7 +186,19 @@ def fake_llm_guard_scanners(monkeypatch):
         FakeBanSubstrings,
         raising=False,
     )
-    return FakeRegex, FakeBanSubstrings
+    monkeypatch.setattr(
+        scanner_schemas_module.llm_guard_output_scanners,
+        "JSON",
+        FakeJSON,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scanner_schemas_module.llm_guard_output_scanners,
+        "ReadingTime",
+        FakeReadingTime,
+        raising=False,
+    )
+    return FakeRegex, FakeBanSubstrings, FakeJSON, FakeReadingTime
 
 
 # ---------------------------------------------------------------------------
@@ -331,6 +373,32 @@ def test_from_config_skips_invalid_scanners_and_filters_non_string_values(
     assert scanners[1].redact is True
 
 
+def test_from_config_loads_json_and_reading_time_scanners(
+    tmp_path, monkeypatch
+):
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: redact
+        scanners:
+          - type: json
+            required_elements: 1
+            repair: false
+          - type: reading_time
+            max_time: 0.25
+            truncate: true
+        """,
+    )
+
+    guardrails = OutputGuardrails.from_config()
+
+    assert guardrails.scanner_configs == (
+        _json_cfg(required_elements=1, repair=False),
+        _reading_time_cfg(max_time=0.25, truncate=True),
+    )
+
+
 def test_from_config_with_empty_policy_path_keeps_defaults(monkeypatch):
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", "")
@@ -472,13 +540,41 @@ def test_parse_policy_scanner_configs_rejects_non_bool_flags():
             {"type": "ban_substrings", "substrings": ["a"], "case_sensitive": "false"},
             {"type": "ban_substrings", "substrings": ["a"], "contains_all": 1},
             {"type": "regex", "patterns": ["a"], "is_blocked": "no"},
+            {"type": "json", "repair": "yes"},
+            {"type": "reading_time", "max_time": 0.5, "truncate": "no"},
             # Native YAML booleans (already parsed to Python bool) are accepted.
             {"type": "ban_substrings", "substrings": ["a"], "case_sensitive": True},
+            {"type": "json", "repair": True},
+            {"type": "reading_time", "max_time": 0.5, "truncate": True},
         ],
         "guardrails.yaml",
     )
 
-    assert parsed == (_ban_subs_cfg(substrings=["a"], case_sensitive=True),)
+    assert parsed == (
+        _ban_subs_cfg(substrings=["a"], case_sensitive=True),
+        _json_cfg(repair=True),
+        _reading_time_cfg(max_time=0.5, truncate=True),
+    )
+
+
+def test_parse_policy_scanner_configs_rejects_invalid_json_and_reading_time_values():
+    parsed = output_guardrails_module._parse_policy_scanner_configs(
+        [
+            {"type": "json", "required_elements": -1},
+            {"type": "json", "required_elements": 1.5},
+            {"type": "reading_time", "max_time": 0},
+            {"type": "reading_time", "max_time": -0.1},
+            {"type": "reading_time", "max_time": "fast"},
+            {"type": "json", "required_elements": 2, "repair": False},
+            {"type": "reading_time", "max_time": 0.1, "truncate": False},
+        ],
+        "guardrails.yaml",
+    )
+
+    assert parsed == (
+        _json_cfg(required_elements=2, repair=False),
+        _reading_time_cfg(max_time=0.1, truncate=False),
+    )
 
 
 def test_parse_policy_scanner_configs_skips_redact_incompatible_scanners(
@@ -549,7 +645,7 @@ def test_parse_policy_scanner_configs_allows_non_redact_scanners_for_block(
 def test_build_scanners_supports_normalized_ban_substrings_type(
     fake_llm_guard_scanners,
 ):
-    _, FakeBanSubstrings = fake_llm_guard_scanners
+    _, FakeBanSubstrings, _, _ = fake_llm_guard_scanners
 
     parsed = output_guardrails_module._parse_policy_scanner_configs(
         [{"type": "ban-substrings", "substrings": ["secret"]}],
@@ -587,6 +683,28 @@ def test_build_scanners_uses_per_scanner_action(fake_llm_guard_scanners):
 
     assert scanners[0].redact is True
     assert scanners[1].redact is False
+
+
+def test_build_scanners_builds_json_and_reading_time(fake_llm_guard_scanners):
+    _, _, FakeJSON, FakeReadingTime = fake_llm_guard_scanners
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        scanner_configs=(
+            _json_cfg(required_elements=2, repair=False),
+            _reading_time_cfg(max_time=0.25, truncate=True),
+        ),
+    )
+
+    scanners = guardrails._build_scanners()
+
+    assert len(scanners) == 2
+    assert isinstance(scanners[0], FakeJSON)
+    assert scanners[0].required_elements == 2
+    assert scanners[0].repair is False
+    assert isinstance(scanners[1], FakeReadingTime)
+    assert scanners[1].max_time == 0.25
+    assert scanners[1].truncate is True
 
 
 def test_build_scanners_skips_configs_whose_build_raises(monkeypatch):
@@ -726,6 +844,75 @@ def test_guard_response_applies_action(
 
     out = guardrails.guard_response(_make_response("dirty"), {"messages": []})
     assert out.choices[0].message.content == expected_content
+
+
+def test_guard_response_preserves_truncated_output_for_reading_time(monkeypatch):
+    _patch_scan_output(
+        monkeypatch,
+        lambda scanners, prompt, output, fail_fast: (
+            "one two three",
+            {"reading_time": False},
+            {"reading_time": 1.0},
+        ),
+    )
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        action_on_hit="redact",
+        scanner_configs=(_reading_time_cfg(max_time=0.01, truncate=True),),
+    )
+
+    out = guardrails.guard_response(
+        _make_response("one two three four five six"), {"messages": []}
+    )
+    assert out.choices[0].message.content == "one two three"
+
+
+def test_guard_response_with_real_json_scanner_blocks_invalid_output(
+    tmp_path, monkeypatch
+):
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: block
+        blockMessage: invalid-json
+        scanners:
+          - type: json
+            required_elements: 1
+            repair: false
+        """,
+    )
+
+    guardrails = OutputGuardrails.from_config()
+
+    out = guardrails.guard_response(_make_response("plain text only"), {"messages": []})
+
+    assert out.choices[0].message.content == "invalid-json"
+
+
+def test_guard_response_with_real_reading_time_scanner_truncates_output(
+    tmp_path, monkeypatch
+):
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: redact
+        scanners:
+          - type: reading_time
+            max_time: 0.01
+            truncate: true
+        """,
+    )
+
+    guardrails = OutputGuardrails.from_config()
+
+    out = guardrails.guard_response(
+        _make_response("one two three four five six"), {"messages": []}
+    )
+
+    assert out.choices[0].message.content == "one two"
 
 
 def test_guard_response_applies_mixed_scanner_actions_in_order(monkeypatch):

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -373,9 +373,7 @@ def test_from_config_skips_invalid_scanners_and_filters_non_string_values(
     assert scanners[1].redact is True
 
 
-def test_from_config_loads_json_and_reading_time_scanners(
-    tmp_path, monkeypatch
-):
+def test_from_config_loads_json_and_reading_time_scanners(tmp_path, monkeypatch):
     _write_policy(
         tmp_path,
         monkeypatch,

--- a/presets/ragengine/tests/guardrails/testdata/json_reading_time_policy.yaml
+++ b/presets/ragengine/tests/guardrails/testdata/json_reading_time_policy.yaml
@@ -1,0 +1,8 @@
+action: redact
+scanners:
+  - type: json
+    required_elements: 1
+    repair: true
+  - type: reading_time
+    max_time: 0.25
+    truncate: true

--- a/presets/ragengine/tests/test_default_guardrails_policy.py
+++ b/presets/ragengine/tests/test_default_guardrails_policy.py
@@ -25,6 +25,12 @@ CHART_TEMPLATE = (
     / "templates"
     / "guardrails-policy-configmap.yaml"
 )
+TESTDATA_POLICY = (
+    Path(__file__).resolve().parent
+    / "guardrails"
+    / "testdata"
+    / "json_reading_time_policy.yaml"
+)
 
 
 def _extract_default_policy_text() -> str:
@@ -65,3 +71,12 @@ def test_default_guardrails_policy_template_has_non_empty_scanners():
     assert parsed
     assert [scanner.type for scanner in parsed] == ["regex"]
     assert [scanner.action_on_hit for scanner in parsed] == ["redact"]
+
+
+def test_json_and_reading_time_policy_fixture_parses():
+    policy = yaml.safe_load(TESTDATA_POLICY.read_text(encoding="utf-8"))
+
+    parsed = _parse_policy_scanner_configs(policy.get("scanners"), str(TESTDATA_POLICY))
+
+    assert [scanner.type for scanner in parsed] == ["json", "reading_time"]
+    assert [scanner.action_on_hit for scanner in parsed] == ["redact", "redact"]


### PR DESCRIPTION
## Summary

Add two deterministic output guardrail scanners to RAGEngine:

- `json`
- `reading_time`

These scanners do not require an LLM and are useful for structured output validation and response length control.

## Changes

- add `JSONConfig` and `ReadingTimeConfig` to the scanner registry
- wire both scanners into policy parsing and runtime construction
- cover the new scanners with policy fixture, unit tests, and runtime tests

## Validation

```bash
python -m pytest test_output_guardrails.py test_default_guardrails_policy.py -q