### PR TITLE
feat: add streaming passthrough chat completions

### DIFF
--- a/presets/ragengine/inference/inference.py
+++ b/presets/ragengine/inference/inference.py
@@ -16,8 +16,8 @@ import asyncio
 import concurrent.futures
 import json
 import logging
-from collections.abc import Sequence
-from typing import Any, AsyncIterator
+from collections.abc import AsyncIterator, Sequence
+from typing import Any
 from urllib.parse import urljoin, urlparse
 
 import httpx

--- a/presets/ragengine/inference/inference.py
+++ b/presets/ragengine/inference/inference.py
@@ -17,7 +17,7 @@ import concurrent.futures
 import json
 import logging
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, AsyncIterator
 from urllib.parse import urljoin, urlparse
 
 import httpx
@@ -312,6 +312,56 @@ class Inference(CustomLLM):
             )
         except Exception as e:
             logger.error(f"Unexpected error during POST request: {e}")
+            raise HTTPException(
+                status_code=500, detail=f"Error during POST request: {str(e)}"
+            )
+
+    async def chat_completions_stream_passthrough(
+        self, chat_completions_request: dict, **kwargs: Any
+    ) -> AsyncIterator[str]:
+        if "/chat/completions" not in LLM_INFERENCE_URL:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Chat completions not supported through endpoint {LLM_INFERENCE_URL}.",
+            )
+
+        request_data = dict(chat_completions_request)
+        request_data["stream"] = True
+
+        client = await self._get_httpx_client()
+        try:
+            async with client.stream(
+                "POST",
+                LLM_INFERENCE_URL,
+                json=request_data,
+                headers=DEFAULT_HEADERS,
+            ) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line:
+                        continue
+                    yield f"{line}\n\n"
+        except HTTPException as http_exc:
+            logger.error(
+                f"HTTP exception during chat completions stream passthrough: {http_exc.detail}"
+            )
+            raise http_exc
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                f"HTTP error {e.response.status_code} during streaming POST request to {LLM_INFERENCE_URL}: {e.response.text}"
+            )
+            raise HTTPException(
+                status_code=e.response.status_code, detail=f"{str(e.response.content)}"
+            )
+        except httpx.RequestError as e:
+            logger.error(
+                f"Error during streaming POST request to {LLM_INFERENCE_URL}: {e}"
+            )
+            raise HTTPException(
+                status_code=500, detail=f"Error during POST request: {str(e)}"
+            )
+        except Exception as e:
+            logger.error(f"Unexpected error during streaming POST request: {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error during POST request: {str(e)}"
             )

--- a/presets/ragengine/main.py
+++ b/presets/ragengine/main.py
@@ -21,7 +21,7 @@ from urllib.parse import unquote
 import nest_asyncio
 from fastapi import FastAPI, HTTPException, Query, Request  # noqa: E402
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest  # noqa: E402
-from starlette.responses import Response  # noqa: E402
+from starlette.responses import Response, StreamingResponse  # noqa: E402
 
 nest_asyncio.apply()  # Allow nested event loops (LlamaIndex sync internals inside FastAPI async)
 
@@ -350,6 +350,17 @@ async def chat_completions(request: dict):
             raise HTTPException(
                 status_code=503,
                 detail="InferenceService not configured. This RAGEngine instance only supports document retrieve via /retrieve API. To use chat completions, configure an InferenceService in the RAGEngine spec.",
+            )
+
+        if request.get("stream") is True:
+            status = STATUS_SUCCESS
+            return StreamingResponse(
+                rag_ops.vector_store.llm.chat_completions_stream_passthrough(request),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "X-Accel-Buffering": "no",
+                },
             )
 
         response = await rag_ops.chat_completion(request)

--- a/presets/ragengine/tests/api/test_chat_completions.py
+++ b/presets/ragengine/tests/api/test_chat_completions.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import re
 import textwrap
 import time
@@ -186,6 +187,48 @@ async def test_chat_completions_without_index_name(mock_get, async_client):
     )
     # Should have source_nodes field but it should be None for passthrough requests
     assert response_data["source_nodes"] is None
+
+
+@pytest.mark.asyncio
+@respx.mock
+@patch("requests.get")
+async def test_chat_completions_stream_passthrough(mock_get, async_client):
+    """Test stream=true passthrough returns SSE and forwards stream upstream."""
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "data": [{"id": "mock-model", "max_model_len": 2048}]
+    }
+
+    sse_payload = (
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'
+        'data: {"choices":[{"delta":{"content":" world"}}]}\n\n'
+        "data: [DONE]\n\n"
+    )
+    route = respx.post("http://localhost:5000/v1/chat/completions").mock(
+        return_value=httpx.Response(
+            200,
+            text=sse_payload,
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+    chat_request = {
+        "model": "mock-model",
+        "messages": [{"role": "user", "content": "Hello, how are you?"}],
+        "stream": True,
+    }
+
+    async with async_client.stream(
+        "POST", "/v1/chat/completions", json=chat_request
+    ) as response:
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        response_body = "".join([chunk async for chunk in response.aiter_text()])
+
+    assert response_body == sse_payload
+    assert len(route.calls) == 1
+    upstream_body = json.loads(route.calls[0].request.content.decode())
+    assert upstream_body["stream"] is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR implements Phase 1 / PR 1 of the streaming guardrails plan: streaming passthrough for `/v1/chat/completions`.

When a request includes `stream: true`, RAGEngine now:

- branches to a streaming response path at the API entrypoint
- forwards `stream: true` to the upstream LLM backend
- consumes upstream SSE chunks
- returns `text/event-stream` to the client

This PR does not add guardrail processing to the streaming path yet. Non-streaming behavior remains unchanged.

## Changes

- add a `stream=true` branch in the `/v1/chat/completions` endpoint
- add upstream chat completions streaming passthrough in the inference layer
- preserve existing non-streaming chat completion flow
- add API coverage for streaming passthrough behavior

## Testing

Validated with focused tests:

- `test_chat_completions_stream_passthrough`
- `test_chat_completions_without_index_name`

Command used:

```bash
./.venv/bin/python -m pytest presets/ragengine/tests/api/test_chat_completions.py -k 'stream_passthrough or without_index_name'