### PR TITLE
feat: add buffer and holdback pipeline for streaming responses

### DIFF
--- a/presets/ragengine/inference/inference.py
+++ b/presets/ragengine/inference/inference.py
@@ -45,14 +45,16 @@ from ragengine.config import (
     LLM_CONTEXT_WINDOW,
     LLM_INFERENCE_URL,
 )
-from ragengine.inference.sse import (
+from ragengine.models import ChatCompletionResponse
+from ragengine.streaming.downstream import (
     build_sse_data_chunk,
     build_sse_done_chunk,
+)
+from ragengine.streaming.upstream import (
     extract_delta_content,
     is_sse_done_event,
     parse_sse_data_line,
 )
-from ragengine.models import ChatCompletionResponse
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)

--- a/presets/ragengine/inference/inference.py
+++ b/presets/ragengine/inference/inference.py
@@ -46,7 +46,9 @@ from ragengine.config import (
     LLM_INFERENCE_URL,
 )
 from ragengine.models import ChatCompletionResponse
+from ragengine.streaming.buffering import NoOpStreamScanner, StreamBuffer
 from ragengine.streaming.downstream import (
+    build_content_sse_chunk,
     build_sse_data_chunk,
     build_sse_done_chunk,
 )
@@ -338,6 +340,7 @@ class Inference(CustomLLM):
         request_data["stream"] = True
 
         client = await self._get_httpx_client()
+        stream_buffer = StreamBuffer(scanner=NoOpStreamScanner())
         try:
             async with client.stream(
                 "POST",
@@ -355,12 +358,21 @@ class Inference(CustomLLM):
                         continue
 
                     if is_sse_done_event(data):
+                        for buffered_text in stream_buffer.flush():
+                            yield build_content_sse_chunk(buffered_text)
                         yield build_sse_done_chunk()
                         break
 
                     payload = json.loads(data)
-                    extract_delta_content(payload)
-                    yield build_sse_data_chunk(payload)
+                    delta_content = extract_delta_content(payload)
+                    if delta_content is None:
+                        for buffered_text in stream_buffer.flush():
+                            yield build_content_sse_chunk(buffered_text)
+                        yield build_sse_data_chunk(payload)
+                        continue
+
+                    for buffered_text in stream_buffer.push_text(delta_content):
+                        yield build_content_sse_chunk(buffered_text)
         except HTTPException as http_exc:
             logger.error(
                 f"HTTP exception during chat completions stream passthrough: {http_exc.detail}"

--- a/presets/ragengine/inference/inference.py
+++ b/presets/ragengine/inference/inference.py
@@ -16,8 +16,8 @@ import asyncio
 import concurrent.futures
 import json
 import logging
-from collections.abc import Sequence
-from typing import Any, AsyncIterator
+from collections.abc import AsyncIterator, Sequence
+from typing import Any
 from urllib.parse import urljoin, urlparse
 
 import httpx

--- a/presets/ragengine/inference/inference.py
+++ b/presets/ragengine/inference/inference.py
@@ -45,6 +45,13 @@ from ragengine.config import (
     LLM_CONTEXT_WINDOW,
     LLM_INFERENCE_URL,
 )
+from ragengine.inference.sse import (
+    build_sse_data_chunk,
+    build_sse_done_chunk,
+    extract_delta_content,
+    is_sse_done_event,
+    parse_sse_data_line,
+)
 from ragengine.models import ChatCompletionResponse
 
 # Configure logging
@@ -340,7 +347,18 @@ class Inference(CustomLLM):
                 async for line in response.aiter_lines():
                     if not line:
                         continue
-                    yield f"{line}\n\n"
+
+                    data = parse_sse_data_line(line)
+                    if data is None:
+                        continue
+
+                    if is_sse_done_event(data):
+                        yield build_sse_done_chunk()
+                        break
+
+                    payload = json.loads(data)
+                    extract_delta_content(payload)
+                    yield build_sse_data_chunk(payload)
         except HTTPException as http_exc:
             logger.error(
                 f"HTTP exception during chat completions stream passthrough: {http_exc.detail}"

--- a/presets/ragengine/inference/inference.py
+++ b/presets/ragengine/inference/inference.py
@@ -17,7 +17,7 @@ import concurrent.futures
 import json
 import logging
 from collections.abc import Sequence
-from typing import Any
+from typing import Any, AsyncIterator
 from urllib.parse import urljoin, urlparse
 
 import httpx
@@ -312,6 +312,56 @@ class Inference(CustomLLM):
             )
         except Exception as e:
             logger.error(f"Unexpected error during POST request: {e}")
+            raise HTTPException(
+                status_code=500, detail=f"Error during POST request: {str(e)}"
+            )
+
+    async def chat_completions_stream_passthrough(
+        self, chat_completions_request: dict, **kwargs: Any
+    ) -> AsyncIterator[str]:
+        if "/chat/completions" not in LLM_INFERENCE_URL:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Chat completions not supported through endpoint {LLM_INFERENCE_URL}.",
+            )
+
+        request_data = dict(chat_completions_request)
+        request_data["stream"] = True
+
+        client = await self._get_httpx_client()
+        try:
+            async with client.stream(
+                "POST",
+                LLM_INFERENCE_URL,
+                json=request_data,
+                headers=DEFAULT_HEADERS,
+            ) as response:
+                response.raise_for_status()
+                async for line in response.aiter_lines():
+                    if not line:
+                        continue
+                    yield f"{line}\n\n"
+        except HTTPException as http_exc:
+            logger.error(
+                f"HTTP exception during chat completions stream passthrough: {http_exc.detail}"
+            )
+            raise http_exc
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                f"HTTP error {e.response.status_code} during streaming POST request to {LLM_INFERENCE_URL}: {e.response.text}"
+            )
+            raise HTTPException(
+                status_code=e.response.status_code, detail=f"{str(e.response.content)}"
+            )
+        except httpx.RequestError as e:
+            logger.error(
+                f"Error during streaming POST request to {LLM_INFERENCE_URL}: {e}"
+            )
+            raise HTTPException(
+                status_code=500, detail=f"Error during POST request: {str(e)}"
+            )
+        except Exception as e:
+            logger.error(f"Unexpected error during streaming POST request: {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error during POST request: {str(e)}"
             )

--- a/presets/ragengine/inference/sse.py
+++ b/presets/ragengine/inference/sse.py
@@ -1,0 +1,49 @@
+import json
+from typing import Any
+
+SSE_DATA_PREFIX = "data:"
+SSE_DONE_MARKER = "[DONE]"
+
+
+def parse_sse_data_line(line: str) -> str | None:
+    if not line.startswith(SSE_DATA_PREFIX):
+        return None
+
+    return line[len(SSE_DATA_PREFIX) :].lstrip()
+
+
+def is_sse_done_event(data: str) -> bool:
+    return data.strip() == SSE_DONE_MARKER
+
+
+def extract_delta_content(payload: dict[str, Any]) -> str | None:
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or not choices:
+        return None
+
+    delta = choices[0].get("delta")
+    if not isinstance(delta, dict):
+        return None
+
+    content = delta.get("content")
+    return content if isinstance(content, str) else None
+
+
+def build_sse_data_chunk(payload: dict[str, Any]) -> str:
+    return f"{SSE_DATA_PREFIX} {json.dumps(payload, separators=(',', ':'))}\n\n"
+
+
+def build_sse_done_chunk() -> str:
+    return f"{SSE_DATA_PREFIX} {SSE_DONE_MARKER}\n\n"
+
+
+def build_block_sse_chunk(message: str) -> str:
+    payload = {
+        "choices": [
+            {
+                "delta": {"content": message},
+                "finish_reason": "content_filter",
+            }
+        ]
+    }
+    return build_sse_data_chunk(payload)

--- a/presets/ragengine/main.py
+++ b/presets/ragengine/main.py
@@ -21,7 +21,7 @@ from urllib.parse import unquote
 import nest_asyncio
 from fastapi import FastAPI, HTTPException, Query, Request  # noqa: E402
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest  # noqa: E402
-from starlette.responses import Response  # noqa: E402
+from starlette.responses import Response, StreamingResponse  # noqa: E402
 
 nest_asyncio.apply()  # Allow nested event loops (LlamaIndex sync internals inside FastAPI async)
 
@@ -350,6 +350,17 @@ async def chat_completions(request: dict):
             raise HTTPException(
                 status_code=503,
                 detail="InferenceService not configured. This RAGEngine instance only supports document retrieve via /retrieve API. To use chat completions, configure an InferenceService in the RAGEngine spec.",
+            )
+
+        if request.get("stream") is True:
+            status = STATUS_SUCCESS
+            return StreamingResponse(
+                rag_ops.vector_store.llm.chat_completions_stream_passthrough(request),
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "X-Accel-Buffering": "no",
+                },
             )
 
         response = await rag_ops.chat_completion(request)

--- a/presets/ragengine/streaming/buffering.py
+++ b/presets/ragengine/streaming/buffering.py
@@ -1,0 +1,101 @@
+from dataclasses import dataclass
+from typing import Literal, Protocol
+
+
+@dataclass(frozen=True)
+class StreamScanDecision:
+    action: Literal["pass"] = "pass"
+
+
+class StreamScanner(Protocol):
+    def inspect(self, text: str) -> StreamScanDecision: ...
+
+
+class NoOpStreamScanner:
+    def inspect(self, text: str) -> StreamScanDecision:
+        return StreamScanDecision()
+
+
+@dataclass(frozen=True)
+class StreamBufferConfig:
+    min_scan_chars: int = 0
+    max_window_chars: int = 4096
+    max_emit_chars: int = 4096
+    holdback_chars: int = 0
+
+
+class StreamBuffer:
+    def __init__(
+        self,
+        config: StreamBufferConfig | None = None,
+        scanner: StreamScanner | None = None,
+    ) -> None:
+        self._config = config or StreamBufferConfig()
+        self._scanner = scanner or NoOpStreamScanner()
+        self._pending_text = ""
+        self._recent_text = ""
+
+    @property
+    def pending_text(self) -> str:
+        return self._pending_text
+
+    def push_text(self, text: str) -> list[str]:
+        if not text:
+            return []
+
+        self._pending_text += text
+        self._recent_text += text
+        self._scan_pending_text_if_needed()
+        return self._drain_emittable_text()
+
+    def flush(self) -> list[str]:
+        if not self._pending_text:
+            return []
+
+        self._scan_pending_text_if_needed()
+        return self._drain_all_text()
+
+    def _scan_pending_text_if_needed(self) -> None:
+        scan_window = self._get_scan_window()
+        if len(scan_window) < self._config.min_scan_chars:
+            return
+
+        decision = self._scanner.inspect(scan_window)
+        if decision.action != "pass":
+            raise NotImplementedError("Only pass decisions are supported in PR3")
+
+    def _get_scan_window(self) -> str:
+        max_window_chars = self._config.max_window_chars
+        if max_window_chars <= 0:
+            return self._recent_text
+
+        return self._recent_text[-max_window_chars:]
+
+    def _drain_emittable_text(self) -> list[str]:
+        emittable_chars = len(self._pending_text) - max(self._config.holdback_chars, 0)
+        if emittable_chars <= 0:
+            return []
+
+        return self._drain_text(emittable_chars)
+
+    def _drain_all_text(self) -> list[str]:
+        return self._drain_text(len(self._pending_text))
+
+    def _drain_text(self, total_chars: int) -> list[str]:
+        if total_chars <= 0:
+            return []
+
+        drained_chunks: list[str] = []
+        max_emit_chars = self._config.max_emit_chars
+        remaining_chars = total_chars
+
+        while remaining_chars > 0:
+            chunk_size = remaining_chars
+            if max_emit_chars > 0:
+                chunk_size = min(chunk_size, max_emit_chars)
+
+            drained_chunks.append(self._pending_text[:chunk_size])
+            self._pending_text = self._pending_text[chunk_size:]
+            remaining_chars -= chunk_size
+
+        return drained_chunks

--- a/presets/ragengine/streaming/downstream.py
+++ b/presets/ragengine/streaming/downstream.py
@@ -1,0 +1,24 @@
+import json
+from typing import Any
+
+from ragengine.streaming.upstream import SSE_DATA_PREFIX, SSE_DONE_MARKER
+
+
+def build_sse_data_chunk(payload: dict[str, Any]) -> str:
+    return f"{SSE_DATA_PREFIX} {json.dumps(payload, separators=(',', ':'))}\n\n"
+
+
+def build_sse_done_chunk() -> str:
+    return f"{SSE_DATA_PREFIX} {SSE_DONE_MARKER}\n\n"
+
+
+def build_block_sse_chunk(message: str) -> str:
+    payload = {
+        "choices": [
+            {
+                "delta": {"content": message},
+                "finish_reason": "content_filter",
+            }
+        ]
+    }
+    return build_sse_data_chunk(payload)

--- a/presets/ragengine/streaming/downstream.py
+++ b/presets/ragengine/streaming/downstream.py
@@ -8,6 +8,11 @@ def build_sse_data_chunk(payload: dict[str, Any]) -> str:
     return f"{SSE_DATA_PREFIX} {json.dumps(payload, separators=(',', ':'))}\n\n"
 
 
+def build_content_sse_chunk(content: str) -> str:
+    payload = {"choices": [{"delta": {"content": content}}]}
+    return build_sse_data_chunk(payload)
+
+
 def build_sse_done_chunk() -> str:
     return f"{SSE_DATA_PREFIX} {SSE_DONE_MARKER}\n\n"
 

--- a/presets/ragengine/streaming/upstream.py
+++ b/presets/ragengine/streaming/upstream.py
@@ -1,4 +1,3 @@
-import json
 from typing import Any
 
 SSE_DATA_PREFIX = "data:"
@@ -27,23 +26,3 @@ def extract_delta_content(payload: dict[str, Any]) -> str | None:
 
     content = delta.get("content")
     return content if isinstance(content, str) else None
-
-
-def build_sse_data_chunk(payload: dict[str, Any]) -> str:
-    return f"{SSE_DATA_PREFIX} {json.dumps(payload, separators=(',', ':'))}\n\n"
-
-
-def build_sse_done_chunk() -> str:
-    return f"{SSE_DATA_PREFIX} {SSE_DONE_MARKER}\n\n"
-
-
-def build_block_sse_chunk(message: str) -> str:
-    payload = {
-        "choices": [
-            {
-                "delta": {"content": message},
-                "finish_reason": "content_filter",
-            }
-        ]
-    }
-    return build_sse_data_chunk(payload)

--- a/presets/ragengine/tests/api/test_buffering.py
+++ b/presets/ragengine/tests/api/test_buffering.py
@@ -1,0 +1,65 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+from ragengine.streaming.buffering import (
+    NoOpStreamScanner,
+    StreamBuffer,
+    StreamBufferConfig,
+    StreamScanDecision,
+)
+
+
+class RecordingScanner:
+    def __init__(self) -> None:
+        self.scanned_texts: list[str] = []
+
+    def inspect(self, text: str) -> StreamScanDecision:
+        self.scanned_texts.append(text)
+        return StreamScanDecision()
+
+
+def test_stream_buffer_holds_back_suffix_until_flush():
+    stream_buffer = StreamBuffer(
+        config=StreamBufferConfig(holdback_chars=2),
+        scanner=NoOpStreamScanner(),
+    )
+
+    assert stream_buffer.push_text("Hello") == ["Hel"]
+    assert stream_buffer.pending_text == "lo"
+    assert stream_buffer.flush() == ["lo"]
+    assert stream_buffer.pending_text == ""
+
+
+def test_stream_buffer_respects_max_emit_chars():
+    stream_buffer = StreamBuffer(
+        config=StreamBufferConfig(max_emit_chars=3),
+        scanner=NoOpStreamScanner(),
+    )
+
+    assert stream_buffer.push_text("Hello") == ["Hel", "lo"]
+    assert stream_buffer.pending_text == ""
+
+
+def test_stream_buffer_scans_only_after_min_chars_and_uses_window_suffix():
+    scanner = RecordingScanner()
+    stream_buffer = StreamBuffer(
+        config=StreamBufferConfig(min_scan_chars=4, max_window_chars=4),
+        scanner=scanner,
+    )
+
+    assert stream_buffer.push_text("abc") == ["abc"]
+    assert scanner.scanned_texts == []
+
+    assert stream_buffer.push_text("def") == ["def"]
+    assert scanner.scanned_texts == ["cdef"]
+
+
+def test_stream_buffer_flush_emits_holdback_suffix():
+    stream_buffer = StreamBuffer(
+        config=StreamBufferConfig(holdback_chars=3),
+        scanner=NoOpStreamScanner(),
+    )
+
+    assert stream_buffer.push_text("abcdef") == ["abc"]
+    assert stream_buffer.flush() == ["def"]

--- a/presets/ragengine/tests/api/test_chat_completions.py
+++ b/presets/ragengine/tests/api/test_chat_completions.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import re
 import textwrap
 import time
@@ -186,6 +187,48 @@ async def test_chat_completions_without_index_name(mock_get, async_client):
     )
     # Should have source_nodes field but it should be None for passthrough requests
     assert response_data["source_nodes"] is None
+
+
+@pytest.mark.asyncio
+@respx.mock
+@patch("requests.get")
+async def test_chat_completions_stream_passthrough(mock_get, async_client):
+    """Test stream=true passthrough returns SSE and forwards stream upstream."""
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "data": [{"id": "mock-model", "max_model_len": 2048}]
+    }
+
+    sse_payload = (
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n'
+        'data: {"choices":[{"delta":{"content":" world"}}]}\n\n'
+        "data: [DONE]\n\n"
+    )
+    route = respx.post("http://localhost:5000/v1/chat/completions").mock(
+        return_value=httpx.Response(
+            200,
+            text=sse_payload,
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+    chat_request = {
+        "model": "mock-model",
+        "messages": [{"role": "user", "content": "Hello, how are you?"}],
+        "stream": True,
+    }
+
+    async with async_client.stream(
+        "POST", "/v1/chat/completions", json=chat_request
+    ) as response:
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+        response_body = "".join([chunk async for chunk in response.aiter_text()])
+
+    assert response_body == sse_payload
+    assert len(route.calls) == 1
+    upstream_body = json.loads(route.calls[0].request.content.decode())
+    assert upstream_body["stream"] is True
 
 
 @pytest.mark.asyncio

--- a/presets/ragengine/tests/api/test_sse.py
+++ b/presets/ragengine/tests/api/test_sse.py
@@ -1,0 +1,58 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+import json
+
+from ragengine.inference.sse import (
+    build_block_sse_chunk,
+    build_sse_data_chunk,
+    build_sse_done_chunk,
+    extract_delta_content,
+    is_sse_done_event,
+    parse_sse_data_line,
+)
+
+
+def test_parse_sse_data_line_extracts_payload():
+    assert parse_sse_data_line('data: {"hello":"world"}') == '{"hello":"world"}'
+
+
+def test_parse_sse_data_line_ignores_non_data_lines():
+    assert parse_sse_data_line("event: message") is None
+
+
+def test_is_sse_done_event_detects_done_marker():
+    assert is_sse_done_event("[DONE]") is True
+    assert is_sse_done_event('{"choices":[]}') is False
+
+
+def test_extract_delta_content_returns_first_choice_content():
+    payload = {"choices": [{"delta": {"content": "Hello"}}]}
+
+    assert extract_delta_content(payload) == "Hello"
+
+
+def test_build_sse_data_chunk_builds_openai_compatible_frame():
+    payload = {"choices": [{"delta": {"content": "Hello"}}]}
+
+    frame = build_sse_data_chunk(payload)
+
+    assert frame.endswith("\n\n")
+    parsed_payload = parse_sse_data_line(frame.strip())
+    assert parsed_payload is not None
+    assert json.loads(parsed_payload) == payload
+
+
+def test_build_sse_done_chunk_builds_done_frame():
+    assert build_sse_done_chunk() == "data: [DONE]\n\n"
+
+
+def test_build_block_sse_chunk_builds_content_filter_frame():
+    frame = build_block_sse_chunk("blocked")
+
+    parsed_payload = parse_sse_data_line(frame.strip())
+    assert parsed_payload is not None
+    payload = json.loads(parsed_payload)
+    assert payload["choices"][0]["delta"]["content"] == "blocked"
+    assert payload["choices"][0]["finish_reason"] == "content_filter"

--- a/presets/ragengine/tests/api/test_sse.py
+++ b/presets/ragengine/tests/api/test_sse.py
@@ -4,10 +4,12 @@
 
 import json
 
-from ragengine.inference.sse import (
+from ragengine.streaming.downstream import (
     build_block_sse_chunk,
     build_sse_data_chunk,
     build_sse_done_chunk,
+)
+from ragengine.streaming.upstream import (
     extract_delta_content,
     is_sse_done_event,
     parse_sse_data_line,


### PR DESCRIPTION
## Summary

This PR adds the first buffering pipeline for streaming chat responses.

It introduces a pending buffer between upstream SSE deltas and downstream SSE emission, with a no-op scanner seam so the buffering runtime can be exercised before wiring in streaming guardrails decisions.

## What changed

- Added `StreamBuffer` and `StreamBufferConfig` in `presets/ragengine/streaming/buffering.py`
- Added a scanner interface with a default `NoOpStreamScanner`
- Added support for:
  - pending buffer accumulation
  - holdback suffix behavior
  - `min_scan_chars`
  - `max_window_chars`
  - `max_emit_chars`
  - final flush on stream completion
- Updated streaming chat passthrough in `presets/ragengine/inference/inference.py` to:
  - buffer `delta.content` before emitting
  - flush buffered content before `[DONE]`
  - flush buffered content before forwarding non-content SSE payloads
- Added `build_content_sse_chunk` in `presets/ragengine/streaming/downstream.py`
- Added focused buffering tests in `presets/ragengine/tests/api/test_buffering.py`

## Scope

This PR is intentionally limited to the buffering runtime.

It does **not** add streaming guardrails decisions yet:
- no block path
- no rewrite path
- no policy-driven scanner integration

The scanner seam is present, but the default implementation is a no-op and always returns `pass`.

## Behavior

Current streaming behavior is now:

1. upstream `delta.content` is appended into a pending buffer
2. the buffer optionally scans a rolling suffix window
3. emittable content is released according to holdback and max-emit settings
4. any remaining buffered content is flushed when the stream ends

With the default configuration used in this PR, behavior remains compatible with the existing passthrough test path while introducing the buffering pipeline needed for the next step.

## Tests

Validated with:

- `./.venv/bin/python -m pytest presets/ragengine/tests/api/test_buffering.py presets/ragengine/tests/api/test_chat_completions.py -k 'buffering or stream_passthrough'`
- `./.venv/bin/python -m ruff check presets/ragengine/streaming/buffering.py presets/ragengine/streaming/downstream.py presets/ragengine/inference/inference.py presets/ragengine/tests/api/test_buffering.py`

## Follow-up

A follow-up PR can plug streaming guardrails into the scanner seam by introducing policy-driven stream decisions such as `pass`, `block`, and later `rewrite`.