### PR TITLE
fix: allow scaling InferenceSet replicas to 0

### DIFF
--- a/api/v1alpha1/inferenceset_default.go
+++ b/api/v1alpha1/inferenceset_default.go
@@ -19,11 +19,7 @@ import (
 
 // SetDefaults for the InferenceSet
 func (w *InferenceSet) SetDefaults(_ context.Context) {
-	// Default replicas to 1 if not set or explicitly set to 0.
-	// This ensures that InferenceSets always have at least one workspace.
-	// Note: Since Replicas is an int (not *int), the zero value (0) is
-	// indistinguishable from an omitted field after unmarshaling.
-	if w.Spec.Replicas == 0 {
-		w.Spec.Replicas = 1
-	}
+	// No-op: the CRD schema default (+kubebuilder:default:=1) handles
+	// the case where replicas is omitted. Explicit 0 is now valid
+	// for scale-to-zero scenarios (KEDA, manual drain, etc.).
 }

--- a/api/v1alpha1/inferenceset_types.go
+++ b/api/v1alpha1/inferenceset_types.go
@@ -46,8 +46,8 @@ type InferenceSetSpec struct {
 	// Replicas is the desired number of workspaces to be created.
 	// +optional
 	// +kubebuilder:default:=1
-	// +kubebuilder:validation:Minimum=1
-	Replicas int `json:"replicas,omitempty"`
+	// +kubebuilder:validation:Minimum=0
+	Replicas *int32 `json:"replicas,omitempty"`
 	// NodeCountLimit is the maximum number of GPU nodes that can be created for the InferenceSet.
 	// If not specified, there is no limit on the number of GPU nodes that can be created.
 	// +optional

--- a/api/v1alpha1/inferenceset_validation.go
+++ b/api/v1alpha1/inferenceset_validation.go
@@ -51,9 +51,9 @@ func (is *InferenceSet) Validate(ctx context.Context) (errs *apis.FieldError) {
 }
 
 func (is *InferenceSet) validateCreate() (errs *apis.FieldError) {
-	// Validate replicas is at least 1
-	if is.Spec.Replicas < 1 {
-		errs = errs.Also(apis.ErrInvalidValue(is.Spec.Replicas, "replicas", "must be at least 1"))
+	// Validate replicas is non-negative
+	if is.Spec.Replicas != nil && *is.Spec.Replicas < 0 {
+		errs = errs.Also(apis.ErrInvalidValue(*is.Spec.Replicas, "replicas", "must be non-negative"))
 	}
 	return errs
 }

--- a/api/v1alpha1/inferenceset_validation_test.go
+++ b/api/v1alpha1/inferenceset_validation_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"knative.dev/pkg/apis"
 )
 
 func TestInferenceSet_SupportedVerbs(t *testing.T) {
@@ -48,26 +49,27 @@ func TestInferenceSet_SupportedVerbs(t *testing.T) {
 	}
 }
 
+func ptrInt32(i int32) *int32 { return &i }
 func TestInferenceSet_SetDefaults(t *testing.T) {
 	tests := []struct {
 		name            string
 		inferenceset    *InferenceSet
-		expectedReplica int
+		expectedReplica *int32
 	}{
 		{
-			name: "replicas should default to 1 when not set",
+			name: "explicit replicas 0 is preserved by SetDefaults (scale-to-zero)",
 			inferenceset: &InferenceSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-inferenceset",
 					Namespace: "default",
 				},
 				Spec: InferenceSetSpec{
-					// Replicas omitted - represented as 0 (zero value for int)
-					// This simulates what happens when the field is not present in YAML/JSON
-					Replicas: 0,
+					// Explicit 0 should not be overridden by SetDefaults.
+					// The CRD schema default handles the truly-omitted case at admission time.
+					Replicas: ptrInt32(0),
 				},
 			},
-			expectedReplica: 1,
+			expectedReplica: ptrInt32(0),
 		},
 		{
 			name: "replicas should not change when already set",
@@ -77,10 +79,10 @@ func TestInferenceSet_SetDefaults(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: InferenceSetSpec{
-					Replicas: 3,
+					Replicas: ptrInt32(3),
 				},
 			},
-			expectedReplica: 3,
+			expectedReplica: ptrInt32(3),
 		},
 	}
 
@@ -109,7 +111,7 @@ func TestInferenceSet_Validate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: InferenceSetSpec{
-					Replicas: 1,
+					Replicas: ptrInt32(1),
 				},
 			},
 			oldIS:   nil,
@@ -123,7 +125,7 @@ func TestInferenceSet_Validate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: InferenceSetSpec{
-					Replicas: 1,
+					Replicas: ptrInt32(1),
 				},
 			},
 			oldIS:    nil,
@@ -138,7 +140,7 @@ func TestInferenceSet_Validate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: InferenceSetSpec{
-					Replicas: 1,
+					Replicas: ptrInt32(1),
 				},
 			},
 			oldIS:    nil,
@@ -153,7 +155,7 @@ func TestInferenceSet_Validate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: InferenceSetSpec{
-					Replicas: 1,
+					Replicas: ptrInt32(1),
 				},
 			},
 			oldIS:    nil,
@@ -168,7 +170,7 @@ func TestInferenceSet_Validate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: InferenceSetSpec{
-					Replicas: 1,
+					Replicas: ptrInt32(1),
 				},
 			},
 			oldIS: &InferenceSet{
@@ -177,25 +179,24 @@ func TestInferenceSet_Validate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: InferenceSetSpec{
-					Replicas: 1,
+					Replicas: ptrInt32(1),
 				},
 			},
 			wantErr: false,
 		},
 		{
-			name: "invalid replicas value less than 1",
+			name: "valid replicas value 0 (scale-to-zero)",
 			inferencSet: &InferenceSet{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "valid-name",
 					Namespace: "default",
 				},
 				Spec: InferenceSetSpec{
-					Replicas: 0,
+					Replicas: ptrInt32(0),
 				},
 			},
-			oldIS:    nil,
-			wantErr:  true,
-			errField: "replicas",
+			oldIS:   nil,
+			wantErr: false,
 		},
 		{
 			name: "invalid replicas negative value",
@@ -205,7 +206,7 @@ func TestInferenceSet_Validate(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: InferenceSetSpec{
-					Replicas: -1,
+					Replicas: ptrInt32(-1),
 				},
 			},
 			oldIS:    nil,
@@ -217,6 +218,9 @@ func TestInferenceSet_Validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
+			if tt.oldIS != nil {
+				ctx = apis.WithinUpdate(ctx, tt.oldIS)
+			}
 			err := tt.inferencSet.Validate(ctx)
 			if tt.wantErr {
 				assert.NotNil(t, err)
@@ -241,29 +245,38 @@ func TestInferenceSet_validateCreate(t *testing.T) {
 			name: "valid replicas value",
 			is: &InferenceSet{
 				Spec: InferenceSetSpec{
-					Replicas: 1,
+					Replicas: ptrInt32(1),
 				},
 			},
 			wantErr: false,
 		},
 		{
-			name: "invalid replicas value 0",
+			name: "valid replicas value 0 (scale-to-zero)",
 			is: &InferenceSet{
 				Spec: InferenceSetSpec{
-					Replicas: 0,
+					Replicas: ptrInt32(0),
 				},
 			},
-			wantErr:  true,
-			errField: "replicas",
+			wantErr: false,
 		},
 		{
 			name: "valid replicas value greater than 1",
 			is: &InferenceSet{
 				Spec: InferenceSetSpec{
-					Replicas: 5,
+					Replicas: ptrInt32(5),
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "invalid negative replicas value",
+			is: &InferenceSet{
+				Spec: InferenceSetSpec{
+					Replicas: ptrInt32(-1),
+				},
+			},
+			wantErr:  true,
+			errField: "replicas",
 		},
 	}
 

--- a/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
+++ b/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
@@ -109,7 +109,7 @@ spec:
               replicas:
                 default: 1
                 description: Replicas is the desired number of workspaces to be created.
-                minimum: 1
+                minimum: 0
                 type: integer
               template:
                 description: Template is the template used to create the InferenceSet.

--- a/config/crd/bases/kaito.sh_inferencesets.yaml
+++ b/config/crd/bases/kaito.sh_inferencesets.yaml
@@ -109,7 +109,7 @@ spec:
               replicas:
                 default: 1
                 description: Replicas is the desired number of workspaces to be created.
-                minimum: 1
+                minimum: 0
                 type: integer
               template:
                 description: Template is the template used to create the InferenceSet.

--- a/pkg/controllers/multiroleinference/controller.go
+++ b/pkg/controllers/multiroleinference/controller.go
@@ -389,7 +389,7 @@ func (r *MultiRoleInferenceReconciler) reconcileInferenceSet(
 		// Spec — only reconcile replicas when explicitly set (non-nil).
 		// When nil, autoscaling is assumed and the controller skips replica reconciliation.
 		if role.Replicas != nil {
-			desired.Spec.Replicas = int(*role.Replicas)
+			desired.Spec.Replicas = role.Replicas
 		}
 
 		// LabelSelector — start from the MRI's labelSelector and inject role info.

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -209,12 +209,16 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 	if err != nil {
 		return ctrl.Result{}, err
 	}
-	klog.InfoS("Found workspaces for inference set", "name", iObj.Name, "current", len(wsList.Items), "desired", iObj.Spec.Replicas)
+	desiredReplicas := int32(1)
+	if iObj.Spec.Replicas != nil {
+		desiredReplicas = *iObj.Spec.Replicas
+	}
+	klog.InfoS("Found workspaces for inference set", "name", iObj.Name, "current", len(wsList.Items), "desired", desiredReplicas)
 
-	replicaNumToDelete := len(wsList.Items) - iObj.Spec.Replicas
+	replicaNumToDelete := len(wsList.Items) - int(desiredReplicas)
 	var deletingWorkspaces []string
 	if replicaNumToDelete > 0 {
-		klog.InfoS("Found extra workspaces, deleting...", "current", len(wsList.Items), "desired", iObj.Spec.Replicas)
+		klog.InfoS("Found extra workspaces, deleting...", "current", len(wsList.Items), "desired", desiredReplicas)
 		// first delete workspace that is not in ready state
 		for _, ws := range wsList.Items {
 			if !ws.DeletionTimestamp.IsZero() {
@@ -266,9 +270,9 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 		}
 	}
 
-	replicaNumToCreate := iObj.Spec.Replicas - len(wsList.Items)
+	replicaNumToCreate := int(desiredReplicas) - len(wsList.Items)
 	if replicaNumToCreate > 0 {
-		klog.InfoS("Need to create more workspaces...", "current", len(wsList.Items), "desired", iObj.Spec.Replicas)
+		klog.InfoS("Need to create more workspaces...", "current", len(wsList.Items), "desired", desiredReplicas)
 		for i := range replicaNumToCreate {
 			workspaceObj := &kaitov1beta1.Workspace{}
 			workspaceObj.GenerateName = iObj.Name + "-"
@@ -315,7 +319,7 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 
 	// update the replicas in the status
 	if err = inferenceset.UpdateInferenceSetStatus(ctx, c.Client, &client.ObjectKey{Name: iObj.Name, Namespace: iObj.Namespace}, func(status *kaitov1alpha1.InferenceSetStatus) error {
-		status.Replicas = iObj.Spec.Replicas
+		status.Replicas = int(desiredReplicas)
 		status.ReadyReplicas = readyReplicas
 		// set selector for HPA/VPA
 		status.Selector = fmt.Sprintf("%s=%s", consts.WorkspaceCreatedByInferenceSetLabel, iObj.Name)
@@ -359,7 +363,7 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 		return reconcile.Result{}, err
 	}
 
-	if readyReplicas == iObj.Spec.Replicas {
+	if readyReplicas == int(desiredReplicas) {
 		if err = inferenceset.UpdateStatusConditionIfNotMatch(ctx, c.Client, iObj, kaitov1alpha1.InferenceSetConditionTypeReady, metav1.ConditionTrue,
 			"inferencesetReady", "inferenceset is ready"); err != nil {
 			klog.ErrorS(err, "failed to update inferenceset status", "inferenceset", klog.KObj(iObj))
@@ -367,7 +371,7 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 		}
 	} else {
 		if err = inferenceset.UpdateStatusConditionIfNotMatch(ctx, c.Client, iObj, kaitov1alpha1.InferenceSetConditionTypeReady, metav1.ConditionFalse,
-			"inferencesetNotReady", fmt.Sprintf("inferenceset is not ready, %d/%d replicas are ready", readyReplicas, iObj.Spec.Replicas)); err != nil {
+			"inferencesetNotReady", fmt.Sprintf("inferenceset is not ready, %d/%d replicas are ready", readyReplicas, desiredReplicas)); err != nil {
 			klog.ErrorS(err, "failed to update inferenceset status", "inferenceset", klog.KObj(iObj))
 			return reconcile.Result{}, err
 		}
@@ -375,15 +379,15 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 
 	// Surface benchmark progress when the annotation is set.
 	if kaitov1alpha1.ShouldRunBenchmark(iObj) {
-		if benchmarkedReplicas == iObj.Spec.Replicas && iObj.Spec.Replicas > 0 {
+		if benchmarkedReplicas == int(desiredReplicas) && desiredReplicas > 0 {
 			if err = inferenceset.UpdateStatusConditionIfNotMatch(ctx, c.Client, iObj, kaitov1alpha1.InferenceSetConditionTypeBenchmarkCompleted, metav1.ConditionTrue,
-				"BenchmarkCompleted", fmt.Sprintf("%d/%d replicas benchmarked", benchmarkedReplicas, iObj.Spec.Replicas)); err != nil {
+				"BenchmarkCompleted", fmt.Sprintf("%d/%d replicas benchmarked", benchmarkedReplicas, desiredReplicas)); err != nil {
 				klog.ErrorS(err, "failed to update inferenceset benchmark status", "inferenceset", klog.KObj(iObj))
 				return reconcile.Result{}, err
 			}
 		} else {
 			if err = inferenceset.UpdateStatusConditionIfNotMatch(ctx, c.Client, iObj, kaitov1alpha1.InferenceSetConditionTypeBenchmarkCompleted, metav1.ConditionFalse,
-				"BenchmarkPending", fmt.Sprintf("%d/%d replicas benchmarked", benchmarkedReplicas, iObj.Spec.Replicas)); err != nil {
+				"BenchmarkPending", fmt.Sprintf("%d/%d replicas benchmarked", benchmarkedReplicas, desiredReplicas)); err != nil {
 				klog.ErrorS(err, "failed to update inferenceset benchmark status", "inferenceset", klog.KObj(iObj))
 				return reconcile.Result{}, err
 			}

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -23,6 +23,7 @@ import (
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	appsv1 "k8s.io/api/apps/v1"
@@ -391,7 +392,7 @@ func TestInferenceSetBenchmarkAggregation(t *testing.T) {
 	makeInferenceSet := func(replicas int, benchmarkOff bool) *v1alpha1.InferenceSet {
 		iObj := &v1alpha1.InferenceSet{
 			ObjectMeta: v1.ObjectMeta{Name: "phi-4-mini", Namespace: "default"},
-			Spec:       v1alpha1.InferenceSetSpec{Replicas: replicas},
+			Spec:       v1alpha1.InferenceSetSpec{Replicas: lo.ToPtr(int32(replicas))},
 		}
 		if benchmarkOff {
 			iObj.Annotations = map[string]string{
@@ -464,6 +465,14 @@ func TestInferenceSetBenchmarkAggregation(t *testing.T) {
 			expectBenchmarkStatus: v1.ConditionFalse,
 			expectBenchmarkMsg:    "2/3 replicas benchmarked",
 		},
+		"zero replicas (scale-to-zero) — benchmark not applicable": {
+			workspaces:            []v1beta1.Workspace{},
+			inferenceset:          makeInferenceSet(0, false),
+			expectedTPM:           "",
+			expectBenchmarkCond:   true,
+			expectBenchmarkStatus: v1.ConditionFalse,
+			expectBenchmarkMsg:    "0/0 replicas benchmarked",
+		},
 	}
 
 	for name, tc := range tests {
@@ -486,14 +495,14 @@ func TestInferenceSetBenchmarkAggregation(t *testing.T) {
 
 			assert.True(t, v1alpha1.IsRunBenchmarkEnabled(tc.inferenceset))
 
-			allBenchmarked := benchmarkedReplicas == tc.inferenceset.Spec.Replicas && tc.inferenceset.Spec.Replicas > 0
+			allBenchmarked := tc.inferenceset.Spec.Replicas != nil && benchmarkedReplicas == int(*tc.inferenceset.Spec.Replicas) && *tc.inferenceset.Spec.Replicas > 0
 			if tc.expectBenchmarkStatus == v1.ConditionTrue {
 				assert.True(t, allBenchmarked)
 			} else {
 				assert.False(t, allBenchmarked)
 			}
 			assert.Equal(t, tc.expectBenchmarkMsg,
-				fmt.Sprintf("%d/%d replicas benchmarked", benchmarkedReplicas, tc.inferenceset.Spec.Replicas))
+				fmt.Sprintf("%d/%d replicas benchmarked", benchmarkedReplicas, *tc.inferenceset.Spec.Replicas))
 		})
 	}
 }

--- a/pkg/utils/inferenceset/inferenceset_test.go
+++ b/pkg/utils/inferenceset/inferenceset_test.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -529,7 +530,7 @@ func TestComputeInferenceSetHash(t *testing.T) {
 				},
 			},
 			Spec: kaitov1alpha1.InferenceSetSpec{
-				Replicas: 3,
+				Replicas: lo.ToPtr(int32(3)),
 			},
 		}
 
@@ -549,7 +550,7 @@ func TestComputeInferenceSetHash(t *testing.T) {
 				Namespace: "default",
 			},
 			Spec: kaitov1alpha1.InferenceSetSpec{
-				Replicas: 3,
+				Replicas: lo.ToPtr(int32(3)),
 			},
 		}
 
@@ -559,7 +560,7 @@ func TestComputeInferenceSetHash(t *testing.T) {
 				Namespace: "default",
 			},
 			Spec: kaitov1alpha1.InferenceSetSpec{
-				Replicas: 3,
+				Replicas: lo.ToPtr(int32(3)),
 			},
 		}
 
@@ -576,7 +577,7 @@ func TestComputeInferenceSetHash(t *testing.T) {
 				Namespace: "default",
 			},
 			Spec: kaitov1alpha1.InferenceSetSpec{
-				Replicas: 3,
+				Replicas: lo.ToPtr(int32(3)),
 			},
 		}
 
@@ -586,7 +587,7 @@ func TestComputeInferenceSetHash(t *testing.T) {
 				Namespace: "default",
 			},
 			Spec: kaitov1alpha1.InferenceSetSpec{
-				Replicas: 5,
+				Replicas: lo.ToPtr(int32(5)),
 			},
 		}
 
@@ -603,7 +604,7 @@ func TestComputeInferenceSetHash(t *testing.T) {
 				Namespace: "default",
 			},
 			Spec: kaitov1alpha1.InferenceSetSpec{
-				Replicas: 3,
+				Replicas: lo.ToPtr(int32(3)),
 			},
 			Status: kaitov1alpha1.InferenceSetStatus{
 				Conditions: []metav1.Condition{},
@@ -616,7 +617,7 @@ func TestComputeInferenceSetHash(t *testing.T) {
 				Namespace: "default",
 			},
 			Spec: kaitov1alpha1.InferenceSetSpec{
-				Replicas: 3,
+				Replicas: lo.ToPtr(int32(3)),
 			},
 			Status: kaitov1alpha1.InferenceSetStatus{
 				Conditions: []metav1.Condition{
@@ -655,7 +656,7 @@ func TestComputeInferenceSetHash(t *testing.T) {
 				},
 			},
 			Spec: kaitov1alpha1.InferenceSetSpec{
-				Replicas: 3,
+				Replicas: lo.ToPtr(int32(3)),
 			},
 		}
 
@@ -668,7 +669,7 @@ func TestComputeInferenceSetHash(t *testing.T) {
 				},
 			},
 			Spec: kaitov1alpha1.InferenceSetSpec{
-				Replicas: 3,
+				Replicas: lo.ToPtr(int32(3)),
 			},
 		}
 
@@ -691,7 +692,7 @@ func TestMarshalInferenceSetFields(t *testing.T) {
 	t.Run("Should marshal InferenceSet fields successfully", func(t *testing.T) {
 		inferenceset := &kaitov1alpha1.InferenceSet{
 			Spec: kaitov1alpha1.InferenceSetSpec{
-				Replicas: 3,
+				Replicas: lo.ToPtr(int32(3)),
 			},
 		}
 
@@ -740,7 +741,7 @@ func TestMarshalInferenceSetFields(t *testing.T) {
 	t.Run("Should exclude Status field", func(t *testing.T) {
 		inferenceset := &kaitov1alpha1.InferenceSet{
 			Spec: kaitov1alpha1.InferenceSetSpec{
-				Replicas: 3,
+				Replicas: lo.ToPtr(int32(3)),
 			},
 			Status: kaitov1alpha1.InferenceSetStatus{
 				Conditions: []metav1.Condition{
@@ -785,7 +786,7 @@ func TestMarshalInferenceSetFields(t *testing.T) {
 				},
 			},
 			Spec: kaitov1alpha1.InferenceSetSpec{
-				Replicas: 5,
+				Replicas: lo.ToPtr(int32(5)),
 			},
 		}
 
@@ -807,7 +808,7 @@ func TestMarshalInferenceSetFields(t *testing.T) {
 				Namespace: "default",
 			},
 			Spec: kaitov1alpha1.InferenceSetSpec{
-				Replicas: 3,
+				Replicas: lo.ToPtr(int32(3)),
 			},
 		}
 

--- a/pkg/workspace/controllers/workspace_controller_test.go
+++ b/pkg/workspace/controllers/workspace_controller_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	appsv1 "k8s.io/api/apps/v1"
@@ -1013,7 +1014,7 @@ func TestSyncWorkspaceStatus(t *testing.T) {
 			statefulSet: &appsv1.StatefulSet{
 				ObjectMeta: v1.ObjectMeta{Name: test.MockWorkspaceDistributedModel.Name, Namespace: test.MockWorkspaceDistributedModel.Namespace},
 				Spec: appsv1.StatefulSetSpec{
-					Replicas: func() *int32 { c := int32(1); return &c }(),
+					Replicas: lo.ToPtr(int32(1)),
 				},
 				Status: appsv1.StatefulSetStatus{ReadyReplicas: 1},
 			},

--- a/test/e2e/utils/utils.go
+++ b/test/e2e/utils/utils.go
@@ -334,7 +334,7 @@ func GenerateInferenceSetManifest(name, namespace, imageName string, replicas in
 			Namespace: namespace,
 		},
 		Spec: kaitov1alpha1.InferenceSetSpec{
-			Replicas: replicas,
+			Replicas: lo.ToPtr(int32(replicas)),
 			Selector: labelSelector,
 			Template: kaitov1alpha1.InferenceSetTemplate{
 				Resource: kaitov1alpha1.InferenceSetResourceSpec{


### PR DESCRIPTION
**Problem:**
`kubectl scale inferenceset <name> --replicas=0` fails with:
```
The InferenceSet "phi-4" is invalid: spec.replicas: Invalid value: 0: spec.replicas in body should be greater than or equal to 1
```

**Why scale-to-zero matters:**
- KEDA scale-to-zero during idle periods to save GPU costs
- Manual drain before maintenance
- Controlled rollout (scale down one role while keeping another)

**Changes:**
1. Changed `InferenceSetSpec.Replicas` from `int` to `*int32` — explicit 0 is now always serialized (won't be dropped by `omitempty`) and distinguishable from "not set" (nil → CRD default of 1 applies at admission)
2. Removed webhook defaulting that coerced 0→1 (no longer needed with pointer type)
3. Updated validation to reject only negative values (not 0)
4. Regenerated CRD manifests (`config/crd/bases/` and Helm chart) with `minimum: 0`
5. Updated `MultiRoleInference` controller to assign pointer directly
6. Updated all tests for pointer type

**Note:** This is an API type change (`int` → `*int32`). Go consumers importing `kaito.sh/v1alpha1` will need to update their code. The wire format (JSON/YAML) is backwards-compatible: existing manifests with `replicas: N` (N≥1) continue to work unchanged. The default remains 1 via `+kubebuilder:default:=1`.