### PR TITLE
fix: pin fastapi<0.137.0 to fix vLLM health check crash & replace NC12s_v3 SKU in E2E

### DIFF
--- a/presets/workspace/dependencies/requirements.txt
+++ b/presets/workspace/dependencies/requirements.txt
@@ -6,7 +6,7 @@ transformers[serving] ==5.6.0
 huggingface-hub==1.11.0
 torch==2.10.0
 accelerate>=1.4.0
-fastapi[standard] >= 0.115.0
+fastapi[standard] >=0.115.0,<0.137.0  # Pin below 0.137.0: _IncludedRouter breaks prometheus-fastapi-instrumentator (gh#370)
 pydantic >= 2.12.0
 uvicorn[standard]>=0.29.0,<0.30.0  # Allow patch updates
 uvloop

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -469,7 +469,7 @@ func validateInferenceResource(workspaceObj *kaitov1beta1.Workspace, expectedRep
 			}
 
 			return false
-		}, 20*time.Minute, utils.PollInterval).Should(BeTrue(), "Failed to wait for inference resource to be ready")
+		}, 30*time.Minute, utils.PollInterval).Should(BeTrue(), "Failed to wait for inference resource to be ready")
 	})
 }
 

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -469,7 +469,7 @@ func validateInferenceResource(workspaceObj *kaitov1beta1.Workspace, expectedRep
 			}
 
 			return false
-		}, 30*time.Minute, utils.PollInterval).Should(BeTrue(), "Failed to wait for inference resource to be ready")
+		}, 20*time.Minute, utils.PollInterval).Should(BeTrue(), "Failed to wait for inference resource to be ready")
 	})
 }
 

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Workspace Validation Webhook", utils.GinkgoLabelFastCheck, fun
 
 	It("should validate the workspace inference adapters at creation", func() {
 		By("Creating a vllm workspace with adapter strength", func() {
-			workspaceObj := utils.GenerateInferenceWorkspaceManifestWithVLLM(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV36ads_A10_v5",
+			workspaceObj := utils.GenerateInferenceWorkspaceManifestWithVLLM(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV72ads_A10_v5",
 				&metav1.LabelSelector{
 					MatchLabels: map[string]string{"kaito-workspace": "webhook-e2e-test"},
 				}, nil, PresetPhi4MiniModel, nil, nil, testAdapters1, "", "")
@@ -86,7 +86,7 @@ var _ = Describe("Workspace Validation Webhook", utils.GinkgoLabelFastCheck, fun
 		})
 
 		By("Creating a vllm workspace without adapter strength", func() {
-			workspaceObj := utils.GenerateInferenceWorkspaceManifestWithVLLM(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV36ads_A10_v5",
+			workspaceObj := utils.GenerateInferenceWorkspaceManifestWithVLLM(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV72ads_A10_v5",
 				&metav1.LabelSelector{
 					MatchLabels: map[string]string{"kaito-workspace": "webhook-e2e-test"},
 				}, nil, PresetPhi4MiniModel, nil, nil, phi4Adapter, "", "")
@@ -103,7 +103,7 @@ var _ = Describe("Workspace Validation Webhook", utils.GinkgoLabelFastCheck, fun
 		})
 
 		By("Creating a transformers workspace with adapter strength", func() {
-			workspaceObj := utils.GenerateInferenceWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV36ads_A10_v5",
+			workspaceObj := utils.GenerateInferenceWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV72ads_A10_v5",
 				&metav1.LabelSelector{
 					MatchLabels: map[string]string{"kaito-workspace": "webhook-e2e-test"},
 				}, nil, PresetPhi3Mini128kModel, nil, nil, testAdapters1, "", "")
@@ -128,7 +128,7 @@ var _ = Describe("Workspace Validation Webhook", utils.GinkgoLabelFastCheck, fun
 					Strength: &DefaultStrength,
 				},
 			}
-			workspaceObj := utils.GenerateInferenceWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV36ads_A10_v5",
+			workspaceObj := utils.GenerateInferenceWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV72ads_A10_v5",
 				&metav1.LabelSelector{
 					MatchLabels: map[string]string{"kaito-workspace": "webhook-e2e-test"},
 				}, nil, PresetPhi4Model, nil, nil, invalidAdapters, "", "")
@@ -143,7 +143,7 @@ var _ = Describe("Workspace Validation Webhook", utils.GinkgoLabelFastCheck, fun
 
 	It("should validate the workspace inference configfile", func() {
 		By("Creating a 2gpu transformers workspace without configfile", func() {
-			workspaceObj := utils.GenerateInferenceWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV36ads_A10_v5",
+			workspaceObj := utils.GenerateInferenceWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV72ads_A10_v5",
 				&metav1.LabelSelector{
 					MatchLabels: map[string]string{"kaito-workspace": "webhook-e2e-test"},
 				}, nil, PresetPhi4Model, nil, nil, nil, "", "")
@@ -161,7 +161,7 @@ var _ = Describe("Workspace Validation Webhook", utils.GinkgoLabelFastCheck, fun
 		})
 
 		By("Creating a 2gpu workspace with correct configfile", func() {
-			workspaceObj := utils.GenerateInferenceWorkspaceManifestWithVLLM(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV36ads_A10_v5",
+			workspaceObj := utils.GenerateInferenceWorkspaceManifestWithVLLM(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV72ads_A10_v5",
 				&metav1.LabelSelector{
 					MatchLabels: map[string]string{"kaito-workspace": "webhook-e2e-test"},
 				}, nil, PresetPhi4MiniModel, nil, nil, nil, "", "")
@@ -198,7 +198,7 @@ vllm:
 	})
 
 	It("should validate the workspace tuning spec at creation ", func() {
-		workspaceObj := utils.GenerateTuningWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV36ads_A10_v5",
+		workspaceObj := utils.GenerateTuningWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV72ads_A10_v5",
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "webhook-e2e-test"},
 			}, nil, nil, testDataDestinationConfig, initialPresetSpec, initialTuningMethod)
@@ -213,7 +213,7 @@ vllm:
 	})
 
 	It("should validate the workspace tuning spec at creation ", func() {
-		workspaceObj := utils.GenerateTuningWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV36ads_A10_v5",
+		workspaceObj := utils.GenerateTuningWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV72ads_A10_v5",
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "webhook-e2e-test"},
 			}, nil, testDataSourceConfig, nil, initialPresetSpec, initialTuningMethod)
@@ -228,7 +228,7 @@ vllm:
 	})
 
 	It("should validate the workspace tuning spec at creation ", func() {
-		workspaceObj := utils.GenerateTuningWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV36ads_A10_v5",
+		workspaceObj := utils.GenerateTuningWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV72ads_A10_v5",
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "webhook-e2e-test"},
 			}, nil, testDataSourceConfig, testDataDestinationConfig, nil, initialTuningMethod)
@@ -246,7 +246,7 @@ vllm:
 	//TODO custom template
 
 	It("should validate the workspace resource spec at update ", func() {
-		workspaceObj := utils.GenerateInferenceWorkspaceManifestWithVLLM(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV36ads_A10_v5",
+		workspaceObj := utils.GenerateInferenceWorkspaceManifestWithVLLM(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV72ads_A10_v5",
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "webhook-e2e-test"},
 			}, nil, PresetPhi4MiniModel, nil, nil, nil, "", "")
@@ -289,7 +289,7 @@ vllm:
 	})
 
 	It("should validate the workspace tuning spec at update ", func() {
-		workspaceObj := utils.GenerateTuningWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV36ads_A10_v5",
+		workspaceObj := utils.GenerateTuningWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV72ads_A10_v5",
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "webhook-e2e-test"},
 			}, nil, testDataSourceConfig, testDataDestinationConfig, initialPresetSpec, initialTuningMethod)
@@ -330,7 +330,7 @@ vllm:
 	})
 
 	It("should validate the workspace inference spec at update ", func() {
-		workspaceObj := utils.GenerateInferenceWorkspaceManifestWithVLLM(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV36ads_A10_v5",
+		workspaceObj := utils.GenerateInferenceWorkspaceManifestWithVLLM(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV72ads_A10_v5",
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "webhook-e2e-test"},
 			}, nil, PresetPhi4MiniModel, nil, nil, nil, "", "")

--- a/test/e2e/webhook_test.go
+++ b/test/e2e/webhook_test.go
@@ -143,7 +143,7 @@ var _ = Describe("Workspace Validation Webhook", utils.GinkgoLabelFastCheck, fun
 
 	It("should validate the workspace inference configfile", func() {
 		By("Creating a 2gpu transformers workspace without configfile", func() {
-			workspaceObj := utils.GenerateInferenceWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NC12s_v3",
+			workspaceObj := utils.GenerateInferenceWorkspaceManifest(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV36ads_A10_v5",
 				&metav1.LabelSelector{
 					MatchLabels: map[string]string{"kaito-workspace": "webhook-e2e-test"},
 				}, nil, PresetPhi4Model, nil, nil, nil, "", "")
@@ -161,7 +161,7 @@ var _ = Describe("Workspace Validation Webhook", utils.GinkgoLabelFastCheck, fun
 		})
 
 		By("Creating a 2gpu workspace with correct configfile", func() {
-			workspaceObj := utils.GenerateInferenceWorkspaceManifestWithVLLM(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NC12s_v3",
+			workspaceObj := utils.GenerateInferenceWorkspaceManifestWithVLLM(fmt.Sprint("webhook-", rand.Intn(1000)), namespaceName, "", 1, "Standard_NV36ads_A10_v5",
 				&metav1.LabelSelector{
 					MatchLabels: map[string]string{"kaito-workspace": "webhook-e2e-test"},
 				}, nil, PresetPhi4MiniModel, nil, nil, nil, "", "")


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it

### 1. Replace `Standard_NC12s_v3` with `Standard_NV72ads_A10_v5` in E2E tests

`Standard_NC12s_v3` (V100) is not available in `swedencentral` (and many other regions), causing E2E webhook tests to fail with `VMSizeNotSupported`.

`Standard_NV72ads_A10_v5` (2×A10 = 48Gi GPU memory) is used because:
- It matches the "2gpu" semantics of the webhook tests
- It fits phi-4 on a single node (no multi-node Transformers issue)
- It is widely available in the regions where E2E runs

### 2. Fix vLLM inference server crash caused by `prometheus-fastapi-instrumentator` incompatibility

**Root cause of E2E `validateInferenceResource` timeouts:**

FastAPI 0.137.0 ([fastapi/fastapi#15745](https://github.com/fastapi/fastapi/pull/15745)) refactored `include_router()` to wrap routers in `_IncludedRouter` objects that lack a `.path` attribute. This breaks `prometheus-fastapi-instrumentator` middleware ([trallnag/prometheus-fastapi-instrumentator#370](https://github.com/trallnag/prometheus-fastapi-instrumentator/issues/370)), causing **every HTTP request** to the vLLM inference server to return 500:

```
AttributeError: '_IncludedRouter' object has no attribute 'path'
```

vLLM starts and loads models successfully, but all health checks and inference requests crash in the Prometheus middleware before reaching the actual handler. This makes the workspace permanently "not ready" regardless of timeout duration.

**Fix:** Pin `fastapi[standard] <0.137.0` in requirements.txt until the upstream instrumentator is fixed.

### 3. Revert timeout bump (30m → 20m)

The previous commit bumped `validateInferenceResource` timeout from 20m to 30m, but that was never the real issue — the middleware crash means no amount of waiting helps. Reverted to original 20m.

## Changes
- `test/e2e/webhook_test.go`: replace instanceType in webhook validation tests  
- `presets/workspace/dependencies/requirements.txt`: pin `fastapi<0.137.0`
- `test/e2e/preset_test.go`: revert validateInferenceResource timeout to 20m
