### PR TITLE
ci: switch nightly images to semver tag and publish to corp ACR

### DIFF
--- a/.github/workflows/publish-controller-acr-nightly-images.yaml
+++ b/.github/workflows/publish-controller-acr-nightly-images.yaml
@@ -1,0 +1,113 @@
+name: Publish nightly controller ACR images
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: 'Git ref to build from (branch, tag, or SHA)'
+        required: false
+        default: 'main'
+        type: string
+
+permissions:
+  contents: read
+
+env:
+  GO_VERSION: '1.26.3'
+  REGISTRY: aitoolchainoperatoratcorp.azurecr.io
+
+concurrency:
+  group: nightly-acr-images
+  cancel-in-progress: true
+
+jobs:
+  build-publish-acr-nightly-images:
+    runs-on:
+      labels:
+        - self-hosted
+        - 1ES.Pool=ai-toolchain-operator-at-corp
+        - JobId=buildPublishAcrNightly-${{ strategy.job-index }}-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    environment: publish-mcr
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image_name: workspace
+            chart_path: charts/kaito/workspace
+            make_image_target: docker-build-workspace
+            make_chart_target: helm-package-workspace
+            image_name_var: IMG_NAME
+          - image_name: ragengine
+            chart_path: charts/kaito/ragengine
+            make_image_target: docker-build-ragengine
+            make_chart_target: helm-package-ragengine
+            image_name_var: RAGENGINE_IMAGE_NAME
+    steps:
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.19.4'
+
+      - name: Install ORAS
+        run: |
+          VER='1.3.0'
+          curl -LO "https://github.com/oras-project/oras/releases/download/v${VER}/oras_${VER}_linux_amd64.tar.gz"
+          sudo tar -zxf "./oras_${VER}_linux_amd64.tar.gz" -C '/usr/local/bin'
+          rm -f "./oras_${VER}_linux_amd64.tar.gz"
+
+      - name: Set up Go ${{ env.GO_VERSION }}
+        uses: actions/setup-go@v5.5.0
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+        with:
+          fetch-depth: 0
+          submodules: true
+          ref: ${{ github.event.inputs.git_ref || 'main' }}
+
+      - id: get-image-tag
+        name: Compute nightly image tag
+        run: |
+          # Semver-compatible nightly tag: <base VERSION>-<UTC date>, e.g. 0.10.0-20260609.
+          base_version="$(grep -E '^VERSION \?=' Makefile | awk '{print $3}' | sed 's/^v//')"
+          date_tag="$(date -u +%Y%m%d)"
+          echo "img_tag=${base_version}-${date_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to ACR
+        run: |
+          az login --identity
+          az acr login -n ${{ env.REGISTRY }}
+
+      - name: Build and push ${{ matrix.image_name }}:${{ steps.get-image-tag.outputs.img_tag }}
+        run: |
+          make "${{ matrix.make_image_target }}" \
+            REGISTRY="${REGISTRY}" \
+            IMG_TAG="${IMG_TAG}" \
+            "${{ matrix.image_name_var }}=${{ matrix.image_name }}"
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMG_TAG: ${{ steps.get-image-tag.outputs.img_tag }}
+
+      - name: Override chart version to match image tag
+        run: |
+          # helm package derives the tgz file name from Chart.yaml's version field, and the
+          # Makefile target expects <name>-<IMG_TAG>.tgz, so pin both fields to IMG_TAG.
+          sed -i.bak -E "s/^version:.*/version: ${IMG_TAG}/" "${CHART_PATH}/Chart.yaml"
+          sed -i.bak -E "s/^appVersion:.*/appVersion: ${IMG_TAG}/" "${CHART_PATH}/Chart.yaml"
+          rm -f "${CHART_PATH}/Chart.yaml.bak"
+        env:
+          CHART_PATH: ${{ matrix.chart_path }}
+          IMG_TAG: ${{ steps.get-image-tag.outputs.img_tag }}
+
+      - name: Package and push chart ${{ matrix.image_name }}:${{ steps.get-image-tag.outputs.img_tag }}
+        run: |
+          make "${{ matrix.make_chart_target }}" \
+            REGISTRY="${REGISTRY}/helm" \
+            IMG_TAG="${IMG_TAG}" \
+            "${{ matrix.image_name_var }}=${{ matrix.image_name }}"
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMG_TAG: ${{ steps.get-image-tag.outputs.img_tag }}

--- a/.github/workflows/publish-controller-acr-nightly-images.yaml
+++ b/.github/workflows/publish-controller-acr-nightly-images.yaml
@@ -16,7 +16,6 @@ permissions:
 
 env:
   GO_VERSION: '1.26.3'
-  REGISTRY: aitoolchainoperatoratcorp.azurecr.io
 
 concurrency:
   group: nightly-acr-images
@@ -79,7 +78,9 @@ jobs:
       - name: Authenticate to ACR
         run: |
           az login --identity
-          az acr login -n ${{ env.REGISTRY }}
+          az acr login -n "${REGISTRY}"
+        env:
+          REGISTRY: ${{ secrets.KAITO_ACR_REGISTRY }}
 
       - name: Build and push ${{ matrix.image_name }}:${{ steps.get-image-tag.outputs.img_tag }}
         run: |
@@ -88,7 +89,7 @@ jobs:
             IMG_TAG="${IMG_TAG}" \
             "${{ matrix.image_name_var }}=${{ matrix.image_name }}"
         env:
-          REGISTRY: ${{ env.REGISTRY }}
+          REGISTRY: ${{ secrets.KAITO_ACR_REGISTRY }}
           IMG_TAG: ${{ steps.get-image-tag.outputs.img_tag }}
 
       - name: Override chart version to match image tag
@@ -109,5 +110,5 @@ jobs:
             IMG_TAG="${IMG_TAG}" \
             "${{ matrix.image_name_var }}=${{ matrix.image_name }}"
         env:
-          REGISTRY: ${{ env.REGISTRY }}
+          REGISTRY: ${{ secrets.KAITO_ACR_REGISTRY }}
           IMG_TAG: ${{ steps.get-image-tag.outputs.img_tag }}

--- a/.github/workflows/publish-controller-gh-nightly-images.yaml
+++ b/.github/workflows/publish-controller-gh-nightly-images.yaml
@@ -57,9 +57,10 @@ jobs:
       - id: get-image-tag
         name: Compute nightly image tag
         run: |
-          short_sha="$(git rev-parse --short=12 HEAD)"
-          echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
-          echo "img_tag=nightly-$short_sha" >> "$GITHUB_OUTPUT"
+          # Semver-compatible nightly tag: <base VERSION>-<UTC date>, e.g. 0.10.0-20260609.
+          base_version="$(grep -E '^VERSION \?=' Makefile | awk '{print $3}' | sed 's/^v//')"
+          date_tag="$(date -u +%Y%m%d)"
+          echo "img_tag=${base_version}-${date_tag}" >> "$GITHUB_OUTPUT"
 
       - name: Login to ${{ steps.get-registry.outputs.registry_repository }}
         uses: docker/login-action@5e57cd118135c172c3672efd75eb46360885c0ef


### PR DESCRIPTION

**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

- publish-controller-gh-nightly-images: tag GHCR nightly images as <base VERSION>-<UTC date> (e.g. 0.10.0-20260609) instead of nightly-<sha>, so the tag is semver-compatible.
- publish-controller-acr-nightly-images: new workflow that builds workspace and ragengine images on the corp 1ES pool ai-toolchain-operator-at-corp and pushes both images and helm charts to aitoolchainoperatoratcorp.azurecr.io with the same semver tag. Chart.yaml version/appVersion are pinned to the nightly tag at package time.


**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: