### PR TITLE
feat: expose model download bandwidth metrics in vLLM pod

### DIFF
--- a/charts/kaito/workspace/templates/supported-models-configmap.yaml
+++ b/charts/kaito/workspace/templates/supported-models-configmap.yaml
@@ -11,7 +11,7 @@ data:
       - name: base
         type: text-generation
         runtime: tfs
-        tag: 0.3.2
+        tag: 0.3.3
       - name: llama-3.1-8b-instruct
         type: text-generation
         version: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/commit/0e9e39f249a16976918f6564b8830bc894c89659

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -12,9 +12,15 @@
 # limitations under the License.
 
 import argparse
+import collections
 import logging
 import os
+import socket
+import threading
+import time
 from dataclasses import dataclass
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
 from typing import Any
 
 import psutil
@@ -22,8 +28,11 @@ import pynvml
 import uvloop
 import vllm.entrypoints.openai.api_server as api_server
 import yaml
+from huggingface_hub import HfFileSystem, scan_cache_dir
+from prometheus_client import CONTENT_TYPE_LATEST, Gauge, generate_latest
 from vllm.entrypoints.openai.models.protocol import LoRAModulePath
 from vllm.utils.argparse_utils import FlexibleArgumentParser
+from vllm.v1.metrics.prometheus import get_prometheus_registry
 
 # Initialize logger
 logger = logging.getLogger(__name__)
@@ -32,6 +41,21 @@ logging.basicConfig(
     level=logging.DEBUG if debug_mode else logging.INFO,
     format="%(levelname)s %(asctime)s %(filename)s:%(lineno)d] %(message)s",
     datefmt="%m-%d %H:%M:%S",
+)
+
+# Prometheus metrics for model download monitoring.
+# Explicitly registered in vLLM's prometheus registry so they appear at the
+# /metrics endpoint served by vLLM's FastAPI app.
+_registry = get_prometheus_registry()
+kaito_model_download_speed_bytes_per_second = Gauge(
+    "kaito_model_download_speed_bytes_per_second",
+    "Current model download speed in bytes per second",
+    registry=_registry,
+)
+kaito_model_download_remaining_seconds = Gauge(
+    "kaito_model_download_remaining_seconds",
+    "Estimated remaining time for model download in seconds; -1 when unknown",
+    registry=_registry,
 )
 
 
@@ -147,6 +171,227 @@ class KaitoConfig:
         return yaml.dump(self.__dict__)
 
 
+def _model_repo_path(model_id: str | None, cache_dir: str) -> str | None:
+    """Return the HF cache repo directory for *model_id*, or None if not present."""
+    if not model_id:
+        return None
+    try:
+        for repo in scan_cache_dir(cache_dir=cache_dir).repos:
+            if repo.repo_id == model_id:
+                return str(repo.repo_path)
+    except Exception as exc:
+        logger.debug("Could not determine cache path for %s: %s", model_id, exc)
+    return None
+
+
+def _model_cache_size_bytes(repo_path: str | None) -> int:
+    """Return bytes currently on disk under *repo_path*.
+
+    Walks the repo dir counting only non-symlink files so HF Hub's snapshots/
+    symlinks into blobs/ are not double-counted.  In-progress ``*.incomplete``
+    blobs in blobs/ are included.
+    """
+    if repo_path is None:
+        return 0
+    try:
+        return sum(
+            f.stat().st_size
+            for f in Path(repo_path).rglob("*")
+            if f.is_file() and not f.is_symlink()
+        )
+    except OSError:
+        return 0
+
+
+def _download_in_progress(repo_path: str | None) -> bool:
+    """True when HF Hub has in-progress ``*.incomplete`` blobs under *repo_path*.
+
+    HF Hub writes blobs to ``blobs/<hash>.incomplete`` and atomically renames
+    them once a file finishes downloading, so the presence of any such file
+    is the authoritative signal that a download is still running.
+    """
+    if repo_path is None:
+        return False
+    blobs_dir = Path(repo_path) / "blobs"
+    if not blobs_dir.is_dir():
+        return False
+    try:
+        return any(p.name.endswith(".incomplete") for p in blobs_dir.iterdir())
+    except OSError:
+        return False
+
+
+def _hf_model_total_bytes(
+    model_id: str,
+    token: str | None = None,
+) -> int | None:
+    """Return the total size in bytes of all files in *model_id* on HuggingFace Hub.
+
+    Uses HfFileSystem so the result reflects the actual remote file sizes
+    regardless of what is already cached locally.
+    Returns None when the size cannot be determined.
+    """
+    try:
+        fs = HfFileSystem(token=token)
+        entries = fs.ls(model_id, detail=True)
+        total = sum(
+            info["size"]
+            for info in entries
+            if info.get("type") == "file" and info.get("size")
+        )
+        logger.debug("Model %s remote size: %.2f GiB", model_id, total / 1024**3)
+        return total if total > 0 else None
+    except Exception as exc:
+        logger.warning("Could not fetch remote size for %s: %s", model_id, exc)
+        return None
+
+
+class ModelDownloadMonitor:
+    """Background daemon thread that tracks HuggingFace model download progress.
+
+    Polls *watch_dir* every ``_SAMPLE_INTERVAL`` seconds, maintains a rolling
+    average speed over ``_WINDOW_SIZE`` samples (~10 s), and updates the two
+    module-level Prometheus gauges:
+      - kaito_model_download_speed_bytes_per_second
+      - kaito_model_download_remaining_seconds  (-1 when total size is unknown)
+    """
+
+    _SAMPLE_INTERVAL: float = 2.0
+    _WINDOW_SIZE: int = 5  # rolling window → ~10 s of history
+
+    def __init__(self, watch_dir: str) -> None:
+        self._watch_dir = watch_dir
+        self._stop = threading.Event()
+
+    def start(self, model_id: str | None = None, hf_token: str | None = None) -> None:
+        t = threading.Thread(
+            target=self._run,
+            args=(model_id, hf_token),
+            daemon=True,
+            name="kaito-download-monitor",
+        )
+        t.start()
+
+    def stop(self) -> None:
+        kaito_model_download_speed_bytes_per_second.set(0)
+        kaito_model_download_remaining_seconds.set(0)
+        self._stop.set()
+
+    def _run(self, model_id: str | None, hf_token: str | None) -> None:
+        # For local model paths nothing is downloaded; publish zero immediately.
+        if not model_id or os.path.isabs(model_id):
+            kaito_model_download_speed_bytes_per_second.set(0)
+            kaito_model_download_remaining_seconds.set(0)
+            return
+
+        expected_bytes: int | None = None
+        if model_id:
+            expected_bytes = _hf_model_total_bytes(model_id, token=hf_token)
+            if expected_bytes:
+                logger.info(
+                    "Expected model size: %.2f GiB",
+                    expected_bytes / 1024**3,
+                )
+
+        samples: collections.deque[float] = collections.deque(maxlen=self._WINDOW_SIZE)
+        repo_path = _model_repo_path(model_id, self._watch_dir)
+        last_size = _model_cache_size_bytes(repo_path)
+        start_ts = time.monotonic()
+        last_ts = start_ts
+
+        while not self._stop.wait(self._SAMPLE_INTERVAL):
+            now = time.monotonic()
+            # Re-resolve the repo path until it exists; HF creates it lazily
+            # on first download.
+            if repo_path is None:
+                repo_path = _model_repo_path(model_id, self._watch_dir)
+            current_size = _model_cache_size_bytes(repo_path)
+            elapsed = now - last_ts
+
+            if elapsed > 0:
+                samples.append((current_size - last_size) / elapsed)
+
+            avg_speed = sum(samples) / len(samples) if samples else 0.0
+            kaito_model_download_speed_bytes_per_second.set(max(0.0, avg_speed))
+
+            # Authoritative completion signal: HF Hub no longer has any
+            # *.incomplete blobs. This avoids relying on expected_bytes,
+            # which is over-counted when the repo ships duplicate weight
+            # formats (e.g. *.bin AND *.safetensors) but vLLM only fetches
+            # one set.
+            if (
+                repo_path is not None
+                and current_size > 0
+                and not _download_in_progress(repo_path)
+            ):
+                kaito_model_download_remaining_seconds.set(0)
+                logger.info(
+                    "Model %s download complete: %.2f GiB on disk in %.1fs",
+                    model_id,
+                    current_size / 1024**3,
+                    now - start_ts,
+                )
+                break
+            elif expected_bytes is not None:
+                remaining_bytes = max(0, expected_bytes - current_size)
+                if remaining_bytes == 0:
+                    kaito_model_download_remaining_seconds.set(0)
+                elif avg_speed > 0:
+                    kaito_model_download_remaining_seconds.set(
+                        remaining_bytes / avg_speed
+                    )
+                else:
+                    kaito_model_download_remaining_seconds.set(-1)
+            else:
+                kaito_model_download_remaining_seconds.set(-1)
+
+            last_size = current_size
+            last_ts = now
+
+
+class _PreDownloadMetricsServer:
+    """Thread-based HTTP server that serves /metrics on vLLM's port during
+    model download, before vLLM's own HTTP server is ready.
+
+    Running in a dedicated thread — completely separate from vLLM's asyncio
+    event loop — ensures Prometheus scrapes are answered even when the event
+    loop is blocked by heavy engine initialisation (CUDA setup, weight loading).
+    """
+
+    def __init__(self, sock_dup: socket.socket) -> None:
+        class _Handler(BaseHTTPRequestHandler):
+            def do_GET(self) -> None:
+                output = generate_latest(_registry)
+                self.send_response(200)
+                self.send_header("Content-Type", CONTENT_TYPE_LATEST)
+                self.send_header("Content-Length", str(len(output)))
+                self.send_header("Connection", "close")
+                self.end_headers()
+                self.wfile.write(output)
+
+            def log_message(self, *args) -> None:
+                pass  # suppress access logs
+
+        # bind_and_activate=False → TCPServer creates a socket but does not
+        # call bind()/listen().  We close that unused socket and swap in our
+        # pre-bound dup'd fd so that HTTPServer accepts on the right port.
+        self._httpd = HTTPServer(("", 0), _Handler, bind_and_activate=False)
+        self._httpd.socket.close()
+        self._httpd.socket = sock_dup
+
+    def start(self) -> None:
+        t = threading.Thread(
+            target=self._httpd.serve_forever,
+            daemon=True,
+            name="kaito-pre-download-metrics",
+        )
+        t.start()
+
+    def stop(self) -> None:
+        self._httpd.shutdown()
+        self._httpd.server_close()
+
+
 def load_lora_adapters(adapters_dir: str) -> LoRAModulePath | None:
     lora_list: list[LoRAModulePath] = []
 
@@ -242,8 +487,73 @@ if __name__ == "__main__":
 
     set_kv_transfer_config_if_applicable(args)
 
-    # Run the serving server
     logger.info(f"Starting server on port {args.port}")
-    # See https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html for more
-    # details about serving server.
+
+    # Always start the download monitor so both metrics are always exposed.
+    # For local model paths _run returns 0 immediately; for HF repo IDs it
+    # tracks bandwidth throughout the download.
+    watch_dir = getattr(args, "download_dir", None) or os.path.join(
+        os.environ.get("HF_HOME", os.path.expanduser("~/.cache/huggingface")),
+        "hub",
+    )
+    monitor = ModelDownloadMonitor(watch_dir=watch_dir)
+    monitor.start(model_id=args.model, hf_token=os.environ.get("HF_TOKEN"))
+
+    if not os.path.isabs(args.model):
+        # --model is a HuggingFace repo ID: vLLM downloads weights at startup.
+        # We pre-bind vLLM's port and serve /metrics on it so Prometheus can
+        # scrape download progress before vLLM's HTTP server is ready.
+        #
+        # Sequence:
+        #   1. We bind args.port and dup() the socket.
+        #   2. Thread-based metrics server accepts on the dup — completely
+        #      independent of vLLM's asyncio event loop, so it responds even
+        #      when the loop is blocked by CUDA init / weight loading.
+        #   3. Patched setup_server returns the original socket to vLLM
+        #      (no re-bind; port stays claimed throughout).
+        #   4. vLLM downloads the model — metrics server still accepting.
+        #   5. Patched build_and_serve stops the thread before uvicorn starts,
+        #      zeros the gauges, and hands the port to vLLM.
+
+        # Pre-bind the port vLLM will use.
+        pre_sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        pre_sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        pre_sock.bind(("0.0.0.0", args.port))
+        pre_sock.listen(getattr(args, "backlog", 2048))
+
+        # Thread takes ownership of the dup'd fd; pre_sock is kept for
+        # later transfer to vLLM's setup_server.
+        pre_metrics = _PreDownloadMetricsServer(pre_sock.dup())
+        pre_metrics.start()
+        logger.info("Pre-download metrics server listening on port %d", args.port)
+
+        # Return our already-bound socket so vLLM does not try to bind a
+        # new one (which would fail with "address already in use").
+        def _patched_setup(setup_args: argparse.Namespace):
+            host = getattr(setup_args, "host", "0.0.0.0")
+            return f"http://{host}:{setup_args.port}", pre_sock
+
+        api_server.setup_server = _patched_setup
+
+        # Stop the metrics thread just before vLLM's app starts accepting
+        # connections, so only one listener is active at a time.  Zero both
+        # gauges so Prometheus sees a clean state once vLLM is serving.
+        _orig_build_and_serve = api_server.build_and_serve
+
+        async def _patched_build_and_serve(
+            engine_client, listen_address, sock, bargs, **kw
+        ):
+            pre_metrics.stop()
+            monitor.stop()
+            logger.info(
+                "Pre-download metrics server stopped; vLLM taking over port %d",
+                args.port,
+            )
+            return await _orig_build_and_serve(
+                engine_client, listen_address, sock, bargs, **kw
+            )
+
+        api_server.build_and_serve = _patched_build_and_serve
+
+    # See https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
     uvloop.run(api_server.run_server(args))

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -541,9 +541,10 @@ if __name__ == "__main__":
 
         api_server.setup_server = _patched_setup
 
-        # Stop the metrics thread just before vLLM's app starts accepting
-        # connections, so only one listener is active at a time.  Zero both
-        # gauges so Prometheus sees a clean state once vLLM is serving.
+        # By the time build_and_serve runs, model downloading, KV cache
+        # allocation, and model warmup are all complete. Stop the metrics
+        # thread just before vLLM's app starts accepting connections, so
+        # only one listener is active at a time.
         _orig_build_and_serve = api_server.build_and_serve
 
         async def _patched_build_and_serve(

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -361,6 +361,12 @@ class _PreDownloadMetricsServer:
     def __init__(self, sock_dup: socket.socket) -> None:
         class _Handler(BaseHTTPRequestHandler):
             def do_GET(self) -> None:
+                if self.path.split("?", 1)[0] != "/metrics":
+                    self.send_response(404)
+                    self.send_header("Content-Length", "0")
+                    self.send_header("Connection", "close")
+                    self.end_headers()
+                    return
                 output = generate_latest(_registry)
                 self.send_response(200)
                 self.send_header("Content-Type", CONTENT_TYPE_LATEST)

--- a/presets/workspace/inference/vllm/tests/test_download_monitor.py
+++ b/presets/workspace/inference/vllm/tests/test_download_monitor.py
@@ -1,0 +1,462 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for DownloadMonitor and related helpers in inference_api.py.
+
+All heavy runtime dependencies (vllm, prometheus_client, pynvml, …) are
+stubbed via sys.modules so these tests run on any machine, including Mac
+dev environments without a GPU or vllm installed.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ── Stub all dependencies that aren't available on a plain dev machine ───────
+# Use setdefault so we don't replace already-loaded real modules when the
+# full test suite runs in a GPU environment.
+_HF_MOCK = MagicMock(name="huggingface_hub")
+_STUBS = {
+    "vllm": MagicMock(),
+    "vllm.entrypoints": MagicMock(),
+    "vllm.entrypoints.openai": MagicMock(),
+    "vllm.entrypoints.openai.api_server": MagicMock(),
+    "vllm.entrypoints.openai.models": MagicMock(),
+    "vllm.entrypoints.openai.models.protocol": MagicMock(),
+    "vllm.utils": MagicMock(),
+    "vllm.utils.argparse_utils": MagicMock(),
+    "vllm.v1": MagicMock(),
+    "vllm.v1.metrics": MagicMock(),
+    "vllm.v1.metrics.prometheus": MagicMock(),
+    "pynvml": MagicMock(),
+    "uvloop": MagicMock(),
+    "psutil": MagicMock(),
+    "prometheus_client": MagicMock(),
+    "yaml": MagicMock(),
+    "huggingface_hub": _HF_MOCK,
+}
+for _name, _mock in _STUBS.items():
+    sys.modules.setdefault(_name, _mock)
+
+_PARENT = str(Path(__file__).resolve().parent.parent)
+if _PARENT not in sys.path:
+    sys.path.insert(0, _PARENT)
+
+import inference_api  # noqa: E402
+from inference_api import (
+    ModelDownloadMonitor,
+    _download_in_progress,
+    _hf_model_total_bytes,
+    _model_cache_size_bytes,
+    _model_repo_path,
+)
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+MB = 1024**2
+
+
+# ── _hf_model_total_bytes ─────────────────────────────────────────────────────
+class TestHfModelTotalBytes:
+    def _fs_entry(self, size, name="file.bin"):
+        return {"type": "file", "name": f"org/model/{name}", "size": size}
+
+    def _mock_fs(self, entries):
+        """Return a mock HfFileSystem whose .ls() yields *entries*."""
+        mock_fs_instance = MagicMock()
+        mock_fs_instance.ls.return_value = entries
+        mock_fs_cls = MagicMock(return_value=mock_fs_instance)
+        return mock_fs_cls, mock_fs_instance
+
+    def test_sums_file_sizes_ignoring_dirs_and_zero(self):
+        entries = [
+            self._fs_entry(1000, "config.json"),
+            self._fs_entry(2000, "model.safetensors"),
+            {"type": "directory", "name": "org/model/", "size": 0},  # skipped
+            {"type": "file", "name": "org/model/empty", "size": 0},  # skipped (falsy)
+        ]
+        mock_cls, _ = self._mock_fs(entries)
+        with patch.object(inference_api, "HfFileSystem", mock_cls):
+            assert _hf_model_total_bytes("org/model") == 3000
+
+    def test_returns_none_on_api_exception(self):
+        mock_cls = MagicMock(side_effect=Exception("network error"))
+        with patch.object(inference_api, "HfFileSystem", mock_cls):
+            assert _hf_model_total_bytes("org/model") is None
+
+    def test_returns_none_when_no_files(self):
+        mock_cls, _ = self._mock_fs([])
+        with patch.object(inference_api, "HfFileSystem", mock_cls):
+            assert _hf_model_total_bytes("org/model") is None
+
+    def test_passes_token_to_hffilesystem(self):
+        mock_cls, mock_instance = self._mock_fs([self._fs_entry(500)])
+        with patch.object(inference_api, "HfFileSystem", mock_cls):
+            _hf_model_total_bytes("org/model", token="tok-abc")
+        mock_cls.assert_called_once_with(token="tok-abc")
+        mock_instance.ls.assert_called_once_with("org/model", detail=True)
+
+
+# ── DownloadMonitor ───────────────────────────────────────────────────────────
+class TestDownloadMonitor:
+    """
+    Each test drives DownloadMonitor._run() directly (no real thread) by
+    mocking _stop.wait() to control the number of loop iterations, and
+    patching _model_cache_size_bytes and time.monotonic for deterministic timing.
+    """
+
+    def _run_monitor(
+        self,
+        dir_sizes,
+        timestamps,
+        wait_returns,
+        model_id=None,
+        total_bytes=None,
+        repo_path="/fake/weights/models--org--model",
+        download_in_progress=True,
+    ):
+        """
+        Helper that runs ModelDownloadMonitor._run synchronously and collects
+        the values passed to both Prometheus gauge .set() calls.
+
+        Returns (speed_calls, eta_calls).
+
+        _model_cache_size_bytes is mocked to consume dir_sizes in order on
+        every call (initial + each loop iteration).
+
+        download_in_progress controls the value returned by the patched
+        _download_in_progress helper.  Pass a bool for a constant value, or
+        an iterable to return different values across loop iterations (used
+        to simulate a download that completes mid-monitoring).  Set
+        repo_path=None to simulate the case where the cache dir does not
+        exist yet (falls back to expected_bytes-based ETA).
+        """
+        monitor = ModelDownloadMonitor(watch_dir="/fake/weights")
+        speed_calls = []
+        eta_calls = []
+
+        speed_gauge = MagicMock(name="speed_gauge")
+        speed_gauge.set.side_effect = speed_calls.append
+        eta_gauge = MagicMock(name="eta_gauge")
+        eta_gauge.set.side_effect = eta_calls.append
+
+        size_iter = iter(dir_sizes)
+        ts_iter = iter(timestamps)
+
+        # _model_cache_size_bytes is called for every size sample (initial + loop).
+        def _mock_cache_size(*_args, **_kwargs):
+            return next(size_iter)
+
+        if isinstance(download_in_progress, bool):
+            dip_kwargs = {"return_value": download_in_progress}
+        else:
+            dip_iter = iter(download_in_progress)
+            dip_kwargs = {"side_effect": lambda *_a, **_k: next(dip_iter)}
+
+        with (
+            patch(
+                "inference_api._model_cache_size_bytes", side_effect=_mock_cache_size
+            ),
+            patch("inference_api._model_repo_path", return_value=repo_path),
+            patch("inference_api._download_in_progress", **dip_kwargs),
+            patch("inference_api._hf_model_total_bytes", return_value=total_bytes),
+            patch("time.monotonic", side_effect=lambda: next(ts_iter)),
+            patch.object(monitor._stop, "wait", side_effect=wait_returns),
+            patch.object(
+                inference_api,
+                "kaito_model_download_speed_bytes_per_second",
+                speed_gauge,
+            ),
+            patch.object(
+                inference_api,
+                "kaito_model_download_remaining_seconds",
+                eta_gauge,
+            ),
+        ):
+            monitor._run(model_id=model_id, hf_token=None)
+
+        return speed_calls, eta_calls
+
+    def test_speed_rolling_average_two_iterations(self):
+        # Two identical intervals: 100 MiB downloaded in 5 s each → 20 MiB/s
+        speed_calls, _ = self._run_monitor(
+            dir_sizes=[0, 100 * MB, 200 * MB],
+            timestamps=[0.0, 5.0, 10.0],
+            wait_returns=[False, False, True],
+            model_id="org/model",
+        )
+        expected = 100 * MB / 5.0
+        assert len(speed_calls) == 2
+        assert speed_calls[0] == pytest.approx(expected)
+        assert speed_calls[1] == pytest.approx(expected)
+
+    def test_eta_computed_when_total_size_known(self):
+        # Total 500 MiB, first sample downloads 100 MiB in 5 s
+        # speed = 20 MiB/s  →  ETA = 400 MiB / 20 MiB/s = 20 s
+        TOTAL = 500 * MB
+        DOWNLOADED = 100 * MB
+        _, eta_calls = self._run_monitor(
+            dir_sizes=[0, DOWNLOADED],
+            timestamps=[0.0, 5.0],
+            wait_returns=[False, True],
+            model_id="org/model",
+            total_bytes=TOTAL,
+        )
+        expected_eta = (TOTAL - DOWNLOADED) / (DOWNLOADED / 5.0)
+        assert len(eta_calls) == 1
+        assert eta_calls[0] == pytest.approx(expected_eta)
+
+    def test_eta_is_minus_one_when_total_size_unknown(self):
+        _, eta_calls = self._run_monitor(
+            dir_sizes=[0, 100 * MB],
+            timestamps=[0.0, 5.0],
+            wait_returns=[False, True],
+            model_id="org/model",
+            total_bytes=None,
+        )
+        assert eta_calls == [-1]
+
+    def test_eta_is_minus_one_when_speed_stays_zero(self):
+        # Download stalled: bytes on disk didn't change, so avg_speed=0.
+        # Even with a known total, we cannot compute a meaningful ETA →
+        # publish -1 (sentinel for "unknown").
+        DOWNLOADED = 100 * MB
+        _, eta_calls = self._run_monitor(
+            dir_sizes=[DOWNLOADED, DOWNLOADED],
+            timestamps=[0.0, 5.0],
+            wait_returns=[False, True],
+            model_id="org/model",
+            total_bytes=500 * MB,
+        )
+        assert eta_calls == [-1]
+
+    def test_zero_metrics_when_no_model_id(self):
+        # model_id=None means a local path — both metrics are set to 0 immediately.
+        speed_calls, eta_calls = self._run_monitor(
+            dir_sizes=[0],
+            timestamps=[],
+            wait_returns=[],
+            model_id=None,
+        )
+        assert speed_calls == [0]
+        assert eta_calls == [0]
+
+    def test_zero_metrics_for_absolute_model_path(self):
+        # Absolute path → local weights, no download.  Both metrics set
+        # to 0 once and the loop never runs (wait_returns is empty so
+        # any iteration would raise StopIteration).
+        speed_calls, eta_calls = self._run_monitor(
+            dir_sizes=[],
+            timestamps=[],
+            wait_returns=[],
+            model_id="/workspace/vllm/weights",
+        )
+        assert speed_calls == [0]
+        assert eta_calls == [0]
+
+    def test_speed_is_zero_when_directory_unchanged(self):
+        speed_calls, _ = self._run_monitor(
+            dir_sizes=[500, 500],
+            timestamps=[0.0, 5.0],
+            wait_returns=[False, True],
+        )
+        assert speed_calls == [0.0]
+
+    def test_speed_never_negative(self):
+        # Simulate a transient size decrease (e.g. partial file rewrite)
+        speed_calls, _ = self._run_monitor(
+            dir_sizes=[200 * MB, 100 * MB],
+            timestamps=[0.0, 5.0],
+            wait_returns=[False, True],
+        )
+        assert all(v >= 0.0 for v in speed_calls)
+
+    def test_eta_clamps_to_zero_when_download_exceeds_total(self):
+        # downloaded > total (race between HF metadata and actual files)
+        TOTAL = 50 * MB
+        DOWNLOADED = 100 * MB  # more than total
+        _, eta_calls = self._run_monitor(
+            dir_sizes=[0, DOWNLOADED],
+            timestamps=[0.0, 5.0],
+            wait_returns=[False, True],
+            model_id="org/model",
+            total_bytes=TOTAL,
+        )
+        assert eta_calls[0] == pytest.approx(0.0)
+
+    def test_eta_correct_with_nonzero_initial_size(self):
+        # 50 MiB already present when monitoring starts (partial prior download).
+        # expected_bytes is the FULL remote model size; remaining = expected - current_on_disk.
+        TOTAL = 450 * MB
+        INITIAL = 50 * MB
+        DELTA = 100 * MB
+        _, eta_calls = self._run_monitor(
+            dir_sizes=[INITIAL, INITIAL + DELTA],
+            timestamps=[0.0, 5.0],
+            wait_returns=[False, True],
+            model_id="org/model",
+            total_bytes=TOTAL,
+        )
+        speed = DELTA / 5.0
+        # remaining = TOTAL - current_size = 450MB - 150MB = 300MB
+        expected_eta = (TOTAL - (INITIAL + DELTA)) / speed
+        assert len(eta_calls) == 1
+        assert eta_calls[0] == pytest.approx(expected_eta)
+
+    def test_eta_zero_when_no_incomplete_blobs_even_if_total_overcounts(self):
+        # Regression: HF repos that ship duplicate weight formats
+        # (e.g. pytorch_model-*.bin AND model-*.safetensors) make
+        # expected_bytes larger than what vLLM actually downloads.  The
+        # authoritative completion signal — absence of *.incomplete blobs —
+        # must drive ETA to 0 regardless of expected_bytes.
+        INFLATED_TOTAL = 1000 * MB
+        ON_DISK = 500 * MB  # download is done, but smaller than INFLATED_TOTAL
+        _, eta_calls = self._run_monitor(
+            dir_sizes=[ON_DISK, ON_DISK],
+            timestamps=[0.0, 5.0],
+            wait_returns=[False, True],
+            model_id="org/model",
+            total_bytes=INFLATED_TOTAL,
+            download_in_progress=False,
+        )
+        assert eta_calls == [0]
+
+    def test_eta_uses_expected_bytes_when_repo_path_missing(self):
+        # repo_path=None → cache dir not yet created, fall back to
+        # expected_bytes-based ETA so we still publish a number during
+        # the brief window before HF creates the repo dir.
+        TOTAL = 500 * MB
+        DOWNLOADED = 100 * MB
+        _, eta_calls = self._run_monitor(
+            dir_sizes=[0, DOWNLOADED],
+            timestamps=[0.0, 5.0],
+            wait_returns=[False, True],
+            model_id="org/model",
+            total_bytes=TOTAL,
+            repo_path=None,
+        )
+        expected_eta = (TOTAL - DOWNLOADED) / (DOWNLOADED / 5.0)
+        assert len(eta_calls) == 1
+        assert eta_calls[0] == pytest.approx(expected_eta)
+
+    def test_partial_resume_completes_mid_loop(self):
+        # Real partial-download-resume: 200 MiB already on disk with an
+        # *.incomplete blob still present.  After one more sample interval
+        # the download finishes (HF renames the blob, no more *.incomplete).
+        # Verify:
+        #   * during the in-progress iteration ETA uses expected_bytes,
+        #   * on the completing iteration ETA is set to exactly 0,
+        #   * the loop breaks (wait_returns[2] is never consumed — if it
+        #     were, StopIteration would surface from the size/ts iterators).
+        TOTAL = 500 * MB
+        INITIAL = 200 * MB
+        AFTER_RESUME = 350 * MB
+        FINAL = 500 * MB
+        _, eta_calls = self._run_monitor(
+            # initial sample + iter1 sample + iter2 sample.  No more reads
+            # after break, so iterators are sized exactly to enforce that.
+            dir_sizes=[INITIAL, AFTER_RESUME, FINAL],
+            timestamps=[0.0, 5.0, 10.0],
+            # wait_returns has an extra entry we expect NOT to be consumed.
+            wait_returns=[False, False, "unreachable"],
+            model_id="org/model",
+            total_bytes=TOTAL,
+            # iter1: still downloading; iter2: HF finished, blob renamed.
+            download_in_progress=[True, False],
+        )
+        # iter1 ETA from expected_bytes; iter2 must be exactly 0.
+        speed_iter1 = (AFTER_RESUME - INITIAL) / 5.0
+        expected_eta_iter1 = (TOTAL - AFTER_RESUME) / speed_iter1
+        assert len(eta_calls) == 2
+        assert eta_calls[0] == pytest.approx(expected_eta_iter1)
+        assert eta_calls[1] == 0
+
+
+# ── _model_repo_path ──────────────────────────────────────────────────────────
+class TestModelRepoPath:
+    def test_returns_path_when_repo_present(self):
+        repo = MagicMock()
+        repo.repo_id = "org/model"
+        repo.repo_path = Path("/cache/models--org--model")
+        scan_result = MagicMock()
+        scan_result.repos = [repo]
+        with patch.object(inference_api, "scan_cache_dir", return_value=scan_result):
+            assert (
+                _model_repo_path("org/model", "/cache") == "/cache/models--org--model"
+            )
+
+    def test_returns_none_when_repo_missing(self):
+        other = MagicMock()
+        other.repo_id = "other/model"
+        scan_result = MagicMock()
+        scan_result.repos = [other]
+        with patch.object(inference_api, "scan_cache_dir", return_value=scan_result):
+            assert _model_repo_path("org/model", "/cache") is None
+
+    def test_returns_none_when_model_id_empty(self):
+        assert _model_repo_path(None, "/cache") is None
+        assert _model_repo_path("", "/cache") is None
+
+    def test_returns_none_on_scan_exception(self):
+        with patch.object(inference_api, "scan_cache_dir", side_effect=OSError("boom")):
+            assert _model_repo_path("org/model", "/cache") is None
+
+
+# ── _download_in_progress ─────────────────────────────────────────────────────
+class TestDownloadInProgress:
+    def test_returns_false_when_repo_path_none(self):
+        assert _download_in_progress(None) is False
+
+    def test_returns_false_when_blobs_dir_missing(self, tmp_path):
+        # repo dir exists but no blobs/ subdir yet
+        assert _download_in_progress(str(tmp_path)) is False
+
+    def test_returns_false_when_no_incomplete_blobs(self, tmp_path):
+        blobs = tmp_path / "blobs"
+        blobs.mkdir()
+        (blobs / "abcdef1234").write_bytes(b"finished blob")
+        assert _download_in_progress(str(tmp_path)) is False
+
+    def test_returns_true_with_incomplete_blob(self, tmp_path):
+        blobs = tmp_path / "blobs"
+        blobs.mkdir()
+        (blobs / "abcdef1234").write_bytes(b"done")
+        (blobs / "abcdef5678.incomplete").write_bytes(b"partial")
+        assert _download_in_progress(str(tmp_path)) is True
+
+
+# ── _model_cache_size_bytes ───────────────────────────────────────────────────
+class TestModelCacheSizeBytes:
+    def test_returns_zero_when_repo_path_none(self):
+        assert _model_cache_size_bytes(None) == 0
+
+    def test_counts_only_non_symlink_files(self, tmp_path):
+        # Mimic HF cache layout: blobs/ holds real bytes, snapshots/ has
+        # symlinks pointing into blobs/.  We must count blobs/ only.
+        blobs = tmp_path / "blobs"
+        blobs.mkdir()
+        blob = blobs / "abcdef"
+        blob.write_bytes(b"x" * 1000)
+        incomplete = blobs / "abcdef.incomplete"
+        incomplete.write_bytes(b"x" * 200)
+
+        snapshots = tmp_path / "snapshots" / "rev1"
+        snapshots.mkdir(parents=True)
+        try:
+            (snapshots / "weights.bin").symlink_to(blob)
+        except OSError:
+            pytest.skip("symlinks not supported on this filesystem")
+
+        # 1000 (blob) + 200 (incomplete); symlink ignored
+        assert _model_cache_size_bytes(str(tmp_path)) == 1200

--- a/presets/workspace/inference/vllm/tests/test_download_monitor.py
+++ b/presets/workspace/inference/vllm/tests/test_download_monitor.py
@@ -55,7 +55,7 @@ if _PARENT not in sys.path:
     sys.path.insert(0, _PARENT)
 
 import inference_api  # noqa: E402
-from inference_api import (
+from inference_api import (  # noqa: E402
     ModelDownloadMonitor,
     _download_in_progress,
     _hf_model_total_bytes,

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -3,8 +3,9 @@ models:
   - name: base
     type: text-generation
     runtime: tfs
-    tag: 0.3.2
+    tag: 0.3.3
     # Tag history:
+    # 0.3.3 - add model download monitor
     # 0.3.2 - make Worker nodes always ready in distributed inference to unblock StatefulSet rolling upgrade. bump lmcache to 0.4.6 and use its CUDA 12.9 wheel
     # 0.3.1 - add NixlConnector kv_transfer_config for P/D disaggregation
     # 0.3.0 - bump vllm to 0.19.1, transformers to 5.6.0


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Add two Prometheus gauges — kaito_model_download_speed_bytes_per_second and kaito_model_download_remaining_seconds — that are visible at vLLM's /metrics endpoint throughout the pod lifetime.

Key design:
- Pre-download phase (HF repo ID): the pod pre-binds vLLM's port and serves /metrics from a thread-based HTTPServer that runs independently of vLLM's asyncio loop. This ensures Prometheus scrapes are answered even when the event loop is blocked by CUDA init or weight loading. A patched setup_server hands the already-bound socket to vLLM so the port is never released. A patched build_and_serve stops the thread and zeros both gauges just before uvicorn starts accepting connections.

- Local model paths (abs path): the monitor reports 0 immediately so the same metrics are always exposed regardless of model source.

- Bandwidth tracking: ModelDownloadMonitor polls the model's HF Hub cache subdirectory (discovered via scan_cache_dir, not path mangling) every 2 s. It counts only non-symlink files so blobs/ and snapshots/ symlinks are not double-counted. Total expected size is fetched once from HfFileSystem.ls. ETA measures bytes downloaded since monitoring started, not total on disk, to stay correct for partial re-downloads.

Tests (tests/test_download_monitor.py, fully offline via sys.modules stubs and tmp_path) cover:
1. Absolute model path (local weights) — both metrics stay at 0.
2. Model ID downloaded from scratch — speed tracks rolling average, ETA derived from expected_bytes.
3. Interrupted download resumed mid-loop — partial bytes already on disk, completes during monitoring, loop breaks and ETA flips to 0.
4. Model already fully downloaded on startup (no *.incomplete blobs) — ETA set to 0 on the first iteration even when expected_bytes over-counts (e.g. duplicate *.bin + *.safetensors weights).
5. Download stalled (speed stays at 0) with unknown total — remaining time set to -1.


**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: