### PR TITLE
ci: pin nightly chart to nightly image and document new tag format

### DIFF
--- a/.github/workflows/publish-controller-acr-nightly-images.yaml
+++ b/.github/workflows/publish-controller-acr-nightly-images.yaml
@@ -92,15 +92,18 @@ jobs:
           REGISTRY: ${{ secrets.KAITO_ACR_REGISTRY }}
           IMG_TAG: ${{ steps.get-image-tag.outputs.img_tag }}
 
-      - name: Override chart version to match image tag
+      - name: Pin chart version and image to nightly tag
         run: |
-          # helm package derives the tgz file name from Chart.yaml's version field, and the
-          # Makefile target expects <name>-<IMG_TAG>.tgz, so pin both fields to IMG_TAG.
-          sed -i.bak -E "s/^version:.*/version: ${IMG_TAG}/" "${CHART_PATH}/Chart.yaml"
-          sed -i.bak -E "s/^appVersion:.*/appVersion: ${IMG_TAG}/" "${CHART_PATH}/Chart.yaml"
-          rm -f "${CHART_PATH}/Chart.yaml.bak"
+          # Chart.yaml: align version/appVersion with IMG_TAG so helm package emits
+          # <name>-<IMG_TAG>.tgz, which is what the Makefile target expects.
+          yq -i ".version = \"${IMG_TAG}\" | .appVersion = \"${IMG_TAG}\"" "${CHART_PATH}/Chart.yaml"
+          # values.yaml: point the controller image at the nightly ACR registry+tag
+          # so installs of the nightly chart pull the matching nightly image.
+          yq -i ".image.repository = \"${REGISTRY}/${IMAGE_NAME}\" | .image.tag = \"${IMG_TAG}\"" "${CHART_PATH}/values.yaml"
         env:
           CHART_PATH: ${{ matrix.chart_path }}
+          IMAGE_NAME: ${{ matrix.image_name }}
+          REGISTRY: ${{ secrets.KAITO_ACR_REGISTRY }}
           IMG_TAG: ${{ steps.get-image-tag.outputs.img_tag }}
 
       - name: Package and push chart ${{ matrix.image_name }}:${{ steps.get-image-tag.outputs.img_tag }}

--- a/website/docs/installation.md
+++ b/website/docs/installation.md
@@ -39,7 +39,7 @@ Nightly builds are **not recommended for production use**. They are built from t
 Each nightly image is tagged with:
 
 - **`nightly-latest`** — always points to the most recent successful nightly build
-- **`nightly-<sha>`** — pinned to a specific commit (12-character short SHA)
+- **`<base_version>-<YYYYMMDD>`** — pinned to a specific build, e.g. `0.10.0-20260609`. The base version comes from the `main` branch's `Makefile` (`VERSION`) and the date is the UTC build date.
 
 To install the workspace controller using the latest nightly image:
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

- publish-controller-acr-nightly-images: set values.yaml image.repository/image.tag to the nightly ACR registry and tag before packaging the chart.
- installation.md: replace nightly-<sha> with the new <base_version>-<YYYYMMDD> tag format (e.g. 0.10.0-20260609).

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: