### PR TITLE
fix: add nodeSelector to local-csi-manager to prevent scheduling on Windows nodes

### DIFF
--- a/charts/kaito/workspace/values.yaml
+++ b/charts/kaito/workspace/values.yaml
@@ -142,6 +142,10 @@ local-csi-driver:
       pullPolicy: Always
     nodeDriverRegistrar:
       pullPolicy: Always
+  manager:
+    deployment:
+      nodeSelector:
+        kubernetes.io/os: linux
   daemonset:
     podSelector:
       app: csi-local-node


### PR DESCRIPTION
The `local-csi-manager` image (`mcr.microsoft.com/acstor/local-csi-manager`) is linux-only. Without a `nodeSelector`, it can be scheduled on Windows nodes in mixed-OS clusters, resulting in `ImagePullBackOff`:

```
Failed to pull image "mcr.microsoft.com/acstor/local-csi-manager:v0.2.9": 
no match for platform in manifest: not found
```

This adds `kubernetes.io/os: linux` to the manager deployment via the `local-csi-driver` subchart values override.

**Reproduction:**
1. Deploy KAITO workspace on a cluster with both Linux and Windows node pools
2. The `csi-local-manager` pod may be scheduled on a Windows node
3. Pod enters ImagePullBackOff because the image has no Windows platform

**Fix:**
Set `local-csi-driver.manager.deployment.nodeSelector` to `{kubernetes.io/os: linux}` in the workspace chart values.