### PR TITLE
fix: install keda-kaito-scaler in the same namespace as KEDA in aikit-integration-test

### DIFF
--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -109,8 +109,24 @@ jobs:
       - name: Deploy KEDA Kaito Scaler
         run: |
           helm repo add keda-kaito-scaler https://kaito-project.github.io/keda-kaito-scaler/charts/kaito-project
-          helm upgrade --install keda-kaito-scaler -n ${{ env.KAITO_NAMESPACE }} keda-kaito-scaler/keda-kaito-scaler
-          kubectl wait --for=condition=available --timeout=300s deployment/keda-kaito-scaler -n ${{ env.KAITO_NAMESPACE }}
+          # keda-kaito-scaler must be in the same namespace as KEDA (shares TLS secrets)
+          helm upgrade --install keda-kaito-scaler -n keda keda-kaito-scaler/keda-kaito-scaler
+          kubectl wait --for=condition=available --timeout=300s deployment/keda-kaito-scaler -n keda
+
+          # Wait for keda-kaito-scaler TLS certs to be fully provisioned before
+          # KEDA attempts its first gRPC connection (avoids pool poisoning).
+          echo "Waiting for keda-kaito-scaler TLS certs..."
+          for i in $(seq 1 30); do
+            if kubectl get secret keda-kaito-scaler-server-certs -n keda -o jsonpath='{.data.ca\.crt}' 2>/dev/null | grep -q .; then
+              echo "✓ TLS certs ready"
+              break
+            fi
+            sleep 2
+          done
+
+          # Restart KEDA operator to pick up certs with a clean gRPC pool
+          kubectl -n keda rollout restart deploy/keda-operator
+          kubectl -n keda rollout status deploy/keda-operator --timeout=120s
 
       - name: Create AIKit workspace
         run: |


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
## Root Cause

The `aikit-integration-test` CI workflow broke (https://github.com/kaito-project/kaito/actions/runs/26847411200/job/79170525855?pr=2078) after upgrading to **KEDA v2.20.0** (released June 1, 2026). Two issues combined:

1. **Namespace mismatch**: `keda-kaito-scaler` was installed in `$KAITO_NAMESPACE` (`kaito-system`) while KEDA runs in `keda`. The `ClusterTriggerAuthentication` references TLS secrets by name without a namespace field, so KEDA looks for them in its own namespace (`keda`) — where they don't exist.

2. **gRPC connection pool poisoning** (new in v2.20.0): KEDA's gRPC pool cache key now includes TLS context ([PR #7687](https://github.com/kedacore/keda/pull/7687)). Previously, a poisoned plaintext connection was reused silently. Now, when KEDA connects before certs are ready, the failed TLS handshake (`"error reading server preface: EOF"`) gets cached per-TLS-context and is never retried with valid certs.

The combination means KEDA could never establish a working mTLS connection to the external scaler → `GetMetricSpecForScaling` always fails → no HPA is created.

## Fix (aikit.yaml)

1. Install `keda-kaito-scaler` in the **`keda` namespace** (same as KEDA) so secrets are discoverable. This is suggested in https://github.com/kaito-project/keda-kaito-scaler/blob/main/README.md#deploy-keda-kaito-scaler.
2. **Wait for TLS certs** (`ca.crt` non-empty in `keda-kaito-scaler-server-certs`) before KEDA attempts any gRPC connections.
3. **Restart KEDA operator** after certs are ready to guarantee a clean gRPC connection pool.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: