### PR TITLE
feat: Add response-path guardrails metrics

### DIFF
--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -28,6 +28,8 @@ from ragengine.guardrails.scanner_schemas import (
 from ragengine.metrics.prometheus_metrics import (
     STATUS_FAILURE,
     STATUS_SUCCESS,
+    guardrails_response_actions_total,
+    guardrails_response_scanner_hits_total,
     output_guardrails_actions_total,
     output_guardrails_policy_load_total,
     output_guardrails_scanner_build_total,
@@ -38,6 +40,7 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BLOCK_MESSAGE = "The model output was blocked by output guardrails."
 DEFAULT_ACTION_ON_HIT = "redact"
+RESPONSE_STAGE = "response"
 
 
 class OutputGuardrailsError(RuntimeError):
@@ -145,7 +148,7 @@ class OutputGuardrails:
                     continue
 
                 sanitized_output = content
-                final_action = None
+                final_action = "allow"
                 triggered_scanners: list[dict[str, Any]] = []
                 for parsed, scanner in built_scanners:
                     scanner_action_on_hit = parsed.action_on_hit or self.action_on_hit
@@ -154,6 +157,12 @@ class OutputGuardrails:
                     )
                     if all(results_valid.values()):
                         continue
+
+                    guardrails_response_scanner_hits_total.labels(
+                        scanner_type=parsed.type,
+                        action=scanner_action_on_hit,
+                        stage=RESPONSE_STAGE,
+                    ).inc()
 
                     triggered_scanners.append(
                         {
@@ -169,6 +178,7 @@ class OutputGuardrails:
                     final_action = "redact"
 
                 if not triggered_scanners:
+                    self._record_response_action("allow")
                     continue
 
                 if final_action == "block":
@@ -176,6 +186,7 @@ class OutputGuardrails:
                 else:
                     message["content"] = sanitized_output
 
+                self._record_response_action(final_action)
                 output_guardrails_actions_total.labels(action=final_action).inc()
                 logger.info(
                     "output_guardrails_triggered action=%s response_id=%s scanners=%s policy_hash=%s",
@@ -187,6 +198,9 @@ class OutputGuardrails:
 
             return ChatCompletionResponse(**response_data)
         except Exception as exc:
+            self._record_response_action(
+                "fail_open" if self.fail_open else "fail_closed"
+            )
             logger.exception(
                 "output_guardrails_failed fail_open=%s response_id=%s",
                 self.fail_open,
@@ -200,6 +214,13 @@ class OutputGuardrails:
 
     def _build_scanners(self) -> list[Any]:
         return [scanner for _, scanner in self._build_scanners_with_configs()]
+
+    def _record_response_action(self, final_action: str) -> None:
+        guardrails_response_actions_total.labels(
+            final_action=final_action,
+            stage=RESPONSE_STAGE,
+            fail_open=str(self.fail_open).lower(),
+        ).inc()
 
     def _build_scanners_with_configs(self) -> list[tuple[ParsedScannerConfig, Any]]:
         scanners: list[tuple[ParsedScannerConfig, Any]] = []

--- a/presets/ragengine/guardrails/output_guardrails.py
+++ b/presets/ragengine/guardrails/output_guardrails.py
@@ -30,7 +30,6 @@ from ragengine.metrics.prometheus_metrics import (
     STATUS_SUCCESS,
     guardrails_response_actions_total,
     guardrails_response_scanner_hits_total,
-    output_guardrails_actions_total,
     output_guardrails_policy_load_total,
     output_guardrails_scanner_build_total,
 )
@@ -40,7 +39,6 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BLOCK_MESSAGE = "The model output was blocked by output guardrails."
 DEFAULT_ACTION_ON_HIT = "redact"
-RESPONSE_STAGE = "response"
 
 
 class OutputGuardrailsError(RuntimeError):
@@ -161,7 +159,6 @@ class OutputGuardrails:
                     guardrails_response_scanner_hits_total.labels(
                         scanner_type=parsed.type,
                         action=scanner_action_on_hit,
-                        stage=RESPONSE_STAGE,
                     ).inc()
 
                     triggered_scanners.append(
@@ -187,7 +184,6 @@ class OutputGuardrails:
                     message["content"] = sanitized_output
 
                 self._record_response_action(final_action)
-                output_guardrails_actions_total.labels(action=final_action).inc()
                 logger.info(
                     "output_guardrails_triggered action=%s response_id=%s scanners=%s policy_hash=%s",
                     final_action,
@@ -198,9 +194,8 @@ class OutputGuardrails:
 
             return ChatCompletionResponse(**response_data)
         except Exception as exc:
-            self._record_response_action(
-                "fail_open" if self.fail_open else "fail_closed"
-            )
+            if not self.fail_open:
+                self._record_response_action("fail_closed")
             logger.exception(
                 "output_guardrails_failed fail_open=%s response_id=%s",
                 self.fail_open,
@@ -218,8 +213,6 @@ class OutputGuardrails:
     def _record_response_action(self, final_action: str) -> None:
         guardrails_response_actions_total.labels(
             final_action=final_action,
-            stage=RESPONSE_STAGE,
-            fail_open=str(self.fail_open).lower(),
         ).inc()
 
     def _build_scanners_with_configs(self) -> list[tuple[ParsedScannerConfig, Any]]:

--- a/presets/ragengine/metrics/prometheus_metrics.py
+++ b/presets/ragengine/metrics/prometheus_metrics.py
@@ -309,11 +309,29 @@ RELOAD_RESULT_LABEL = "result"
 RELOAD_RESULT_SUCCESS = "success"
 RELOAD_RESULT_FAILURE = "failure"
 RELOAD_RESULT_NOOP = "noop"
+GUARDRAILS_SCANNER_TYPE_LABEL = "scanner_type"
+GUARDRAILS_FINAL_ACTION_LABEL = "final_action"
+GUARDRAILS_FAIL_OPEN_LABEL = "fail_open"
+GUARDRAILS_STAGE_LABEL = "stage"
 
 guardrails_policy_reload_total = Counter(
     "guardrails_policy_reload_total",
     "Count of output guardrails policy reload attempts.",
     labelnames=[RELOAD_RESULT_LABEL],
+)
+guardrails_response_scanner_hits_total = Counter(
+    "ragengine_guardrails_response_scanner_hits_total",
+    "Count of output guardrails scanner hits while scanning responses.",
+    labelnames=[GUARDRAILS_SCANNER_TYPE_LABEL, ACTION_LABEL, GUARDRAILS_STAGE_LABEL],
+)
+guardrails_response_actions_total = Counter(
+    "ragengine_guardrails_response_actions_total",
+    "Count of final output guardrails actions while scanning responses.",
+    labelnames=[
+        GUARDRAILS_FINAL_ACTION_LABEL,
+        GUARDRAILS_STAGE_LABEL,
+        GUARDRAILS_FAIL_OPEN_LABEL,
+    ],
 )
 guardrails_policy_loaded_timestamp = Gauge(
     "guardrails_policy_loaded_timestamp_seconds",

--- a/presets/ragengine/metrics/prometheus_metrics.py
+++ b/presets/ragengine/metrics/prometheus_metrics.py
@@ -311,7 +311,6 @@ RELOAD_RESULT_FAILURE = "failure"
 RELOAD_RESULT_NOOP = "noop"
 GUARDRAILS_SCANNER_TYPE_LABEL = "scanner_type"
 GUARDRAILS_FINAL_ACTION_LABEL = "final_action"
-GUARDRAILS_FAIL_OPEN_LABEL = "fail_open"
 GUARDRAILS_STAGE_LABEL = "stage"
 
 guardrails_policy_reload_total = Counter(
@@ -330,7 +329,6 @@ guardrails_response_actions_total = Counter(
     labelnames=[
         GUARDRAILS_FINAL_ACTION_LABEL,
         GUARDRAILS_STAGE_LABEL,
-        GUARDRAILS_FAIL_OPEN_LABEL,
     ],
 )
 guardrails_policy_loaded_timestamp = Gauge(

--- a/presets/ragengine/metrics/prometheus_metrics.py
+++ b/presets/ragengine/metrics/prometheus_metrics.py
@@ -311,7 +311,6 @@ RELOAD_RESULT_FAILURE = "failure"
 RELOAD_RESULT_NOOP = "noop"
 GUARDRAILS_SCANNER_TYPE_LABEL = "scanner_type"
 GUARDRAILS_FINAL_ACTION_LABEL = "final_action"
-GUARDRAILS_STAGE_LABEL = "stage"
 
 guardrails_policy_reload_total = Counter(
     "guardrails_policy_reload_total",
@@ -321,15 +320,12 @@ guardrails_policy_reload_total = Counter(
 guardrails_response_scanner_hits_total = Counter(
     "ragengine_guardrails_response_scanner_hits_total",
     "Count of output guardrails scanner hits while scanning responses.",
-    labelnames=[GUARDRAILS_SCANNER_TYPE_LABEL, ACTION_LABEL, GUARDRAILS_STAGE_LABEL],
+    labelnames=[GUARDRAILS_SCANNER_TYPE_LABEL, ACTION_LABEL],
 )
 guardrails_response_actions_total = Counter(
     "ragengine_guardrails_response_actions_total",
     "Count of final output guardrails actions while scanning responses.",
-    labelnames=[
-        GUARDRAILS_FINAL_ACTION_LABEL,
-        GUARDRAILS_STAGE_LABEL,
-    ],
+    labelnames=[GUARDRAILS_FINAL_ACTION_LABEL],
 )
 guardrails_policy_loaded_timestamp = Gauge(
     "guardrails_policy_loaded_timestamp_seconds",

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -36,7 +36,6 @@ from ragengine.guardrails.scanner_schemas import (
 from ragengine.metrics.prometheus_metrics import (
     guardrails_response_actions_total,
     guardrails_response_scanner_hits_total,
-    output_guardrails_actions_total,
     output_guardrails_policy_load_total,
     output_guardrails_scanner_build_total,
 )
@@ -761,8 +760,6 @@ def test_guard_response_passes_through_when_no_scanner_triggered(monkeypatch):
     before = _counter_value(
         guardrails_response_actions_total,
         final_action="allow",
-        stage="response",
-        fail_open="true",
     )
 
     _patch_scan_output(
@@ -785,21 +782,12 @@ def test_guard_response_passes_through_when_no_scanner_triggered(monkeypatch):
         _counter_value(
             guardrails_response_actions_total,
             final_action="allow",
-            stage="response",
-            fail_open="true",
         )
         == before + 1
     )
 
 
 def test_guard_response_recovers_when_scan_output_raises(monkeypatch):
-    before = _counter_value(
-        guardrails_response_actions_total,
-        final_action="fail_open",
-        stage="response",
-        fail_open="true",
-    )
-
     def _boom(*args, **kwargs):
         raise RuntimeError("scanner exploded")
 
@@ -813,15 +801,6 @@ def test_guard_response_recovers_when_scan_output_raises(monkeypatch):
 
     # Internal failure must degrade safely: return the original response object.
     assert guardrails.guard_response(response, {"messages": []}) is response
-    assert (
-        _counter_value(
-            guardrails_response_actions_total,
-            final_action="fail_open",
-            stage="response",
-            fail_open="true",
-        )
-        == before + 1
-    )
 
 
 @pytest.mark.parametrize(
@@ -837,8 +816,6 @@ def test_guard_response_applies_action(
     response_before = _counter_value(
         guardrails_response_actions_total,
         final_action=action,
-        stage="response",
-        fail_open="true",
     )
 
     _patch_scan_output(
@@ -857,17 +834,12 @@ def test_guard_response_applies_action(
         scanner_configs=[_regex_cfg(patterns=[r"\S+"], action_on_hit=action)],
     )
 
-    before = _counter_value(output_guardrails_actions_total, action=action)
-
     out = guardrails.guard_response(_make_response("dirty"), {"messages": []})
     assert out.choices[0].message.content == expected_content
-    assert _counter_value(output_guardrails_actions_total, action=action) == before + 1
     assert (
         _counter_value(
             guardrails_response_actions_total,
             final_action=action,
-            stage="response",
-            fail_open="true",
         )
         == response_before + 1
     )
@@ -878,7 +850,6 @@ def test_guard_response_increments_hit_metric(monkeypatch):
         guardrails_response_scanner_hits_total,
         scanner_type="regex",
         action="redact",
-        stage="response",
     )
 
     _patch_scan_output(
@@ -902,7 +873,6 @@ def test_guard_response_increments_hit_metric(monkeypatch):
             guardrails_response_scanner_hits_total,
             scanner_type="regex",
             action="redact",
-            stage="response",
         )
         == before + 1
     )
@@ -912,8 +882,6 @@ def test_guard_response_increments_fail_closed_metric(monkeypatch):
     before = _counter_value(
         guardrails_response_actions_total,
         final_action="fail_closed",
-        stage="response",
-        fail_open="false",
     )
 
     def _boom(*args, **kwargs):
@@ -934,8 +902,6 @@ def test_guard_response_increments_fail_closed_metric(monkeypatch):
         _counter_value(
             guardrails_response_actions_total,
             final_action="fail_closed",
-            stage="response",
-            fail_open="false",
         )
         == before + 1
     )

--- a/presets/ragengine/tests/guardrails/test_output_guardrails.py
+++ b/presets/ragengine/tests/guardrails/test_output_guardrails.py
@@ -34,6 +34,8 @@ from ragengine.guardrails.scanner_schemas import (
     RegexConfig,
 )
 from ragengine.metrics.prometheus_metrics import (
+    guardrails_response_actions_total,
+    guardrails_response_scanner_hits_total,
     output_guardrails_actions_total,
     output_guardrails_policy_load_total,
     output_guardrails_scanner_build_total,
@@ -756,6 +758,13 @@ def test_guard_response_skips_non_string_content(monkeypatch):
 
 
 def test_guard_response_passes_through_when_no_scanner_triggered(monkeypatch):
+    before = _counter_value(
+        guardrails_response_actions_total,
+        final_action="allow",
+        stage="response",
+        fail_open="true",
+    )
+
     _patch_scan_output(
         monkeypatch,
         lambda scanners, prompt, output, fail_fast: (
@@ -772,9 +781,25 @@ def test_guard_response_passes_through_when_no_scanner_triggered(monkeypatch):
 
     out = guardrails.guard_response(_make_response("clean output"), {"messages": []})
     assert out.choices[0].message.content == "clean output"
+    assert (
+        _counter_value(
+            guardrails_response_actions_total,
+            final_action="allow",
+            stage="response",
+            fail_open="true",
+        )
+        == before + 1
+    )
 
 
 def test_guard_response_recovers_when_scan_output_raises(monkeypatch):
+    before = _counter_value(
+        guardrails_response_actions_total,
+        final_action="fail_open",
+        stage="response",
+        fail_open="true",
+    )
+
     def _boom(*args, **kwargs):
         raise RuntimeError("scanner exploded")
 
@@ -788,6 +813,15 @@ def test_guard_response_recovers_when_scan_output_raises(monkeypatch):
 
     # Internal failure must degrade safely: return the original response object.
     assert guardrails.guard_response(response, {"messages": []}) is response
+    assert (
+        _counter_value(
+            guardrails_response_actions_total,
+            final_action="fail_open",
+            stage="response",
+            fail_open="true",
+        )
+        == before + 1
+    )
 
 
 @pytest.mark.parametrize(
@@ -800,6 +834,13 @@ def test_guard_response_recovers_when_scan_output_raises(monkeypatch):
 def test_guard_response_applies_action(
     monkeypatch, action, block_message, expected_content
 ):
+    response_before = _counter_value(
+        guardrails_response_actions_total,
+        final_action=action,
+        stage="response",
+        fail_open="true",
+    )
+
     _patch_scan_output(
         monkeypatch,
         lambda scanners, prompt, output, fail_fast: (
@@ -821,6 +862,83 @@ def test_guard_response_applies_action(
     out = guardrails.guard_response(_make_response("dirty"), {"messages": []})
     assert out.choices[0].message.content == expected_content
     assert _counter_value(output_guardrails_actions_total, action=action) == before + 1
+    assert (
+        _counter_value(
+            guardrails_response_actions_total,
+            final_action=action,
+            stage="response",
+            fail_open="true",
+        )
+        == response_before + 1
+    )
+
+
+def test_guard_response_increments_hit_metric(monkeypatch):
+    before = _counter_value(
+        guardrails_response_scanner_hits_total,
+        scanner_type="regex",
+        action="redact",
+        stage="response",
+    )
+
+    _patch_scan_output(
+        monkeypatch,
+        lambda scanners, prompt, output, fail_fast: (
+            "REDACTED-CONTENT",
+            {"regex": False},
+            {"regex": 0.9},
+        ),
+    )
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        scanner_configs=(_regex_cfg(patterns=[r"\S+"], action_on_hit="redact"),),
+    )
+
+    guardrails.guard_response(_make_response("dirty"), {"messages": []})
+
+    assert (
+        _counter_value(
+            guardrails_response_scanner_hits_total,
+            scanner_type="regex",
+            action="redact",
+            stage="response",
+        )
+        == before + 1
+    )
+
+
+def test_guard_response_increments_fail_closed_metric(monkeypatch):
+    before = _counter_value(
+        guardrails_response_actions_total,
+        final_action="fail_closed",
+        stage="response",
+        fail_open="false",
+    )
+
+    def _boom(*args, **kwargs):
+        raise RuntimeError("scanner exploded")
+
+    _patch_scan_output(monkeypatch, _boom)
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        fail_open=False,
+        scanner_configs=(_regex_cfg(patterns=[r"\S+"]),),
+    )
+
+    with pytest.raises(output_guardrails_module.OutputGuardrailsError):
+        guardrails.guard_response(_make_response("dirty"), {"messages": []})
+
+    assert (
+        _counter_value(
+            guardrails_response_actions_total,
+            final_action="fail_closed",
+            stage="response",
+            fail_open="false",
+        )
+        == before + 1
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR adds response-path observability for output guardrails.

It introduces:
- a counter for per-scanner response hits
- a counter for final response outcomes

The runtime now records `allow`, `redact`, `block`, and `fail_closed` outcomes in `guard_response()`, and the PR adds focused unit tests for this behavior.

## Out of scope

- reload metrics
- policy state exposure
- broader logging changes
- input or streaming metrics