### PR TITLE
fix: inference deployment for model moonshotai/Kimi-K2.5

### DIFF
--- a/charts/kaito/workspace/templates/supported-models-configmap.yaml
+++ b/charts/kaito/workspace/templates/supported-models-configmap.yaml
@@ -11,7 +11,7 @@ data:
       - name: base
         type: text-generation
         runtime: tfs
-        tag: 0.4.0
+        tag: 0.4.1
       - name: llama-3.1-8b-instruct
         type: text-generation
         version: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/commit/0e9e39f249a16976918f6564b8830bc894c89659

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -366,6 +366,15 @@ func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
 	}
 	p.VLLM.ModelRunParams["gpu-memory-utilization"] = "0.84"
 
+	// Disable the allreduce + RMSNorm fusion pass. Since vLLM 0.22.1 this pass is
+	// enabled by default and routes through FlashInfer's TRT-LLM MNNVL kernel, which
+	// is JIT-compiled at runtime and requires the CUDA toolkit (nvcc). The slim
+	// runtime image does not ship nvcc, so engine initialization crashes during CUDA
+	// graph capture with "Could not find nvcc". The fusion is only a performance
+	// optimization and the MNNVL (multi-node NVLink) path is not usable on our SKUs
+	// anyway, so it is safe to turn off for all vLLM models.
+	p.VLLM.ModelRunParams["compilation-config.pass_config.fuse_allreduce_rms"] = "False"
+
 	// Dynamically determine dtype based on GPU compute capability.
 	// bfloat16 requires CUDA compute capability >= 8.0 (Ampere+).
 	// Fall back to float16 on older GPUs.

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -134,6 +134,13 @@ const (
 	// requires a CUDA toolchain (nvcc) that the base image does not ship.
 	VLLMUseFlashInferSamplerEnvName = "VLLM_USE_FLASHINFER_SAMPLER"
 
+	// VLLMUseDeepGEMMEnvName toggles vLLM's DeepGEMM FP8 kernels. vLLM 0.22.1
+	// defaults this on and reports DeepGEMM as available (it finds the vendored
+	// wrapper module), but the native FP8 GEMM backend is not present in the base
+	// image, so the FP8 warmup hard-fails with "DeepGEMM backend is not available".
+	// Set to "0" to keep FP8 models on their non-DeepGEMM kernel path.
+	VLLMUseDeepGEMMEnvName = "VLLM_USE_DEEP_GEMM"
+
 	// ConditionReady is the condition type for a ready condition.
 	ConditionReady = "Ready"
 

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -515,6 +515,13 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int) func(*gene
 				Name:  consts.VLLMUseFlashInferSamplerEnvName,
 				Value: "0",
 			})
+			// Disable vLLM's DeepGEMM FP8 kernels. vLLM 0.22.1 enables them by default
+			// and reports DeepGEMM as available, but the native backend is absent from
+			// the base image, so the FP8 warmup hard-fails at engine init.
+			mainContainerEnv = append(mainContainerEnv, corev1.EnvVar{
+				Name:  consts.VLLMUseDeepGEMMEnvName,
+				Value: "0",
+			})
 		}
 
 		spec.Containers = []corev1.Container{

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -414,6 +414,14 @@ func TestGeneratePresetInference(t *testing.T) {
 			expectedMaincmd := strings.Split(tc.expectedCmd, "--")[0]
 			expectedParams := toParameterMap(strings.Split(tc.expectedCmd, "--")[1:])
 
+			// For vLLM, production always disables the FlashInfer allreduce+RMSNorm
+			// fusion pass (its TRT-LLM MNNVL kernel JIT-compiles at runtime and needs
+			// nvcc, which is absent from the runtime image). Inject it into the
+			// expectation so each vLLM case doesn't need to list the flag explicitly.
+			if strings.Contains(tc.expectedCmd, "/workspace/vllm/inference_api.py") {
+				expectedParams["compilation-config.pass_config.fuse_allreduce_rms"] = "False"
+			}
+
 			if mainCmd != expectedMaincmd {
 				t.Errorf("%s main cmdline is not expected, got %s, expect %s ", k, workloadCmd, tc.expectedCmd)
 			}

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -53,6 +53,13 @@ var flashInferSamplerEnvVar = corev1.EnvVar{
 	Value: "0",
 }
 
+// deepGEMMEnvVar is injected into every vLLM inference container to disable
+// vLLM's DeepGEMM FP8 kernels (the native backend is absent from the base image).
+var deepGEMMEnvVar = corev1.EnvVar{
+	Name:  consts.VLLMUseDeepGEMMEnvName,
+	Value: "0",
+}
+
 func TestGeneratePresetInference(t *testing.T) {
 	test.RegisterTestModel()
 	baseImage := metadata.MustGet("base")
@@ -386,8 +393,17 @@ func TestGeneratePresetInference(t *testing.T) {
 				t.Errorf("%s: image is not expected, got %s, expect %s", k, image, baseImageName)
 			}
 
-			if !reflect.DeepEqual(envVars, tc.expectedEnvVars) {
-				t.Errorf("%s: EnvVars are not expected, got %v, expect %v", k, envVars, tc.expectedEnvVars)
+			// For vLLM, production injects VLLM_USE_DEEP_GEMM=0 immediately after the
+			// FlashInfer sampler env. Mirror that here so the per-case expectations only
+			// need to list the FlashInfer env plus any case-specific vars.
+			expectedEnvVars := tc.expectedEnvVars
+			if len(expectedEnvVars) > 0 && expectedEnvVars[0] == flashInferSamplerEnvVar {
+				withDefaults := []corev1.EnvVar{flashInferSamplerEnvVar, deepGEMMEnvVar}
+				expectedEnvVars = append(withDefaults, expectedEnvVars[1:]...)
+			}
+
+			if !reflect.DeepEqual(envVars, expectedEnvVars) {
+				t.Errorf("%s: EnvVars are not expected, got %v, expect %v", k, envVars, expectedEnvVars)
 			}
 
 			workloadCmd := strings.Join(statefulset.Spec.Template.Spec.Containers[0].Command, " ")

--- a/presets/workspace/inference/vllm/benchmark_entrypoint.py
+++ b/presets/workspace/inference/vllm/benchmark_entrypoint.py
@@ -467,6 +467,7 @@ def _run_guidellm(processor: str, max_concurrency: int):
         rate=[float(max_concurrency)],
         max_seconds=BENCHMARK_DURATION,
         processor=processor or None,
+        processor_args={"trust_remote_code": True},
         data_num_workers=0,
         random_seed=int(time.time()),
         outputs=[],

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -3,8 +3,9 @@ models:
   - name: base
     type: text-generation
     runtime: tfs
-    tag: 0.4.0
+    tag: 0.4.1
     # Tag history:
+    # 0.4.1 - pass trust_remote_code=true to GuideLLM benchmark
     # 0.4.0 - bump vllm to 0.22.1, torch to 2.11.0
     # 0.3.3 - add model download monitor
     # 0.3.2 - make Worker nodes always ready in distributed inference to unblock StatefulSet rolling upgrade. bump lmcache to 0.4.6 and use its CUDA 12.9 wheel

--- a/presets/workspace/models/vllm_model.go
+++ b/presets/workspace/models/vllm_model.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -28,6 +29,38 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/presets/workspace/generator"
 )
+
+const (
+	// defaultReadinessTimeout is the startup probe timeout for typical preset models.
+	defaultReadinessTimeout = 30 * time.Minute
+
+	// largeModelReadinessTimeout is the startup probe timeout for large preset models
+	// whose runtime weight download and load exceed the default window.
+	largeModelReadinessTimeout = 60 * time.Minute
+
+	// largeModelSizeThreshold is the model weight size above which
+	// largeModelReadinessTimeout is used instead of defaultReadinessTimeout.
+	largeModelSizeThreshold = "300Gi"
+)
+
+// readinessTimeoutForModelSize returns the startup probe timeout for a preset model
+// based on its weight size (from model_catalog.yaml). Models larger than
+// largeModelSizeThreshold get a longer timeout to accommodate the extended
+// download/load time; all others use the default.
+func readinessTimeoutForModelSize(modelFileSize string) time.Duration {
+	if modelFileSize == "" {
+		return defaultReadinessTimeout
+	}
+	size, err := resource.ParseQuantity(modelFileSize)
+	if err != nil {
+		return defaultReadinessTimeout
+	}
+	threshold := resource.MustParse(largeModelSizeThreshold)
+	if size.Cmp(threshold) > 0 {
+		return largeModelReadinessTimeout
+	}
+	return defaultReadinessTimeout
+}
 
 var (
 	//go:embed model_catalog.yaml
@@ -198,7 +231,7 @@ func (m *vLLMCompatibleModel) GetInferenceParameters() *model.PresetParam {
 			Transformers: tfsParam,
 			VLLM:         vllmParam,
 		},
-		ReadinessTimeout: time.Duration(30) * time.Minute,
+		ReadinessTimeout: readinessTimeoutForModelSize(m.model.ModelFileSize),
 	}
 
 	return presetParam

--- a/presets/workspace/models/vllm_model_test.go
+++ b/presets/workspace/models/vllm_model_test.go
@@ -198,6 +198,61 @@ func TestVLLMCompatibleModel_GetInferenceParameters(t *testing.T) {
 	}
 }
 
+func TestReadinessTimeoutForModelSize(t *testing.T) {
+	tests := []struct {
+		name          string
+		modelFileSize string
+		expected      time.Duration
+	}{
+		{
+			name:          "large model above threshold uses 60m",
+			modelFileSize: "554.32Gi", // Kimi-K2.5
+			expected:      largeModelReadinessTimeout,
+		},
+		{
+			name:          "very large model above threshold uses 60m",
+			modelFileSize: "641.30Gi", // DeepSeek-R1-0528
+			expected:      largeModelReadinessTimeout,
+		},
+		{
+			name:          "model just above threshold uses 60m",
+			modelFileSize: "300.01Gi",
+			expected:      largeModelReadinessTimeout,
+		},
+		{
+			name:          "model at threshold uses default",
+			modelFileSize: "300Gi",
+			expected:      defaultReadinessTimeout,
+		},
+		{
+			name:          "model below threshold uses default",
+			modelFileSize: "131.42Gi", // Llama-3.3-70B
+			expected:      defaultReadinessTimeout,
+		},
+		{
+			name:          "small model uses default",
+			modelFileSize: "7.15Gi",
+			expected:      defaultReadinessTimeout,
+		},
+		{
+			name:          "empty size uses default",
+			modelFileSize: "",
+			expected:      defaultReadinessTimeout,
+		},
+		{
+			name:          "unparseable size uses default",
+			modelFileSize: "not-a-size",
+			expected:      defaultReadinessTimeout,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, readinessTimeoutForModelSize(tt.modelFileSize))
+		})
+	}
+}
+
 func TestVLLMCompatibleModel_GetInferenceParameters_TransformerLookup(t *testing.T) {
 	tests := []struct {
 		name                       string

--- a/presets/workspace/models/vllm_model_test.go
+++ b/presets/workspace/models/vllm_model_test.go
@@ -240,7 +240,7 @@ func TestReadinessTimeoutForModelSize(t *testing.T) {
 			expected:      defaultReadinessTimeout,
 		},
 		{
-			name:          "unparseable size uses default",
+			name:          "unparsable size uses default",
 			modelFileSize: "not-a-size",
 			expected:      defaultReadinessTimeout,
 		},


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
Currently KAITO deployment for model `moonshotai/Kimi-K2.5` is broken because:

**1. GuideLLM benchmark deserializer crash**
- Benchmark failed because the tokenizer needed `trust_remote_code`. Fixed by passing `trust_remote_code=True` in `benchmark_entrypoint.py` and bumping KAITO base image to 0.4.1.

**2. DeepGEMM FP8 warmup crash** 
- `RuntimeError: DeepGEMM backend is not available or outdated` at engine warmup. vLLM 0.22.1 defaults `VLLM_USE_DEEP_GEMM=True` and `has_deep_gemm()` falsely reports True (it finds the vendored wrapper module), but the native FP8 backend isn't in the slim image.
- Fix: inject `VLLM_USE_DEEP_GEMM=0` as a runtime env in preset_inferences.go, mirroring the existing `VLLM_USE_FLASHINFER_SAMPLER=0` pattern (new const `VLLMUseDeepGEMMEnvName`). 

**3. FlashInfer allreduce-RMS fusion `nvcc` crash** 
- Engine got to CUDA graph capture (~76%) then died: `Could not find nvcc and default cuda_home='/usr/local/cuda' doesn't exist`. vLLM 0.22.1 defaults the `fuse_allreduce_rms` pass on, which routes through FlashInfer's TRT-LLM MNNVL kernel that JIT-compiles at runtime — but the slim image has no CUDA toolkit.
- Fix: pass `--compilation-config.pass_config.fuse_allreduce_rms=False` for all vLLM models in interface.go.

This PR also bumps the readiness timeout from 30 min to 60 min for models larger than 300GB to avoid unintended inference pod restarts.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).
- [x] manually deployed moonshotai/Kimi-K2.5 in AKS.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: