### PR TITLE
fix: inference deployment of Qwen3.6-35B-A3B and gpt-oss-120b

### DIFF
--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -414,10 +414,12 @@ func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
 		p.VLLM.ModelRunParams["performance-mode"] = rc.PerformanceMode
 	}
 
-	// Hybrid Mamba/Attention models (e.g., NemotronH) require the hybrid KV cache
-	// manager in vLLM, which is incompatible with LMCache KV cache CPU offloading.
-	// Disable offloading for these architectures to prevent startup crashes.
-	if p.isVLLMHybridKVCacheManagerRequired() {
+	// Disable LMCache KV cache CPU offloading for models where it is known to be
+	// problematic, either because:
+	//   - the model needs vLLM's hybrid KV cache manager (incompatible with the
+	//     LMCache connector), or
+	//   - LMCache is disabled for this model (see isLMCacheDisabled).
+	if p.isVLLMHybridKVCacheManagerRequired() || p.isLMCacheDisabled() {
 		p.VLLM.ModelRunParams["kaito-kv-cache-cpu-memory-utilization"] = "0"
 	}
 
@@ -548,7 +550,22 @@ func (p *PresetParam) isVLLMHybridKVCacheManagerRequired() bool {
 		switch arch {
 		case "NemotronHForCausalLM", "NemotronH_Nano_VL_V2", "NemotronHMTPModel", "NemotronHPuzzleForCausalLM",
 			"Gemma4ForCausalLM", "Gemma4ForConditionalGeneration",
-			"Qwen3_5ForConditionalGeneration":
+			"Qwen3_5ForConditionalGeneration", "Qwen3_5MoeForConditionalGeneration":
+			return true
+		}
+	}
+	return false
+}
+
+// isLMCacheDisabled returns true for architectures where LMCache needs to be disabled.
+// There is a known bug in LMCache that causes vLLM crashes on request abortion:
+// https://github.com/LMCache/LMCache/issues/3688
+// This bug will crash the vLLM engine during the TPM phase for certain models in KAITO.
+// TODO: remove this once the issue is resolved.
+func (p *PresetParam) isLMCacheDisabled() bool {
+	for _, arch := range p.Architectures {
+		switch arch {
+		case "GptOssForCausalLM":
 			return true
 		}
 	}

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -155,6 +155,21 @@ const (
 	// Set to "0" to keep FP8 models on their non-DeepGEMM kernel path.
 	VLLMUseDeepGEMMEnvName = "VLLM_USE_DEEP_GEMM"
 
+	// The VLLMUseFlashInferMoe*EnvName variables toggle vLLM's per-precision
+	// FlashInfer MoE backends. For MoE models vLLM auto-selects a FlashInfer
+	// (TRTLLM/CUTLASS) expert kernel, which JIT-compiles at runtime via nvcc — a
+	// CUDA toolchain the base image does not ship — crashing the engine at startup.
+	// Setting each explicitly to "0" removes the FlashInfer backends from the
+	// candidate list so vLLM falls back to the Triton MoE kernel, which needs no
+	// nvcc JIT (KAITO does not support FlashInfer). One variable exists per MoE
+	// weight/activation precision, so all must be disabled to cover every model.
+	VLLMUseFlashInferMoeFP16EnvName              = "VLLM_USE_FLASHINFER_MOE_FP16"
+	VLLMUseFlashInferMoeFP8EnvName               = "VLLM_USE_FLASHINFER_MOE_FP8"
+	VLLMUseFlashInferMoeFP4EnvName               = "VLLM_USE_FLASHINFER_MOE_FP4"
+	VLLMUseFlashInferMoeMXFP4BF16EnvName         = "VLLM_USE_FLASHINFER_MOE_MXFP4_BF16"
+	VLLMUseFlashInferMoeMXFP4MXFP8EnvName        = "VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8"
+	VLLMUseFlashInferMoeMXFP4MXFP8CutlassEnvName = "VLLM_USE_FLASHINFER_MOE_MXFP4_MXFP8_CUTLASS"
+
 	// ConditionReady is the condition type for a ready condition.
 	ConditionReady = "Ready"
 

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -570,6 +570,24 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int, streamingM
 				Name:  consts.VLLMUseDeepGEMMEnvName,
 				Value: "0",
 			})
+			// Disable vLLM's FlashInfer MoE backends across all precisions. For MoE
+			// models vLLM auto-selects a FlashInfer (TRTLLM/CUTLASS) expert kernel,
+			// which JIT-compiles at runtime via nvcc (absent from the base image) and
+			// crashes the engine at startup. Setting each per-precision toggle to "0"
+			// forces the Triton MoE fallback, which needs no nvcc JIT.
+			for _, name := range []string{
+				consts.VLLMUseFlashInferMoeFP16EnvName,
+				consts.VLLMUseFlashInferMoeFP8EnvName,
+				consts.VLLMUseFlashInferMoeFP4EnvName,
+				consts.VLLMUseFlashInferMoeMXFP4BF16EnvName,
+				consts.VLLMUseFlashInferMoeMXFP4MXFP8EnvName,
+				consts.VLLMUseFlashInferMoeMXFP4MXFP8CutlassEnvName,
+			} {
+				mainContainerEnv = append(mainContainerEnv, corev1.EnvVar{
+					Name:  name,
+					Value: "0",
+				})
+			}
 		}
 
 		spec.Containers = []corev1.Container{

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -61,6 +61,19 @@ var deepGEMMEnvVar = corev1.EnvVar{
 	Value: "0",
 }
 
+// flashInferMoeEnvVars are injected into every vLLM inference container to
+// disable vLLM's FlashInfer MoE backends across all precisions so MoE models
+// fall back to the Triton kernel (FlashInfer needs an nvcc JIT absent from the
+// base image). Order must match production wiring in GenerateInferencePodSpec.
+var flashInferMoeEnvVars = []corev1.EnvVar{
+	{Name: consts.VLLMUseFlashInferMoeFP16EnvName, Value: "0"},
+	{Name: consts.VLLMUseFlashInferMoeFP8EnvName, Value: "0"},
+	{Name: consts.VLLMUseFlashInferMoeFP4EnvName, Value: "0"},
+	{Name: consts.VLLMUseFlashInferMoeMXFP4BF16EnvName, Value: "0"},
+	{Name: consts.VLLMUseFlashInferMoeMXFP4MXFP8EnvName, Value: "0"},
+	{Name: consts.VLLMUseFlashInferMoeMXFP4MXFP8CutlassEnvName, Value: "0"},
+}
+
 func TestGeneratePresetInference(t *testing.T) {
 	test.RegisterTestModel()
 	baseImage := metadata.MustGet("base")
@@ -404,6 +417,7 @@ func TestGeneratePresetInference(t *testing.T) {
 			expectedEnvVars := tc.expectedEnvVars
 			if len(expectedEnvVars) > 0 && expectedEnvVars[0] == flashInferSamplerEnvVar {
 				withDefaults := []corev1.EnvVar{flashInferSamplerEnvVar, deepGEMMEnvVar}
+				withDefaults = append(withDefaults, flashInferMoeEnvVars...)
 				expectedEnvVars = append(withDefaults, expectedEnvVars[1:]...)
 			}
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
This PR fixes the deployment of models Qwen3.6-35B-A3B and gpt-oss-120b, which encountered the following issues in vllm 0.22.1 and lmcache 0.4.6:

### 1. FlashInfer MoE backends are selected by default
- **Crash:** vllm EngineCore died at startup when deploying `Qwen3.6-35B-A3B` — `Could not find nvcc` from the FlashInfer CUTLASS MoE kernel JIT-compiling at runtime (the slim base image ships no CUDA toolkit).
- **Fix:** inject `VLLM_USE_FLASHINFER_MOE_{FP16,FP8,FP4,MXFP4_BF16,MXFP4_MXFP8,MXFP4_MXFP8_CUTLASS}=0` for all vLLM pods, forcing the Triton MoE fallback.

### 2. Qwen3.6-35B-A3B is incompatible with LMCache
- **Crash:** `Hybrid KV cache manager is disabled but failed to convert the KV cache specs to one unified type` — qwen3.6-35b-a3b is a GDN linear+full hybrid; LMCache's connector isn't `SupportsHMA`, so vLLM disabled the hybrid manager and choked.
- **Fix:** added `Qwen3_5MoeForConditionalGeneration` to `isVLLMHybridKVCacheManagerRequired()`.

### 3. gpt-oss-120b crashed at TPM phase
- **Crash:** see https://github.com/kaito-project/kaito/issues/2126
- **Fix:** disabled LMCache for gpt-oss models

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).
- [x] tested model deployment with Standard_NC80adis_H100_v5 in AKS. 

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Fixes #2126 

**Notes for Reviewers**: