### PR TITLE
feat: add invisible text and token limit guardrail scanners

### DIFF
--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -399,13 +399,15 @@ jobs:
           MODELS_RESPONSE=$(curl -s http://localhost:8080/v1/models)
           echo "Models response: $MODELS_RESPONSE"
 
-          # Validate that the response contains at least one non-empty model id.
-          if echo "$MODELS_RESPONSE" | jq -e '(.data | type == "array") and (.data | length > 0) and (.data[0].id | type == "string") and (.data[0].id | length > 0)' >/dev/null; then
-            MODEL_NAME=$(echo "$MODELS_RESPONSE" | jq -r '.data[0].id')
-            echo "Extracted model name: $MODEL_NAME"
+          # Extract the first model name from the response
+          MODEL_NAME=$(echo "$MODELS_RESPONSE" | jq -r '.data[0].id')
+          echo "Extracted model name: $MODEL_NAME"
+
+          # Check if response contains 'llama'
+          if echo "$MODELS_RESPONSE" | grep -i 'llama'; then
             echo 'Model response validation passed!'
           else
-            echo 'Model response validation failed - missing usable model id'
+            echo 'Model response validation failed - no llama model found'
             kill $PORT_FORWARD_PID
             exit 1
           fi

--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -399,15 +399,13 @@ jobs:
           MODELS_RESPONSE=$(curl -s http://localhost:8080/v1/models)
           echo "Models response: $MODELS_RESPONSE"
 
-          # Extract the first model name from the response
-          MODEL_NAME=$(echo "$MODELS_RESPONSE" | jq -r '.data[0].id')
-          echo "Extracted model name: $MODEL_NAME"
-
-          # Check if response contains 'llama'
-          if echo "$MODELS_RESPONSE" | grep -i 'llama'; then
+          # Validate that the response contains at least one non-empty model id.
+          if echo "$MODELS_RESPONSE" | jq -e '(.data | type == "array") and (.data | length > 0) and (.data[0].id | type == "string") and (.data[0].id | length > 0)' >/dev/null; then
+            MODEL_NAME=$(echo "$MODELS_RESPONSE" | jq -r '.data[0].id')
+            echo "Extracted model name: $MODEL_NAME"
             echo 'Model response validation passed!'
           else
-            echo 'Model response validation failed - no llama model found'
+            echo 'Model response validation failed - missing usable model id'
             kill $PORT_FORWARD_PID
             exit 1
           fi

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -277,7 +277,8 @@ class InvisibleTextConfig:
 
 @dataclass
 # Enforces a maximum output token budget using llm_guard's tiktoken-based
-# counting. limit is the token cap, while encoding_name and model_name control
+# counting. Outputs whose token count exceeds limit are marked invalid. This
+# limits tokens, not characters or words; encoding_name and model_name control
 # which tokenizer is used for counting.
 class TokenLimitConfig:
     supports_redact: ClassVar[bool] = True

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -145,7 +145,7 @@ class SensitiveConfig:
         )
 
 
-# Adapts llm_guard's input-side InvisibleText scanner for output guardrails.
+# Adapts llm_guard InvisibleText for model output scanning.
 class InvisibleTextOutputAdapter:
     def __init__(self) -> None:
         self._scanner = llm_guard_input_scanners.InvisibleText()
@@ -155,7 +155,7 @@ class InvisibleTextOutputAdapter:
         return sanitized_output, is_valid, score
 
 
-# Adapts llm_guard's input-side TokenLimit scanner for output guardrails.
+# Adapts llm_guard TokenLimit to limit model output token count.
 class TokenLimitOutputAdapter:
     def __init__(
         self,

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -34,6 +34,7 @@ import re
 from dataclasses import dataclass
 from typing import Any, ClassVar
 
+import llm_guard.input_scanners as llm_guard_input_scanners
 import llm_guard.output_scanners as llm_guard_output_scanners
 from llm_guard.input_scanners.ban_substrings import (
     MatchType as BanSubstringsMatchType,
@@ -45,6 +46,34 @@ from llm_guard.input_scanners.regex import MatchType as RegexMatchType
 # letting the error surface only when the scanner is built.
 _BAN_SUBSTRINGS_MATCH_TYPES = frozenset(m.value for m in BanSubstringsMatchType)
 _REGEX_MATCH_TYPES = frozenset(m.value for m in RegexMatchType)
+
+
+class InvisibleTextOutputAdapter:
+    def __init__(self) -> None:
+        self._scanner = llm_guard_input_scanners.InvisibleText()
+
+    def scan(self, prompt: str, output: str) -> tuple[str, bool, float]:
+        sanitized_output, is_valid, score = self._scanner.scan(output)
+        return sanitized_output, is_valid, score
+
+
+class TokenLimitOutputAdapter:
+    def __init__(
+        self,
+        *,
+        limit: int,
+        encoding_name: str = "cl100k_base",
+        model_name: str | None = None,
+    ) -> None:
+        self._scanner = llm_guard_input_scanners.TokenLimit(
+            limit=limit,
+            encoding_name=encoding_name,
+            model_name=model_name,
+        )
+
+    def scan(self, prompt: str, output: str) -> tuple[str, bool, float]:
+        sanitized_output, is_valid, score = self._scanner.scan(output)
+        return sanitized_output, is_valid, score
 
 
 @dataclass
@@ -131,9 +160,60 @@ class RegexConfig:
         )
 
 
+@dataclass
+class InvisibleTextConfig:
+    supports_redact: ClassVar[bool] = True
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "InvisibleTextConfig":
+        if raw:
+            raise ValueError("invisible_text does not accept any configuration fields")
+        return cls()
+
+    def build(self, action_on_hit: str) -> Any:
+        return InvisibleTextOutputAdapter()
+
+
+@dataclass
+class TokenLimitConfig:
+    supports_redact: ClassVar[bool] = True
+    limit: int = 4096
+    encoding_name: str = "cl100k_base"
+    model_name: str | None = None
+
+    @classmethod
+    def from_dict(cls, raw: dict) -> "TokenLimitConfig":
+        limit = raw.get("limit", 4096)
+        if not isinstance(limit, int) or limit <= 0:
+            raise ValueError("token_limit 'limit' must be a positive integer")
+
+        encoding_name = raw.get("encoding_name", "cl100k_base")
+        if not isinstance(encoding_name, str) or not encoding_name:
+            raise ValueError("token_limit 'encoding_name' must be a non-empty string")
+
+        model_name = raw.get("model_name")
+        if model_name is not None and (
+            not isinstance(model_name, str) or not model_name
+        ):
+            raise ValueError(
+                "token_limit 'model_name' must be a non-empty string when set"
+            )
+
+        return cls(limit=limit, encoding_name=encoding_name, model_name=model_name)
+
+    def build(self, action_on_hit: str) -> Any:
+        return TokenLimitOutputAdapter(
+            limit=self.limit,
+            encoding_name=self.encoding_name,
+            model_name=self.model_name,
+        )
+
+
 SCANNER_REGISTRY: dict[str, type] = {
     "ban_substrings": BanSubstringsConfig,
+    "invisible_text": InvisibleTextConfig,
     "regex": RegexConfig,
+    "token_limit": TokenLimitConfig,
 }
 
 

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -145,6 +145,7 @@ class SensitiveConfig:
         )
 
 
+# Adapts llm_guard's input-side InvisibleText scanner for output guardrails.
 class InvisibleTextOutputAdapter:
     def __init__(self) -> None:
         self._scanner = llm_guard_input_scanners.InvisibleText()
@@ -154,6 +155,7 @@ class InvisibleTextOutputAdapter:
         return sanitized_output, is_valid, score
 
 
+# Adapts llm_guard's input-side TokenLimit scanner for output guardrails.
 class TokenLimitOutputAdapter:
     def __init__(
         self,
@@ -258,6 +260,8 @@ class RegexConfig:
 
 
 @dataclass
+# Detects and removes invisible or non-printable Unicode characters that can
+# hide instructions or other steganographic content in model output.
 class InvisibleTextConfig:
     supports_redact: ClassVar[bool] = True
 
@@ -272,6 +276,9 @@ class InvisibleTextConfig:
 
 
 @dataclass
+# Enforces a maximum output token budget using llm_guard's tiktoken-based
+# counting. limit is the token cap, while encoding_name and model_name control
+# which tokenizer is used for counting.
 class TokenLimitConfig:
     supports_redact: ClassVar[bool] = True
     limit: int = 4096

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -109,6 +109,8 @@ class SecretsConfig:
 
 
 @dataclass
+# Detects common sensitive data such as email addresses, phone numbers,
+# credit cards, and IP addresses.
 class SensitiveConfig:
     supports_redact: ClassVar[bool] = True
     detectors: list[str]

--- a/presets/ragengine/guardrails/scanner_schemas.py
+++ b/presets/ragengine/guardrails/scanner_schemas.py
@@ -276,10 +276,9 @@ class InvisibleTextConfig:
 
 
 @dataclass
-# Enforces a maximum output token budget using llm_guard's tiktoken-based
-# counting. Outputs whose token count exceeds limit are marked invalid. This
-# limits tokens, not characters or words; encoding_name and model_name control
-# which tokenizer is used for counting.
+# Limits the token count of model output. Outputs that exceed limit are marked
+# invalid. This counts tokens, not characters or words; encoding_name and
+# model_name control which tokenizer is used for counting.
 class TokenLimitConfig:
     supports_redact: ClassVar[bool] = True
     limit: int = 4096

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -36,9 +36,9 @@ from ragengine.guardrails.scanner_schemas import (
     ParsedScannerConfig,
     ReadingTimeConfig,
     RegexConfig,
-    TokenLimitConfig,
     SecretsConfig,
     SensitiveConfig,
+    TokenLimitConfig,
 )
 from ragengine.metrics.prometheus_metrics import (
     guardrails_response_actions_total,

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -29,8 +29,10 @@ from ragengine.guardrails.output_guardrails import (
 )
 from ragengine.guardrails.scanner_schemas import (
     BanSubstringsConfig,
+    InvisibleTextConfig,
     ParsedScannerConfig,
     RegexConfig,
+    TokenLimitConfig,
 )
 from ragengine.models import ChatCompletionResponse
 
@@ -63,6 +65,22 @@ def _ban_subs_cfg(
         type="ban_substrings",
         action_on_hit=action_on_hit,
         config=BanSubstringsConfig(substrings=list(substrings), **kw),
+    )
+
+
+def _invisible_text_cfg(action_on_hit="redact") -> ParsedScannerConfig:
+    return ParsedScannerConfig(
+        type="invisible_text",
+        action_on_hit=action_on_hit,
+        config=InvisibleTextConfig(),
+    )
+
+
+def _token_limit_cfg(limit=10, action_on_hit="redact", **kw) -> ParsedScannerConfig:
+    return ParsedScannerConfig(
+        type="token_limit",
+        action_on_hit=action_on_hit,
+        config=TokenLimitConfig(limit=limit, **kw),
     )
 
 
@@ -144,6 +162,19 @@ def fake_llm_guard_scanners(monkeypatch):
             self.contains_all = contains_all
             self.redact = redact
 
+    class FakeInvisibleText:
+        def scan(self, prompt):
+            return prompt.replace("\u200b", ""), "\u200b" not in prompt, 1.0
+
+    class FakeTokenLimit:
+        def __init__(self, *, limit=4096, encoding_name="cl100k_base", model_name=None):
+            self.limit = limit
+            self.encoding_name = encoding_name
+            self.model_name = model_name
+
+        def scan(self, prompt):
+            return prompt[: self.limit], len(prompt) <= self.limit, 1.0
+
     monkeypatch.setattr(
         scanner_schemas_module.llm_guard_output_scanners,
         "Regex",
@@ -156,7 +187,19 @@ def fake_llm_guard_scanners(monkeypatch):
         FakeBanSubstrings,
         raising=False,
     )
-    return FakeRegex, FakeBanSubstrings
+    monkeypatch.setattr(
+        scanner_schemas_module.llm_guard_input_scanners,
+        "InvisibleText",
+        FakeInvisibleText,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        scanner_schemas_module.llm_guard_input_scanners,
+        "TokenLimit",
+        FakeTokenLimit,
+        raising=False,
+    )
+    return FakeRegex, FakeBanSubstrings, FakeInvisibleText, FakeTokenLimit
 
 
 # ---------------------------------------------------------------------------
@@ -331,6 +374,30 @@ def test_from_config_skips_invalid_scanners_and_filters_non_string_values(
     assert scanners[1].redact is True
 
 
+def test_from_config_loads_invisible_text_and_token_limit_scanners(
+    tmp_path, monkeypatch
+):
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: redact
+        scanners:
+          - type: invisible_text
+          - type: token_limit
+            limit: 128
+            encoding_name: cl100k_base
+        """,
+    )
+
+    guardrails = OutputGuardrails.from_config()
+
+    assert guardrails.scanner_configs == (
+        _invisible_text_cfg(),
+        _token_limit_cfg(limit=128, encoding_name="cl100k_base"),
+    )
+
+
 def test_from_config_with_empty_policy_path_keeps_defaults(monkeypatch):
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_ENABLED", True)
     monkeypatch.setattr(config, "OUTPUT_GUARDRAILS_POLICY_PATH", "")
@@ -481,6 +548,27 @@ def test_parse_policy_scanner_configs_rejects_non_bool_flags():
     assert parsed == (_ban_subs_cfg(substrings=["a"], case_sensitive=True),)
 
 
+def test_parse_policy_scanner_configs_rejects_invalid_invisible_text_and_token_limit_values():
+    parsed = output_guardrails_module._parse_policy_scanner_configs(
+        [
+            {"type": "invisible_text", "unexpected": True},
+            {"type": "token_limit", "limit": 0},
+            {"type": "token_limit", "limit": -1},
+            {"type": "token_limit", "limit": "many"},
+            {"type": "token_limit", "limit": 32, "encoding_name": ""},
+            {"type": "token_limit", "limit": 32, "model_name": ""},
+            {"type": "token_limit", "limit": 64, "encoding_name": "cl100k_base"},
+            {"type": "invisible_text"},
+        ],
+        "guardrails.yaml",
+    )
+
+    assert parsed == (
+        _token_limit_cfg(limit=64, encoding_name="cl100k_base"),
+        _invisible_text_cfg(),
+    )
+
+
 def test_parse_policy_scanner_configs_skips_redact_incompatible_scanners(
     monkeypatch,
 ):
@@ -549,7 +637,7 @@ def test_parse_policy_scanner_configs_allows_non_redact_scanners_for_block(
 def test_build_scanners_supports_normalized_ban_substrings_type(
     fake_llm_guard_scanners,
 ):
-    _, FakeBanSubstrings = fake_llm_guard_scanners
+    _, FakeBanSubstrings, _, _ = fake_llm_guard_scanners
 
     parsed = output_guardrails_module._parse_policy_scanner_configs(
         [{"type": "ban-substrings", "substrings": ["secret"]}],
@@ -587,6 +675,26 @@ def test_build_scanners_uses_per_scanner_action(fake_llm_guard_scanners):
 
     assert scanners[0].redact is True
     assert scanners[1].redact is False
+
+
+def test_build_scanners_builds_invisible_text_and_token_limit(fake_llm_guard_scanners):
+    _, _, FakeInvisibleText, FakeTokenLimit = fake_llm_guard_scanners
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        scanner_configs=(
+            _invisible_text_cfg(),
+            _token_limit_cfg(limit=32, encoding_name="cl100k_base"),
+        ),
+    )
+
+    scanners = guardrails._build_scanners()
+
+    assert len(scanners) == 2
+    assert isinstance(scanners[0]._scanner, FakeInvisibleText)
+    assert isinstance(scanners[1]._scanner, FakeTokenLimit)
+    assert scanners[1]._scanner.limit == 32
+    assert scanners[1]._scanner.encoding_name == "cl100k_base"
 
 
 def test_build_scanners_skips_configs_whose_build_raises(monkeypatch):
@@ -726,6 +834,50 @@ def test_guard_response_applies_action(
 
     out = guardrails.guard_response(_make_response("dirty"), {"messages": []})
     assert out.choices[0].message.content == expected_content
+
+
+def test_guard_response_with_real_invisible_text_scanner_redacts_output(
+    tmp_path, monkeypatch
+):
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: redact
+        scanners:
+          - type: invisible_text
+        """,
+    )
+
+    guardrails = OutputGuardrails.from_config()
+
+    out = guardrails.guard_response(
+        _make_response("hello\u200bworld"), {"messages": []}
+    )
+
+    assert out.choices[0].message.content == "helloworld"
+
+
+def test_guard_response_with_real_token_limit_scanner_truncates_output(
+    tmp_path, monkeypatch
+):
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        """
+        action: redact
+        scanners:
+          - type: token_limit
+            limit: 1
+            encoding_name: cl100k_base
+        """,
+    )
+
+    guardrails = OutputGuardrails.from_config()
+
+    out = guardrails.guard_response(_make_response("hello world"), {"messages": []})
+
+    assert out.choices[0].message.content == "hello"
 
 
 def test_guard_response_applies_mixed_scanner_actions_in_order(monkeypatch):

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -581,30 +581,30 @@ def test_from_config_loads_invisible_text_and_token_limit_scanners(
 
 
 def test_from_config_loads_json_and_reading_time_scanners(tmp_path, monkeypatch):
-        fifteen_seconds_in_minutes = 0.25
-        policy = (
-                "action: redact\n"
-                "scanners:\n"
-                "  - type: json\n"
-                "    required_elements: 1\n"
-                "    repair: false\n"
-                "  - type: reading_time\n"
-                "    max_time: 0.25\n"
-                "    truncate: true\n"
-        )
+    fifteen_seconds_in_minutes = 0.25
+    policy = (
+        "action: redact\n"
+        "scanners:\n"
+        "  - type: json\n"
+        "    required_elements: 1\n"
+        "    repair: false\n"
+        "  - type: reading_time\n"
+        "    max_time: 0.25\n"
+        "    truncate: true\n"
+    )
 
-        _write_policy(
-                tmp_path,
-                monkeypatch,
-                policy,
-        )
+    _write_policy(
+        tmp_path,
+        monkeypatch,
+        policy,
+    )
 
-        guardrails = OutputGuardrails.from_config()
+    guardrails = OutputGuardrails.from_config()
 
-        assert guardrails.scanner_configs == (
-                _json_cfg(required_elements=1, repair=False),
-                _reading_time_cfg(max_time=fifteen_seconds_in_minutes, truncate=True),
-        )
+    assert guardrails.scanner_configs == (
+        _json_cfg(required_elements=1, repair=False),
+        _reading_time_cfg(max_time=fifteen_seconds_in_minutes, truncate=True),
+    )
 
 
 def test_from_config_with_empty_policy_path_keeps_defaults(monkeypatch):
@@ -933,6 +933,8 @@ def test_build_scanners_uses_per_scanner_action(fake_llm_guard_scanners):
 
     assert scanners[0].redact is True
     assert scanners[1].redact is False
+
+
 def test_build_scanners_builds_invisible_text_and_token_limit(fake_llm_guard_scanners):
     _, _, FakeInvisibleText, FakeTokenLimit, _, _ = fake_llm_guard_scanners
 

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -955,6 +955,27 @@ def test_build_scanners_builds_invisible_text_and_token_limit(fake_llm_guard_sca
     assert scanners[1]._scanner.encoding_name == "cl100k_base"
 
 
+def test_build_scanners_forwards_token_limit_model_name(fake_llm_guard_scanners):
+    _, _, _, FakeTokenLimit, _, _ = fake_llm_guard_scanners
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        scanner_configs=(
+            _token_limit_cfg(
+                limit=32,
+                encoding_name="cl100k_base",
+                model_name="gpt-4",
+            ),
+        ),
+    )
+
+    scanners = guardrails._build_scanners()
+
+    assert len(scanners) == 1
+    assert isinstance(scanners[0]._scanner, FakeTokenLimit)
+    assert scanners[0]._scanner.model_name == "gpt-4"
+
+
 def test_build_scanners_builds_json_and_reading_time(fake_llm_guard_scanners):
     _, _, _, _, FakeJSON, FakeReadingTime = fake_llm_guard_scanners
 

--- a/presets/ragengine/tests/guardrails/testdata/invisible_text_token_limit_policy.yaml
+++ b/presets/ragengine/tests/guardrails/testdata/invisible_text_token_limit_policy.yaml
@@ -1,0 +1,6 @@
+action: redact
+scanners:
+  - type: invisible_text
+  - type: token_limit
+    limit: 128
+    encoding_name: cl100k_base

--- a/presets/ragengine/tests/test_default_guardrails_policy.py
+++ b/presets/ragengine/tests/test_default_guardrails_policy.py
@@ -84,7 +84,9 @@ def test_default_guardrails_policy_template_has_non_empty_scanners():
 
 
 def test_json_and_reading_time_policy_fixture_parses():
-    policy = yaml.safe_load(JSON_READING_TIME_TESTDATA_POLICY.read_text(encoding="utf-8"))
+    policy = yaml.safe_load(
+        JSON_READING_TIME_TESTDATA_POLICY.read_text(encoding="utf-8")
+    )
 
     parsed = _parse_policy_scanner_configs(
         policy.get("scanners"),

--- a/presets/ragengine/tests/test_default_guardrails_policy.py
+++ b/presets/ragengine/tests/test_default_guardrails_policy.py
@@ -25,6 +25,12 @@ CHART_TEMPLATE = (
     / "templates"
     / "guardrails-policy-configmap.yaml"
 )
+TESTDATA_POLICY = (
+    Path(__file__).resolve().parent
+    / "guardrails"
+    / "testdata"
+    / "invisible_text_token_limit_policy.yaml"
+)
 
 
 def _extract_default_policy_text() -> str:
@@ -65,3 +71,12 @@ def test_default_guardrails_policy_template_has_non_empty_scanners():
     assert parsed
     assert [scanner.type for scanner in parsed] == ["regex"]
     assert [scanner.action_on_hit for scanner in parsed] == ["redact"]
+
+
+def test_invisible_text_and_token_limit_policy_fixture_parses():
+    policy = yaml.safe_load(TESTDATA_POLICY.read_text(encoding="utf-8"))
+
+    parsed = _parse_policy_scanner_configs(policy.get("scanners"), str(TESTDATA_POLICY))
+
+    assert [scanner.type for scanner in parsed] == ["invisible_text", "token_limit"]
+    assert [scanner.action_on_hit for scanner in parsed] == ["redact", "redact"]


### PR DESCRIPTION
## Summary

Add two deterministic output guardrail scanners to RAGEngine:

- `invisible_text`
- `token_limit`

These scanners do not require an LLM and provide low-cost protection for hidden text and output token budget overruns.

## Changes

- add `InvisibleText` and `TokenLimit` scanner schemas to the guardrail scanner registry
- add output adapters that reuse llm-guard input-side deterministic scanner logic for output guardrails
- wire both scanners into policy parsing and runtime scanner construction
- add a policy fixture covering `invisible_text` and `token_limit`
- add unit tests for parser validation, scanner build behavior, runtime behavior, and invalid config handling

## Notes

- llm-guard `0.3.16` does not provide output-side `InvisibleText` or `TokenLimit` scanners
- this PR adapts the existing input-side deterministic scanner logic for output use
- default chart policy is unchanged