### PR TITLE
[WIP] feat: add tokenizer sidecar to EPP for precise-prefix-cache-scorer

### DIFF
--- a/pkg/controllers/multiroleinference/controller.go
+++ b/pkg/controllers/multiroleinference/controller.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -506,10 +507,18 @@ const (
 
 // defaultPDPluginsConfigTemplate is the default EPP plugins YAML template for P/D disaggregated serving.
 // Uses the llm-d EndpointPickerConfig format with schedulingProfiles for prefill and decode.
+// The %%MODEL_NAME%% placeholder is replaced with the actual model name from the MRI spec.
+// The token-producer plugin calls the vLLM render sidecar (localhost:8100) for tokenization,
+// which enables the precise-prefix-cache-scorer to compute prefix cache hit ratios.
 const defaultPDPluginsConfigTemplate = `apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
   - type: disagg-headers-handler
+  - type: token-producer
+    parameters:
+      modelName: %%MODEL_NAME%%
+      vllm:
+        http: "http://localhost:8100"
   - type: prefix-based-pd-decider
     parameters:
       nonCachedTokens: 4
@@ -517,6 +526,13 @@ plugins:
     parameters:
       deciders:
         prefill: prefix-based-pd-decider
+  - type: precise-prefix-cache-scorer
+    parameters:
+      tokenProcessorConfig:
+        blockSize: 64
+      indexerConfig:
+        kvBlockIndexConfig:
+          enableMetrics: true
   - type: by-label-selector
     name: prefill-filter
     parameters:
@@ -535,29 +551,29 @@ schedulingProfiles:
   - name: prefill
     plugins:
       - pluginRef: prefill-filter
+      - pluginRef: precise-prefix-cache-scorer
+        weight: 50
       - pluginRef: load-aware-scorer
         weight: 10
       - pluginRef: max-score-picker
   - name: decode
     plugins:
       - pluginRef: decode-filter
+      - pluginRef: precise-prefix-cache-scorer
+        weight: 50
       - pluginRef: load-aware-scorer
         weight: 10
       - pluginRef: max-score-picker
 `
 
-// defaultPDPluginsConfig returns the default P/D plugins config.
-// Note: precise-prefix-cache-scorer is omitted because it requires a tokenizer
-// sidecar (UDS socket) that is not yet deployed by KAITO. Once tokenizer sidecar
-// support is added, this config should be updated to include it.
-func defaultPDPluginsConfig() string {
-	return defaultPDPluginsConfigTemplate
+// defaultPDPluginsConfig returns the default P/D plugins config with the model name substituted.
+func defaultPDPluginsConfig(modelName string) string {
+	return strings.ReplaceAll(defaultPDPluginsConfigTemplate, "%%MODEL_NAME%%", modelName)
 }
 
 // inferencePoolName returns the name of the InferencePool resources for the MRI.
-// Delegates to the shared utils.InferencePoolName helper.
 func inferencePoolName(mriName string) string {
-	return utils.InferencePoolName(mriName)
+	return fmt.Sprintf("%s-inferencepool", mriName)
 }
 
 // reconcileInferencePool creates or updates the Flux OCIRepository and HelmRelease
@@ -620,7 +636,7 @@ func (r *MultiRoleInferenceReconciler) reconcileInferencePool(
 	}
 
 	// Load plugins config: either from user-provided ConfigMap or auto-generated default.
-	pluginsYAML := defaultPDPluginsConfig()
+	pluginsYAML := defaultPDPluginsConfig(mri.Spec.Model.Name)
 	if mri.Spec.EPPPluginsConfig != "" {
 		cm := &corev1.ConfigMap{}
 		if err := r.Get(ctx, client.ObjectKey{Name: mri.Spec.EPPPluginsConfig, Namespace: mri.Namespace}, cm); err != nil {
@@ -640,6 +656,40 @@ func (r *MultiRoleInferenceReconciler) reconcileInferencePool(
 	// behind the mesh, matching standalone InferenceSet behavior.
 	eppValues["flags"] = map[string]string{
 		"secure-serving": "false",
+	}
+	// Tokenizer sidecar: GPU-less vLLM render process for token-producer plugin.
+	// Runs alongside EPP to serve tokenization requests via HTTP on port 8100.
+	eppValues["sidecar"] = map[string]any{
+		"enabled":         true,
+		"name":            "tokenizer",
+		"image":           consts.TokenizerSidecarImage,
+		"imagePullPolicy": string(corev1.PullIfNotPresent),
+		"command":         "python3",
+		"args":            []string{"-m", "vllm.entrypoints.cli.main", "launch", "render", mri.Spec.Model.Name, fmt.Sprintf("--port=%d", consts.TokenizerSidecarPort)},
+		"env": []map[string]string{
+			{"name": "VLLM_TARGET_DEVICE", "value": "cpu"},
+			{"name": "USER", "value": "nonroot"},
+			{"name": "TORCHINDUCTOR_CACHE_DIR", "value": "/tmp/torch-cache"},
+			{"name": "HF_HOME", "value": "/tmp/hf-home"},
+			{"name": "TRANSFORMERS_CACHE", "value": "/tmp/hf-home"},
+			{"name": "VLLM_CACHE_ROOT", "value": "/tmp/vllm-cache"},
+		},
+		"ports": []map[string]any{
+			{
+				"containerPort": consts.TokenizerSidecarPort,
+				"name":          "tokenizer",
+				"protocol":      "TCP",
+			},
+		},
+		"resources": map[string]any{
+			"requests": map[string]string{
+				"cpu":    "500m",
+				"memory": "1Gi",
+			},
+			"limits": map[string]string{
+				"memory": "2Gi",
+			},
+		},
 	}
 
 	helmValues := map[string]any{
@@ -694,18 +744,14 @@ func (r *MultiRoleInferenceReconciler) reconcileInferencePool(
 }
 
 // isInferencePoolReady checks if the InferencePool HelmRelease is ready.
-// When Gateway API Inference Extension is disabled, no pool is reconciled so we return true.
 func (r *MultiRoleInferenceReconciler) isInferencePoolReady(ctx context.Context, mri *kaitov1alpha1.MultiRoleInference) bool {
-	if !r.EnableGatewayAPIInferenceExt {
-		return true
-	}
 	poolName := inferencePoolName(mri.Name)
 	hr := &helmv2.HelmRelease{}
 	if err := r.Get(ctx, client.ObjectKey{Name: poolName, Namespace: mri.Namespace}, hr); err != nil {
 		return false
 	}
 	for _, cond := range hr.Status.Conditions {
-		if cond.Type == consts.ConditionReady && cond.Status == metav1.ConditionTrue &&
+		if cond.Type == "Ready" && cond.Status == metav1.ConditionTrue &&
 			hr.Status.ObservedGeneration >= hr.Generation {
 			return true
 		}

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -322,9 +322,7 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 		}
 	}
 
-	// Reconcile labels on existing workspaces by additively propagating InferenceSet metadata labels.
-	// Note: this only adds/updates desired labels; it does not remove stale labels to avoid
-	// conflicting with labels managed by other controllers.
+	// Reconcile labels on existing workspaces to match template labels and InferenceSet metadata labels.
 	// This ensures label changes (e.g., adding kaito.sh/inference-role) propagate
 	// to workspaces that were created before the label was set.
 	desiredLabels := make(map[string]string)

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -344,20 +344,11 @@ func (p *PresetParam) buildHuggingfaceInferenceCommand() []string {
 }
 
 func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
-	// For InferenceSet-managed workspaces, determine the served-model-name:
-	// - MRI workspaces (have multiroleinference.kaito.sh/created-by label): use VLLM.ModelName
-	//   so all roles share a single model identifier for EPP routing.
-	// - Standalone InferenceSet workspaces: use the InferenceSet name (label value)
-	//   so EPP routes requests by InferenceSet identity.
-	// - Fallback: use VLLM.ModelName if available.
-	if isName, ok := rc.WorkspaceMetadata.Labels[consts.WorkspaceCreatedByInferenceSetLabel]; ok && isName != "" {
-		// Note: string literal used to avoid import cycle with api/v1alpha1 package.
-		// Matches v1alpha1.LabelMultiRoleInferenceParent.
-		if _, isMRI := rc.WorkspaceMetadata.Labels["multiroleinference.kaito.sh/created-by"]; isMRI && p.VLLM.ModelName != "" {
-			p.VLLM.ModelRunParams["served-model-name"] = p.VLLM.ModelName
-		} else {
-			p.VLLM.ModelRunParams["served-model-name"] = isName
-		}
+	// For InferenceSet-managed workspaces (both MRI and standalone), use the model name
+	// as served-model-name so all roles share a single model identifier for EPP routing.
+	// p.VLLM.ModelName is derived from the workspace's inference.preset.name field.
+	if _, ok := rc.WorkspaceMetadata.Labels[consts.WorkspaceCreatedByInferenceSetLabel]; ok && p.VLLM.ModelName != "" {
+		p.VLLM.ModelRunParams["served-model-name"] = p.VLLM.ModelName
 	} else if p.VLLM.ModelName != "" {
 		p.VLLM.ModelRunParams["served-model-name"] = p.VLLM.ModelName
 	}

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -110,6 +110,12 @@ const (
 	EPPImageName = "llm-d-inference-scheduler"
 	EPPImageTag  = "v0.8.0"
 
+	// TokenizerSidecar runs a GPU-less vLLM render process for tokenization.
+	// It exposes /v1/completions/render and /v1/chat/completions/render on port 8100,
+	// used by the token-producer EPP plugin for prefix cache scoring.
+	TokenizerSidecarImage = "vllm/vllm-openai-cpu:v0.21.0"
+	TokenizerSidecarPort  = 8100
+
 	// Routing sidecar for P/D disaggregation on decode workspaces.
 	// The sidecar listens on port 5001 (PortRoutingSidecar) and forwards
 	// to vLLM on port 5000 (PortInferenceServer). The Service targetPort


### PR DESCRIPTION
## What this PR does / why we need it

Deploys a GPU-less vLLM render sidecar alongside the EPP and implements proper port layout for P/D disaggregated serving with prefix cache awareness.

### Changes:
1. **Token-producer plugin** — calls vLLM render sidecar at localhost:8100 to tokenize incoming requests for prefix cache scoring
2. **Tokenizer sidecar container** — deployed via InferencePool HelmRelease values (`python3 -m vllm.entrypoints.cli.main launch render <model> --port=8100`)
3. **Decode port swap** — routing sidecar listens on port 5000 (uniform InferencePool targetPort), vLLM moved to port 5001 via `VLLM_PORT` env var; probes rewritten accordingly
4. **llm-d images** — updated to v0.8.0
5. **served-model-name** — simplified: always use model name for InferenceSet workspaces (both MRI and standalone)
6. **Tokenizer sidecar env vars** — set env for nonroot UID 65532 (USER, TORCHINDUCTOR_CACHE_DIR, HF_HOME, VLLM_TARGET_DEVICE=cpu)
7. **inference_api.py** — respect `VLLM_PORT` env var override (default unchanged: 5000+local_rank)

### Port layout

| Pod type | Port 5000 | Port 5001 |
|----------|-----------|-----------|
| Prefill  | vLLM (direct) | — |
| Decode   | Routing sidecar | vLLM |

InferencePool targets port 5000 uniformly across all pods.

### Image
- Tokenizer sidecar: `upstream.azurecr.io/oss/v2/vllm/vllm-openai-cpu:v0.21.0`

### How to test
- Deploy a MultiRoleInference CR with phi-4-mini-instruct
- Verify EPP pod has tokenizer sidecar running on port 8100
- Verify decode pods have routing sidecar on 5000, vLLM on 5001
- Send chat completion requests and verify P/D routing works with prefix cache scoring

Signed-off-by: Andy Zhang <andyzhangx@live.com>