### PR TITLE
feat: Add streaming guardrails design proposal

### DIFF
--- a/docs/proposals/20260416-ragengine-guardrails-ux-api.md
+++ b/docs/proposals/20260416-ragengine-guardrails-ux-api.md
@@ -1,511 +1,234 @@
 ---
-title: RAGEngine Streaming Output Guardrails Design
+title: RAGEngine Guardrails UX and API
 authors:
   - "@xiaoqi-7"
 reviewers:
   - "@Fei-Guo"
 creation-date: 2026-04-16
-last-updated: 2026-06-18
+last-updated: 2026-05-19
 status: provisional
 see-also:
-  - "/docs/proposals/20260612-ragengine-streaming-guardrails.md"
   - "/docs/proposals/20250715-inference-aware-routing-layer.md"
 ---
 
 ## Summary
 
-This design adds streaming support for RAGEngine chat completions and introduces a
-streaming output guardrail path.
+This proposal defines the intended user-facing model for RAGEngine output guardrails.
+The goal is to keep the CRD surface minimal while allowing guardrail policy to evolve as
+we add more scanners and runtime capabilities.
 
-When a client sends `stream: true`, RAGEngine will request the upstream LLM backend
-with `stream: true`, consume upstream OpenAI-compatible SSE chunks, apply
-streaming-compatible output guardrails, and emit safe SSE chunks to the client.
+The proposed user model is:
 
-The existing non-streaming guardrail path remains unchanged.
+```yaml
+spec:
+  guardrails:
+    enabled: true
+```
+
+Detailed guardrail behavior is stored in a ConfigMap as YAML rather than modeled as
+scanner-specific fields in the `RAGEngine` CRD.
 
 ## Goals
 
-- Support OpenAI-compatible streaming for `/v1/chat/completions`.
-- Forward `stream: true` from RAGEngine to the upstream LLM backend.
-- Add a server-side streaming guardrail processor between upstream LLM chunks and
-  downstream client chunks.
-- Support low-latency streaming for scanners that can operate on partial output.
-- Avoid scanning the full accumulated response on every chunk.
-- Keep each implementation PR small, around 200 core lines where possible.
+- Define a small, stable UX entry point for enabling RAGEngine guardrails.
+- Keep detailed guardrail policy outside the CRD in a ConfigMap-backed YAML document.
+- Allow scanner additions and policy evolution without repeated CRD changes.
 
 ## Non-Goals
 
-- Do not change upstream LLM token generation behavior.
-- Do not guarantee full-response-equivalent safety for all scanner types in true
-  streaming mode.
-- Do not run expensive or full-output scanners on every streaming chunk.
-- Do not introduce full semantic or LLM-based streaming scanners in the first
-  version.
-- Do not refactor the entire RAG pipeline in the first PR.
+- Implement the full runtime behavior in this PR.
+- Expose scanner-specific configuration in the CRD.
+- Finalize streaming, auditing, or error-handling semantics in this document.
 
-## Current Behavior
+## Proposed UX and API Shape
 
-Today, RAGEngine handles `/v1/chat/completions` as a non-streaming request.
+### Minimal CRD Entry Point
 
-The high-level flow is:
+The intended user-facing switch is a minimal `guardrails.enabled` field in the
+`RAGEngine` spec.
 
-```text
-client request
-  ↓
-RAGEngine /v1/chat/completions
-  ↓
-rag_ops.chat_completion(request)
-  ↓
-wait for full upstream response
-  ↓
-guardrails.guard_response(response, request)
-  ↓
-return full JSON response
+```yaml
+apiVersion: kaito.sh/v1beta1
+kind: RAGEngine
+metadata:
+  name: ragengine-with-guardrails
+spec:
+  guardrails:
+    enabled: true
 ```
 
-This works for non-streaming guardrails, but it cannot provide token-level
-streaming because RAGEngine currently waits for the complete response before
-applying guardrails.
+At this stage, the proposal does not add scanner-specific CRD fields such as `action`,
+`scanners`, `patterns`, or `blockMessage`.
 
-## Proposed Behavior
+### ConfigMap-Based YAML Policy
 
-When the request contains:
+Detailed policy is defined in YAML and delivered through a ConfigMap.
 
-```json
-{
-  "stream": true
-}
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ragengine-guardrails-policy
+data:
+  guardrails.yaml: |
+    blockMessage: The model output was blocked by output guardrails.
+    scanners:
+      - type: regex
+        action: redact
+        patterns:
+          - 'https?://\\S+'
+      - type: ban_substrings
+        action: block
+        substrings:
+          - secret
 ```
 
-RAGEngine enters the streaming path:
+The exact YAML schema can evolve, but the design principle is fixed: detailed policy lives
+in ConfigMap YAML, not in the CRD.
 
-```text
-Client
-  ↓ POST /v1/chat/completions stream=true
-RAGEngine
-  ↓ call upstream LLM with stream=true
-Upstream LLM
-  ↓ returns OpenAI-compatible SSE chunks
-RAGEngine streaming guardrail processor
-  ↓ buffer / scan / redact / block
-RAGEngine
-  ↓ emits safe SSE chunks
-Client
+### Default ConfigMap Support
+
+If `spec.guardrails.enabled` is `true` and `configMapRef` is not set, the
+controller copies the default guardrails policy ConfigMap
+(`ragengine-guardrails-policy-template`) into the RAGEngine namespace and mounts
+it into the Pod.
+
+- Auto-copied ConfigMaps are namespace-scoped shared resources and do not carry
+  an `OwnerReference` to any individual RAGEngine. This avoids deleting a
+  shared ConfigMap during cleanup of one RAGEngine while other RAGEngines in the
+  same namespace still depend on it.
+- User-provided ConfigMaps are not modified or owned by the controller.
+- Hot reload is not part of this PR.
+
+The default template provides a conservative deterministic baseline for
+credential and lightweight PII leakage:
+
+- a regex scanner for a few high-signal token formats
+- a `secrets` scanner backed by `detect-secrets`
+- a lightweight `sensitive` scanner for common PII patterns
+
+The regex scanner covers obvious credential leakage, including:
+
+- PEM private key headers
+- AWS access key IDs (`AKIA...`)
+- Google API keys (`AIza...`)
+- GitHub tokens (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`)
+- `sk-...` style API keys
+- `Bearer ...` authorization tokens
+
+The `sensitive` scanner covers:
+
+- email addresses
+- phone numbers
+- credit card-like numbers (Luhn-validated)
+- IPv4 addresses
+
+This is baseline protection, not a complete content-safety policy. Additional
+scanners can still be added via a custom ConfigMap.
+
+### Runtime Failure Semantics
+
+Output guardrails wrap an external ML pipeline (`llm_guard`) whose scanners may fail at
+runtime (e.g. GPU OOM, model download failure, tokenizer errors, library bugs). The
+runtime is currently hard-coded to fail closed when this happens.
+
+| Env Var                          | Default | Description                                                                                  |
+| -------------------------------- | ------- | -------------------------------------------------------------------------------------------- |
+| `OUTPUT_GUARDRAILS_ENABLED`      | `false` | Master switch. When `false`, guardrails are bypassed entirely. |
+| `OUTPUT_GUARDRAILS_POLICY_PATH`  | `""`    | Path to the policy ConfigMap YAML. When unset, the runtime falls back to the default ConfigMap shipped with the system. |
+
+Behavior:
+
+- **Fail-closed** (current behavior): If a scanner raises during `guard_response`, the
+  runtime raises `OutputGuardrailsError`, which the `/v1/chat/completions` handler maps
+  to `HTTP 500` with a fixed detail message
+  (`"Output guardrails failed while scanning the model response."`). The original
+  exception is preserved via `__cause__` for logs, but is not exposed in the HTTP body.
+  Users who encounter a problematic scanner can work around it by disabling that scanner
+  in the guardrails ConfigMap.
+
+Operator guidance: fail-closed should be paired with model pre-warming, dedicated GPU
+quota for guardrails, and Prometheus alerts on `output_guardrails_failed` log volume to
+avoid converting transient ML failures into request errors.
+
+Example deployment (fail-closed for a regulated workload):
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ragengine-guardrails-failclosed
+spec:
+  containers:
+    - name: ragengine
+      image: kaito/ragengine:latest
+      env:
+        - name: OUTPUT_GUARDRAILS_ENABLED
+          value: "true"
+        - name: OUTPUT_GUARDRAILS_POLICY_PATH
+          value: /etc/ragengine/guardrails.yaml
+      volumeMounts:
+        - name: guardrails-policy
+          mountPath: /etc/ragengine
+  volumes:
+    - name: guardrails-policy
+      configMap:
+        name: ragengine-guardrails-policy
 ```
 
-When `stream` is absent or false, RAGEngine continues using the existing
-non-streaming path.
+Sample HTTP response when a scanner fails under fail-closed:
 
-## Architecture
+```http
+HTTP/1.1 500 Internal Server Error
+Content-Type: application/json
 
-### 1. Endpoint Layer
-
-The `/v1/chat/completions` endpoint should branch on `stream`.
-
-```python
-if request.get("stream") is True:
-    return StreamingResponse(
-        guarded_stream_generator,
-        media_type="text/event-stream",
-        headers={
-            "Cache-Control": "no-cache",
-            "X-Accel-Buffering": "no",
-        },
-    )
-
-response = await rag_ops.chat_completion(request)
-guardrails = guardrails_reloader.get_current()
-response = guardrails.guard_response(response, request)
-return response
+{"detail": "Output guardrails failed while scanning the model response."}
 ```
 
-### 2. Upstream Streaming Client
+Future work may introduce per-scanner fail modes inside the policy YAML; the env-level
+switch or CRD/API control can be added later if we need operator-configurable failure
+handling.
 
-RAGEngine should call the upstream LLM backend with:
+## Deferred Scope
 
-```json
-{
-  "stream": true
-}
-```
+This proposal defines the UX shape only. The following items are deferred to follow-up
+implementation PRs:
 
-The upstream response is expected to be OpenAI-compatible SSE:
+- additional scanners beyond the current baseline set
+- audit event model
+- streaming scanning behavior
+- per-scanner fail modes inside the policy YAML
+- configurable failure handling beyond the current fail-closed behavior
 
-```text
-data: {"choices":[{"delta":{"content":"Hello"}}]}
+## Follow-Up Implementation Plan
 
-data: {"choices":[{"delta":{"content":" world"}}]}
+This proposal is intended to support the following implementation sequence:
 
-data: [DONE]
-```
+1. Land the initial non-streaming output guardrails hook. (done)
+2. Define explicit error-handling semantics. (done)
+3. Introduce a runtime YAML policy loader. (done)
+4. Add default ConfigMap support. (done)
+5. Add hot-reload of the guardrails policy ConfigMap. (done)
+6. Refactor scanner construction into a registry/factory structure. (done)
+7. Add more scanners in small batches. (partial)
+8. Add audit foundations. (not done)
+9. Add minimal streaming scanning support. (not done)
+10. Polish graceful UX and operational behavior. (partial)
 
-RAGEngine consumes these upstream SSE events asynchronously.
+### Hot-reload runtime behavior (implemented)
 
-### 3. Streaming Guardrail Processor
+The runtime watches the guardrails policy file and swaps the active
+`OutputGuardrails` instance when the policy changes. For ConfigMap-mounted files,
+it watches the parent directory so Kubernetes symlink updates are detected.
 
-The guardrail processor sits between the upstream LLM stream and the downstream
-client stream.
+Reload semantics:
 
-```text
-upstream SSE event
-  ↓
-parse event
-  ↓
-extract choices[].delta.content
-  ↓
-append to pending buffer
-  ↓
-scan recent window
-  ↓
-emit safe prefix
-  ↓
-keep holdback suffix
-```
+- If a new policy fails to load, the previous policy stays active.
+- Reloads use a 1-second debounce window.
+- Hot reload can be disabled with `OUTPUT_GUARDRAILS_HOT_RELOAD_ENABLED=false`,
+  in which case the policy is loaded once at startup.
 
-RAGEngine should not directly forward every upstream chunk. It should only emit
-content after it has been checked by streaming-compatible scanners.
+Observability:
 
-## Buffering Strategy
-
-Use an un-emitted `pending_buffer`.
-
-```text
-pending_buffer += new_delta
-```
-
-The processor should keep a holdback suffix so that patterns split across chunks
-can still be detected.
-
-Example:
-
-```text
-chunk 1: "u"
-chunk 2: "rl"
-```
-
-If the policy blocks `"url"`, RAGEngine should not emit `"u"` immediately. It
-keeps `"u"` in the holdback buffer. When `"rl"` arrives, the scanner sees
-`"url"` before unsafe content is sent to the client.
-
-Recommended defaults:
-
-```text
-min_scan_chars   = 128
-scan_interval_ms = 50
-holdback_chars   = 256
-max_window_chars = 2048
-max_emit_chars   = 512
-```
-
-Parameter meanings:
-
-```text
-min_scan_chars:
-  Coalesce small chunks before scanning.
-
-scan_interval_ms:
-  Avoid waiting too long when model output is slow.
-
-holdback_chars:
-  Keep the last N characters un-emitted to detect patterns split across chunks.
-
-max_window_chars:
-  Scan only a bounded recent window instead of the full accumulated response.
-
-max_emit_chars:
-  Control downstream SSE chunk size.
-```
-
-At stream end, the holdback buffer must not be dropped. RAGEngine performs a
-final scan and then flushes, redacts, or blocks the remaining content.
-
-## Scanner Capability Model
-
-Streaming guardrails should classify scanners into two groups.
-
-### Streaming-Compatible Scanners
-
-These scanners can make local decisions over partial text and are suitable for
-the streaming path:
-
-```text
-ban_substrings
-regex
-secrets
-sensitive
-invisible_text
-token_limit
-```
-
-### Finalize-Only Scanners
-
-These scanners require complete output and should not run on every streaming
-chunk:
-
-```text
-json
-reading_time
-full-structure checks
-semantic scanners
-LLM-based scanners
-```
-
-## Mixed Scanner Policy
-
-If a policy contains both streaming-compatible scanners and finalize-only
-scanners, RAGEngine must use clear product semantics.
-
-Recommended default: **strict mode**.
-
-```text
-If all scanners are streaming-compatible:
-  use true streaming guardrails
-
-If policy contains finalize-only scanners with block/redact action:
-  fall back to non-streaming guarded execution
-
-If future policy supports audit/log-only finalize scanners:
-  allow best-effort streaming and run finalize scanners at the end
-```
-
-Reason:
-
-```text
-Once content is emitted to the client, it cannot be recalled.
-Therefore, finalize-only blocking scanners cannot provide full blocking guarantees in true streaming mode.
-```
-
-This means a mixed policy with blocking JSON validation will not get true
-streaming in strict mode. This is intentional to preserve safety semantics.
-
-## Guardrail Actions
-
-### Pass
-
-No scanner hit. RAGEngine emits safe content as OpenAI-compatible SSE chunks.
-
-```text
-data: {"choices":[{"delta":{"content":"safe text"}}]}
-```
-
-### Redact
-
-Sensitive spans are replaced before content is emitted.
-
-Example:
-
-```text
-original: my email is user@example.com
-redacted: my email is [REDACTED]
-```
-
-### Block
-
-RAGEngine stops forwarding upstream content and emits a guarded block chunk,
-followed by `[DONE]`.
-
-```text
-data: {"choices":[{"delta":{"content":"Response blocked by output guardrails."},"finish_reason":"content_filter"}]}
-
-data: [DONE]
-```
-
-## Performance Strategy
-
-Do not scan every upstream chunk with every scanner.
-
-Instead:
-
-```text
-coalesce small chunks
-  ↓
-run only streaming-compatible fast scanners
-  ↓
-scan only a bounded recent window
-  ↓
-emit safe prefixes continuously
-  ↓
-flush only the holdback buffer at the end
-```
-
-This keeps scanning pipelined with LLM generation.
-
-The goal is not necessarily to reduce total CPU compared with non-streaming
-scanning. The goal is to reduce time-to-first-safe-output while keeping total
-overhead bounded.
-
-## Safety Limitations
-
-Streaming guardrails are not equivalent to full-response non-streaming
-guardrails for all scanner types.
-
-Limitations:
-
-```text
-Already-emitted content cannot be recalled.
-Holdback only protects bounded local patterns.
-Global scanners still require full output.
-Complex semantic scanners are not suitable for per-chunk execution.
-```
-
-Therefore:
-
-```text
-Fast local scanners can support true streaming.
-Full-output blocking scanners should fall back to non-streaming in strict mode.
-```
-
-## Failure Behavior
-
-Recommended behavior:
-
-```text
-scanner error:
-  fail closed
-
-unsupported streaming scanner in strict mode:
-  fall back to non-streaming guarded execution
-
-upstream stream error:
-  terminate downstream stream safely
-
-client disconnect:
-  stop consuming upstream stream
-
-buffer overflow:
-  fail closed or block stream
-```
-
-## Metrics
-
-Add streaming guardrail metrics:
-
-```text
-stream_guardrails_requests_total
-stream_guardrails_fallback_total{reason}
-stream_guardrails_scans_total
-stream_guardrails_scan_latency_seconds
-stream_guardrails_block_total
-stream_guardrails_redact_total
-stream_guardrails_pending_buffer_chars
-stream_guardrails_time_to_first_safe_chunk_seconds
-stream_guardrails_finalize_latency_seconds
-```
-
-Useful fallback reasons:
-
-```text
-finalize_only_scanner
-scanner_error
-buffer_overflow
-unsupported_policy
-```
-
-## Testing Plan
-
-Add tests for:
-
-```text
-stream=true calls upstream with stream=true
-stream=true returns text/event-stream
-safe chunks are emitted downstream
-blocked substring split across chunks is detected
-holdback is not emitted early
-holdback is flushed at [DONE]
-block emits block message and [DONE]
-redact emits redacted content
-finalize-only scanner triggers strict fallback
-guardrails disabled preserves streaming passthrough
-non-stream path remains unchanged
-```
-
-## PR Plan
-
-To keep PRs small, split implementation into small reviewable changes.
-
-### PR 1: Streaming Passthrough
-
-Scope:
-
-```text
-Add stream=true branch in /v1/chat/completions
-Call upstream LLM with stream=true
-Consume upstream SSE events
-Return StreamingResponse to client
-No guardrail processing yet
-```
-
-Expected core code size: around 150–220 lines.
-
-### PR 2: SSE Utilities
-
-Scope:
-
-```text
-Add SSE parsing helpers
-Detect data: [DONE]
-Extract delta.content
-Build downstream OpenAI-compatible SSE chunks
-Build block SSE chunk
-```
-
-Expected core code size: around 120–180 lines.
-
-### PR 3: Buffer and Holdback
-
-Scope:
-
-```text
-Add pending buffer
-Add holdback suffix
-Add min_scan_chars / max_window_chars / max_emit_chars
-Add final flush behavior
-Use no-op scanner initially
-```
-
-Expected core code size: around 150–220 lines.
-
-### PR 4: Fast Scanner Block Path
-
-Scope:
-
-```text
-Run streaming-compatible scanners on scan window
-Start with ban_substrings and/or regex
-Support block action
-Emit block message and [DONE]
-Add split-chunk block tests
-```
-
-Expected core code size: around 180–250 lines.
-
-### PR 5: Redact, Fallback, and Metrics
-
-Scope:
-
-```text
-Support redact action
-Add scanner capability classification
-Add strict fallback for finalize-only scanners
-Add streaming guardrail metrics
-Add mixed-policy tests
-```
-
-Expected core code size: around 180–250 lines.
-
-## Recommendation
-
-Implement strict mode by default.
-
-This gives clear semantics:
-
-```text
-Policies with only streaming-compatible scanners:
-  true streaming guardrails
-
-Policies with finalize-only blocking scanners:
-  fallback to non-streaming guarded execution
-```
-
-This avoids claiming that streaming guardrails provide the same guarantees as
-full-response non-stream scanning for all scanner types.
+- `guardrails_policy_reload_total{result="success|failure|noop"}`
+- `guardrails_policy_loaded_timestamp_seconds`

--- a/docs/proposals/20260416-ragengine-guardrails-ux-api.md
+++ b/docs/proposals/20260416-ragengine-guardrails-ux-api.md
@@ -1,234 +1,511 @@
 ---
-title: RAGEngine Guardrails UX and API
+title: RAGEngine Streaming Output Guardrails Design
 authors:
   - "@xiaoqi-7"
 reviewers:
   - "@Fei-Guo"
 creation-date: 2026-04-16
-last-updated: 2026-05-19
+last-updated: 2026-06-18
 status: provisional
 see-also:
+  - "/docs/proposals/20260612-ragengine-streaming-guardrails.md"
   - "/docs/proposals/20250715-inference-aware-routing-layer.md"
 ---
 
 ## Summary
 
-This proposal defines the intended user-facing model for RAGEngine output guardrails.
-The goal is to keep the CRD surface minimal while allowing guardrail policy to evolve as
-we add more scanners and runtime capabilities.
+This design adds streaming support for RAGEngine chat completions and introduces a
+streaming output guardrail path.
 
-The proposed user model is:
+When a client sends `stream: true`, RAGEngine will request the upstream LLM backend
+with `stream: true`, consume upstream OpenAI-compatible SSE chunks, apply
+streaming-compatible output guardrails, and emit safe SSE chunks to the client.
 
-```yaml
-spec:
-  guardrails:
-    enabled: true
-```
-
-Detailed guardrail behavior is stored in a ConfigMap as YAML rather than modeled as
-scanner-specific fields in the `RAGEngine` CRD.
+The existing non-streaming guardrail path remains unchanged.
 
 ## Goals
 
-- Define a small, stable UX entry point for enabling RAGEngine guardrails.
-- Keep detailed guardrail policy outside the CRD in a ConfigMap-backed YAML document.
-- Allow scanner additions and policy evolution without repeated CRD changes.
+- Support OpenAI-compatible streaming for `/v1/chat/completions`.
+- Forward `stream: true` from RAGEngine to the upstream LLM backend.
+- Add a server-side streaming guardrail processor between upstream LLM chunks and
+  downstream client chunks.
+- Support low-latency streaming for scanners that can operate on partial output.
+- Avoid scanning the full accumulated response on every chunk.
+- Keep each implementation PR small, around 200 core lines where possible.
 
 ## Non-Goals
 
-- Implement the full runtime behavior in this PR.
-- Expose scanner-specific configuration in the CRD.
-- Finalize streaming, auditing, or error-handling semantics in this document.
+- Do not change upstream LLM token generation behavior.
+- Do not guarantee full-response-equivalent safety for all scanner types in true
+  streaming mode.
+- Do not run expensive or full-output scanners on every streaming chunk.
+- Do not introduce full semantic or LLM-based streaming scanners in the first
+  version.
+- Do not refactor the entire RAG pipeline in the first PR.
 
-## Proposed UX and API Shape
+## Current Behavior
 
-### Minimal CRD Entry Point
+Today, RAGEngine handles `/v1/chat/completions` as a non-streaming request.
 
-The intended user-facing switch is a minimal `guardrails.enabled` field in the
-`RAGEngine` spec.
+The high-level flow is:
 
-```yaml
-apiVersion: kaito.sh/v1beta1
-kind: RAGEngine
-metadata:
-  name: ragengine-with-guardrails
-spec:
-  guardrails:
-    enabled: true
+```text
+client request
+  ↓
+RAGEngine /v1/chat/completions
+  ↓
+rag_ops.chat_completion(request)
+  ↓
+wait for full upstream response
+  ↓
+guardrails.guard_response(response, request)
+  ↓
+return full JSON response
 ```
 
-At this stage, the proposal does not add scanner-specific CRD fields such as `action`,
-`scanners`, `patterns`, or `blockMessage`.
+This works for non-streaming guardrails, but it cannot provide token-level
+streaming because RAGEngine currently waits for the complete response before
+applying guardrails.
 
-### ConfigMap-Based YAML Policy
+## Proposed Behavior
 
-Detailed policy is defined in YAML and delivered through a ConfigMap.
+When the request contains:
 
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: ragengine-guardrails-policy
-data:
-  guardrails.yaml: |
-    blockMessage: The model output was blocked by output guardrails.
-    scanners:
-      - type: regex
-        action: redact
-        patterns:
-          - 'https?://\\S+'
-      - type: ban_substrings
-        action: block
-        substrings:
-          - secret
+```json
+{
+  "stream": true
+}
 ```
 
-The exact YAML schema can evolve, but the design principle is fixed: detailed policy lives
-in ConfigMap YAML, not in the CRD.
+RAGEngine enters the streaming path:
 
-### Default ConfigMap Support
-
-If `spec.guardrails.enabled` is `true` and `configMapRef` is not set, the
-controller copies the default guardrails policy ConfigMap
-(`ragengine-guardrails-policy-template`) into the RAGEngine namespace and mounts
-it into the Pod.
-
-- Auto-copied ConfigMaps are namespace-scoped shared resources and do not carry
-  an `OwnerReference` to any individual RAGEngine. This avoids deleting a
-  shared ConfigMap during cleanup of one RAGEngine while other RAGEngines in the
-  same namespace still depend on it.
-- User-provided ConfigMaps are not modified or owned by the controller.
-- Hot reload is not part of this PR.
-
-The default template provides a conservative deterministic baseline for
-credential and lightweight PII leakage:
-
-- a regex scanner for a few high-signal token formats
-- a `secrets` scanner backed by `detect-secrets`
-- a lightweight `sensitive` scanner for common PII patterns
-
-The regex scanner covers obvious credential leakage, including:
-
-- PEM private key headers
-- AWS access key IDs (`AKIA...`)
-- Google API keys (`AIza...`)
-- GitHub tokens (`ghp_`, `gho_`, `ghu_`, `ghs_`, `ghr_`)
-- `sk-...` style API keys
-- `Bearer ...` authorization tokens
-
-The `sensitive` scanner covers:
-
-- email addresses
-- phone numbers
-- credit card-like numbers (Luhn-validated)
-- IPv4 addresses
-
-This is baseline protection, not a complete content-safety policy. Additional
-scanners can still be added via a custom ConfigMap.
-
-### Runtime Failure Semantics
-
-Output guardrails wrap an external ML pipeline (`llm_guard`) whose scanners may fail at
-runtime (e.g. GPU OOM, model download failure, tokenizer errors, library bugs). The
-runtime is currently hard-coded to fail closed when this happens.
-
-| Env Var                          | Default | Description                                                                                  |
-| -------------------------------- | ------- | -------------------------------------------------------------------------------------------- |
-| `OUTPUT_GUARDRAILS_ENABLED`      | `false` | Master switch. When `false`, guardrails are bypassed entirely. |
-| `OUTPUT_GUARDRAILS_POLICY_PATH`  | `""`    | Path to the policy ConfigMap YAML. When unset, the runtime falls back to the default ConfigMap shipped with the system. |
-
-Behavior:
-
-- **Fail-closed** (current behavior): If a scanner raises during `guard_response`, the
-  runtime raises `OutputGuardrailsError`, which the `/v1/chat/completions` handler maps
-  to `HTTP 500` with a fixed detail message
-  (`"Output guardrails failed while scanning the model response."`). The original
-  exception is preserved via `__cause__` for logs, but is not exposed in the HTTP body.
-  Users who encounter a problematic scanner can work around it by disabling that scanner
-  in the guardrails ConfigMap.
-
-Operator guidance: fail-closed should be paired with model pre-warming, dedicated GPU
-quota for guardrails, and Prometheus alerts on `output_guardrails_failed` log volume to
-avoid converting transient ML failures into request errors.
-
-Example deployment (fail-closed for a regulated workload):
-
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: ragengine-guardrails-failclosed
-spec:
-  containers:
-    - name: ragengine
-      image: kaito/ragengine:latest
-      env:
-        - name: OUTPUT_GUARDRAILS_ENABLED
-          value: "true"
-        - name: OUTPUT_GUARDRAILS_POLICY_PATH
-          value: /etc/ragengine/guardrails.yaml
-      volumeMounts:
-        - name: guardrails-policy
-          mountPath: /etc/ragengine
-  volumes:
-    - name: guardrails-policy
-      configMap:
-        name: ragengine-guardrails-policy
+```text
+Client
+  ↓ POST /v1/chat/completions stream=true
+RAGEngine
+  ↓ call upstream LLM with stream=true
+Upstream LLM
+  ↓ returns OpenAI-compatible SSE chunks
+RAGEngine streaming guardrail processor
+  ↓ buffer / scan / redact / block
+RAGEngine
+  ↓ emits safe SSE chunks
+Client
 ```
 
-Sample HTTP response when a scanner fails under fail-closed:
+When `stream` is absent or false, RAGEngine continues using the existing
+non-streaming path.
 
-```http
-HTTP/1.1 500 Internal Server Error
-Content-Type: application/json
+## Architecture
 
-{"detail": "Output guardrails failed while scanning the model response."}
+### 1. Endpoint Layer
+
+The `/v1/chat/completions` endpoint should branch on `stream`.
+
+```python
+if request.get("stream") is True:
+    return StreamingResponse(
+        guarded_stream_generator,
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+response = await rag_ops.chat_completion(request)
+guardrails = guardrails_reloader.get_current()
+response = guardrails.guard_response(response, request)
+return response
 ```
 
-Future work may introduce per-scanner fail modes inside the policy YAML; the env-level
-switch or CRD/API control can be added later if we need operator-configurable failure
-handling.
+### 2. Upstream Streaming Client
 
-## Deferred Scope
+RAGEngine should call the upstream LLM backend with:
 
-This proposal defines the UX shape only. The following items are deferred to follow-up
-implementation PRs:
+```json
+{
+  "stream": true
+}
+```
 
-- additional scanners beyond the current baseline set
-- audit event model
-- streaming scanning behavior
-- per-scanner fail modes inside the policy YAML
-- configurable failure handling beyond the current fail-closed behavior
+The upstream response is expected to be OpenAI-compatible SSE:
 
-## Follow-Up Implementation Plan
+```text
+data: {"choices":[{"delta":{"content":"Hello"}}]}
 
-This proposal is intended to support the following implementation sequence:
+data: {"choices":[{"delta":{"content":" world"}}]}
 
-1. Land the initial non-streaming output guardrails hook. (done)
-2. Define explicit error-handling semantics. (done)
-3. Introduce a runtime YAML policy loader. (done)
-4. Add default ConfigMap support. (done)
-5. Add hot-reload of the guardrails policy ConfigMap. (done)
-6. Refactor scanner construction into a registry/factory structure. (done)
-7. Add more scanners in small batches. (partial)
-8. Add audit foundations. (not done)
-9. Add minimal streaming scanning support. (not done)
-10. Polish graceful UX and operational behavior. (partial)
+data: [DONE]
+```
 
-### Hot-reload runtime behavior (implemented)
+RAGEngine consumes these upstream SSE events asynchronously.
 
-The runtime watches the guardrails policy file and swaps the active
-`OutputGuardrails` instance when the policy changes. For ConfigMap-mounted files,
-it watches the parent directory so Kubernetes symlink updates are detected.
+### 3. Streaming Guardrail Processor
 
-Reload semantics:
+The guardrail processor sits between the upstream LLM stream and the downstream
+client stream.
 
-- If a new policy fails to load, the previous policy stays active.
-- Reloads use a 1-second debounce window.
-- Hot reload can be disabled with `OUTPUT_GUARDRAILS_HOT_RELOAD_ENABLED=false`,
-  in which case the policy is loaded once at startup.
+```text
+upstream SSE event
+  ↓
+parse event
+  ↓
+extract choices[].delta.content
+  ↓
+append to pending buffer
+  ↓
+scan recent window
+  ↓
+emit safe prefix
+  ↓
+keep holdback suffix
+```
 
-Observability:
+RAGEngine should not directly forward every upstream chunk. It should only emit
+content after it has been checked by streaming-compatible scanners.
 
-- `guardrails_policy_reload_total{result="success|failure|noop"}`
-- `guardrails_policy_loaded_timestamp_seconds`
+## Buffering Strategy
+
+Use an un-emitted `pending_buffer`.
+
+```text
+pending_buffer += new_delta
+```
+
+The processor should keep a holdback suffix so that patterns split across chunks
+can still be detected.
+
+Example:
+
+```text
+chunk 1: "u"
+chunk 2: "rl"
+```
+
+If the policy blocks `"url"`, RAGEngine should not emit `"u"` immediately. It
+keeps `"u"` in the holdback buffer. When `"rl"` arrives, the scanner sees
+`"url"` before unsafe content is sent to the client.
+
+Recommended defaults:
+
+```text
+min_scan_chars   = 128
+scan_interval_ms = 50
+holdback_chars   = 256
+max_window_chars = 2048
+max_emit_chars   = 512
+```
+
+Parameter meanings:
+
+```text
+min_scan_chars:
+  Coalesce small chunks before scanning.
+
+scan_interval_ms:
+  Avoid waiting too long when model output is slow.
+
+holdback_chars:
+  Keep the last N characters un-emitted to detect patterns split across chunks.
+
+max_window_chars:
+  Scan only a bounded recent window instead of the full accumulated response.
+
+max_emit_chars:
+  Control downstream SSE chunk size.
+```
+
+At stream end, the holdback buffer must not be dropped. RAGEngine performs a
+final scan and then flushes, redacts, or blocks the remaining content.
+
+## Scanner Capability Model
+
+Streaming guardrails should classify scanners into two groups.
+
+### Streaming-Compatible Scanners
+
+These scanners can make local decisions over partial text and are suitable for
+the streaming path:
+
+```text
+ban_substrings
+regex
+secrets
+sensitive
+invisible_text
+token_limit
+```
+
+### Finalize-Only Scanners
+
+These scanners require complete output and should not run on every streaming
+chunk:
+
+```text
+json
+reading_time
+full-structure checks
+semantic scanners
+LLM-based scanners
+```
+
+## Mixed Scanner Policy
+
+If a policy contains both streaming-compatible scanners and finalize-only
+scanners, RAGEngine must use clear product semantics.
+
+Recommended default: **strict mode**.
+
+```text
+If all scanners are streaming-compatible:
+  use true streaming guardrails
+
+If policy contains finalize-only scanners with block/redact action:
+  fall back to non-streaming guarded execution
+
+If future policy supports audit/log-only finalize scanners:
+  allow best-effort streaming and run finalize scanners at the end
+```
+
+Reason:
+
+```text
+Once content is emitted to the client, it cannot be recalled.
+Therefore, finalize-only blocking scanners cannot provide full blocking guarantees in true streaming mode.
+```
+
+This means a mixed policy with blocking JSON validation will not get true
+streaming in strict mode. This is intentional to preserve safety semantics.
+
+## Guardrail Actions
+
+### Pass
+
+No scanner hit. RAGEngine emits safe content as OpenAI-compatible SSE chunks.
+
+```text
+data: {"choices":[{"delta":{"content":"safe text"}}]}
+```
+
+### Redact
+
+Sensitive spans are replaced before content is emitted.
+
+Example:
+
+```text
+original: my email is user@example.com
+redacted: my email is [REDACTED]
+```
+
+### Block
+
+RAGEngine stops forwarding upstream content and emits a guarded block chunk,
+followed by `[DONE]`.
+
+```text
+data: {"choices":[{"delta":{"content":"Response blocked by output guardrails."},"finish_reason":"content_filter"}]}
+
+data: [DONE]
+```
+
+## Performance Strategy
+
+Do not scan every upstream chunk with every scanner.
+
+Instead:
+
+```text
+coalesce small chunks
+  ↓
+run only streaming-compatible fast scanners
+  ↓
+scan only a bounded recent window
+  ↓
+emit safe prefixes continuously
+  ↓
+flush only the holdback buffer at the end
+```
+
+This keeps scanning pipelined with LLM generation.
+
+The goal is not necessarily to reduce total CPU compared with non-streaming
+scanning. The goal is to reduce time-to-first-safe-output while keeping total
+overhead bounded.
+
+## Safety Limitations
+
+Streaming guardrails are not equivalent to full-response non-streaming
+guardrails for all scanner types.
+
+Limitations:
+
+```text
+Already-emitted content cannot be recalled.
+Holdback only protects bounded local patterns.
+Global scanners still require full output.
+Complex semantic scanners are not suitable for per-chunk execution.
+```
+
+Therefore:
+
+```text
+Fast local scanners can support true streaming.
+Full-output blocking scanners should fall back to non-streaming in strict mode.
+```
+
+## Failure Behavior
+
+Recommended behavior:
+
+```text
+scanner error:
+  fail closed
+
+unsupported streaming scanner in strict mode:
+  fall back to non-streaming guarded execution
+
+upstream stream error:
+  terminate downstream stream safely
+
+client disconnect:
+  stop consuming upstream stream
+
+buffer overflow:
+  fail closed or block stream
+```
+
+## Metrics
+
+Add streaming guardrail metrics:
+
+```text
+stream_guardrails_requests_total
+stream_guardrails_fallback_total{reason}
+stream_guardrails_scans_total
+stream_guardrails_scan_latency_seconds
+stream_guardrails_block_total
+stream_guardrails_redact_total
+stream_guardrails_pending_buffer_chars
+stream_guardrails_time_to_first_safe_chunk_seconds
+stream_guardrails_finalize_latency_seconds
+```
+
+Useful fallback reasons:
+
+```text
+finalize_only_scanner
+scanner_error
+buffer_overflow
+unsupported_policy
+```
+
+## Testing Plan
+
+Add tests for:
+
+```text
+stream=true calls upstream with stream=true
+stream=true returns text/event-stream
+safe chunks are emitted downstream
+blocked substring split across chunks is detected
+holdback is not emitted early
+holdback is flushed at [DONE]
+block emits block message and [DONE]
+redact emits redacted content
+finalize-only scanner triggers strict fallback
+guardrails disabled preserves streaming passthrough
+non-stream path remains unchanged
+```
+
+## PR Plan
+
+To keep PRs small, split implementation into small reviewable changes.
+
+### PR 1: Streaming Passthrough
+
+Scope:
+
+```text
+Add stream=true branch in /v1/chat/completions
+Call upstream LLM with stream=true
+Consume upstream SSE events
+Return StreamingResponse to client
+No guardrail processing yet
+```
+
+Expected core code size: around 150–220 lines.
+
+### PR 2: SSE Utilities
+
+Scope:
+
+```text
+Add SSE parsing helpers
+Detect data: [DONE]
+Extract delta.content
+Build downstream OpenAI-compatible SSE chunks
+Build block SSE chunk
+```
+
+Expected core code size: around 120–180 lines.
+
+### PR 3: Buffer and Holdback
+
+Scope:
+
+```text
+Add pending buffer
+Add holdback suffix
+Add min_scan_chars / max_window_chars / max_emit_chars
+Add final flush behavior
+Use no-op scanner initially
+```
+
+Expected core code size: around 150–220 lines.
+
+### PR 4: Fast Scanner Block Path
+
+Scope:
+
+```text
+Run streaming-compatible scanners on scan window
+Start with ban_substrings and/or regex
+Support block action
+Emit block message and [DONE]
+Add split-chunk block tests
+```
+
+Expected core code size: around 180–250 lines.
+
+### PR 5: Redact, Fallback, and Metrics
+
+Scope:
+
+```text
+Support redact action
+Add scanner capability classification
+Add strict fallback for finalize-only scanners
+Add streaming guardrail metrics
+Add mixed-policy tests
+```
+
+Expected core code size: around 180–250 lines.
+
+## Recommendation
+
+Implement strict mode by default.
+
+This gives clear semantics:
+
+```text
+Policies with only streaming-compatible scanners:
+  true streaming guardrails
+
+Policies with finalize-only blocking scanners:
+  fallback to non-streaming guarded execution
+```
+
+This avoids claiming that streaming guardrails provide the same guarantees as
+full-response non-stream scanning for all scanner types.

--- a/docs/proposals/20260612-ragengine-streaming-guardrails.md
+++ b/docs/proposals/20260612-ragengine-streaming-guardrails.md
@@ -93,6 +93,92 @@ be added separately with clear precedence rules:
 1. explicit request value wins
 2. service-level default applies only when request value is absent
 
+### End User, Orchestrator, and Runtime Responsibilities
+
+Request-level streaming does not require the originating actor to set `stream`
+manually on every call.
+
+In many deployments, the direct caller of `/v1/chat/completions` is an SDK,
+workflow engine, agent orchestrator, or UI backend rather than a human-operated
+API client. The responsibility boundary should therefore be explicit:
+
+- the originating caller or workflow defines the intended streaming mode
+- the orchestrator or client layer translates that intent into request bodies
+- the runtime consumes the resolved `stream` value for that specific call
+
+Recommended precedence rules are:
+
+1. explicit request `stream` value wins
+2. orchestrator or SDK default applies only when request `stream` is absent
+3. runtime fallback applies only when neither is provided
+
+Under this model:
+
+- the runtime is not responsible for inferring user preference
+- scanners are not responsible for deciding whether a request should stream
+- the orchestrator is responsible for expanding product defaults into concrete per-request values
+
+This separation is especially important for agentic and multi-call workflows, where a
+single upstream action may result in many `/v1/chat/completions` calls. In those
+cases, the orchestrator should materialize the selected mode into the `stream`
+field of each downstream request.
+
+#### Resolution Rule and Recommended Placement
+
+The effective `stream` value for a given call should be resolved using the following
+logic:
+
+```python
+if request explicitly provides stream:
+  use request.stream
+elif orchestrator or SDK default is configured:
+  use that default
+else:
+  use the runtime fallback
+```
+
+For the first implementation, the runtime fallback should remain conservative and
+default to non-streaming.
+
+Representative request shapes are:
+
+Direct API caller:
+
+```json
+{
+  "model": "example-model",
+  "messages": [{"role": "user", "content": "hello"}],
+  "stream": true
+}
+```
+
+Orchestrator-managed caller with a higher-level default:
+
+```json
+{
+  "model": "example-model",
+  "messages": [{"role": "user", "content": "hello"}]
+}
+```
+
+In the second case, the orchestrator resolves its configured default before sending
+the downstream request. The runtime still consumes a concrete per-request `stream`
+value; it does not infer workflow policy on its own.
+
+Recommended placement is:
+
+- end-user preference and workflow defaults live in the UI, SDK, or orchestrator layer
+- request materialization happens in the client or orchestrator request builder
+- final `stream` resolution happens at the `/v1/chat/completions` entrypoint before transport selection
+- streaming guardrails logic runs only after the request has already been classified as streaming
+
+In the current RAGEngine structure, that means:
+
+- higher-level defaults should be resolved before constructing the downstream request body
+- the API entrypoint should consume the final `stream` value and choose between streaming and non-streaming paths
+- the streaming processor should not re-decide whether streaming was intended
+- scanners should operate only on the chosen streaming lifecycle and should not participate in request policy resolution
+
 ### Streaming Runtime Model
 
 The streaming lifecycle is conceptually:

--- a/docs/proposals/20260612-ragengine-streaming-guardrails.md
+++ b/docs/proposals/20260612-ragengine-streaming-guardrails.md
@@ -77,9 +77,6 @@ Streaming is request-driven, not service-default.
 The runtime should continue treating `stream` as a per-request input rather than a global
 deployment switch.
 
-If product requirements later call for a service-level default streaming mode, it should
-be added separately with clear precedence rules.
-
 In the current RAGEngine UX model, `spec.guardrails.enabled` should remain a minimal
 capability switch. Detailed streaming participation policy should live with other
 runtime policy in ConfigMap-backed configuration rather than being folded into
@@ -115,7 +112,6 @@ That yields the following control model:
 
 1. explicit request value wins
 2. scanner-level streaming policy applies only after a request has already been classified as streaming
-3. runtime fallback applies only when neither is provided
 
 ### End User, Orchestrator, and Runtime Responsibilities
 
@@ -134,19 +130,18 @@ For operator-driven deployments, this same model applies one layer up:
 
 - the operator configures scanner-level streaming participation through ConfigMap-backed runtime policy
 - the request path still decides whether a given call is streaming
-- the runtime resolves the final value once at request entry
+- the runtime resolves request-level streaming once at request entry
 
 Recommended precedence rules are:
 
 1. explicit request `stream` value wins
-2. orchestrator or SDK default applies only when request `stream` is absent
-3. runtime fallback applies only when neither is provided
+2. if `stream` is absent, the runtime treats the request as non-streaming
 
 Under this model:
 
 - the runtime is not responsible for inferring user preference
 - scanners are not responsible for deciding whether a request should stream
-- the orchestrator is responsible for expanding product defaults into concrete per-request values
+- the caller is responsible for setting request-level `stream` when streaming is intended
 
 This separation is especially important for agentic and multi-call workflows, where a
 single upstream action may result in many `/v1/chat/completions` calls. In those
@@ -161,13 +156,11 @@ logic:
 ```python
 if request explicitly provides stream:
   use request.stream
-elif orchestrator or SDK default is configured:
-  use that default
 else:
-  use the runtime fallback
+  use false
 ```
 
-For the first implementation, the runtime fallback should remain conservative and
+For the first implementation, omission of `stream` should remain conservative and
 default to non-streaming.
 
 Representative request shapes are:
@@ -182,18 +175,18 @@ Direct API caller:
 }
 ```
 
-Orchestrator-managed caller with a higher-level default:
+Explicit non-streaming caller:
 
 ```json
 {
   "model": "example-model",
-  "messages": [{"role": "user", "content": "hello"}]
+  "messages": [{"role": "user", "content": "hello"}],
+  "stream": false
 }
 ```
 
-In the second case, the orchestrator resolves its configured default before sending
-the downstream request. The runtime still consumes a concrete per-request `stream`
-value; it does not infer workflow policy on its own.
+In the second case, the caller explicitly keeps the request on the non-streaming
+path. The runtime does not infer streaming intent from scanner policy.
 
 Recommended placement is:
 
@@ -208,7 +201,6 @@ In the current RAGEngine structure, that means:
 
 - `guardrails.enabled` remains the minimal CRD switch for enabling guardrails capability
 - scanner-level streaming participation policy should be added to ConfigMap-backed runtime policy rather than encoded in `guardrails.enabled`
-- higher-level defaults should be resolved before constructing the downstream request body
 - the API entrypoint should consume the final `stream` value and choose between streaming and non-streaming paths
 - the streaming processor should not re-decide whether streaming was intended
 - scanners should operate only on the chosen streaming lifecycle and should not participate in request policy resolution

--- a/docs/proposals/20260612-ragengine-streaming-guardrails.md
+++ b/docs/proposals/20260612-ragengine-streaming-guardrails.md
@@ -67,61 +67,29 @@ The current codebase contains the following pieces:
 
 ## Proposed Design
 
-### Request-Level vs Service-Level Control
+### Request-Level Control
 
-Streaming is request-driven, not service-default.
+Streaming is request-driven.
 
-- service-level configuration enables or disables guardrails and points to policy data
 - request-level configuration decides whether a specific call uses streaming
-
-The runtime should continue treating `stream` as a per-request input rather than a global
-deployment switch.
+- scanner-level configuration only affects how scanners participate after a call has entered the streaming path
 
 In the current RAGEngine UX model, `spec.guardrails.enabled` should remain a minimal
 capability switch. Detailed streaming participation policy should live with other
 runtime policy in ConfigMap-backed configuration rather than being folded into
 `guardrails.enabled` itself.
 
-For example, an operator-facing policy document could eventually carry
-scanner-specific streaming participation settings alongside other runtime policy data:
-
-```yaml
-blockMessage: The model output was blocked by output guardrails.
-scanners:
-  - type: regex
-    action: redact
-    streaming:
-      enabled: true
-      mode: finalize_only
-    patterns:
-      - 'https?://\\S+'
-```
-
-In this example, `mode: finalize_only` means the scanner participates in the
-streaming lifecycle but only makes its effective decision at end-of-stream after
-full buffering. Future modes could include richer options such as
-`incremental_redact`, `early_block`, or other capability-specific variants once
-their runtime semantics are well-defined.
-
-This example is illustrative of placement rather than a finalized schema. The key
-point is that scanner-level streaming participation belongs in detailed
-ConfigMap-backed runtime policy, while `guardrails.enabled` remains the minimal
-CRD switch.
-
 That yields the following control model:
 
-1. explicit request value wins
-2. scanner-level streaming policy applies only after a request has already been classified as streaming
+1. explicit request value determines whether the call is streaming
+2. scanner-level streaming policy applies only after the call has entered the streaming path
 
 ### Control Model
 
 Request-level streaming does not require the originating actor to set `stream`
 manually on every call. In many deployments, the direct caller of
 `/v1/chat/completions` is an SDK, workflow engine, agent orchestrator, or UI
-backend rather than a human-operated API client. In operator-driven deployments,
-scanner-level streaming participation is configured through ConfigMap-backed
-runtime policy, but request-level `stream` still determines whether a given call
-enters the streaming path at all.
+backend rather than a human-operated API client.
 
 The effective `stream` value for a call should be resolved using the following
 logic:
@@ -164,7 +132,7 @@ path. The runtime does not infer streaming intent from scanner policy.
 Recommended placement is:
 
 - request materialization happens in the client, SDK, or orchestrator layer
-- operator-managed scanner streaming policy lives in ConfigMap-backed runtime configuration
+- scanner streaming policy lives in ConfigMap-backed runtime configuration
 - final `stream` resolution happens at the `/v1/chat/completions` entrypoint before transport selection
 - scanner-level streaming policy does not determine whether a request is streamed; it only determines how a scanner participates after a request has entered the streaming path
 - streaming guardrails logic runs only after the request has already been classified as streaming

--- a/docs/proposals/20260612-ragengine-streaming-guardrails.md
+++ b/docs/proposals/20260612-ragengine-streaming-guardrails.md
@@ -78,10 +78,44 @@ The runtime should continue treating `stream` as a per-request input rather than
 deployment switch.
 
 If product requirements later call for a service-level default streaming mode, it should
-be added separately with clear precedence rules:
+be added separately with clear precedence rules.
+
+In the current RAGEngine UX model, `spec.guardrails.enabled` should remain a minimal
+capability switch. Detailed streaming participation policy should live with other
+runtime policy in ConfigMap-backed configuration rather than being folded into
+`guardrails.enabled` itself.
+
+For example, an operator-facing policy document could eventually carry
+scanner-specific streaming participation settings alongside other runtime policy data:
+
+```yaml
+blockMessage: The model output was blocked by output guardrails.
+scanners:
+  - type: regex
+    action: redact
+    streaming:
+      enabled: true
+      mode: finalize_only
+    patterns:
+      - 'https?://\\S+'
+```
+
+In this example, `mode: finalize_only` means the scanner participates in the
+streaming lifecycle but only makes its effective decision at end-of-stream after
+full buffering. Future modes could include richer options such as
+`incremental_redact`, `early_block`, or other capability-specific variants once
+their runtime semantics are well-defined.
+
+This example is illustrative of placement rather than a finalized schema. The key
+point is that scanner-level streaming participation belongs in detailed
+ConfigMap-backed runtime policy, while `guardrails.enabled` remains the minimal
+CRD switch.
+
+That yields the following control model:
 
 1. explicit request value wins
-2. service-level default applies only when request value is absent
+2. scanner-level streaming policy applies only after a request has already been classified as streaming
+3. runtime fallback applies only when neither is provided
 
 ### End User, Orchestrator, and Runtime Responsibilities
 
@@ -95,6 +129,12 @@ API client. The responsibility boundary should therefore be explicit:
 - the originating caller or workflow defines the intended streaming mode
 - the orchestrator or client layer translates that intent into request bodies
 - the runtime consumes the resolved `stream` value for that specific call
+
+For operator-driven deployments, this same model applies one layer up:
+
+- the operator configures scanner-level streaming participation through ConfigMap-backed runtime policy
+- the request path still decides whether a given call is streaming
+- the runtime resolves the final value once at request entry
 
 Recommended precedence rules are:
 
@@ -158,12 +198,16 @@ value; it does not infer workflow policy on its own.
 Recommended placement is:
 
 - end-user preference and workflow defaults live in the UI, SDK, or orchestrator layer
+- operator-managed scanner streaming policy lives in ConfigMap-backed runtime configuration
 - request materialization happens in the client or orchestrator request builder
 - final `stream` resolution happens at the `/v1/chat/completions` entrypoint before transport selection
+- scanner-level streaming policy does not determine whether a request is streamed; it only determines how a scanner participates after a request has entered the streaming path
 - streaming guardrails logic runs only after the request has already been classified as streaming
 
 In the current RAGEngine structure, that means:
 
+- `guardrails.enabled` remains the minimal CRD switch for enabling guardrails capability
+- scanner-level streaming participation policy should be added to ConfigMap-backed runtime policy rather than encoded in `guardrails.enabled`
 - higher-level defaults should be resolved before constructing the downstream request body
 - the API entrypoint should consume the final `stream` value and choose between streaming and non-streaming paths
 - the streaming processor should not re-decide whether streaming was intended
@@ -173,7 +217,7 @@ In the current RAGEngine structure, that means:
 
 The streaming lifecycle is conceptually:
 
-1. receive upstream SSE chunks
+1. receive upstream SSE (Server-Sent Events) chunks
 2. accumulate assistant text
 3. invoke scanner `on_chunk(...)`
 4. invoke scanner `finalize(...)`

--- a/docs/proposals/20260612-ragengine-streaming-guardrails.md
+++ b/docs/proposals/20260612-ragengine-streaming-guardrails.md
@@ -1,55 +1,530 @@
 ---
-title: RAGEngine Streaming Guardrails
+title: RAGEngine Streaming Output Guardrails Design
 authors:
   - "@xiaoqi-7"
 reviewers:
 creation-date: 2026-06-12
-last-updated: 2026-06-12
+last-updated: 2026-06-18
 status: provisional
 see-also:
   - "/docs/proposals/20260416-ragengine-guardrails-ux-api.md"
 ---
 
-# RAGEngine Streaming Guardrails
+# RAGEngine Streaming Output Guardrails Design
 
 ## Summary
 
-This proposal defines how streaming output guardrails should work in RAGEngine.
+This design adds streaming support for RAGEngine chat completions and introduces a streaming output guardrail path.
 
-The current codebase supports non-streaming guardrails. The next step is to make streaming guardrails a well-defined runtime
-feature with clear scanner contracts, explicit user-visible behavior, and phased support
-for passthrough and RAG streaming.
+When a client sends `stream: true`, RAGEngine will request the upstream LLM backend with `stream: true`, consume upstream OpenAI-compatible SSE chunks, apply streaming-compatible output guardrails, and emit safe SSE chunks to the client.
 
-The guiding principles are:
+The existing non-streaming guardrail path remains unchanged.
 
-- start with deterministic scanners whose streaming behavior is predictable
-- keep the first implementation conservative and buffering-first
-- treat passthrough streaming and RAG streaming as separate workstreams
-- define explicit runtime contracts rather than relying on implicit behavior
+---
 
-## Motivation
+## Goals
 
-RAGEngine currently applies output guardrails to complete responses after generation.
-This works for non-streaming responses because scanners can evaluate a full answer
-after generation has completed. It does not yet define how scanners should behave
-when the model returns output incrementally in chunks.
+- Support OpenAI-compatible streaming for `/v1/chat/completions`.
+- Forward `stream: true` from RAGEngine to the upstream LLM backend.
+- Add a server-side streaming guardrail processor between upstream LLM chunks and downstream client chunks.
+- Support low-latency streaming for scanners that can operate on partial output.
+- Avoid scanning the full accumulated response on every chunk.
+- Keep each implementation PR small, around 200 core lines where possible.
 
-Once streaming is introduced, the runtime must decide:
+---
 
-- when content can be emitted safely
-- when content must remain buffered
-- what users see for redact and block
-- how scanner capabilities affect overall stream behavior
+## Non-Goals
 
-These questions do not exist in the same form for full-response scanning. They are
-specific to streaming, where content may already be on its way to the client before
-the full response is available for inspection.
+- Do not change upstream LLM token generation behavior.
+- Do not guarantee full-response-equivalent safety for all scanner types in true streaming mode.
+- Do not run expensive or full-output scanners on every streaming chunk.
+- Do not introduce full semantic or LLM-based streaming scanners in the first version.
+- Do not refactor the entire RAG pipeline in the first PR.
 
-Because these choices affect correctness, user-visible behavior, and API
-compatibility, they should be defined explicitly before streaming support expands
-further.
+---
 
-### Goals
+## Current Behavior
+
+Today, RAGEngine handles `/v1/chat/completions` as a non-streaming request.
+
+The high-level flow is:
+
+```text
+client request
+  ↓
+RAGEngine /v1/chat/completions
+  ↓
+rag_ops.chat_completion(request)
+  ↓
+wait for full upstream response
+  ↓
+guardrails.guard_response(response, request)
+  ↓
+return full JSON response
+```
+
+This works for non-streaming guardrails, but it cannot provide token-level streaming because RAGEngine currently waits for the complete response before applying guardrails.
+
+---
+
+## Proposed Behavior
+
+When the request contains:
+
+```text
+{
+  "stream": true
+}
+```
+
+RAGEngine enters the streaming path:
+
+```text
+Client
+  ↓ POST /v1/chat/completions stream=true
+RAGEngine
+  ↓ call upstream LLM with stream=true
+Upstream LLM
+  ↓ returns OpenAI-compatible SSE chunks
+RAGEngine streaming guardrail processor
+  ↓ buffer / scan / redact / block
+RAGEngine
+  ↓ emits safe SSE chunks
+Client
+```
+
+When `stream` is absent or false, RAGEngine continues using the existing non-streaming path.
+
+---
+
+## Architecture
+
+### 1. Endpoint Layer
+
+The `/v1/chat/completions` endpoint should branch on `stream`.
+
+```text
+if request.get("stream") is True:
+    return StreamingResponse(
+        guarded_stream_generator,
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+response = await rag_ops.chat_completion(request)
+guardrails = guardrails_reloader.get_current()
+response = guardrails.guard_response(response, request)
+return response
+```
+
+### 2. Upstream Streaming Client
+
+RAGEngine should call the upstream LLM backend with:
+
+```text
+{
+  "stream": true
+}
+```
+
+The upstream response is expected to be OpenAI-compatible SSE:
+
+```text
+data: {"choices":[{"delta":{"content":"Hello"}}]}
+
+data: {"choices":[{"delta":{"content":" world"}}]}
+
+data: [DONE]
+```
+
+RAGEngine consumes these upstream SSE events asynchronously.
+
+### 3. Streaming Guardrail Processor
+
+The guardrail processor sits between the upstream LLM stream and the downstream client stream.
+
+```text
+upstream SSE event
+  ↓
+parse event
+  ↓
+extract choices[].delta.content
+  ↓
+append to pending buffer
+  ↓
+scan recent window
+  ↓
+emit safe prefix
+  ↓
+keep holdback suffix
+```
+
+RAGEngine should not directly forward every upstream chunk. It should only emit content after it has been checked by streaming-compatible scanners.
+
+---
+
+## Buffering Strategy
+
+Use an un-emitted `pending_buffer`.
+
+```text
+pending_buffer += new_delta
+```
+
+The processor should keep a holdback suffix so that patterns split across chunks can still be detected.
+
+Example:
+
+```text
+chunk 1: "u"
+chunk 2: "rl"
+```
+
+If the policy blocks `"url"`, RAGEngine should not emit `"u"` immediately. It keeps `"u"` in the holdback buffer. When `"rl"` arrives, the scanner sees `"url"` before unsafe content is sent to the client.
+
+Recommended defaults:
+
+```text
+min_scan_chars   = 128
+scan_interval_ms = 50
+holdback_chars   = 256
+max_window_chars = 2048
+max_emit_chars   = 512
+```
+
+Parameter meanings:
+
+```text
+min_scan_chars:
+  Coalesce small chunks before scanning.
+
+scan_interval_ms:
+  Avoid waiting too long when model output is slow.
+
+holdback_chars:
+  Keep the last N characters un-emitted to detect patterns split across chunks.
+
+max_window_chars:
+  Scan only a bounded recent window instead of the full accumulated response.
+
+max_emit_chars:
+  Control downstream SSE chunk size.
+```
+
+At stream end, the holdback buffer must not be dropped. RAGEngine performs a final scan and then flushes, redacts, or blocks the remaining content.
+
+---
+
+## Scanner Capability Model
+
+Streaming guardrails should classify scanners into two groups.
+
+### Streaming-Compatible Scanners
+
+These scanners can make local decisions over partial text and are suitable for the streaming path:
+
+```text
+ban_substrings
+regex
+secrets
+sensitive
+invisible_text
+token_limit
+```
+
+### Finalize-Only Scanners
+
+These scanners require complete output and should not run on every streaming chunk:
+
+```text
+json
+reading_time
+full-structure checks
+semantic scanners
+LLM-based scanners
+```
+
+---
+
+## Mixed Scanner Policy
+
+If a policy contains both streaming-compatible scanners and finalize-only scanners, RAGEngine must use clear product semantics.
+
+Recommended default: **strict mode**.
+
+```text
+If all scanners are streaming-compatible:
+  use true streaming guardrails
+
+If policy contains finalize-only scanners with block/redact action:
+  fall back to non-streaming guarded execution
+
+If future policy supports audit/log-only finalize scanners:
+  allow best-effort streaming and run finalize scanners at the end
+```
+
+Reason:
+
+```text
+Once content is emitted to the client, it cannot be recalled.
+Therefore, finalize-only blocking scanners cannot provide full blocking guarantees in true streaming mode.
+```
+
+This means a mixed policy with blocking JSON validation will not get true streaming in strict mode. This is intentional to preserve safety semantics.
+
+---
+
+## Guardrail Actions
+
+### Pass
+
+No scanner hit. RAGEngine emits safe content as OpenAI-compatible SSE chunks.
+
+```text
+data: {"choices":[{"delta":{"content":"safe text"}}]}
+```
+
+### Redact
+
+Sensitive spans are replaced before content is emitted.
+
+Example:
+
+```text
+original: my email is user@example.com
+redacted: my email is [REDACTED]
+```
+
+### Block
+
+RAGEngine stops forwarding upstream content and emits a guarded block chunk, followed by `[DONE]`.
+
+```text
+data: {"choices":[{"delta":{"content":"Response blocked by output guardrails."},"finish_reason":"content_filter"}]}
+
+data: [DONE]
+```
+
+---
+
+## Performance Strategy
+
+Do not scan every upstream chunk with every scanner.
+
+Instead:
+
+```text
+coalesce small chunks
+  ↓
+run only streaming-compatible fast scanners
+  ↓
+scan only a bounded recent window
+  ↓
+emit safe prefixes continuously
+  ↓
+flush only the holdback buffer at the end
+```
+
+This keeps scanning pipelined with LLM generation.
+
+The goal is not necessarily to reduce total CPU compared with non-streaming scanning. The goal is to reduce time-to-first-safe-output while keeping total overhead bounded.
+
+---
+
+## Safety Limitations
+
+Streaming guardrails are not equivalent to full-response non-streaming guardrails for all scanner types.
+
+Limitations:
+
+```text
+Already-emitted content cannot be recalled.
+Holdback only protects bounded local patterns.
+Global scanners still require full output.
+Complex semantic scanners are not suitable for per-chunk execution.
+```
+
+Therefore:
+
+```text
+Fast local scanners can support true streaming.
+Full-output blocking scanners should fall back to non-streaming in strict mode.
+```
+
+---
+
+## Failure Behavior
+
+Recommended behavior:
+
+```text
+scanner error:
+  fail closed
+
+unsupported streaming scanner in strict mode:
+  fall back to non-streaming guarded execution
+
+upstream stream error:
+  terminate downstream stream safely
+
+client disconnect:
+  stop consuming upstream stream
+
+buffer overflow:
+  fail closed or block stream
+```
+
+---
+
+## Metrics
+
+Add streaming guardrail metrics:
+
+```text
+stream_guardrails_requests_total
+stream_guardrails_fallback_total{reason}
+stream_guardrails_scans_total
+stream_guardrails_scan_latency_seconds
+stream_guardrails_block_total
+stream_guardrails_redact_total
+stream_guardrails_pending_buffer_chars
+stream_guardrails_time_to_first_safe_chunk_seconds
+stream_guardrails_finalize_latency_seconds
+```
+
+Useful fallback reasons:
+
+```text
+finalize_only_scanner
+scanner_error
+buffer_overflow
+unsupported_policy
+```
+
+---
+
+## Testing Plan
+
+Add tests for:
+
+```text
+stream=true calls upstream with stream=true
+stream=true returns text/event-stream
+safe chunks are emitted downstream
+blocked substring split across chunks is detected
+holdback is not emitted early
+holdback is flushed at [DONE]
+block emits block message and [DONE]
+redact emits redacted content
+finalize-only scanner triggers strict fallback
+guardrails disabled preserves streaming passthrough
+non-stream path remains unchanged
+```
+
+---
+
+## PR Plan
+
+To keep PRs small, split implementation into small reviewable changes.
+
+### PR 1: Streaming Passthrough
+
+Scope:
+
+```text
+Add stream=true branch in /v1/chat/completions
+Call upstream LLM with stream=true
+Consume upstream SSE events
+Return StreamingResponse to client
+No guardrail processing yet
+```
+
+Expected core code size: around 150–220 lines.
+
+---
+
+### PR 2: SSE Utilities
+
+Scope:
+
+```text
+Add SSE parsing helpers
+Detect data: [DONE]
+Extract delta.content
+Build downstream OpenAI-compatible SSE chunks
+Build block SSE chunk
+```
+
+Expected core code size: around 120–180 lines.
+
+---
+
+### PR 3: Buffer and Holdback
+
+Scope:
+
+```text
+Add pending buffer
+Add holdback suffix
+Add min_scan_chars / max_window_chars / max_emit_chars
+Add final flush behavior
+Use no-op scanner initially
+```
+
+Expected core code size: around 150–220 lines.
+
+---
+
+### PR 4: Fast Scanner Block Path
+
+Scope:
+
+```text
+Run streaming-compatible scanners on scan window
+Start with ban_substrings and/or regex
+Support block action
+Emit block message and [DONE]
+Add split-chunk block tests
+```
+
+Expected core code size: around 180–250 lines.
+
+---
+
+### PR 5: Redact, Fallback, and Metrics
+
+Scope:
+
+```text
+Support redact action
+Add scanner capability classification
+Add strict fallback for finalize-only scanners
+Add streaming guardrail metrics
+Add mixed-policy tests
+```
+
+Expected core code size: around 180–250 lines.
+
+---
+
+## Recommendation
+
+Implement strict mode by default.
+
+This gives clear semantics:
+
+```text
+Policies with only streaming-compatible scanners:
+  true streaming guardrails
+
+Policies with finalize-only blocking scanners:
+  fallback to non-streaming guarded execution
+```
+
+This avoids claiming that streaming guardrails provide the same guarantees as full-response non-stream scanning for all scanner types.
 
 - Define the runtime contract for streaming scanners.
 - Support a conservative initial implementation for deterministic scanners.

--- a/docs/proposals/20260612-ragengine-streaming-guardrails.md
+++ b/docs/proposals/20260612-ragengine-streaming-guardrails.md
@@ -44,7 +44,6 @@ The existing non-streaming guardrail path remains unchanged.
 ---
 
 ## Current Behavior
-
 Today, RAGEngine handles `/v1/chat/completions` as a non-streaming request.
 
 The high-level flow is:
@@ -62,13 +61,11 @@ guardrails.guard_response(response, request)
   ↓
 return full JSON response
 ```
-
 This works for non-streaming guardrails, but it cannot provide token-level streaming because RAGEngine currently waits for the complete response before applying guardrails.
 
 ---
 
 ## Proposed Behavior
-
 When the request contains:
 
 ```text
@@ -76,7 +73,6 @@ When the request contains:
   "stream": true
 }
 ```
-
 RAGEngine enters the streaming path:
 
 ```text
@@ -92,7 +88,6 @@ RAGEngine
   ↓ emits safe SSE chunks
 Client
 ```
-
 When `stream` is absent or false, RAGEngine continues using the existing non-streaming path.
 
 ---
@@ -100,7 +95,6 @@ When `stream` is absent or false, RAGEngine continues using the existing non-str
 ## Architecture
 
 ### 1. Endpoint Layer
-
 The `/v1/chat/completions` endpoint should branch on `stream`.
 
 ```text
@@ -121,7 +115,6 @@ return response
 ```
 
 ### 2. Upstream Streaming Client
-
 RAGEngine should call the upstream LLM backend with:
 
 ```text
@@ -129,7 +122,6 @@ RAGEngine should call the upstream LLM backend with:
   "stream": true
 }
 ```
-
 The upstream response is expected to be OpenAI-compatible SSE:
 
 ```text
@@ -139,11 +131,9 @@ data: {"choices":[{"delta":{"content":" world"}}]}
 
 data: [DONE]
 ```
-
 RAGEngine consumes these upstream SSE events asynchronously.
 
 ### 3. Streaming Guardrail Processor
-
 The guardrail processor sits between the upstream LLM stream and the downstream client stream.
 
 ```text
@@ -161,19 +151,16 @@ emit safe prefix
   ↓
 keep holdback suffix
 ```
-
 RAGEngine should not directly forward every upstream chunk. It should only emit content after it has been checked by streaming-compatible scanners.
 
 ---
 
 ## Buffering Strategy
-
 Use an un-emitted `pending_buffer`.
 
 ```text
 pending_buffer += new_delta
 ```
-
 The processor should keep a holdback suffix so that patterns split across chunks can still be detected.
 
 Example:
@@ -182,7 +169,6 @@ Example:
 chunk 1: "u"
 chunk 2: "rl"
 ```
-
 If the policy blocks `"url"`, RAGEngine should not emit `"u"` immediately. It keeps `"u"` in the holdback buffer. When `"rl"` arrives, the scanner sees `"url"` before unsafe content is sent to the client.
 
 Recommended defaults:
@@ -194,7 +180,6 @@ holdback_chars   = 256
 max_window_chars = 2048
 max_emit_chars   = 512
 ```
-
 Parameter meanings:
 
 ```text
@@ -213,17 +198,14 @@ max_window_chars:
 max_emit_chars:
   Control downstream SSE chunk size.
 ```
-
 At stream end, the holdback buffer must not be dropped. RAGEngine performs a final scan and then flushes, redacts, or blocks the remaining content.
 
 ---
 
 ## Scanner Capability Model
-
 Streaming guardrails should classify scanners into two groups.
 
 ### Streaming-Compatible Scanners
-
 These scanners can make local decisions over partial text and are suitable for the streaming path:
 
 ```text
@@ -236,7 +218,6 @@ token_limit
 ```
 
 ### Finalize-Only Scanners
-
 These scanners require complete output and should not run on every streaming chunk:
 
 ```text
@@ -250,7 +231,6 @@ LLM-based scanners
 ---
 
 ## Mixed Scanner Policy
-
 If a policy contains both streaming-compatible scanners and finalize-only scanners, RAGEngine must use clear product semantics.
 
 Recommended default: **strict mode**.
@@ -265,14 +245,12 @@ If policy contains finalize-only scanners with block/redact action:
 If future policy supports audit/log-only finalize scanners:
   allow best-effort streaming and run finalize scanners at the end
 ```
-
 Reason:
 
 ```text
 Once content is emitted to the client, it cannot be recalled.
 Therefore, finalize-only blocking scanners cannot provide full blocking guarantees in true streaming mode.
 ```
-
 This means a mixed policy with blocking JSON validation will not get true streaming in strict mode. This is intentional to preserve safety semantics.
 
 ---
@@ -280,7 +258,6 @@ This means a mixed policy with blocking JSON validation will not get true stream
 ## Guardrail Actions
 
 ### Pass
-
 No scanner hit. RAGEngine emits safe content as OpenAI-compatible SSE chunks.
 
 ```text
@@ -288,7 +265,6 @@ data: {"choices":[{"delta":{"content":"safe text"}}]}
 ```
 
 ### Redact
-
 Sensitive spans are replaced before content is emitted.
 
 Example:
@@ -299,7 +275,6 @@ redacted: my email is [REDACTED]
 ```
 
 ### Block
-
 RAGEngine stops forwarding upstream content and emits a guarded block chunk, followed by `[DONE]`.
 
 ```text
@@ -311,7 +286,6 @@ data: [DONE]
 ---
 
 ## Performance Strategy
-
 Do not scan every upstream chunk with every scanner.
 
 Instead:
@@ -327,7 +301,6 @@ emit safe prefixes continuously
   ↓
 flush only the holdback buffer at the end
 ```
-
 This keeps scanning pipelined with LLM generation.
 
 The goal is not necessarily to reduce total CPU compared with non-streaming scanning. The goal is to reduce time-to-first-safe-output while keeping total overhead bounded.
@@ -335,7 +308,6 @@ The goal is not necessarily to reduce total CPU compared with non-streaming scan
 ---
 
 ## Safety Limitations
-
 Streaming guardrails are not equivalent to full-response non-streaming guardrails for all scanner types.
 
 Limitations:
@@ -346,7 +318,6 @@ Holdback only protects bounded local patterns.
 Global scanners still require full output.
 Complex semantic scanners are not suitable for per-chunk execution.
 ```
-
 Therefore:
 
 ```text
@@ -357,7 +328,6 @@ Full-output blocking scanners should fall back to non-streaming in strict mode.
 ---
 
 ## Failure Behavior
-
 Recommended behavior:
 
 ```text
@@ -380,7 +350,6 @@ buffer overflow:
 ---
 
 ## Metrics
-
 Add streaming guardrail metrics:
 
 ```text
@@ -394,7 +363,6 @@ stream_guardrails_pending_buffer_chars
 stream_guardrails_time_to_first_safe_chunk_seconds
 stream_guardrails_finalize_latency_seconds
 ```
-
 Useful fallback reasons:
 
 ```text
@@ -407,7 +375,6 @@ unsupported_policy
 ---
 
 ## Testing Plan
-
 Add tests for:
 
 ```text
@@ -427,11 +394,9 @@ non-stream path remains unchanged
 ---
 
 ## PR Plan
-
 To keep PRs small, split implementation into small reviewable changes.
 
 ### PR 1: Streaming Passthrough
-
 Scope:
 
 ```text
@@ -441,13 +406,11 @@ Consume upstream SSE events
 Return StreamingResponse to client
 No guardrail processing yet
 ```
-
 Expected core code size: around 150–220 lines.
 
 ---
 
 ### PR 2: SSE Utilities
-
 Scope:
 
 ```text
@@ -457,13 +420,11 @@ Extract delta.content
 Build downstream OpenAI-compatible SSE chunks
 Build block SSE chunk
 ```
-
 Expected core code size: around 120–180 lines.
 
 ---
 
 ### PR 3: Buffer and Holdback
-
 Scope:
 
 ```text
@@ -473,13 +434,11 @@ Add min_scan_chars / max_window_chars / max_emit_chars
 Add final flush behavior
 Use no-op scanner initially
 ```
-
 Expected core code size: around 150–220 lines.
 
 ---
 
 ### PR 4: Fast Scanner Block Path
-
 Scope:
 
 ```text
@@ -489,13 +448,11 @@ Support block action
 Emit block message and [DONE]
 Add split-chunk block tests
 ```
-
 Expected core code size: around 180–250 lines.
 
 ---
 
 ### PR 5: Redact, Fallback, and Metrics
-
 Scope:
 
 ```text
@@ -505,13 +462,11 @@ Add strict fallback for finalize-only scanners
 Add streaming guardrail metrics
 Add mixed-policy tests
 ```
-
 Expected core code size: around 180–250 lines.
 
 ---
 
 ## Recommendation
-
 Implement strict mode by default.
 
 This gives clear semantics:
@@ -523,412 +478,4 @@ Policies with only streaming-compatible scanners:
 Policies with finalize-only blocking scanners:
   fallback to non-streaming guarded execution
 ```
-
 This avoids claiming that streaming guardrails provide the same guarantees as full-response non-stream scanning for all scanner types.
-
-- Define the runtime contract for streaming scanners.
-- Support a conservative initial implementation for deterministic scanners.
-- Define a path for existing output scanners to participate safely in streaming over time, starting with deterministic scanners in the first phase.
-- Clearly separate request-level streaming behavior from service-level guardrails config.
-- Establish explicit UX rules for redact, block, and late violations.
-- Define a staged implementation plan for passthrough streaming first, then RAG streaming.
-
-### Non-Goals
-
-- Use ConfigMap-backed runtime policy to replace request-level `stream` selection for individual calls.
-- Deliver true token-by-token RAG streaming in the first phase.
-- Guarantee that all regex patterns behave identically in streaming and full-response modes.
-
-## Current State
-
-The current codebase contains the following pieces:
-
-- a non-streaming output guardrails runtime that scans full `ChatCompletionResponse` objects
-- a policy/config pipeline driven by environment variables and ConfigMap-backed YAML
-
-## Proposed Design
-
-### Request-Level Control
-
-Streaming is request-driven.
-
-- request-level configuration decides whether a specific call uses streaming
-- scanner-level configuration only affects how scanners participate after a call has entered the streaming path
-
-In the current RAGEngine UX model, `spec.guardrails.enabled` should remain a minimal
-capability switch. Detailed streaming participation policy should live with other
-runtime policy in ConfigMap-backed configuration rather than being folded into
-`guardrails.enabled` itself.
-
-That yields the following control model:
-
-1. request-level `stream` determines whether a call enters the streaming path, and scanner-level policy applies only after that point
-
-### Control Model
-
-Request-level streaming does not require the originating actor to set `stream`
-manually on every call. In many deployments, the direct caller of
-`/v1/chat/completions` is an SDK, workflow engine, agent orchestrator, or UI
-backend rather than a human-operated API client.
-
-The effective `stream` value for a call should be resolved using the following
-logic:
-
-```python
-if request explicitly provides stream:
-  use request.stream
-else:
-  use false
-```
-
-For the first implementation, omission of `stream` should remain conservative and
-default to non-streaming.
-
-Representative request shapes are:
-
-Direct API caller:
-
-```json
-{
-  "model": "example-model",
-  "messages": [{"role": "user", "content": "hello"}],
-  "stream": true
-}
-```
-
-Explicit non-streaming caller:
-
-```json
-{
-  "model": "example-model",
-  "messages": [{"role": "user", "content": "hello"}],
-  "stream": false
-}
-```
-
-In the second case, the caller explicitly keeps the request on the non-streaming
-path. The runtime does not infer streaming intent from scanner policy.
-
-Recommended placement is:
-
-- request materialization happens in the client, SDK, or orchestrator layer
-- scanner streaming policy lives in ConfigMap-backed runtime configuration
-- final `stream` resolution happens at the `/v1/chat/completions` entrypoint before transport selection
-- scanner-level streaming policy does not determine whether a request is streamed; it only determines how a scanner participates after a request has entered the streaming path
-- streaming guardrails logic runs only after the request has already been classified as streaming
-
-In the current RAGEngine structure, that means:
-
-- `guardrails.enabled` remains the minimal CRD switch for enabling guardrails capability
-- scanner-level streaming participation policy should live in ConfigMap-backed runtime policy rather than in `guardrails.enabled`
-- the API entrypoint chooses between streaming and non-streaming paths
-- the streaming processor and scanners operate only after that path has been selected
-
-### Endpoint Branching
-
-At the `/v1/chat/completions` entrypoint, the first phase should branch directly on
-the effective request-level `stream` value.
-
-```python
-if request.get("stream") is True:
-  return StreamingResponse(
-    guarded_stream_generator,
-    media_type="text/event-stream",
-    headers={
-      "Cache-Control": "no-cache",
-      "X-Accel-Buffering": "no",
-    },
-  )
-
-response = await rag_ops.chat_completion(request)
-response = guardrails.guard_response(response, request)
-return response
-```
-
-This keeps the existing non-streaming guardrails path unchanged while making the
-streaming path explicit at the transport boundary.
-
-### Streaming Runtime Model
-
-The streaming lifecycle is conceptually:
-
-1. receive upstream SSE (Server-Sent Events) chunks
-2. accumulate assistant text
-3. invoke scanner `on_chunk(...)`
-4. invoke scanner `finalize(...)`
-5. emit a downstream SSE response
-
-This proposal keeps that lifecycle, but makes the contract explicit:
-
-- `on_chunk(...)` is the incremental observation point
-- `finalize(...)` is the end-of-stream decision point
-- the processor is responsible for SSE parsing and re-emission
-- scanner results must be conservative by default
-
-The first implementation should explicitly forward `stream: true` to the upstream
-LLM backend and consume OpenAI-compatible SSE events such as:
-
-```text
-data: {"choices":[{"delta":{"content":"Hello"}}]}
-
-data: {"choices":[{"delta":{"content":" world"}}]}
-
-data: [DONE]
-```
-
-The downstream stream should also remain OpenAI-compatible SSE so existing SDKs
-and clients continue to work without transport-specific adaptation.
-
-### Buffering and Holdback
-
-The first phase should use a buffering-first strategy rather than forwarding every
-upstream chunk immediately.
-
-Conceptually:
-
-```text
-pending_buffer += new_delta
-scan bounded recent window
-emit only known-safe prefix
-retain holdback suffix
-```
-
-This allows deterministic scanners to detect patterns that span chunk boundaries.
-For example, if one chunk ends with `u` and the next chunk begins with `rl`, a
-`ban_substrings` scanner must be able to see `url` before any unsafe suffix is
-emitted.
-
-Recommended initial defaults:
-
-```text
-min_scan_chars   = 128
-scan_interval_ms = 50
-holdback_chars   = 256
-max_window_chars = 2048
-max_emit_chars   = 512
-```
-
-These values are not API surface. They are runtime defaults intended to keep
-latency bounded while preserving a conservative safe window for early-block
-behavior.
-
-### Scanner Contract
-
-The initial scanner contract is intentionally small:
-
-```python
-class StreamingScanner:
-    def on_chunk(self, text: str) -> StreamingDecision:
-        ...
-
-    def finalize(self, prompt: str, content: str) -> StreamingDecision:
-        ...
-```
-
-This is sufficient for the current buffer/finalize implementation, but follow-up work
-will likely extend it with richer decision payloads and scanner capability metadata.
-
-Likely expansion areas include:
-
-- richer `StreamingDecision` fields for partial emission and terminal control
-- scanner capability metadata such as early-block support and safe-window requirements
-- richer chunk/finalize context instead of plain text-only inputs
-
-### Scanner Support Strategy
-
-The initial streaming feature should focus on deterministic scanners only.
-
-Recommended first scanners:
-
-- `ban_substrings`
-- `regex`
-
-Deferred scanners:
-
-- `secrets`
-- `sensitive`
-- `json`
-- `reading_time`
-- `token_limit`
-- `invisible_text`
-
-These scanners differ in whether they can support early decisions, whether they require
-full-response context, and how safe their streaming behavior would be. Streaming
-capability should therefore be modeled per scanner type, while final stream behavior
-should be resolved using the most conservative aggregate policy.
-
-### Strict Fallback Policy
-
-The default product behavior should be strict.
-
-That means:
-
-```text
-if all configured scanners are streaming-compatible:
-  use true streaming guardrails
-
-if any configured scanner requires full-output blocking or redact semantics:
-  fall back to non-streaming guarded execution
-```
-
-This preserves safety semantics. Once content has been emitted to the client, it
-cannot be recalled, so finalize-only blocking scanners cannot provide equivalent
-guarantees in true streaming mode.
-
-### User Experience and Output Contract
-
-The first streaming UX contract should be conservative.
-
-#### Redact
-
-- redact remains finalize-time only
-- the user sees sanitized output after finalize
-- the system does not attempt incremental redaction in the first phase
-
-#### Block
-
-- block returns a safe replacement message
-- the stream ends with `content_filter` semantics rather than silently disappearing
-
-#### Partial Emission
-
-- partial emission should not be the default
-- it is only allowed when all participating scanners support safe early block behavior
-- safe-window buffering should be used when partial emission is enabled
-
-If content has already been partially emitted and a later chunk triggers block, the first
-phase should use a conservative safe-window strategy: emit only a known-safe prefix,
-stop normal output on block, and return the block message.
-
-Representative block output should remain OpenAI-compatible SSE and end with a
-terminal marker:
-
-```text
-data: {"choices":[{"delta":{"content":"Response blocked by output guardrails."},"finish_reason":"content_filter"}]}
-
-data: [DONE]
-```
-
-### Passthrough Streaming vs RAG Streaming
-
-These should be developed separately.
-
-#### Passthrough Streaming
-
-This is the correct first target because the upstream model already emits SSE and the
-runtime only needs to parse, buffer, decide, and re-emit.
-
-#### RAG Streaming
-
-This is significantly harder because the current RAG path is full-response based.
-The recommended progression is:
-
-1. pseudo-streaming after full generation
-2. true streaming using the underlying runtime's streaming chat API
-
-These should remain separate milestones.
-
-## Phased Implementation Plan
-
-Recommended order for follow-up work:
-
-1. Harden the streaming runtime contract.
-2. Add `ban_substrings` streaming support.
-3. Add bounded `regex` streaming support.
-4. Wire scanner construction into the output guardrails runtime.
-5. Stabilize passthrough SSE handling under guardrails.
-6. Expand streaming metrics and structured logs.
-7. Formalize UX / output contract behavior.
-8. Add RAG pseudo-streaming.
-9. Add true RAG streaming.
-10. Document supported behavior and limitations.
-
-### PR Slicing
-
-To keep implementation reviewable, the first phase should be split into small,
-behavior-scoped PRs.
-
-1. Streaming passthrough: add `stream=true` endpoint branching, forward `stream=true` upstream, consume SSE, and return `StreamingResponse` without guardrail mutation.
-2. SSE utilities: add helpers for parsing `data:` frames, detecting `[DONE]`, extracting `delta.content`, and emitting downstream OpenAI-compatible events.
-3. Buffer and holdback: add `pending_buffer`, bounded scan windows, holdback retention, and finalize flush behavior with a no-op scanner.
-4. Fast block path: add deterministic scanner execution for `ban_substrings` and bounded `regex`, including cross-chunk block tests.
-5. Redact, fallback, and observability: add strict fallback policy, redact behavior, metrics, and mixed-policy coverage.
-
-## Metrics and Observability
-
-The streaming path should introduce dedicated metrics rather than overloading the
-existing non-streaming counters.
-
-Recommended metrics:
-
-- `stream_guardrails_requests_total`
-- `stream_guardrails_fallback_total{reason}`
-- `stream_guardrails_scans_total`
-- `stream_guardrails_scan_latency_seconds`
-- `stream_guardrails_block_total`
-- `stream_guardrails_redact_total`
-- `stream_guardrails_pending_buffer_chars`
-- `stream_guardrails_time_to_first_safe_chunk_seconds`
-- `stream_guardrails_finalize_latency_seconds`
-
-Recommended fallback reasons:
-
-- `finalize_only_scanner`
-- `scanner_error`
-- `buffer_overflow`
-- `unsupported_policy`
-
-## Risks and Mitigations
-
-### Risk: Content Leaks Before Scanners Finish
-
-Streaming can send content to the client before scanners have enough context to make a
-safe decision.
-
-Mitigation:
-
-- default to buffering
-- only allow partial emission when every participating scanner explicitly supports it
-- use safe-window buffering for early-block behavior
-
-### Risk: Different Scanners Need Different Rules
-
-Not every scanner can use the same streaming strategy.
-
-Mitigation:
-
-- treat scanner capability as explicit runtime metadata
-- do not assume one streaming policy fits every scanner
-
-### Risk: Transport Logic and UX Get Mixed Together
-
-It is easy to mix up SSE transport handling with scanner behavior and user-visible
-output rules.
-
-Mitigation:
-
-- keep SSE handling in dedicated runtime code
-- keep scanner contracts explicit
-- define UX behavior separately from transport mechanics
-
-## Alternatives and Validation
-
-Rejected alternatives for the first phase:
-
-- make all streaming guardrails finalize-only
-- make streaming a service-level default
-- require every scanner to implement the same streaming strategy
-
-Validation should cover:
-
-- chunk accumulation correctness
-- cross-chunk deterministic scanner hits
-- early block vs finalize-only behavior
-- fail-open vs fail-closed behavior
-- safe-window buffering rules
-- SSE passthrough parsing and re-emission
-- structured observability outputs
-
-## Implementation History
-
-- [ ] 06/12/2026: Open proposal PR

--- a/docs/proposals/20260612-ragengine-streaming-guardrails.md
+++ b/docs/proposals/20260612-ragengine-streaming-guardrails.md
@@ -16,8 +16,7 @@ see-also:
 
 This proposal defines how streaming output guardrails should work in RAGEngine.
 
-The current codebase already supports non-streaming guardrails and a minimal streaming
-passthrough path. The next step is to make streaming guardrails a first-class runtime
+The current codebase supports non-streaming guardrails. The next step is to make streaming guardrails a first-class runtime
 feature with clear scanner contracts, explicit user-visible behavior, and phased support
 for passthrough and RAG streaming.
 
@@ -61,19 +60,10 @@ before streaming support expands further.
 
 ## Current State
 
-The current codebase already contains the following pieces:
+The current codebase contains the following pieces:
 
 - a non-streaming output guardrails runtime that scans full `ChatCompletionResponse` objects
 - a policy/config pipeline driven by environment variables and ConfigMap-backed YAML
-- a streaming request path in `/v1/chat/completions` that branches on request-level `stream`
-- a passthrough streaming transport to the upstream inference service
-- a minimal streaming guardrails processor skeleton
-
-It also already distinguishes two separate inputs:
-
-- service-level guardrails configuration, read from environment variables such as
-  `OUTPUT_GUARDRAILS_ENABLED` and `OUTPUT_GUARDRAILS_POLICY_PATH`
-- request-level streaming intent, read from the HTTP request body via `request.get("stream")`
 
 ## Proposed Design
 

--- a/docs/proposals/20260612-ragengine-streaming-guardrails.md
+++ b/docs/proposals/20260612-ragengine-streaming-guardrails.md
@@ -113,44 +113,17 @@ That yields the following control model:
 1. explicit request value wins
 2. scanner-level streaming policy applies only after a request has already been classified as streaming
 
-### End User, Orchestrator, and Runtime Responsibilities
+### Control Model
 
 Request-level streaming does not require the originating actor to set `stream`
-manually on every call.
+manually on every call. In many deployments, the direct caller of
+`/v1/chat/completions` is an SDK, workflow engine, agent orchestrator, or UI
+backend rather than a human-operated API client. In operator-driven deployments,
+scanner-level streaming participation is configured through ConfigMap-backed
+runtime policy, but request-level `stream` still determines whether a given call
+enters the streaming path at all.
 
-In many deployments, the direct caller of `/v1/chat/completions` is an SDK,
-workflow engine, agent orchestrator, or UI backend rather than a human-operated
-API client. The responsibility boundary should therefore be explicit:
-
-- the originating caller or workflow defines the intended streaming mode
-- the orchestrator or client layer translates that intent into request bodies
-- the runtime consumes the resolved `stream` value for that specific call
-
-For operator-driven deployments, this same model applies one layer up:
-
-- the operator configures scanner-level streaming participation through ConfigMap-backed runtime policy
-- the request path still decides whether a given call is streaming
-- the runtime resolves request-level streaming once at request entry
-
-Recommended precedence rules are:
-
-1. explicit request `stream` value wins
-2. if `stream` is absent, the runtime treats the request as non-streaming
-
-Under this model:
-
-- the runtime is not responsible for inferring user preference
-- scanners are not responsible for deciding whether a request should stream
-- the caller is responsible for setting request-level `stream` when streaming is intended
-
-This separation is especially important for agentic and multi-call workflows, where a
-single upstream action may result in many `/v1/chat/completions` calls. In those
-cases, the orchestrator should materialize the selected mode into the `stream`
-field of each downstream request.
-
-#### Resolution Rule and Recommended Placement
-
-The effective `stream` value for a given call should be resolved using the following
+The effective `stream` value for a call should be resolved using the following
 logic:
 
 ```python
@@ -190,9 +163,8 @@ path. The runtime does not infer streaming intent from scanner policy.
 
 Recommended placement is:
 
-- end-user preference and workflow defaults live in the UI, SDK, or orchestrator layer
+- request materialization happens in the client, SDK, or orchestrator layer
 - operator-managed scanner streaming policy lives in ConfigMap-backed runtime configuration
-- request materialization happens in the client or orchestrator request builder
 - final `stream` resolution happens at the `/v1/chat/completions` entrypoint before transport selection
 - scanner-level streaming policy does not determine whether a request is streamed; it only determines how a scanner participates after a request has entered the streaming path
 - streaming guardrails logic runs only after the request has already been classified as streaming
@@ -200,10 +172,9 @@ Recommended placement is:
 In the current RAGEngine structure, that means:
 
 - `guardrails.enabled` remains the minimal CRD switch for enabling guardrails capability
-- scanner-level streaming participation policy should be added to ConfigMap-backed runtime policy rather than encoded in `guardrails.enabled`
-- the API entrypoint should consume the final `stream` value and choose between streaming and non-streaming paths
-- the streaming processor should not re-decide whether streaming was intended
-- scanners should operate only on the chosen streaming lifecycle and should not participate in request policy resolution
+- scanner-level streaming participation policy should live in ConfigMap-backed runtime policy rather than in `guardrails.enabled`
+- the API entrypoint chooses between streaming and non-streaming paths
+- the streaming processor and scanners operate only after that path has been selected
 
 ### Streaming Runtime Model
 

--- a/docs/proposals/20260612-ragengine-streaming-guardrails.md
+++ b/docs/proposals/20260612-ragengine-streaming-guardrails.md
@@ -149,6 +149,30 @@ In the current RAGEngine structure, that means:
 - the API entrypoint chooses between streaming and non-streaming paths
 - the streaming processor and scanners operate only after that path has been selected
 
+### Endpoint Branching
+
+At the `/v1/chat/completions` entrypoint, the first phase should branch directly on
+the effective request-level `stream` value.
+
+```python
+if request.get("stream") is True:
+  return StreamingResponse(
+    guarded_stream_generator,
+    media_type="text/event-stream",
+    headers={
+      "Cache-Control": "no-cache",
+      "X-Accel-Buffering": "no",
+    },
+  )
+
+response = await rag_ops.chat_completion(request)
+response = guardrails.guard_response(response, request)
+return response
+```
+
+This keeps the existing non-streaming guardrails path unchanged while making the
+streaming path explicit at the transport boundary.
+
 ### Streaming Runtime Model
 
 The streaming lifecycle is conceptually:
@@ -165,6 +189,53 @@ This proposal keeps that lifecycle, but makes the contract explicit:
 - `finalize(...)` is the end-of-stream decision point
 - the processor is responsible for SSE parsing and re-emission
 - scanner results must be conservative by default
+
+The first implementation should explicitly forward `stream: true` to the upstream
+LLM backend and consume OpenAI-compatible SSE events such as:
+
+```text
+data: {"choices":[{"delta":{"content":"Hello"}}]}
+
+data: {"choices":[{"delta":{"content":" world"}}]}
+
+data: [DONE]
+```
+
+The downstream stream should also remain OpenAI-compatible SSE so existing SDKs
+and clients continue to work without transport-specific adaptation.
+
+### Buffering and Holdback
+
+The first phase should use a buffering-first strategy rather than forwarding every
+upstream chunk immediately.
+
+Conceptually:
+
+```text
+pending_buffer += new_delta
+scan bounded recent window
+emit only known-safe prefix
+retain holdback suffix
+```
+
+This allows deterministic scanners to detect patterns that span chunk boundaries.
+For example, if one chunk ends with `u` and the next chunk begins with `rl`, a
+`ban_substrings` scanner must be able to see `url` before any unsafe suffix is
+emitted.
+
+Recommended initial defaults:
+
+```text
+min_scan_chars   = 128
+scan_interval_ms = 50
+holdback_chars   = 256
+max_window_chars = 2048
+max_emit_chars   = 512
+```
+
+These values are not API surface. They are runtime defaults intended to keep
+latency bounded while preserving a conservative safe window for early-block
+behavior.
 
 ### Scanner Contract
 
@@ -211,6 +282,24 @@ full-response context, and how safe their streaming behavior would be. Streaming
 capability should therefore be modeled per scanner type, while final stream behavior
 should be resolved using the most conservative aggregate policy.
 
+### Strict Fallback Policy
+
+The default product behavior should be strict.
+
+That means:
+
+```text
+if all configured scanners are streaming-compatible:
+  use true streaming guardrails
+
+if any configured scanner requires full-output blocking or redact semantics:
+  fall back to non-streaming guarded execution
+```
+
+This preserves safety semantics. Once content has been emitted to the client, it
+cannot be recalled, so finalize-only blocking scanners cannot provide equivalent
+guarantees in true streaming mode.
+
 ### User Experience and Output Contract
 
 The first streaming UX contract should be conservative.
@@ -235,6 +324,15 @@ The first streaming UX contract should be conservative.
 If content has already been partially emitted and a later chunk triggers block, the first
 phase should use a conservative safe-window strategy: emit only a known-safe prefix,
 stop normal output on block, and return the block message.
+
+Representative block output should remain OpenAI-compatible SSE and end with a
+terminal marker:
+
+```text
+data: {"choices":[{"delta":{"content":"Response blocked by output guardrails."},"finish_reason":"content_filter"}]}
+
+data: [DONE]
+```
 
 ### Passthrough Streaming vs RAG Streaming
 
@@ -269,6 +367,41 @@ Recommended order for follow-up work:
 8. Add RAG pseudo-streaming.
 9. Add true RAG streaming.
 10. Document supported behavior and limitations.
+
+### PR Slicing
+
+To keep implementation reviewable, the first phase should be split into small,
+behavior-scoped PRs.
+
+1. Streaming passthrough: add `stream=true` endpoint branching, forward `stream=true` upstream, consume SSE, and return `StreamingResponse` without guardrail mutation.
+2. SSE utilities: add helpers for parsing `data:` frames, detecting `[DONE]`, extracting `delta.content`, and emitting downstream OpenAI-compatible events.
+3. Buffer and holdback: add `pending_buffer`, bounded scan windows, holdback retention, and finalize flush behavior with a no-op scanner.
+4. Fast block path: add deterministic scanner execution for `ban_substrings` and bounded `regex`, including cross-chunk block tests.
+5. Redact, fallback, and observability: add strict fallback policy, redact behavior, metrics, and mixed-policy coverage.
+
+## Metrics and Observability
+
+The streaming path should introduce dedicated metrics rather than overloading the
+existing non-streaming counters.
+
+Recommended metrics:
+
+- `stream_guardrails_requests_total`
+- `stream_guardrails_fallback_total{reason}`
+- `stream_guardrails_scans_total`
+- `stream_guardrails_scan_latency_seconds`
+- `stream_guardrails_block_total`
+- `stream_guardrails_redact_total`
+- `stream_guardrails_pending_buffer_chars`
+- `stream_guardrails_time_to_first_safe_chunk_seconds`
+- `stream_guardrails_finalize_latency_seconds`
+
+Recommended fallback reasons:
+
+- `finalize_only_scanner`
+- `scanner_error`
+- `buffer_overflow`
+- `unsupported_policy`
 
 ## Risks and Mitigations
 

--- a/docs/proposals/20260612-ragengine-streaming-guardrails.md
+++ b/docs/proposals/20260612-ragengine-streaming-guardrails.md
@@ -16,7 +16,7 @@ see-also:
 
 This proposal defines how streaming output guardrails should work in RAGEngine.
 
-The current codebase supports non-streaming guardrails. The next step is to make streaming guardrails a first-class runtime
+The current codebase supports non-streaming guardrails. The next step is to make streaming guardrails a well-defined runtime
 feature with clear scanner contracts, explicit user-visible behavior, and phased support
 for passthrough and RAG streaming.
 

--- a/docs/proposals/20260612-ragengine-streaming-guardrails.md
+++ b/docs/proposals/20260612-ragengine-streaming-guardrails.md
@@ -54,7 +54,7 @@ before streaming support expands further.
 ### Non-Goals
 
 - Make every existing output scanner streaming-safe in the first phase.
-- Treat service-level config as a replacement for request-level `stream` behavior.
+- Use ConfigMap-backed runtime policy to replace request-level `stream` selection for individual calls.
 - Deliver true token-by-token RAG streaming in the first phase.
 - Guarantee fully general regex streaming semantics for arbitrarily complex patterns.
 

--- a/docs/proposals/20260612-ragengine-streaming-guardrails.md
+++ b/docs/proposals/20260612-ragengine-streaming-guardrails.md
@@ -22,41 +22,47 @@ for passthrough and RAG streaming.
 
 The guiding principles are:
 
-- start with deterministic scanners only
-- keep the first implementation conservative
-- separate passthrough streaming from RAG streaming
-- prefer explicit runtime contracts over implicit behavior
+- start with deterministic scanners whose streaming behavior is predictable
+- keep the first implementation conservative and buffering-first
+- treat passthrough streaming and RAG streaming as separate workstreams
+- define explicit runtime contracts rather than relying on implicit behavior
 
 ## Motivation
 
 RAGEngine currently applies output guardrails to complete responses after generation.
-This works for non-streaming responses, but it does not yet define how scanners should
-participate in a chunked streaming lifecycle.
+This works for non-streaming responses because scanners can evaluate a full answer
+after generation has completed. It does not yet define how scanners should behave
+when the model returns output incrementally in chunks.
 
-Streaming needs explicit decisions for:
+Once streaming is introduced, the runtime must decide:
 
 - when content can be emitted safely
 - when content must remain buffered
 - what users see for redact and block
 - how scanner capabilities affect overall stream behavior
 
-These choices affect correctness, UX, and API compatibility, so they should be agreed on
-before streaming support expands further.
+These questions do not exist in the same form for full-response scanning. They are
+specific to streaming, where content may already be on its way to the client before
+the full response is available for inspection.
+
+Because these choices affect correctness, user-visible behavior, and API
+compatibility, they should be defined explicitly before streaming support expands
+further.
 
 ### Goals
 
 - Define the runtime contract for streaming scanners.
 - Support a conservative initial implementation for deterministic scanners.
+- Define a path for existing output scanners to participate safely in streaming over time, starting with deterministic scanners in the first phase.
 - Clearly separate request-level streaming behavior from service-level guardrails config.
 - Establish explicit UX rules for redact, block, and late violations.
 - Define a staged implementation plan for passthrough streaming first, then RAG streaming.
 
 ### Non-Goals
 
-- Make every existing output scanner streaming-safe in the first phase.
 - Use ConfigMap-backed runtime policy to replace request-level `stream` selection for individual calls.
 - Deliver true token-by-token RAG streaming in the first phase.
-- Guarantee fully general regex streaming semantics for arbitrarily complex patterns.
+- Guarantee that all regex patterns behave identically in streaming and full-response modes.
 
 ## Current State
 
@@ -81,8 +87,7 @@ runtime policy in ConfigMap-backed configuration rather than being folded into
 
 That yields the following control model:
 
-1. explicit request value determines whether the call is streaming
-2. scanner-level streaming policy applies only after the call has entered the streaming path
+1. request-level `stream` determines whether a call enters the streaming path, and scanner-level policy applies only after that point
 
 ### Control Model
 
@@ -267,36 +272,36 @@ Recommended order for follow-up work:
 
 ## Risks and Mitigations
 
-### Risk: Unsafe Partial Emission
+### Risk: Content Leaks Before Scanners Finish
 
-If content is emitted too early, later scanners may detect a violation after unsafe
-content has already reached the client.
+Streaming can send content to the client before scanners have enough context to make a
+safe decision.
 
 Mitigation:
 
 - default to buffering
-- allow partial emission only when every participating scanner explicitly supports it
-- use safe-window buffering for early block capable scanners
+- only allow partial emission when every participating scanner explicitly supports it
+- use safe-window buffering for early-block behavior
 
-### Risk: Scanner Semantics Drift
+### Risk: Different Scanners Need Different Rules
 
-Different scanner types may require different streaming guarantees.
-
-Mitigation:
-
-- treat scanner capability as first-class runtime metadata
-- avoid assuming a single policy works for every scanner
-
-### Risk: Conflating Product UX with Transport Mechanics
-
-Streaming transport, scanner lifecycle, and user-visible output can easily become mixed
-together in implementation.
+Not every scanner can use the same streaming strategy.
 
 Mitigation:
 
-- keep SSE transport concerns in dedicated runtime code
-- keep scanner contract decisions explicit
-- document UX behavior separately from internal transport details
+- treat scanner capability as explicit runtime metadata
+- do not assume one streaming policy fits every scanner
+
+### Risk: Transport Logic and UX Get Mixed Together
+
+It is easy to mix up SSE transport handling with scanner behavior and user-visible
+output rules.
+
+Mitigation:
+
+- keep SSE handling in dedicated runtime code
+- keep scanner contracts explicit
+- define UX behavior separately from transport mechanics
 
 ## Alternatives and Validation
 

--- a/docs/proposals/20260612-ragengine-streaming-guardrails.md
+++ b/docs/proposals/20260612-ragengine-streaming-guardrails.md
@@ -1,0 +1,270 @@
+---
+title: RAGEngine Streaming Guardrails
+authors:
+  - "@xiaoqi-7"
+reviewers:
+creation-date: 2026-06-12
+last-updated: 2026-06-12
+status: provisional
+see-also:
+  - "/docs/proposals/20260416-ragengine-guardrails-ux-api.md"
+---
+
+# RAGEngine Streaming Guardrails
+
+## Summary
+
+This proposal defines how streaming output guardrails should work in RAGEngine.
+
+The current codebase already supports non-streaming guardrails and a minimal streaming
+passthrough path. The next step is to make streaming guardrails a first-class runtime
+feature with clear scanner contracts, explicit user-visible behavior, and phased support
+for passthrough and RAG streaming.
+
+The guiding principles are:
+
+- start with deterministic scanners only
+- keep the first implementation conservative
+- separate passthrough streaming from RAG streaming
+- prefer explicit runtime contracts over implicit behavior
+
+## Motivation
+
+RAGEngine currently applies output guardrails to complete responses after generation.
+This works for non-streaming responses, but it does not yet define how scanners should
+participate in a chunked streaming lifecycle.
+
+Streaming needs explicit decisions for:
+
+- when content can be emitted safely
+- when content must remain buffered
+- what users see for redact and block
+- how scanner capabilities affect overall stream behavior
+
+These choices affect correctness, UX, and API compatibility, so they should be agreed on
+before streaming support expands further.
+
+### Goals
+
+- Define the runtime contract for streaming scanners.
+- Support a conservative initial implementation for deterministic scanners.
+- Clearly separate request-level streaming behavior from service-level guardrails config.
+- Establish explicit UX rules for redact, block, and late violations.
+- Define a staged implementation plan for passthrough streaming first, then RAG streaming.
+
+### Non-Goals
+
+- Make every existing output scanner streaming-safe in the first phase.
+- Treat service-level config as a replacement for request-level `stream` behavior.
+- Deliver true token-by-token RAG streaming in the first phase.
+- Guarantee fully general regex streaming semantics for arbitrarily complex patterns.
+
+## Current State
+
+The current codebase already contains the following pieces:
+
+- a non-streaming output guardrails runtime that scans full `ChatCompletionResponse` objects
+- a policy/config pipeline driven by environment variables and ConfigMap-backed YAML
+- a streaming request path in `/v1/chat/completions` that branches on request-level `stream`
+- a passthrough streaming transport to the upstream inference service
+- a minimal streaming guardrails processor skeleton
+
+It also already distinguishes two separate inputs:
+
+- service-level guardrails configuration, read from environment variables such as
+  `OUTPUT_GUARDRAILS_ENABLED` and `OUTPUT_GUARDRAILS_POLICY_PATH`
+- request-level streaming intent, read from the HTTP request body via `request.get("stream")`
+
+## Proposed Design
+
+### Request-Level vs Service-Level Control
+
+Streaming is request-driven, not service-default.
+
+- service-level configuration enables or disables guardrails and points to policy data
+- request-level configuration decides whether a specific call uses streaming
+
+The runtime should continue treating `stream` as a per-request input rather than a global
+deployment switch.
+
+If product requirements later call for a service-level default streaming mode, it should
+be added separately with clear precedence rules:
+
+1. explicit request value wins
+2. service-level default applies only when request value is absent
+
+### Streaming Runtime Model
+
+The streaming lifecycle is conceptually:
+
+1. receive upstream SSE chunks
+2. accumulate assistant text
+3. invoke scanner `on_chunk(...)`
+4. invoke scanner `finalize(...)`
+5. emit a downstream SSE response
+
+This proposal keeps that lifecycle, but makes the contract explicit:
+
+- `on_chunk(...)` is the incremental observation point
+- `finalize(...)` is the end-of-stream decision point
+- the processor is responsible for SSE parsing and re-emission
+- scanner results must be conservative by default
+
+### Scanner Contract
+
+The initial scanner contract is intentionally small:
+
+```python
+class StreamingScanner:
+    def on_chunk(self, text: str) -> StreamingDecision:
+        ...
+
+    def finalize(self, prompt: str, content: str) -> StreamingDecision:
+        ...
+```
+
+This is sufficient for the current buffer/finalize implementation, but follow-up work
+will likely extend it with richer decision payloads and scanner capability metadata.
+
+Likely expansion areas include:
+
+- richer `StreamingDecision` fields for partial emission and terminal control
+- scanner capability metadata such as early-block support and safe-window requirements
+- richer chunk/finalize context instead of plain text-only inputs
+
+### Scanner Support Strategy
+
+The initial streaming feature should focus on deterministic scanners only.
+
+Recommended first scanners:
+
+- `ban_substrings`
+- `regex`
+
+Deferred scanners:
+
+- `secrets`
+- `sensitive`
+- `json`
+- `reading_time`
+- `token_limit`
+- `invisible_text`
+
+These scanners differ in whether they can support early decisions, whether they require
+full-response context, and how safe their streaming behavior would be. Streaming
+capability should therefore be modeled per scanner type, while final stream behavior
+should be resolved using the most conservative aggregate policy.
+
+### User Experience and Output Contract
+
+The first streaming UX contract should be conservative.
+
+#### Redact
+
+- redact remains finalize-time only
+- the user sees sanitized output after finalize
+- the system does not attempt incremental redaction in the first phase
+
+#### Block
+
+- block returns a safe replacement message
+- the stream ends with `content_filter` semantics rather than silently disappearing
+
+#### Partial Emission
+
+- partial emission should not be the default
+- it is only allowed when all participating scanners support safe early block behavior
+- safe-window buffering should be used when partial emission is enabled
+
+If content has already been partially emitted and a later chunk triggers block, the first
+phase should use a conservative safe-window strategy: emit only a known-safe prefix,
+stop normal output on block, and return the block message.
+
+### Passthrough Streaming vs RAG Streaming
+
+These should be developed separately.
+
+#### Passthrough Streaming
+
+This is the correct first target because the upstream model already emits SSE and the
+runtime only needs to parse, buffer, decide, and re-emit.
+
+#### RAG Streaming
+
+This is significantly harder because the current RAG path is full-response based.
+The recommended progression is:
+
+1. pseudo-streaming after full generation
+2. true streaming using the underlying runtime's streaming chat API
+
+These should remain separate milestones.
+
+## Phased Implementation Plan
+
+Recommended order for follow-up work:
+
+1. Harden the streaming runtime contract.
+2. Add `ban_substrings` streaming support.
+3. Add bounded `regex` streaming support.
+4. Wire scanner construction into the output guardrails runtime.
+5. Stabilize passthrough SSE handling under guardrails.
+6. Expand streaming metrics and structured logs.
+7. Formalize UX / output contract behavior.
+8. Add RAG pseudo-streaming.
+9. Add true RAG streaming.
+10. Document supported behavior and limitations.
+
+## Risks and Mitigations
+
+### Risk: Unsafe Partial Emission
+
+If content is emitted too early, later scanners may detect a violation after unsafe
+content has already reached the client.
+
+Mitigation:
+
+- default to buffering
+- allow partial emission only when every participating scanner explicitly supports it
+- use safe-window buffering for early block capable scanners
+
+### Risk: Scanner Semantics Drift
+
+Different scanner types may require different streaming guarantees.
+
+Mitigation:
+
+- treat scanner capability as first-class runtime metadata
+- avoid assuming a single policy works for every scanner
+
+### Risk: Conflating Product UX with Transport Mechanics
+
+Streaming transport, scanner lifecycle, and user-visible output can easily become mixed
+together in implementation.
+
+Mitigation:
+
+- keep SSE transport concerns in dedicated runtime code
+- keep scanner contract decisions explicit
+- document UX behavior separately from internal transport details
+
+## Alternatives and Validation
+
+Rejected alternatives for the first phase:
+
+- make all streaming guardrails finalize-only
+- make streaming a service-level default
+- require every scanner to implement the same streaming strategy
+
+Validation should cover:
+
+- chunk accumulation correctness
+- cross-chunk deterministic scanner hits
+- early block vs finalize-only behavior
+- fail-open vs fail-closed behavior
+- safe-window buffering rules
+- SSE passthrough parsing and re-emission
+- structured observability outputs
+
+## Implementation History
+
+- [ ] 06/12/2026: Open proposal PR


### PR DESCRIPTION
## Summary

This PR adds a design proposal for streaming output guardrails in RAGEngine.

The proposal captures the current state of the codebase, the key design constraints for streaming guardrails, and a phased implementation plan for evolving from the current minimal passthrough path to a more complete streaming guardrails runtime.

## Highlights

- documents the current request-level vs service-level control model
- defines the intended streaming scanner contract and runtime lifecycle
- explains why deterministic scanners should be the first streaming-safe scanners
- defines a conservative initial UX and output contract for redact/block behavior
- separates passthrough streaming and RAG streaming into different implementation phases
- outlines a staged roadmap for future work

## Why

Streaming guardrails now span multiple concerns across the codebase:
- request routing
- upstream SSE transport
- scanner lifecycle
- UX/output behavior
- observability
- future RAG streaming integration

This proposal is intended to give reviewers and implementers a shared design baseline before further runtime work continues.