### PR TITLE
feat: Support streaming passthrough for RAGEngine chat completions

### DIFF
--- a/presets/ragengine/inference/inference.py
+++ b/presets/ragengine/inference/inference.py
@@ -16,7 +16,7 @@ import asyncio
 import concurrent.futures
 import json
 import logging
-from collections.abc import Sequence
+from collections.abc import AsyncIterator, Sequence
 from typing import Any
 from urllib.parse import urljoin, urlparse
 
@@ -310,11 +310,70 @@ class Inference(CustomLLM):
             raise HTTPException(
                 status_code=500, detail=f"Error during POST request: {str(e)}"
             )
+
+    async def chat_completions_stream_passthrough(
+        self, chatCompletionsRequest: CompletionCreateParams, **kwargs: Any
+    ) -> AsyncIterator[str]:
+        if "/chat/completions" not in LLM_INFERENCE_URL:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Chat completions not supported through endpoint {LLM_INFERENCE_URL}.",
+            )
+
+        client = await self._get_httpx_client()
+        upstream_request = client.build_request(
+            "POST",
+            LLM_INFERENCE_URL,
+            json=chatCompletionsRequest,
+            headers=DEFAULT_HEADERS,
+        )
+        try:
+            response = await client.send(upstream_request, stream=True)
+            response.raise_for_status()
+        except httpx.HTTPStatusError as e:
+            await e.response.aread()
+            logger.error(
+                f"HTTP error {e.response.status_code} during streaming POST request to {LLM_INFERENCE_URL}: {e.response.text}"
+            )
+            await e.response.aclose()
+            raise HTTPException(
+                status_code=e.response.status_code, detail=f"{str(e.response.content)}"
+            )
+        except httpx.RequestError as e:
+            logger.error(
+                f"Error during streaming POST request to {LLM_INFERENCE_URL}: {e}"
+            )
+            raise HTTPException(
+                status_code=500, detail=f"Error during streaming POST request: {str(e)}"
+            )
         except Exception as e:
             logger.error(f"Unexpected error during POST request: {e}")
             raise HTTPException(
                 status_code=500, detail=f"Error during POST request: {str(e)}"
             )
+
+        async def stream_response() -> AsyncIterator[str]:
+            try:
+                async for chunk in response.aiter_text():
+                    if chunk:
+                        yield chunk
+            except httpx.RequestError as e:
+                logger.error(
+                    f"Error during streaming POST request to {LLM_INFERENCE_URL}: {e}"
+                )
+                raise HTTPException(
+                    status_code=500,
+                    detail=f"Error during streaming POST request: {str(e)}",
+                )
+            except Exception as e:
+                logger.error(f"Unexpected error during POST request: {e}")
+                raise HTTPException(
+                    status_code=500, detail=f"Error during POST request: {str(e)}"
+                )
+            finally:
+                await response.aclose()
+
+        return stream_response()
 
     async def _async_completions(
         self, prompt: str, **kwargs: Any

--- a/presets/ragengine/main.py
+++ b/presets/ragengine/main.py
@@ -21,7 +21,7 @@ from urllib.parse import unquote
 import nest_asyncio
 from fastapi import FastAPI, HTTPException, Query, Request  # noqa: E402
 from prometheus_client import CONTENT_TYPE_LATEST, generate_latest  # noqa: E402
-from starlette.responses import Response  # noqa: E402
+from starlette.responses import Response, StreamingResponse  # noqa: E402
 
 nest_asyncio.apply()  # Allow nested event loops (LlamaIndex sync internals inside FastAPI async)
 
@@ -352,8 +352,24 @@ async def chat_completions(request: dict):
                 detail="InferenceService not configured. This RAGEngine instance only supports document retrieve via /retrieve API. To use chat completions, configure an InferenceService in the RAGEngine spec.",
             )
 
-        response = await rag_ops.chat_completion(request)
         guardrails = guardrails_reloader.get_current()
+        if request.get("stream") is True:
+            if guardrails.enabled:
+                raise HTTPException(
+                    status_code=400,
+                    detail="stream=true is not supported when output guardrails are enabled.",
+                )
+            response = await rag_ops.chat_completion(request)
+            status = STATUS_SUCCESS
+            return StreamingResponse(
+                response,
+                media_type="text/event-stream",
+                headers={
+                    "Cache-Control": "no-cache",
+                    "X-Accel-Buffering": "no",
+                },
+            )
+        response = await rag_ops.chat_completion(request)
         response = guardrails.guard_response(response, request)
         status = STATUS_SUCCESS
         return response

--- a/presets/ragengine/tests/api/test_chat_completions.py
+++ b/presets/ragengine/tests/api/test_chat_completions.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import re
 import textwrap
 import time
@@ -186,6 +187,133 @@ async def test_chat_completions_without_index_name(mock_get, async_client):
     )
     # Should have source_nodes field but it should be None for passthrough requests
     assert response_data["source_nodes"] is None
+
+
+@pytest.mark.asyncio
+@respx.mock
+@patch("requests.get")
+async def test_chat_completions_stream_passthrough(mock_get, async_client):
+    """Test stream=true passthrough returns upstream SSE frames."""
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "data": [{"id": "mock-model", "max_model_len": 2048}]
+    }
+
+    route = respx.post("http://localhost:5000/v1/chat/completions").mock(
+        return_value=httpx.Response(
+            200,
+            content=(
+                'data: {"choices":[{"delta":{"content":"First"}}]}\n\n'
+                'data: {"choices":[{"delta":{"content":"Second"}}]}\n\n'
+                "data: [DONE]\n\n"
+            ),
+            headers={"content-type": "text/event-stream"},
+        )
+    )
+
+    chat_request = {
+        "model": "mock-model",
+        "messages": [{"role": "user", "content": "Hello"}],
+        "stream": True,
+    }
+
+    async with async_client.stream(
+        "POST", "/v1/chat/completions", json=chat_request
+    ) as response:
+        body = await response.aread()
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/event-stream")
+    response_text = body.decode()
+    assert 'data: {"choices":[{"delta":{"content":"First"}}]}' in response_text
+    assert 'data: {"choices":[{"delta":{"content":"Second"}}]}' in response_text
+    assert "data: [DONE]" in response_text
+    assert json.loads(route.calls.last.request.content)["stream"] is True
+
+
+@pytest.mark.asyncio
+@respx.mock
+@patch("requests.get")
+async def test_chat_completions_stream_passthrough_upstream_http_error(
+    mock_get, async_client
+):
+    """Test streaming passthrough raises upstream status before response streaming starts."""
+    mock_get.return_value.status_code = 200
+    mock_get.return_value.json.return_value = {
+        "data": [{"id": "mock-model", "max_model_len": 2048}]
+    }
+
+    respx.post("http://localhost:5000/v1/chat/completions").mock(
+        return_value=httpx.Response(401, json={"error": "unauthorized"})
+    )
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 401
+    assert "unauthorized" in response.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_stream_with_index_name_is_rejected(async_client):
+    index_request = {
+        "index_name": "test_index",
+        "documents": [
+            {"text": "This is a test document about streaming support."},
+        ],
+    }
+    response = await async_client.post("/index", json=index_request)
+    assert response.status_code == 200
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        json={
+            "index_name": "test_index",
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "Summarize this"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "stream=true is only supported for passthrough chat completions."
+    )
+
+
+@pytest.mark.asyncio
+async def test_chat_completions_stream_with_output_guardrails_is_rejected(
+    async_client, monkeypatch
+):
+    import ragengine.main
+
+    monkeypatch.setattr(
+        ragengine.main.guardrails_reloader,
+        "_current",
+        OutputGuardrails(enabled=True),
+    )
+
+    response = await async_client.post(
+        "/v1/chat/completions",
+        json={
+            "model": "mock-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "stream": True,
+        },
+    )
+
+    assert response.status_code == 400
+    assert (
+        response.json()["detail"]
+        == "stream=true is not supported when output guardrails are enabled."
+    )
 
 
 @pytest.mark.asyncio

--- a/presets/ragengine/tests/api/test_streaming_realtime.py
+++ b/presets/ragengine/tests/api/test_streaming_realtime.py
@@ -1,0 +1,126 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+import httpx
+import pytest
+import uvicorn
+from fastapi import FastAPI, Request
+from starlette.responses import StreamingResponse
+
+from ragengine.guardrails import OutputGuardrails
+from ragengine.main import app as ragengine_app
+
+
+@asynccontextmanager
+async def run_uvicorn_app(app: FastAPI, port: int) -> AsyncIterator[None]:
+    config = uvicorn.Config(
+        app,
+        host="127.0.0.1",
+        port=port,
+        log_level="warning",
+        lifespan="off",
+    )
+    server = uvicorn.Server(config)
+    task = asyncio.create_task(server.serve())
+
+    try:
+        await asyncio.wait_for(_wait_for_startup(server), timeout=5)
+        yield
+    finally:
+        server.should_exit = True
+        await asyncio.wait_for(task, timeout=5)
+
+
+async def _wait_for_startup(server: uvicorn.Server) -> None:
+    while not server.started:
+        await asyncio.sleep(0.01)
+
+
+async def _next_non_empty_line(lines: AsyncIterator[str]) -> str:
+    async for line in lines:
+        if line:
+            return line
+    raise AssertionError("stream ended before a non-empty SSE line was received")
+
+
+@pytest.mark.asyncio
+async def test_streaming_passthrough_flushes_first_chunk_before_upstream_finishes(
+    monkeypatch, unused_tcp_port_factory
+):
+    upstream_port = unused_tcp_port_factory()
+    ragengine_port = unused_tcp_port_factory()
+    release_second_chunk = asyncio.Event()
+    upstream_requests: list[dict] = []
+
+    upstream_app = FastAPI()
+
+    @upstream_app.post("/v1/chat/completions")
+    async def chat_completions(request: Request):
+        upstream_requests.append(await request.json())
+
+        async def events():
+            yield 'data: {"choices":[{"delta":{"content":"first"}}]}\n\n'
+            await release_second_chunk.wait()
+            yield 'data: {"choices":[{"delta":{"content":"second"}}]}\n\n'
+            yield "data: [DONE]\n\n"
+
+        return StreamingResponse(events(), media_type="text/event-stream")
+
+    import ragengine.inference.inference
+    import ragengine.main
+
+    monkeypatch.setattr(
+        ragengine.inference.inference,
+        "LLM_INFERENCE_URL",
+        f"http://127.0.0.1:{upstream_port}/v1/chat/completions",
+    )
+    monkeypatch.setattr(
+        ragengine.main.guardrails_reloader,
+        "_current",
+        OutputGuardrails(enabled=False),
+    )
+
+    async with (
+        run_uvicorn_app(upstream_app, upstream_port),
+        run_uvicorn_app(ragengine_app, ragengine_port),
+        httpx.AsyncClient(timeout=5) as client,
+        client.stream(
+            "POST",
+            f"http://127.0.0.1:{ragengine_port}/v1/chat/completions",
+            json={
+                "model": "mock-model",
+                "messages": [{"role": "user", "content": "Hello"}],
+                "stream": True,
+            },
+        ) as response,
+    ):
+        assert response.status_code == 200
+        assert response.headers["content-type"].startswith("text/event-stream")
+
+        lines = response.aiter_lines()
+        first_line = await asyncio.wait_for(_next_non_empty_line(lines), timeout=1)
+        assert first_line == 'data: {"choices":[{"delta":{"content":"first"}}]}'
+
+        release_second_chunk.set()
+        second_line = await _next_non_empty_line(lines)
+        done_line = await _next_non_empty_line(lines)
+        async for _ in lines:
+            pass
+
+    assert second_line == 'data: {"choices":[{"delta":{"content":"second"}}]}'
+    assert done_line == "data: [DONE]"
+    assert upstream_requests[0]["stream"] is True

--- a/presets/ragengine/vector_store/base.py
+++ b/presets/ragengine/vector_store/base.py
@@ -235,13 +235,27 @@ class BaseVectorStore(ABC):
             logger.info(
                 "Request does not specify an index, passing through to LLM directly."
             )
+            if request.get("stream") is True:
+                return await self.llm.chat_completions_stream_passthrough(
+                    openai_request
+                )
             return await self.llm.chat_completions_passthrough(openai_request)
 
         if request.get("tools") or request.get("functions"):
             logger.info(
                 "Request contains tools or functions, passing through to LLM directly."
             )
+            if request.get("stream") is True:
+                return await self.llm.chat_completions_stream_passthrough(
+                    openai_request
+                )
             return await self.llm.chat_completions_passthrough(openai_request)
+
+        if request.get("stream") is True:
+            raise HTTPException(
+                status_code=400,
+                detail="stream=true is only supported for passthrough chat completions.",
+            )
 
         # Only support RAG usage on user/system/developer roles in messages and only text content
         for message in request.get("messages", []):


### PR DESCRIPTION
## Summary

Add OpenAI-compatible streaming passthrough support for the RAGEngine `/v1/chat/completions` endpoint when `stream=true`.

This change forwards upstream LLM SSE responses through FastAPI `StreamingResponse`, allowing clients to receive streamed chat completion chunks from the upstream inference service.

RAG streaming with `index_name` and output guardrails streaming are intentionally left unsupported in this PR.

## Changes

- Add SSE helper utilities for upstream parsing and downstream frame construction.
- Add streaming passthrough support in the inference client using `httpx.AsyncClient.stream`.
- Return `StreamingResponse` from `/v1/chat/completions` for supported `stream=true` passthrough requests.
- Reject unsupported streaming combinations:
  - `stream=true` with `index_name`
  - `stream=true` when output guardrails are enabled
- Add API tests for streaming passthrough and unsupported streaming cases.
- Add real uvicorn-based streaming test to verify the first SSE chunk is flushed to the client before the upstream response finishes.
