### PR TITLE
feat: Add streaming regex adapter

### DIFF
--- a/presets/ragengine/guardrails/__init__.py
+++ b/presets/ragengine/guardrails/__init__.py
@@ -13,5 +13,12 @@
 
 from .output_guardrails import OutputGuardrails, OutputGuardrailsError
 from .reload import GuardrailsReloader
+from .streaming import StreamingDecision, StreamingGuardrailsProcessor
 
-__all__ = ["GuardrailsReloader", "OutputGuardrails", "OutputGuardrailsError"]
+__all__ = [
+    "GuardrailsReloader",
+    "OutputGuardrails",
+    "OutputGuardrailsError",
+    "StreamingDecision",
+    "StreamingGuardrailsProcessor",
+]

--- a/presets/ragengine/guardrails/streaming.py
+++ b/presets/ragengine/guardrails/streaming.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
@@ -26,8 +27,9 @@ from ragengine.guardrails.output_guardrails import (
     OutputGuardrails,
     OutputGuardrailsError,
 )
-from ragengine.guardrails.scanner_schemas import ParsedScannerConfig
+from ragengine.guardrails.scanner_schemas import ParsedScannerConfig, RegexConfig
 from ragengine.metrics.prometheus_metrics import (
+    guardrails_response_scanner_hits_total,
     output_guardrails_actions_total,
 )
 
@@ -84,6 +86,36 @@ class DeterministicStreamingScanner(StreamingScanner):
 
 
 @dataclass
+class RegexStreamingScanner(DeterministicStreamingScanner):
+    compiled_patterns: tuple[re.Pattern[str], ...]
+    match_type: str
+    _blocked: bool = False
+
+    def on_chunk(self, text: str) -> StreamingDecision:
+        if self.action_on_hit != "block":
+            return StreamingDecision(state=STREAMING_DECISION_BUFFER)
+
+        if self._matches(text):
+            self._blocked = True
+            return StreamingDecision(state=STREAMING_DECISION_BLOCK)
+
+        return StreamingDecision(state=STREAMING_DECISION_BUFFER)
+
+    def finalize(self, prompt: str, content: str) -> StreamingDecision:
+        if self._blocked:
+            return StreamingDecision(state=STREAMING_DECISION_BLOCK, content=content)
+
+        return super().finalize(prompt, content)
+
+    def _matches(self, text: str) -> bool:
+        if self.match_type == "fullmatch":
+            return any(pattern.fullmatch(text) for pattern in self.compiled_patterns)
+        if self.match_type == "match":
+            return any(pattern.match(text) for pattern in self.compiled_patterns)
+        return any(pattern.search(text) for pattern in self.compiled_patterns)
+
+
+@dataclass
 class ChunkAccumulator:
     response_id: str = ""
     created: int = 0
@@ -133,15 +165,29 @@ class StreamingGuardrailsProcessor:
         self._accumulator = ChunkAccumulator()
         self._scanners = self._build_streaming_scanners()
 
-    def _build_streaming_scanners(self) -> list[DeterministicStreamingScanner]:
-        scanners: list[DeterministicStreamingScanner] = []
+    def _build_streaming_scanners(self) -> list[StreamingScanner]:
+        scanners: list[StreamingScanner] = []
         for parsed, scanner in self._guardrails._build_scanners_with_configs():
+            action_on_hit = parsed.action_on_hit or self._guardrails.action_on_hit
+            if parsed.type == "regex" and isinstance(parsed.config, RegexConfig):
+                scanners.append(
+                    RegexStreamingScanner(
+                        parsed=parsed,
+                        scanner=scanner,
+                        action_on_hit=action_on_hit,
+                        compiled_patterns=tuple(
+                            re.compile(pattern) for pattern in parsed.config.patterns
+                        ),
+                        match_type=parsed.config.match_type,
+                    )
+                )
+                continue
+
             scanners.append(
                 DeterministicStreamingScanner(
                     parsed=parsed,
                     scanner=scanner,
-                    action_on_hit=parsed.action_on_hit
-                    or self._guardrails.action_on_hit,
+                    action_on_hit=action_on_hit,
                 )
             )
         return scanners
@@ -160,8 +206,20 @@ class StreamingGuardrailsProcessor:
 
                 chunk = json.loads(payload)
                 self._accumulator.add_chunk(chunk)
+                should_stop = False
                 for scanner in self._scanners:
-                    scanner.on_chunk(self._accumulator.content)
+                    decision = scanner.on_chunk(self._accumulator.content)
+                    if decision.state == STREAMING_DECISION_ERROR:
+                        raise OutputGuardrailsError(
+                            "Output guardrails failed while scanning the streamed model response."
+                        )
+                    if decision.state == STREAMING_DECISION_BLOCK:
+                        self._accumulator.finish_reason = "content_filter"
+                        should_stop = True
+                        break
+
+                if should_stop:
+                    break
 
             async for chunk in self._finalize_stream():
                 yield chunk
@@ -246,6 +304,11 @@ class StreamingGuardrailsProcessor:
                 and decision.content == sanitized_content
             ):
                 continue
+
+            guardrails_response_scanner_hits_total.labels(
+                scanner_type=scanner.parsed.type,
+                action=scanner.action_on_hit,
+            ).inc()
 
             if decision.state == STREAMING_DECISION_BLOCK:
                 return StreamingFinalizeResult(

--- a/presets/ragengine/guardrails/streaming.py
+++ b/presets/ragengine/guardrails/streaming.py
@@ -1,0 +1,262 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from llm_guard import scan_output
+
+from ragengine.guardrails.output_guardrails import (
+    OutputGuardrails,
+    OutputGuardrailsError,
+)
+from ragengine.guardrails.scanner_schemas import ParsedScannerConfig
+from ragengine.metrics.prometheus_metrics import (
+    output_guardrails_actions_total,
+)
+
+logger = logging.getLogger(__name__)
+
+STREAMING_DECISION_BUFFER = "buffer"
+STREAMING_DECISION_EMIT = "emit"
+STREAMING_DECISION_BLOCK = "block"
+STREAMING_DECISION_ERROR = "error"
+
+
+@dataclass(frozen=True)
+class StreamingDecision:
+    state: Literal["buffer", "emit", "block", "error"]
+    content: str = ""
+    scores: dict[str, Any] = field(default_factory=dict)
+
+
+class StreamingScanner:
+    def on_chunk(self, text: str) -> StreamingDecision:
+        raise NotImplementedError
+
+    def finalize(self, prompt: str, content: str) -> StreamingDecision:
+        raise NotImplementedError
+
+
+@dataclass
+class DeterministicStreamingScanner(StreamingScanner):
+    parsed: ParsedScannerConfig
+    scanner: Any
+    action_on_hit: str
+
+    def on_chunk(self, text: str) -> StreamingDecision:
+        del text
+        return StreamingDecision(state=STREAMING_DECISION_BUFFER)
+
+    def finalize(self, prompt: str, content: str) -> StreamingDecision:
+        sanitized_output, results_valid, results_score = scan_output(
+            [self.scanner], prompt, content, fail_fast=False
+        )
+        if all(results_valid.values()):
+            return StreamingDecision(state=STREAMING_DECISION_EMIT, content=content)
+        if self.action_on_hit == "block":
+            return StreamingDecision(
+                state=STREAMING_DECISION_BLOCK,
+                content=sanitized_output,
+                scores=results_score,
+            )
+        return StreamingDecision(
+            state=STREAMING_DECISION_EMIT,
+            content=sanitized_output,
+            scores=results_score,
+        )
+
+
+@dataclass
+class ChunkAccumulator:
+    response_id: str = ""
+    created: int = 0
+    model: str = ""
+    role: str = "assistant"
+    finish_reason: str | None = None
+    content_parts: list[str] = field(default_factory=list)
+
+    def add_chunk(self, chunk: dict[str, Any]) -> None:
+        self.response_id = self.response_id or str(chunk.get("id") or "")
+        self.created = self.created or int(chunk.get("created") or 0)
+        self.model = self.model or str(chunk.get("model") or "")
+
+        choices = chunk.get("choices") or []
+        if not choices:
+            return
+
+        choice = choices[0]
+        delta = choice.get("delta") or {}
+        if delta.get("tool_calls") or delta.get("function_call"):
+            raise OutputGuardrailsError(
+                "Streaming guardrails currently support assistant text deltas only."
+            )
+
+        self.role = delta.get("role") or self.role
+        content = delta.get("content")
+        if isinstance(content, str) and content:
+            self.content_parts.append(content)
+        if choice.get("finish_reason") is not None:
+            self.finish_reason = choice.get("finish_reason")
+
+    @property
+    def content(self) -> str:
+        return "".join(self.content_parts)
+
+
+@dataclass(frozen=True)
+class StreamingFinalizeResult:
+    content: str
+    action: str | None
+
+
+class StreamingGuardrailsProcessor:
+    def __init__(self, guardrails: OutputGuardrails, request: dict[str, Any]) -> None:
+        self._guardrails = guardrails
+        self._request = request
+        self._accumulator = ChunkAccumulator()
+        self._scanners = self._build_streaming_scanners()
+
+    def _build_streaming_scanners(self) -> list[DeterministicStreamingScanner]:
+        scanners: list[DeterministicStreamingScanner] = []
+        for parsed, scanner in self._guardrails._build_scanners_with_configs():
+            scanners.append(
+                DeterministicStreamingScanner(
+                    parsed=parsed,
+                    scanner=scanner,
+                    action_on_hit=parsed.action_on_hit
+                    or self._guardrails.action_on_hit,
+                )
+            )
+        return scanners
+
+    async def wrap(self, upstream_lines: AsyncIterator[str]) -> AsyncIterator[bytes]:
+        try:
+            async for line in upstream_lines:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                if not stripped.startswith("data:"):
+                    continue
+                payload = stripped[len("data:") :].strip()
+                if payload == "[DONE]":
+                    break
+
+                chunk = json.loads(payload)
+                self._accumulator.add_chunk(chunk)
+                for scanner in self._scanners:
+                    scanner.on_chunk(self._accumulator.content)
+
+            async for chunk in self._finalize_stream():
+                yield chunk
+        except Exception:
+            logger.exception("output_guardrails_streaming_failed")
+            error = {
+                "error": {
+                    "message": "Output guardrails failed while scanning the streamed model response.",
+                    "type": "server_error",
+                }
+            }
+            yield self._format_sse(error)
+            yield b"data: [DONE]\n\n"
+            return
+
+    async def _finalize_stream(self) -> AsyncIterator[bytes]:
+        prompt = self._guardrails._extract_prompt(self._request)
+        result = self._finalize_content(prompt)
+
+        if result.action is not None:
+            output_guardrails_actions_total.labels(action=result.action).inc()
+            logger.info(
+                "output_guardrails_streaming_triggered action=%s response_id=%s policy_hash=%s",
+                result.action,
+                self._accumulator.response_id,
+                self._guardrails.policy_hash,
+            )
+
+        if result.content:
+            yield self._format_sse(
+                {
+                    "id": self._accumulator.response_id or "chatcmpl-stream",
+                    "object": "chat.completion.chunk",
+                    "created": self._accumulator.created or int(time.time()),
+                    "model": self._accumulator.model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "role": self._accumulator.role,
+                                "content": result.content,
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+            )
+
+        yield self._format_sse(
+            {
+                "id": self._accumulator.response_id or "chatcmpl-stream",
+                "object": "chat.completion.chunk",
+                "created": self._accumulator.created or int(time.time()),
+                "model": self._accumulator.model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": self._accumulator.finish_reason or "stop",
+                    }
+                ],
+            }
+        )
+        yield b"data: [DONE]\n\n"
+
+    @staticmethod
+    def _format_sse(payload: dict[str, Any]) -> bytes:
+        return f"data: {json.dumps(payload)}\n\n".encode()
+
+    def _finalize_content(self, prompt: str) -> StreamingFinalizeResult:
+        sanitized_content = self._accumulator.content
+        final_action: str | None = None
+
+        for scanner in self._scanners:
+            decision = scanner.finalize(prompt, sanitized_content)
+            if decision.state == STREAMING_DECISION_ERROR:
+                raise OutputGuardrailsError(
+                    "Output guardrails failed while scanning the streamed model response."
+                )
+            if (
+                decision.state == STREAMING_DECISION_EMIT
+                and decision.content == sanitized_content
+            ):
+                continue
+
+            if decision.state == STREAMING_DECISION_BLOCK:
+                return StreamingFinalizeResult(
+                    content=self._guardrails.block_message,
+                    action="block",
+                )
+
+            sanitized_content = decision.content
+            final_action = "redact"
+
+        return StreamingFinalizeResult(
+            content=sanitized_content,
+            action=final_action,
+        )

--- a/presets/ragengine/inference/inference.py
+++ b/presets/ragengine/inference/inference.py
@@ -16,7 +16,7 @@ import asyncio
 import concurrent.futures
 import json
 import logging
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
@@ -315,6 +315,65 @@ class Inference(CustomLLM):
             raise HTTPException(
                 status_code=500, detail=f"Error during POST request: {str(e)}"
             )
+
+    async def chat_completions_stream_passthrough(
+        self, chat_completions_request: CompletionCreateParams, **kwargs: Any
+    ) -> AsyncIterator[str]:
+        if "/chat/completions" not in LLM_INFERENCE_URL:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Chat completions not supported through endpoint {LLM_INFERENCE_URL}.",
+            )
+
+        client = await self._get_httpx_client()
+
+        async def iter_lines() -> AsyncIterator[str]:
+            try:
+                async with client.stream(
+                    "POST",
+                    LLM_INFERENCE_URL,
+                    json=chat_completions_request,
+                    headers=DEFAULT_HEADERS,
+                ) as response:
+                    response.raise_for_status()
+                    async for line in response.aiter_lines():
+                        if line is not None:
+                            yield line
+            except HTTPException as http_exc:
+                logger.error(
+                    "HTTP exception during streaming chat completions passthrough: %s",
+                    http_exc.detail,
+                )
+                raise http_exc
+            except httpx.HTTPStatusError as exc:
+                logger.error(
+                    "HTTP error %s during streaming POST request to %s: %s",
+                    exc.response.status_code,
+                    LLM_INFERENCE_URL,
+                    exc.response.text,
+                )
+                raise HTTPException(
+                    status_code=exc.response.status_code,
+                    detail=f"{str(exc.response.content)}",
+                ) from exc
+            except httpx.RequestError as exc:
+                logger.error(
+                    "Error during streaming POST request to %s: %s",
+                    LLM_INFERENCE_URL,
+                    exc,
+                )
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Error during streaming POST request: {str(exc)}",
+                ) from exc
+            except Exception as exc:
+                logger.error("Unexpected error during streaming POST request: %s", exc)
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Error during streaming POST request: {str(exc)}",
+                ) from exc
+
+        return iter_lines()
 
     async def _async_completions(
         self, prompt: str, **kwargs: Any

--- a/presets/ragengine/main.py
+++ b/presets/ragengine/main.py
@@ -21,7 +21,7 @@ from urllib.parse import unquote
 import nest_asyncio
 from fastapi import FastAPI, HTTPException, Query, Request  # noqa: E402
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest  # noqa: E402
-from starlette.responses import Response  # noqa: E402
+from starlette.responses import Response, StreamingResponse  # noqa: E402
 
 nest_asyncio.apply()  # Allow nested event loops (LlamaIndex sync internals inside FastAPI async)
 
@@ -59,6 +59,7 @@ from ragengine.config import (  # noqa: E402
 from ragengine.guardrails import (  # noqa: E402
     GuardrailsReloader,
     OutputGuardrailsError,
+    StreamingGuardrailsProcessor,
 )
 from ragengine.metrics.prometheus_metrics import (  # noqa: E402
     MODE_LOCAL,
@@ -352,8 +353,36 @@ async def chat_completions(request: dict):
                 detail="InferenceService not configured. This RAGEngine instance only supports document retrieve via /retrieve API. To use chat completions, configure an InferenceService in the RAGEngine spec.",
             )
 
-        response = await rag_ops.chat_completion(request)
         guardrails = guardrails_reloader.get_current()
+        if request.get("stream"):
+            if request.get("index_name") and not (
+                request.get("tools") or request.get("functions")
+            ):
+                raise HTTPException(
+                    status_code=501,
+                    detail="Streaming chat completions currently support passthrough requests only.",
+                )
+
+            upstream_lines = (
+                await vector_store_handler.llm.chat_completions_stream_passthrough(
+                    request
+                )
+            )
+            if not guardrails.enabled:
+                status = STATUS_SUCCESS
+                return StreamingResponse(
+                    upstream_lines,
+                    media_type="text/event-stream",
+                )
+
+            processor = StreamingGuardrailsProcessor(guardrails, request)
+            status = STATUS_SUCCESS
+            return StreamingResponse(
+                processor.wrap(upstream_lines),
+                media_type="text/event-stream",
+            )
+
+        response = await rag_ops.chat_completion(request)
         response = guardrails.guard_response(response, request)
         status = STATUS_SUCCESS
         return response

--- a/presets/ragengine/tests/api/test_chat_completions.py
+++ b/presets/ragengine/tests/api/test_chat_completions.py
@@ -14,6 +14,7 @@
 import re
 import textwrap
 import time
+from collections.abc import AsyncIterator
 from unittest.mock import patch
 
 import httpx
@@ -22,6 +23,11 @@ import respx
 
 from ragengine.guardrails import OutputGuardrails
 from ragengine.guardrails.scanner_schemas import ParsedScannerConfig, RegexConfig
+
+
+async def _stream_lines(*lines: str) -> AsyncIterator[str]:
+    for line in lines:
+        yield line
 
 
 @pytest.fixture(autouse=True)
@@ -1478,3 +1484,46 @@ async def test_chat_completions_no_max_tokens_specified(mock_get, async_client):
         # Verify the response reaches our business logic (not a validation error)
         assert response.status_code != 422  # Not a validation error
         assert response.status_code in [200, 400, 500]  # Various possible outcomes
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_stream_passthrough_buffer_finalize(async_client):
+    request_payload = {
+        "model": "mock-model",
+        "stream": True,
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+
+    with (
+        patch(
+            "ragengine.inference.inference.Inference.chat_completions_stream_passthrough",
+            return_value=_stream_lines(
+                'data: {"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1,"model":"mock-model","choices":[{"index":0,"delta":{"role":"assistant","content":"hello "},"finish_reason":null}]}',
+                'data: {"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1,"model":"mock-model","choices":[{"index":0,"delta":{"content":"world"},"finish_reason":"stop"}]}',
+                "data: [DONE]",
+            ),
+        ),
+        patch(
+            "ragengine.main.guardrails_reloader.get_current",
+            return_value=OutputGuardrails(
+                enabled=True,
+                scanner_configs=(
+                    ParsedScannerConfig(
+                        type="regex",
+                        config=RegexConfig(patterns=["forbidden"]),
+                        action_on_hit="redact",
+                    ),
+                ),
+            ),
+        ),
+    ):
+        async with async_client.stream(
+            "POST", "/v1/chat/completions", json=request_payload
+        ) as response:
+            assert response.status_code == 200
+            body = await response.aread()
+
+    text = body.decode()
+    assert 'data: {"id": "chatcmpl-stream", "object": "chat.completion.chunk"' in text
+    assert '"content": "hello world"' in text
+    assert text.rstrip().endswith("data: [DONE]")

--- a/presets/ragengine/tests/api/test_chat_completions.py
+++ b/presets/ragengine/tests/api/test_chat_completions.py
@@ -1527,3 +1527,49 @@ async def test_chat_completions_stream_passthrough_buffer_finalize(async_client)
     assert 'data: {"id": "chatcmpl-stream", "object": "chat.completion.chunk"' in text
     assert '"content": "hello world"' in text
     assert text.rstrip().endswith("data: [DONE]")
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_stream_regex_blocks_cross_chunk_pattern(async_client):
+    request_payload = {
+        "model": "mock-model",
+        "stream": True,
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+
+    with (
+        patch(
+            "ragengine.inference.inference.Inference.chat_completions_stream_passthrough",
+            return_value=_stream_lines(
+                'data: {"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1,"model":"mock-model","choices":[{"index":0,"delta":{"role":"assistant","content":"bad"},"finish_reason":null}]}',
+                'data: {"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1,"model":"mock-model","choices":[{"index":0,"delta":{"content":"word"},"finish_reason":null}]}',
+                'data: {"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1,"model":"mock-model","choices":[{"index":0,"delta":{"content":" tail"},"finish_reason":"stop"}]}',
+                "data: [DONE]",
+            ),
+        ),
+        patch(
+            "ragengine.main.guardrails_reloader.get_current",
+            return_value=OutputGuardrails(
+                enabled=True,
+                scanner_configs=(
+                    ParsedScannerConfig(
+                        type="regex",
+                        config=RegexConfig(patterns=["badword"]),
+                        action_on_hit="block",
+                    ),
+                ),
+            ),
+        ),
+    ):
+        async with async_client.stream(
+            "POST", "/v1/chat/completions", json=request_payload
+        ) as response:
+            assert response.status_code == 200
+            body = await response.aread()
+
+    text = body.decode()
+    assert "The model output was blocked by output guardrails." in text
+    assert "badword" not in text
+    assert "tail" not in text
+    assert '"finish_reason": "content_filter"' in text
+    assert text.rstrip().endswith("data: [DONE]")


### PR DESCRIPTION
## Summary

This PR adds the first deterministic streaming scanner adapter: regex.

It validates the streaming scanner contract against the most common cross-chunk matching case by scanning the accumulated stream buffer and handling `block` at stream time before any buffered content is emitted downstream.

## Included

- regex-specific streaming adapter
- cross-chunk regex matching against the accumulated buffer
- first-pass stream handling for `block`
- focused API coverage for cross-chunk regex blocking

## Notes

This PR builds on the phase 1 streaming foundation.

Current behavior is intentionally conservative:
- streamed assistant text remains buffered
- regex can detect matches across chunk boundaries
- `block` stops upstream consumption early and returns a blocked response
- no partial assistant tokens are emitted before the decision is made

## Validation

- `./.venv/bin/python -m pytest presets/ragengine/tests/api/test_chat_completions.py -k 'stream_passthrough_buffer_finalize or stream_regex_blocks_cross_chunk_pattern'`
- `./.venv/bin/python -m pytest presets/ragengine/tests/api/test_chat_completions.py -k 'basic_success or stream_passthrough_buffer_finalize or stream_regex_blocks_cross_chunk_pattern'`
- `./.venv/bin/python -m ruff check presets/ragengine/guardrails/streaming.py presets/ragengine/tests/api/test_chat_completions.py`
- `./.venv/bin/python -m ruff format --check presets/ragengine/guardrails/streaming.py presets/ragengine/tests/api/test_chat_completions.py`