### PR TITLE
feat: Expand streaming guardrails observability

### DIFF
--- a/presets/ragengine/guardrails/__init__.py
+++ b/presets/ragengine/guardrails/__init__.py
@@ -13,5 +13,12 @@
 
 from .output_guardrails import OutputGuardrails, OutputGuardrailsError
 from .reload import GuardrailsReloader
+from .streaming import StreamingDecision, StreamingGuardrailsProcessor
 
-__all__ = ["GuardrailsReloader", "OutputGuardrails", "OutputGuardrailsError"]
+__all__ = [
+    "GuardrailsReloader",
+    "OutputGuardrails",
+    "OutputGuardrailsError",
+    "StreamingDecision",
+    "StreamingGuardrailsProcessor",
+]

--- a/presets/ragengine/guardrails/streaming.py
+++ b/presets/ragengine/guardrails/streaming.py
@@ -1,0 +1,277 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from llm_guard import scan_output
+
+from ragengine.guardrails.output_guardrails import (
+    OutputGuardrails,
+    OutputGuardrailsError,
+)
+from ragengine.guardrails.scanner_schemas import ParsedScannerConfig
+from ragengine.metrics.prometheus_metrics import (
+    output_guardrails_actions_total,
+)
+
+logger = logging.getLogger(__name__)
+
+STREAMING_DECISION_BUFFER = "buffer"
+STREAMING_DECISION_EMIT = "emit"
+STREAMING_DECISION_BLOCK = "block"
+STREAMING_DECISION_ERROR = "error"
+SUPPORTED_STREAMING_SCANNERS = frozenset({"regex", "ban_substrings"})
+
+
+@dataclass(frozen=True)
+class StreamingDecision:
+    state: Literal["buffer", "emit", "block", "error"]
+    content: str = ""
+    scores: dict[str, Any] = field(default_factory=dict)
+
+
+class StreamingScanner:
+    def on_chunk(self, text: str) -> StreamingDecision:
+        raise NotImplementedError
+
+    def finalize(self, prompt: str, content: str) -> StreamingDecision:
+        raise NotImplementedError
+
+
+@dataclass
+class DeterministicStreamingScanner(StreamingScanner):
+    parsed: ParsedScannerConfig
+    scanner: Any
+    action_on_hit: str
+
+    def on_chunk(self, text: str) -> StreamingDecision:
+        del text
+        return StreamingDecision(state=STREAMING_DECISION_BUFFER)
+
+    def finalize(self, prompt: str, content: str) -> StreamingDecision:
+        sanitized_output, results_valid, results_score = scan_output(
+            [self.scanner], prompt, content, fail_fast=False
+        )
+        if all(results_valid.values()):
+            return StreamingDecision(state=STREAMING_DECISION_EMIT, content=content)
+        if self.action_on_hit == "block":
+            return StreamingDecision(
+                state=STREAMING_DECISION_BLOCK,
+                content=sanitized_output,
+                scores=results_score,
+            )
+        return StreamingDecision(
+            state=STREAMING_DECISION_EMIT,
+            content=sanitized_output,
+            scores=results_score,
+        )
+
+
+@dataclass
+class ChunkAccumulator:
+    response_id: str = ""
+    created: int = 0
+    model: str = ""
+    role: str = "assistant"
+    finish_reason: str | None = None
+    content_parts: list[str] = field(default_factory=list)
+
+    def add_chunk(self, chunk: dict[str, Any]) -> None:
+        self.response_id = self.response_id or str(chunk.get("id") or "")
+        self.created = self.created or int(chunk.get("created") or 0)
+        self.model = self.model or str(chunk.get("model") or "")
+
+        choices = chunk.get("choices") or []
+        if not choices:
+            return
+
+        choice = choices[0]
+        delta = choice.get("delta") or {}
+        if delta.get("tool_calls") or delta.get("function_call"):
+            raise OutputGuardrailsError(
+                "Streaming guardrails currently support assistant text deltas only."
+            )
+
+        self.role = delta.get("role") or self.role
+        content = delta.get("content")
+        if isinstance(content, str) and content:
+            self.content_parts.append(content)
+        if choice.get("finish_reason") is not None:
+            self.finish_reason = choice.get("finish_reason")
+
+    @property
+    def content(self) -> str:
+        return "".join(self.content_parts)
+
+
+@dataclass(frozen=True)
+class StreamingFinalizeResult:
+    content: str
+    action: str | None
+    triggered_scanners: tuple[dict[str, Any], ...] = ()
+
+
+class StreamingGuardrailsProcessor:
+    def __init__(self, guardrails: OutputGuardrails, request: dict[str, Any]) -> None:
+        self._guardrails = guardrails
+        self._request = request
+        self._accumulator = ChunkAccumulator()
+        self._scanners = self._build_streaming_scanners()
+
+    def _build_streaming_scanners(self) -> list[DeterministicStreamingScanner]:
+        scanners: list[DeterministicStreamingScanner] = []
+        for parsed, scanner in self._guardrails._build_scanners_with_configs():
+            if parsed.type not in SUPPORTED_STREAMING_SCANNERS:
+                continue
+            scanners.append(
+                DeterministicStreamingScanner(
+                    parsed=parsed,
+                    scanner=scanner,
+                    action_on_hit=parsed.action_on_hit
+                    or self._guardrails.action_on_hit,
+                )
+            )
+        return scanners
+
+    async def wrap(self, upstream_lines: AsyncIterator[str]) -> AsyncIterator[bytes]:
+        try:
+            async for line in upstream_lines:
+                stripped = line.strip()
+                if not stripped:
+                    continue
+                if not stripped.startswith("data:"):
+                    continue
+                payload = stripped[len("data:") :].strip()
+                if payload == "[DONE]":
+                    break
+
+                chunk = json.loads(payload)
+                self._accumulator.add_chunk(chunk)
+                for scanner in self._scanners:
+                    scanner.on_chunk(self._accumulator.content)
+
+            async for chunk in self._finalize_stream():
+                yield chunk
+        except Exception:
+            logger.exception("output_guardrails_streaming_failed")
+            error = {
+                "error": {
+                    "message": "Output guardrails failed while scanning the streamed model response.",
+                    "type": "server_error",
+                }
+            }
+            yield self._format_sse(error)
+            yield b"data: [DONE]\n\n"
+            return
+
+    async def _finalize_stream(self) -> AsyncIterator[bytes]:
+        prompt = self._guardrails._extract_prompt(self._request)
+        result = self._finalize_content(prompt)
+
+        if result.action is not None:
+            output_guardrails_actions_total.labels(action=result.action).inc()
+            logger.info(
+                "output_guardrails_streaming_triggered action=%s response_id=%s scanners=%s policy_hash=%s",
+                result.action,
+                self._accumulator.response_id,
+                list(result.triggered_scanners),
+                self._guardrails.policy_hash,
+            )
+
+        if result.content:
+            yield self._format_sse(
+                {
+                    "id": self._accumulator.response_id or "chatcmpl-stream",
+                    "object": "chat.completion.chunk",
+                    "created": self._accumulator.created or int(time.time()),
+                    "model": self._accumulator.model,
+                    "choices": [
+                        {
+                            "index": 0,
+                            "delta": {
+                                "role": self._accumulator.role,
+                                "content": result.content,
+                            },
+                            "finish_reason": None,
+                        }
+                    ],
+                }
+            )
+
+        yield self._format_sse(
+            {
+                "id": self._accumulator.response_id or "chatcmpl-stream",
+                "object": "chat.completion.chunk",
+                "created": self._accumulator.created or int(time.time()),
+                "model": self._accumulator.model,
+                "choices": [
+                    {
+                        "index": 0,
+                        "delta": {},
+                        "finish_reason": self._accumulator.finish_reason or "stop",
+                    }
+                ],
+            }
+        )
+        yield b"data: [DONE]\n\n"
+
+    @staticmethod
+    def _format_sse(payload: dict[str, Any]) -> bytes:
+        return f"data: {json.dumps(payload)}\n\n".encode()
+
+    def _finalize_content(self, prompt: str) -> StreamingFinalizeResult:
+        sanitized_content = self._accumulator.content
+        triggered_scanners: list[dict[str, Any]] = []
+        final_action: str | None = None
+
+        for scanner in self._scanners:
+            decision = scanner.finalize(prompt, sanitized_content)
+            if decision.state == STREAMING_DECISION_ERROR:
+                raise OutputGuardrailsError(
+                    "Output guardrails failed while scanning the streamed model response."
+                )
+            if (
+                decision.state == STREAMING_DECISION_EMIT
+                and decision.content == sanitized_content
+            ):
+                continue
+
+            triggered_scanners.append(
+                {
+                    "type": scanner.parsed.type,
+                    "action": scanner.action_on_hit,
+                    "scores": decision.scores,
+                }
+            )
+            if decision.state == STREAMING_DECISION_BLOCK:
+                return StreamingFinalizeResult(
+                    content=self._guardrails.block_message,
+                    action="block",
+                    triggered_scanners=tuple(triggered_scanners),
+                )
+
+            sanitized_content = decision.content
+            final_action = "redact"
+
+        return StreamingFinalizeResult(
+            content=sanitized_content,
+            action=final_action,
+            triggered_scanners=tuple(triggered_scanners),
+        )

--- a/presets/ragengine/guardrails/streaming.py
+++ b/presets/ragengine/guardrails/streaming.py
@@ -29,6 +29,13 @@ from ragengine.guardrails.output_guardrails import (
 from ragengine.guardrails.scanner_schemas import ParsedScannerConfig
 from ragengine.metrics.prometheus_metrics import (
     output_guardrails_actions_total,
+    stream_blocks_total,
+    stream_buffer_bytes,
+    stream_chunks_scanned_total,
+    stream_decision_latency_ms,
+    stream_finalize_actions_total,
+    stream_redactions_total,
+    stream_scanner_errors_total,
 )
 
 logger = logging.getLogger(__name__)
@@ -144,6 +151,81 @@ class StreamingGuardrailsProcessor:
         self._accumulator = ChunkAccumulator()
         self._scanners = scanners or self._build_streaming_scanners()
         self._blocked_during_stream = False
+        self._chunk_index = 0
+        self._error_scanner_type = "stream"
+        self._error_phase = "chunk"
+
+    def _stream_id(self) -> str:
+        request_stream_id = str(self._request.get("stream_id") or "")
+        return request_stream_id or self._accumulator.response_id or "chatcmpl-stream"
+
+    def _buffered_bytes(self) -> int:
+        return len(self._accumulator.content.encode("utf-8"))
+
+    @staticmethod
+    def _content_bytes(content: str) -> int:
+        return len(content.encode("utf-8"))
+
+    def _observe_decision_latency(
+        self, scanner_type: str, phase: str, action: str, started_at: float
+    ) -> None:
+        stream_decision_latency_ms.labels(
+            scanner_type=scanner_type,
+            phase=phase,
+            action=action,
+        ).observe((time.perf_counter() - started_at) * 1000)
+
+    def _log_chunk_scanned(self) -> None:
+        logger.info(
+            "output_guardrails_stream_chunk_scanned response_id=%s stream_id=%s chunk_index=%s buffered_bytes=%s fail_open=%s policy_hash=%s",
+            self._accumulator.response_id,
+            self._stream_id(),
+            self._chunk_index,
+            self._buffered_bytes(),
+            self._guardrails.fail_open,
+            self._guardrails.policy_hash,
+        )
+
+    def _log_partial_decision(self, scanner_type: str, partial_action: str) -> None:
+        logger.info(
+            "output_guardrails_stream_partial_decision response_id=%s stream_id=%s chunk_index=%s scanner_type=%s partial_action=%s buffered_bytes=%s emitted_bytes=%s fail_open=%s policy_hash=%s",
+            self._accumulator.response_id,
+            self._stream_id(),
+            self._chunk_index,
+            scanner_type,
+            partial_action,
+            self._buffered_bytes(),
+            0,
+            self._guardrails.fail_open,
+            self._guardrails.policy_hash,
+        )
+
+    def _log_scanner_error(self, *, scanner_type: str, phase: str) -> None:
+        logger.error(
+            "output_guardrails_stream_scanner_error response_id=%s stream_id=%s chunk_index=%s scanner_type=%s fail_open=%s policy_hash=%s phase=%s buffered_bytes=%s",
+            self._accumulator.response_id,
+            self._stream_id(),
+            self._chunk_index,
+            scanner_type,
+            self._guardrails.fail_open,
+            self._guardrails.policy_hash,
+            phase,
+            self._buffered_bytes(),
+        )
+
+    def _log_finalize(self, *, result: StreamingFinalizeResult) -> None:
+        scanner_types = ",".join(item["type"] for item in result.triggered_scanners)
+        logger.info(
+            "output_guardrails_stream_finalize response_id=%s stream_id=%s scanner_type=%s final_action=%s buffered_bytes=%s emitted_bytes=%s fail_open=%s policy_hash=%s",
+            self._accumulator.response_id,
+            self._stream_id(),
+            scanner_types,
+            result.action or "allow",
+            self._buffered_bytes(),
+            self._content_bytes(result.content),
+            self._guardrails.fail_open,
+            self._guardrails.policy_hash,
+        )
 
     def _build_streaming_scanners(self) -> list[DeterministicStreamingScanner]:
         scanners: list[DeterministicStreamingScanner] = []
@@ -174,8 +256,21 @@ class StreamingGuardrailsProcessor:
 
                 chunk = json.loads(payload)
                 self._accumulator.add_chunk(chunk)
+                self._chunk_index += 1
+                stream_chunks_scanned_total.inc()
+                stream_buffer_bytes.set(self._buffered_bytes())
+                self._log_chunk_scanned()
                 for scanner in self._scanners:
+                    self._error_scanner_type = scanner.parsed.type
+                    self._error_phase = "chunk"
+                    decision_started_at = time.perf_counter()
                     decision = scanner.on_chunk(self._accumulator.content)
+                    self._observe_decision_latency(
+                        scanner.parsed.type,
+                        "chunk",
+                        decision.state,
+                        decision_started_at,
+                    )
                     if decision.state == STREAMING_DECISION_ERROR:
                         raise OutputGuardrailsError(
                             "Output guardrails failed while scanning the streamed model response."
@@ -190,13 +285,24 @@ class StreamingGuardrailsProcessor:
                     if decision.state == STREAMING_DECISION_BLOCK:
                         self._blocked_during_stream = True
                         self._accumulator.finish_reason = "content_filter"
+                        self._log_partial_decision(scanner.parsed.type, "block")
                         async for chunk_bytes in self._finalize_stream():
                             yield chunk_bytes
                         return
 
+            self._error_phase = "finalize"
             async for chunk in self._finalize_stream():
                 yield chunk
         except Exception:
+            stream_scanner_errors_total.labels(
+                scanner_type=self._error_scanner_type,
+                phase=self._error_phase,
+                fail_open=str(self._guardrails.fail_open).lower(),
+            ).inc()
+            self._log_scanner_error(
+                scanner_type=self._error_scanner_type,
+                phase=self._error_phase,
+            )
             logger.exception(
                 "output_guardrails_streaming_failed fail_open=%s",
                 self._guardrails.fail_open,
@@ -223,13 +329,24 @@ class StreamingGuardrailsProcessor:
 
         if result.action is not None:
             output_guardrails_actions_total.labels(action=result.action).inc()
-            logger.info(
-                "output_guardrails_streaming_triggered action=%s response_id=%s scanners=%s policy_hash=%s",
-                result.action,
-                self._accumulator.response_id,
-                list(result.triggered_scanners),
-                self._guardrails.policy_hash,
-            )
+            if result.action == "block":
+                if result.triggered_scanners:
+                    for scanner_info in result.triggered_scanners:
+                        stream_blocks_total.labels(
+                            scanner_type=scanner_info["type"]
+                        ).inc()
+                else:
+                    stream_blocks_total.labels(scanner_type="stream").inc()
+            elif result.action == "redact":
+                for scanner_info in result.triggered_scanners:
+                    stream_redactions_total.labels(
+                        scanner_type=scanner_info["type"]
+                    ).inc()
+
+        stream_finalize_actions_total.labels(
+            final_action=result.action or "allow"
+        ).inc()
+        self._log_finalize(result=result)
 
         finish_reason = self._accumulator.finish_reason
         if result.action == "block":
@@ -303,7 +420,16 @@ class StreamingGuardrailsProcessor:
         final_action: str | None = None
 
         for scanner in self._scanners:
+            self._error_scanner_type = scanner.parsed.type
+            self._error_phase = "finalize"
+            decision_started_at = time.perf_counter()
             decision = scanner.finalize(prompt, sanitized_content)
+            self._observe_decision_latency(
+                scanner.parsed.type,
+                "finalize",
+                decision.state,
+                decision_started_at,
+            )
             if decision.state == STREAMING_DECISION_ERROR:
                 raise OutputGuardrailsError(
                     "Output guardrails failed while scanning the streamed model response."

--- a/presets/ragengine/guardrails/streaming.py
+++ b/presets/ragengine/guardrails/streaming.py
@@ -48,6 +48,10 @@ class StreamingDecision:
 
 
 class StreamingScanner:
+    # Streaming redact remains finalize-only until incremental redaction
+    # semantics are explicitly defined.
+    supports_early_block = False
+
     def on_chunk(self, text: str) -> StreamingDecision:
         raise NotImplementedError
 
@@ -129,11 +133,17 @@ class StreamingFinalizeResult:
 
 
 class StreamingGuardrailsProcessor:
-    def __init__(self, guardrails: OutputGuardrails, request: dict[str, Any]) -> None:
+    def __init__(
+        self,
+        guardrails: OutputGuardrails,
+        request: dict[str, Any],
+        scanners: list[StreamingScanner] | None = None,
+    ) -> None:
         self._guardrails = guardrails
         self._request = request
         self._accumulator = ChunkAccumulator()
-        self._scanners = self._build_streaming_scanners()
+        self._scanners = scanners or self._build_streaming_scanners()
+        self._blocked_during_stream = False
 
     def _build_streaming_scanners(self) -> list[DeterministicStreamingScanner]:
         scanners: list[DeterministicStreamingScanner] = []
@@ -165,12 +175,38 @@ class StreamingGuardrailsProcessor:
                 chunk = json.loads(payload)
                 self._accumulator.add_chunk(chunk)
                 for scanner in self._scanners:
-                    scanner.on_chunk(self._accumulator.content)
+                    decision = scanner.on_chunk(self._accumulator.content)
+                    if decision.state == STREAMING_DECISION_ERROR:
+                        raise OutputGuardrailsError(
+                            "Output guardrails failed while scanning the streamed model response."
+                        )
+                    if (
+                        decision.state == STREAMING_DECISION_EMIT
+                        and decision.content != self._accumulator.content
+                    ):
+                        raise OutputGuardrailsError(
+                            "Streaming guardrails only support finalize-time redaction."
+                        )
+                    if decision.state == STREAMING_DECISION_BLOCK:
+                        self._blocked_during_stream = True
+                        self._accumulator.finish_reason = "content_filter"
+                        async for chunk_bytes in self._finalize_stream():
+                            yield chunk_bytes
+                        return
 
             async for chunk in self._finalize_stream():
                 yield chunk
         except Exception:
-            logger.exception("output_guardrails_streaming_failed")
+            logger.exception(
+                "output_guardrails_streaming_failed fail_open=%s",
+                self._guardrails.fail_open,
+            )
+            if self._guardrails.fail_open:
+                async for chunk_bytes in self._emit_passthrough_stream():
+                    yield chunk_bytes
+                return
+
+            output_guardrails_actions_total.labels(action="fail_closed").inc()
             error = {
                 "error": {
                     "message": "Output guardrails failed while scanning the streamed model response.",
@@ -195,7 +231,30 @@ class StreamingGuardrailsProcessor:
                 self._guardrails.policy_hash,
             )
 
-        if result.content:
+        finish_reason = self._accumulator.finish_reason
+        if result.action == "block":
+            finish_reason = "content_filter"
+        async for chunk_bytes in self._emit_terminal_stream(
+            result.content,
+            finish_reason=finish_reason or "stop",
+        ):
+            yield chunk_bytes
+
+    @staticmethod
+    def _format_sse(payload: dict[str, Any]) -> bytes:
+        return f"data: {json.dumps(payload)}\n\n".encode()
+
+    async def _emit_passthrough_stream(self) -> AsyncIterator[bytes]:
+        async for chunk_bytes in self._emit_terminal_stream(
+            self._accumulator.content,
+            finish_reason=self._accumulator.finish_reason or "stop",
+        ):
+            yield chunk_bytes
+
+    async def _emit_terminal_stream(
+        self, content: str, *, finish_reason: str
+    ) -> AsyncIterator[bytes]:
+        if content:
             yield self._format_sse(
                 {
                     "id": self._accumulator.response_id or "chatcmpl-stream",
@@ -207,7 +266,7 @@ class StreamingGuardrailsProcessor:
                             "index": 0,
                             "delta": {
                                 "role": self._accumulator.role,
-                                "content": result.content,
+                                "content": content,
                             },
                             "finish_reason": None,
                         }
@@ -225,18 +284,20 @@ class StreamingGuardrailsProcessor:
                     {
                         "index": 0,
                         "delta": {},
-                        "finish_reason": self._accumulator.finish_reason or "stop",
+                        "finish_reason": finish_reason,
                     }
                 ],
             }
         )
         yield b"data: [DONE]\n\n"
 
-    @staticmethod
-    def _format_sse(payload: dict[str, Any]) -> bytes:
-        return f"data: {json.dumps(payload)}\n\n".encode()
-
     def _finalize_content(self, prompt: str) -> StreamingFinalizeResult:
+        if self._blocked_during_stream:
+            return StreamingFinalizeResult(
+                content=self._guardrails.block_message,
+                action="block",
+            )
+
         sanitized_content = self._accumulator.content
         triggered_scanners: list[dict[str, Any]] = []
         final_action: str | None = None

--- a/presets/ragengine/inference/inference.py
+++ b/presets/ragengine/inference/inference.py
@@ -16,7 +16,7 @@ import asyncio
 import concurrent.futures
 import json
 import logging
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
@@ -315,6 +315,65 @@ class Inference(CustomLLM):
             raise HTTPException(
                 status_code=500, detail=f"Error during POST request: {str(e)}"
             )
+
+    async def chat_completions_stream_passthrough(
+        self, chat_completions_request: CompletionCreateParams, **kwargs: Any
+    ) -> AsyncIterator[str]:
+        if "/chat/completions" not in LLM_INFERENCE_URL:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Chat completions not supported through endpoint {LLM_INFERENCE_URL}.",
+            )
+
+        client = await self._get_httpx_client()
+
+        async def iter_lines() -> AsyncIterator[str]:
+            try:
+                async with client.stream(
+                    "POST",
+                    LLM_INFERENCE_URL,
+                    json=chat_completions_request,
+                    headers=DEFAULT_HEADERS,
+                ) as response:
+                    response.raise_for_status()
+                    async for line in response.aiter_lines():
+                        if line is not None:
+                            yield line
+            except HTTPException as http_exc:
+                logger.error(
+                    "HTTP exception during streaming chat completions passthrough: %s",
+                    http_exc.detail,
+                )
+                raise http_exc
+            except httpx.HTTPStatusError as exc:
+                logger.error(
+                    "HTTP error %s during streaming POST request to %s: %s",
+                    exc.response.status_code,
+                    LLM_INFERENCE_URL,
+                    exc.response.text,
+                )
+                raise HTTPException(
+                    status_code=exc.response.status_code,
+                    detail=f"{str(exc.response.content)}",
+                ) from exc
+            except httpx.RequestError as exc:
+                logger.error(
+                    "Error during streaming POST request to %s: %s",
+                    LLM_INFERENCE_URL,
+                    exc,
+                )
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Error during streaming POST request: {str(exc)}",
+                ) from exc
+            except Exception as exc:
+                logger.error("Unexpected error during streaming POST request: %s", exc)
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Error during streaming POST request: {str(exc)}",
+                ) from exc
+
+        return iter_lines()
 
     async def _async_completions(
         self, prompt: str, **kwargs: Any

--- a/presets/ragengine/main.py
+++ b/presets/ragengine/main.py
@@ -21,7 +21,7 @@ from urllib.parse import unquote
 import nest_asyncio
 from fastapi import FastAPI, HTTPException, Query, Request  # noqa: E402
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest  # noqa: E402
-from starlette.responses import Response  # noqa: E402
+from starlette.responses import Response, StreamingResponse  # noqa: E402
 
 nest_asyncio.apply()  # Allow nested event loops (LlamaIndex sync internals inside FastAPI async)
 
@@ -59,6 +59,7 @@ from ragengine.config import (  # noqa: E402
 from ragengine.guardrails import (  # noqa: E402
     GuardrailsReloader,
     OutputGuardrailsError,
+    StreamingGuardrailsProcessor,
 )
 from ragengine.metrics.prometheus_metrics import (  # noqa: E402
     MODE_LOCAL,
@@ -352,8 +353,36 @@ async def chat_completions(request: dict):
                 detail="InferenceService not configured. This RAGEngine instance only supports document retrieve via /retrieve API. To use chat completions, configure an InferenceService in the RAGEngine spec.",
             )
 
-        response = await rag_ops.chat_completion(request)
         guardrails = guardrails_reloader.get_current()
+        if request.get("stream"):
+            if request.get("index_name") and not (
+                request.get("tools") or request.get("functions")
+            ):
+                raise HTTPException(
+                    status_code=501,
+                    detail="Streaming chat completions currently support passthrough requests only.",
+                )
+
+            upstream_lines = (
+                await vector_store_handler.llm.chat_completions_stream_passthrough(
+                    request
+                )
+            )
+            if not guardrails.enabled:
+                status = STATUS_SUCCESS
+                return StreamingResponse(
+                    upstream_lines,
+                    media_type="text/event-stream",
+                )
+
+            processor = StreamingGuardrailsProcessor(guardrails, request)
+            status = STATUS_SUCCESS
+            return StreamingResponse(
+                processor.wrap(upstream_lines),
+                media_type="text/event-stream",
+            )
+
+        response = await rag_ops.chat_completion(request)
         response = guardrails.guard_response(response, request)
         status = STATUS_SUCCESS
         return response

--- a/presets/ragengine/metrics/prometheus_metrics.py
+++ b/presets/ragengine/metrics/prometheus_metrics.py
@@ -280,6 +280,47 @@ output_guardrails_scanner_build_total = Counter(
     labelnames=[TYPE_LABEL, STATUS_LABEL],
 )
 
+stream_chunks_scanned_total = Counter(
+    "stream_chunks_scanned_total",
+    "Count of streaming chunks scanned by output guardrails.",
+)
+
+stream_blocks_total = Counter(
+    "stream_blocks_total",
+    "Count of streaming responses blocked by output guardrails.",
+    labelnames=["scanner_type"],
+)
+
+stream_redactions_total = Counter(
+    "stream_redactions_total",
+    "Count of streaming responses redacted by output guardrails.",
+    labelnames=["scanner_type"],
+)
+
+stream_finalize_actions_total = Counter(
+    "stream_finalize_actions_total",
+    "Count of final streaming guardrails actions.",
+    labelnames=["final_action"],
+)
+
+stream_scanner_errors_total = Counter(
+    "stream_scanner_errors_total",
+    "Count of streaming scanner errors by scanner, phase, and fail-open mode.",
+    labelnames=["scanner_type", "phase", "fail_open"],
+)
+
+stream_buffer_bytes = Gauge(
+    "stream_buffer_bytes",
+    "Current buffered byte size for the active streaming response.",
+)
+
+stream_decision_latency_ms = Histogram(
+    "stream_decision_latency_ms",
+    "Streaming guardrails decision latency in milliseconds.",
+    labelnames=["scanner_type", "phase", ACTION_LABEL],
+    buckets=(0.05, 0.1, 0.25, 0.5, 1, 2, 5, 10, 25, 50, 100, 250, 500),
+)
+
 rag_hybrid_sparse_candidates = Histogram(
     "rag_hybrid_sparse_candidates",
     "Number of sparse (BM25) candidate nodes returned before fusion",

--- a/presets/ragengine/tests/api/test_chat_completions.py
+++ b/presets/ragengine/tests/api/test_chat_completions.py
@@ -1547,7 +1547,7 @@ async def test_chat_completions_stream_returns_guardrails_error_event(async_clie
         ),
         patch(
             "ragengine.main.guardrails_reloader.get_current",
-            return_value=OutputGuardrails(enabled=True),
+            return_value=OutputGuardrails(enabled=True, fail_open=False),
         ),
     ):
         async with async_client.stream(

--- a/presets/ragengine/tests/api/test_chat_completions.py
+++ b/presets/ragengine/tests/api/test_chat_completions.py
@@ -14,6 +14,7 @@
 import re
 import textwrap
 import time
+from collections.abc import AsyncIterator
 from unittest.mock import patch
 
 import httpx
@@ -22,6 +23,11 @@ import respx
 
 from ragengine.guardrails import OutputGuardrails
 from ragengine.guardrails.scanner_schemas import ParsedScannerConfig, RegexConfig
+
+
+async def _stream_lines(*lines: str) -> AsyncIterator[str]:
+    for line in lines:
+        yield line
 
 
 @pytest.fixture(autouse=True)
@@ -1478,3 +1484,80 @@ async def test_chat_completions_no_max_tokens_specified(mock_get, async_client):
         # Verify the response reaches our business logic (not a validation error)
         assert response.status_code != 422  # Not a validation error
         assert response.status_code in [200, 400, 500]  # Various possible outcomes
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_stream_passthrough_buffer_finalize(async_client):
+    request_payload = {
+        "model": "mock-model",
+        "stream": True,
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+
+    with (
+        patch(
+            "ragengine.inference.inference.Inference.chat_completions_stream_passthrough",
+            return_value=_stream_lines(
+                'data: {"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1,"model":"mock-model","choices":[{"index":0,"delta":{"role":"assistant","content":"hello "},"finish_reason":null}]}',
+                'data: {"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1,"model":"mock-model","choices":[{"index":0,"delta":{"content":"world"},"finish_reason":"stop"}]}',
+                "data: [DONE]",
+            ),
+        ),
+        patch(
+            "ragengine.main.guardrails_reloader.get_current",
+            return_value=OutputGuardrails(
+                enabled=True,
+                scanner_configs=(
+                    ParsedScannerConfig(
+                        type="regex",
+                        config=RegexConfig(patterns=["forbidden"]),
+                        action_on_hit="redact",
+                    ),
+                ),
+            ),
+        ),
+    ):
+        async with async_client.stream(
+            "POST", "/v1/chat/completions", json=request_payload
+        ) as response:
+            assert response.status_code == 200
+            body = await response.aread()
+
+    text = body.decode()
+    assert 'data: {"id": "chatcmpl-stream", "object": "chat.completion.chunk"' in text
+    assert '"content": "hello world"' in text
+    assert text.rstrip().endswith("data: [DONE]")
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_stream_returns_guardrails_error_event(async_client):
+    request_payload = {
+        "model": "mock-model",
+        "stream": True,
+        "messages": [{"role": "user", "content": "hello"}],
+    }
+
+    with (
+        patch(
+            "ragengine.inference.inference.Inference.chat_completions_stream_passthrough",
+            return_value=_stream_lines(
+                'data: {"id":"chatcmpl-stream","object":"chat.completion.chunk","created":1,"model":"mock-model","choices":[{"index":0,"delta":{"tool_calls":[{"id":"call-1"}]},"finish_reason":null}]}',
+                "data: [DONE]",
+            ),
+        ),
+        patch(
+            "ragengine.main.guardrails_reloader.get_current",
+            return_value=OutputGuardrails(enabled=True),
+        ),
+    ):
+        async with async_client.stream(
+            "POST", "/v1/chat/completions", json=request_payload
+        ) as response:
+            assert response.status_code == 200
+            body = await response.aread()
+
+    text = body.decode()
+    assert (
+        "Output guardrails failed while scanning the streamed model response." in text
+    )
+    assert text.rstrip().endswith("data: [DONE]")

--- a/presets/ragengine/tests/guardrails/test_streaming.py
+++ b/presets/ragengine/tests/guardrails/test_streaming.py
@@ -1,0 +1,309 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+
+from ragengine.guardrails.output_guardrails import OutputGuardrails
+from ragengine.guardrails.streaming import (
+    STREAMING_DECISION_BLOCK,
+    STREAMING_DECISION_BUFFER,
+    STREAMING_DECISION_EMIT,
+    ChunkAccumulator,
+    StreamingDecision,
+    StreamingGuardrailsProcessor,
+    StreamingScanner,
+)
+
+
+class _LineStream:
+    def __init__(self, *lines: str) -> None:
+        self._lines = list(lines)
+        self.consumed = 0
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self) -> str:
+        if self.consumed >= len(self._lines):
+            raise StopAsyncIteration
+        line = self._lines[self.consumed]
+        self.consumed += 1
+        return line
+
+
+class _FakeScannerBase(StreamingScanner):
+    def __init__(
+        self, *, scanner_type: str = "test", action_on_hit: str = "block"
+    ) -> None:
+        self.parsed = SimpleNamespace(type=scanner_type)
+        self.action_on_hit = action_on_hit
+
+
+class _EarlyBlockScanner(_FakeScannerBase):
+    supports_early_block = True
+
+    def __init__(self, needle: str) -> None:
+        super().__init__(scanner_type="early_block", action_on_hit="block")
+        self._needle = needle
+
+    def on_chunk(self, text: str) -> StreamingDecision:
+        if self._needle in text:
+            return StreamingDecision(state=STREAMING_DECISION_BLOCK)
+        return StreamingDecision(state=STREAMING_DECISION_BUFFER)
+
+    def finalize(self, prompt: str, content: str) -> StreamingDecision:
+        del prompt, content
+        return StreamingDecision(state=STREAMING_DECISION_EMIT)
+
+
+class _FinalizeBlockScanner(_FakeScannerBase):
+    def __init__(self, needle: str) -> None:
+        super().__init__(scanner_type="finalize_block", action_on_hit="block")
+        self._needle = needle
+
+    def on_chunk(self, text: str) -> StreamingDecision:
+        del text
+        return StreamingDecision(state=STREAMING_DECISION_BUFFER)
+
+    def finalize(self, prompt: str, content: str) -> StreamingDecision:
+        del prompt
+        if self._needle in content:
+            return StreamingDecision(state=STREAMING_DECISION_BLOCK, content=content)
+        return StreamingDecision(state=STREAMING_DECISION_EMIT, content=content)
+
+
+class _FinalizeRedactScanner(_FakeScannerBase):
+    def __init__(self, needle: str, replacement: str) -> None:
+        super().__init__(scanner_type="finalize_redact", action_on_hit="redact")
+        self._needle = needle
+        self._replacement = replacement
+
+    def on_chunk(self, text: str) -> StreamingDecision:
+        del text
+        return StreamingDecision(state=STREAMING_DECISION_BUFFER)
+
+    def finalize(self, prompt: str, content: str) -> StreamingDecision:
+        del prompt
+        if self._needle not in content:
+            return StreamingDecision(state=STREAMING_DECISION_EMIT, content=content)
+        return StreamingDecision(
+            state=STREAMING_DECISION_EMIT,
+            content=content.replace(self._needle, self._replacement),
+        )
+
+
+class _ExplodingScanner(_FakeScannerBase):
+    def __init__(self, *, explode_on: str) -> None:
+        super().__init__(scanner_type="exploding", action_on_hit="block")
+        self._explode_on = explode_on
+
+    def on_chunk(self, text: str) -> StreamingDecision:
+        del text
+        if self._explode_on == "chunk":
+            raise RuntimeError("scanner exploded")
+        return StreamingDecision(state=STREAMING_DECISION_BUFFER)
+
+    def finalize(self, prompt: str, content: str) -> StreamingDecision:
+        del prompt, content
+        if self._explode_on == "finalize":
+            raise RuntimeError("scanner exploded")
+        return StreamingDecision(state=STREAMING_DECISION_EMIT)
+
+
+def _make_line(content: str, *, finish_reason: str | None = None) -> str:
+    payload = {
+        "id": "chatcmpl-stream",
+        "object": "chat.completion.chunk",
+        "created": 1,
+        "model": "mock-model",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"role": "assistant", "content": content},
+                "finish_reason": finish_reason,
+            }
+        ],
+    }
+    return f"data: {json.dumps(payload)}"
+
+
+async def _collect_stream(processor: StreamingGuardrailsProcessor, upstream) -> str:
+    chunks: list[str] = []
+    async for chunk in processor.wrap(upstream):
+        chunks.append(chunk.decode())
+    return "".join(chunks)
+
+
+@pytest.mark.asyncio
+async def test_streaming_early_block_stops_after_middle_chunk() -> None:
+    guardrails = OutputGuardrails(
+        enabled=True, fail_open=False, block_message="blocked"
+    )
+    upstream = _LineStream(
+        _make_line("bad"),
+        _make_line("word"),
+        _make_line(" tail", finish_reason="stop"),
+        "data: [DONE]",
+    )
+    processor = StreamingGuardrailsProcessor(
+        guardrails,
+        {"messages": []},
+        scanners=[_EarlyBlockScanner("badword")],
+    )
+
+    text = await _collect_stream(processor, upstream)
+
+    assert "blocked" in text
+    assert "tail" not in text
+    assert '"finish_reason": "content_filter"' in text
+    assert upstream.consumed == 2
+
+
+@pytest.mark.asyncio
+async def test_streaming_finalize_violation_blocks_after_buffering() -> None:
+    guardrails = OutputGuardrails(
+        enabled=True, fail_open=False, block_message="blocked"
+    )
+    upstream = _LineStream(
+        _make_line("bad"),
+        _make_line("word"),
+        _make_line(" tail", finish_reason="stop"),
+        "data: [DONE]",
+    )
+    processor = StreamingGuardrailsProcessor(
+        guardrails,
+        {"messages": []},
+        scanners=[_FinalizeBlockScanner("badword")],
+    )
+
+    text = await _collect_stream(processor, upstream)
+
+    assert "blocked" in text
+    assert '"finish_reason": "content_filter"' in text
+    assert upstream.consumed == 4
+
+
+@pytest.mark.asyncio
+async def test_streaming_finalize_redaction_handles_cross_chunk_content() -> None:
+    guardrails = OutputGuardrails(enabled=True, fail_open=False)
+    upstream = _LineStream(
+        _make_line("bad"),
+        _make_line("word"),
+        _make_line(" tail", finish_reason="stop"),
+        "data: [DONE]",
+    )
+    processor = StreamingGuardrailsProcessor(
+        guardrails,
+        {"messages": []},
+        scanners=[_FinalizeRedactScanner("badword", "[REDACTED]")],
+    )
+
+    text = await _collect_stream(processor, upstream)
+
+    assert '"content": "[REDACTED] tail"' in text
+    assert text.rstrip().endswith("data: [DONE]")
+
+
+@pytest.mark.asyncio
+async def test_streaming_fail_open_emits_original_content_on_scanner_exception() -> (
+    None
+):
+    guardrails = OutputGuardrails(enabled=True, fail_open=True)
+    upstream = _LineStream(
+        _make_line("hello "),
+        _make_line("world", finish_reason="stop"),
+        "data: [DONE]",
+    )
+    processor = StreamingGuardrailsProcessor(
+        guardrails,
+        {"messages": []},
+        scanners=[_ExplodingScanner(explode_on="finalize")],
+    )
+
+    text = await _collect_stream(processor, upstream)
+
+    assert '"content": "hello world"' in text
+    assert '"type": "server_error"' not in text
+    assert '"finish_reason": "stop"' in text
+
+
+@pytest.mark.asyncio
+async def test_streaming_fail_closed_emits_error_on_scanner_exception() -> None:
+    guardrails = OutputGuardrails(enabled=True, fail_open=False)
+    upstream = _LineStream(
+        _make_line("hello "),
+        _make_line("world", finish_reason="stop"),
+        "data: [DONE]",
+    )
+    processor = StreamingGuardrailsProcessor(
+        guardrails,
+        {"messages": []},
+        scanners=[_ExplodingScanner(explode_on="finalize")],
+    )
+
+    text = await _collect_stream(processor, upstream)
+
+    assert '"type": "server_error"' in text
+    assert '"content": "hello world"' not in text
+
+
+def test_chunk_accumulator_handles_empty_small_and_large_chunks() -> None:
+    accumulator = ChunkAccumulator()
+    accumulator.add_chunk(
+        {
+            "id": "chatcmpl-stream",
+            "created": 1,
+            "model": "mock-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": ""},
+                    "finish_reason": None,
+                }
+            ],
+        }
+    )
+    accumulator.add_chunk(
+        {
+            "id": "chatcmpl-stream",
+            "created": 1,
+            "model": "mock-model",
+            "choices": [{"index": 0, "delta": {"content": "a"}, "finish_reason": None}],
+        }
+    )
+    accumulator.add_chunk(
+        {
+            "id": "chatcmpl-stream",
+            "created": 1,
+            "model": "mock-model",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": "b" * 100_000},
+                    "finish_reason": "stop",
+                }
+            ],
+        }
+    )
+
+    assert accumulator.role == "assistant"
+    assert accumulator.finish_reason == "stop"
+    assert accumulator.content.startswith("a")
+    assert len(accumulator.content) == 100_001

--- a/presets/ragengine/tests/guardrails/test_streaming.py
+++ b/presets/ragengine/tests/guardrails/test_streaming.py
@@ -30,6 +30,15 @@ from ragengine.guardrails.streaming import (
     StreamingGuardrailsProcessor,
     StreamingScanner,
 )
+from ragengine.metrics.prometheus_metrics import (
+    stream_blocks_total,
+    stream_buffer_bytes,
+    stream_chunks_scanned_total,
+    stream_decision_latency_ms,
+    stream_finalize_actions_total,
+    stream_redactions_total,
+    stream_scanner_errors_total,
+)
 
 
 class _LineStream:
@@ -151,10 +160,36 @@ async def _collect_stream(processor: StreamingGuardrailsProcessor, upstream) -> 
     return "".join(chunks)
 
 
+def _counter_value(metric, **labels) -> float:
+    return metric.labels(**labels)._value.get()
+
+
+def _histogram_count(metric, **labels) -> float:
+    for sample in metric.collect()[0].samples:
+        if sample.name.endswith("_count") and sample.labels == labels:
+            return sample.value
+    return 0.0
+
+
 @pytest.mark.asyncio
-async def test_streaming_early_block_stops_after_middle_chunk() -> None:
+async def test_streaming_early_block_stops_after_middle_chunk(caplog) -> None:
     guardrails = OutputGuardrails(
-        enabled=True, fail_open=False, block_message="blocked"
+        enabled=True,
+        fail_open=False,
+        block_message="blocked",
+        policy_hash="policy-123",
+    )
+    before_chunks = stream_chunks_scanned_total._value.get()
+    before_finalize = _counter_value(
+        stream_finalize_actions_total,
+        final_action="block",
+    )
+    before_blocks = _counter_value(stream_blocks_total, scanner_type="stream")
+    before_latency = _histogram_count(
+        stream_decision_latency_ms,
+        scanner_type="early_block",
+        phase="chunk",
+        action=STREAMING_DECISION_BLOCK,
     )
     upstream = _LineStream(
         _make_line("bad"),
@@ -168,12 +203,40 @@ async def test_streaming_early_block_stops_after_middle_chunk() -> None:
         scanners=[_EarlyBlockScanner("badword")],
     )
 
-    text = await _collect_stream(processor, upstream)
+    with caplog.at_level("INFO"):
+        text = await _collect_stream(processor, upstream)
 
     assert "blocked" in text
     assert "tail" not in text
     assert '"finish_reason": "content_filter"' in text
     assert upstream.consumed == 2
+    assert stream_chunks_scanned_total._value.get() == before_chunks + 2
+    assert (
+        _counter_value(stream_finalize_actions_total, final_action="block")
+        == before_finalize + 1
+    )
+    assert (
+        _counter_value(stream_blocks_total, scanner_type="stream") == before_blocks + 1
+    )
+    assert (
+        _histogram_count(
+            stream_decision_latency_ms,
+            scanner_type="early_block",
+            phase="chunk",
+            action=STREAMING_DECISION_BLOCK,
+        )
+        == before_latency + 1
+    )
+    assert stream_buffer_bytes._value.get() == len(b"badword")
+    assert "stream_id=chatcmpl-stream" in caplog.text
+    assert "chunk_index=2" in caplog.text
+    assert "scanner_type=early_block" in caplog.text
+    assert "partial_action=block" in caplog.text
+    assert "final_action=block" in caplog.text
+    assert "buffered_bytes=7" in caplog.text
+    assert "emitted_bytes=7" in caplog.text
+    assert "fail_open=False" in caplog.text
+    assert "policy_hash=policy-123" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -203,6 +266,10 @@ async def test_streaming_finalize_violation_blocks_after_buffering() -> None:
 @pytest.mark.asyncio
 async def test_streaming_finalize_redaction_handles_cross_chunk_content() -> None:
     guardrails = OutputGuardrails(enabled=True, fail_open=False)
+    before_redactions = _counter_value(
+        stream_redactions_total,
+        scanner_type="finalize_redact",
+    )
     upstream = _LineStream(
         _make_line("bad"),
         _make_line("word"),
@@ -219,6 +286,10 @@ async def test_streaming_finalize_redaction_handles_cross_chunk_content() -> Non
 
     assert '"content": "[REDACTED] tail"' in text
     assert text.rstrip().endswith("data: [DONE]")
+    assert (
+        _counter_value(stream_redactions_total, scanner_type="finalize_redact")
+        == before_redactions + 1
+    )
 
 
 @pytest.mark.asyncio
@@ -226,6 +297,12 @@ async def test_streaming_fail_open_emits_original_content_on_scanner_exception()
     None
 ):
     guardrails = OutputGuardrails(enabled=True, fail_open=True)
+    before_errors = _counter_value(
+        stream_scanner_errors_total,
+        scanner_type="exploding",
+        phase="finalize",
+        fail_open="true",
+    )
     upstream = _LineStream(
         _make_line("hello "),
         _make_line("world", finish_reason="stop"),
@@ -242,6 +319,15 @@ async def test_streaming_fail_open_emits_original_content_on_scanner_exception()
     assert '"content": "hello world"' in text
     assert '"type": "server_error"' not in text
     assert '"finish_reason": "stop"' in text
+    assert (
+        _counter_value(
+            stream_scanner_errors_total,
+            scanner_type="exploding",
+            phase="finalize",
+            fail_open="true",
+        )
+        == before_errors + 1
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR expands observability for streaming output guardrails in RAGEngine.

It adds streaming-specific metrics and structured logs so streaming decisions can be debugged more clearly, especially for mid-stream block, finalize-time actions, and scanner failures.

## Included

- chunk-level streaming scan metrics
- block / redact / finalize action counters
- scanner error counters with phase and fail-open context
- buffer size and decision latency metrics
- structured logs for chunk scans, partial decisions, finalize actions, and scanner errors

## Notes

This PR builds on the streaming correctness hardening work and does not change the streaming control-plane contract. Its goal is to make streaming behavior easier to trace in production when a response is blocked, redacted, or fails open/closed.