### PR TITLE
fix: exempt legacy workspaces from benchmarking checks and retain first benchmark res and status

### DIFF
--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -680,7 +680,7 @@ func (c *WorkspaceReconciler) syncWorkspaceStatus(ctx context.Context, key types
 		return err
 	}
 
-	inferenceReady, err := c.collectInferenceReadyStatus(ctx, wObj)
+	inferenceReady, hasBenchmarkProbe, err := c.collectInferenceReadyStatus(ctx, wObj)
 	if err != nil {
 		return err
 	}
@@ -689,6 +689,12 @@ func (c *WorkspaceReconciler) syncWorkspaceStatus(ctx context.Context, key types
 	if err != nil {
 		return err
 	}
+
+	// benchmarkApplicable gates the benchmark on the *running* pod: it requires both
+	// that the workspace should benchmark and that the StatefulSet actually
+	// carries the benchmark startup probe. Legacy workspaces created before the
+	// benchmark feature have no probe (backward compatibility).
+	benchmarkApplicable := kaitov1beta1.ShouldRunBenchmark(wObj) && hasBenchmarkProbe
 
 	appendReconcileErrMessage := buildReconcileErrMessageAppender(reconcileErr)
 
@@ -766,7 +772,7 @@ func (c *WorkspaceReconciler) syncWorkspaceStatus(ctx context.Context, key types
 				}
 			}
 
-			applyInferenceWorkspaceStatus(ctx, status, wObj, appendReconcileErrMessage, inferenceReady, resourceConditionStatus)
+			applyInferenceWorkspaceStatus(ctx, status, wObj, appendReconcileErrMessage, inferenceReady, resourceConditionStatus, benchmarkApplicable)
 			return nil
 		}
 
@@ -813,17 +819,20 @@ func (c *WorkspaceReconciler) collectNodeStatusSnapshot(ctx context.Context, wOb
 	return snapshot, nil
 }
 
-func (c *WorkspaceReconciler) collectInferenceReadyStatus(ctx context.Context, wObj *kaitov1beta1.Workspace) (bool, error) {
+// collectInferenceReadyStatus reports whether the inference workload is ready and
+// whether its StatefulSet carries the benchmark startup probe (false for legacy,
+// pre-benchmark-feature workspaces).
+func (c *WorkspaceReconciler) collectInferenceReadyStatus(ctx context.Context, wObj *kaitov1beta1.Workspace) (inferenceReady bool, hasBenchmarkProbe bool, err error) {
 	if wObj.Inference == nil {
-		return false, nil
+		return false, false, nil
 	}
 
 	ss := &appsv1.StatefulSet{}
 	if err := c.Get(ctx, types.NamespacedName{Name: wObj.Name, Namespace: wObj.Namespace}, ss); err != nil {
 		if apierrors.IsNotFound(err) {
-			return false, nil
+			return false, false, nil
 		}
-		return false, err
+		return false, false, err
 	}
 
 	replicas := int32(1)
@@ -831,7 +840,31 @@ func (c *WorkspaceReconciler) collectInferenceReadyStatus(ctx context.Context, w
 		replicas = *ss.Spec.Replicas
 	}
 
-	return ss.Status.ReadyReplicas == replicas, nil
+	return ss.Status.ReadyReplicas == replicas, hasBenchmarkStartupProbe(ss), nil
+}
+
+// benchmarkEntrypointMarker is the script basename that uniquely identifies the
+// benchmark startup probe. Kept in sync with buildBenchmarkStartupProbe in
+// pkg/workspace/inference/preset_inferences.go.
+const benchmarkEntrypointMarker = "benchmark_entrypoint.py"
+
+// hasBenchmarkStartupProbe reports whether the StatefulSet's pod template has the
+// benchmark startup probe on any container. This is used to determine if it is
+// a legacy workspace without the probe (backward compatibility)
+func hasBenchmarkStartupProbe(ss *appsv1.StatefulSet) bool {
+	if ss == nil {
+		return false
+	}
+	for i := range ss.Spec.Template.Spec.Containers {
+		p := ss.Spec.Template.Spec.Containers[i].StartupProbe
+		if p == nil || p.Exec == nil || len(p.Exec.Command) == 0 {
+			continue
+		}
+		if strings.Contains(strings.Join(p.Exec.Command, " "), benchmarkEntrypointMarker) {
+			return true
+		}
+	}
+	return false
 }
 
 type tuningStatusSnapshot struct {
@@ -921,7 +954,7 @@ func applyTuningWorkspaceStatus(status *kaitov1beta1.WorkspaceStatus, generation
 }
 
 func applyInferenceWorkspaceStatus(ctx context.Context, status *kaitov1beta1.WorkspaceStatus, wObj *kaitov1beta1.Workspace, appendMessage func(string) string,
-	inferenceReady bool, resourceConditionStatus metav1.ConditionStatus) {
+	inferenceReady bool, resourceConditionStatus metav1.ConditionStatus, benchmarkApplicable bool) {
 	generation := wObj.GetGeneration()
 	resourceReady := resourceConditionStatus == metav1.ConditionTrue
 	isInferenceEstablished := status.State == kaitov1beta1.WorkspaceStateReady || status.State == kaitov1beta1.WorkspaceStateNotReady
@@ -930,7 +963,7 @@ func applyInferenceWorkspaceStatus(ctx context.Context, status *kaitov1beta1.Wor
 		setWorkspaceCondition(status, generation, appendMessage,
 			kaitov1beta1.WorkspaceConditionTypeInferenceStatus, metav1.ConditionTrue, "WorkspaceInferenceStatusSuccess", "Inference has been deployed successfully")
 
-		if kaitov1beta1.ShouldRunBenchmark(wObj) {
+		if benchmarkApplicable {
 			if err := applyBenchmarkStatus(ctx, status, wObj, generation, appendMessage); err != nil {
 				setWorkspaceCondition(status, generation, appendMessage,
 					kaitov1beta1.WorkspaceConditionTypeSucceeded, metav1.ConditionFalse, "BenchmarkFailed", err.Error())
@@ -949,12 +982,7 @@ func applyInferenceWorkspaceStatus(ctx context.Context, status *kaitov1beta1.Wor
 		kaitov1beta1.WorkspaceConditionTypeInferenceStatus, metav1.ConditionFalse, "WorkspaceInferenceStatusPending", "Inference workload is not ready")
 	setWorkspaceCondition(status, generation, appendMessage,
 		kaitov1beta1.WorkspaceConditionTypeSucceeded, metav1.ConditionFalse, "workspacePending", "workspace is waiting for inference workload readiness")
-	// Clear benchmark state so applyBenchmarkStatus re-runs once inference recovers.
-	// This ensures a pod restart or rolling update doesn't leave stale results.
-	if kaitov1beta1.ShouldRunBenchmark(wObj) {
-		meta.RemoveStatusCondition(&status.Conditions, string(kaitov1beta1.WorkspaceConditionTypeBenchmarkCompleted))
-		status.Performance = nil
-	}
+
 	if isInferenceEstablished {
 		status.State = kaitov1beta1.WorkspaceStateNotReady
 	} else {
@@ -965,11 +993,11 @@ func applyInferenceWorkspaceStatus(ctx context.Context, status *kaitov1beta1.Wor
 // applyBenchmarkStatus reads and parses the benchmark result from pod logs,
 // then sets the BenchmarkCompleted condition on the workspace status.
 // Returns nil on success (or when already recorded), non-nil on terminal failure.
-// Skips the log read when BenchmarkCompleted is already True — the not-ready path
-// clears the condition on any pod restart or rolling update.
+// The result is write-once: the skip guard below returns early once
+// BenchmarkCompleted is True, so a recorded result is never re-read or overwritten.
 func applyBenchmarkStatus(ctx context.Context, status *kaitov1beta1.WorkspaceStatus, wObj *kaitov1beta1.Workspace, generation int64, appendMessage func(string) string) error {
-	// Skip once the benchmark is done. Safe because the not-ready path clears BenchmarkCompleted
-	// whenever inference goes down, so we won't get into a stale state.
+	// Skip once the benchmark is done (write-once). Nothing clears BenchmarkCompleted on a
+	// readiness transition, so a recorded result survives transient flaps and pod restarts.
 	if c := meta.FindStatusCondition(status.Conditions, string(kaitov1beta1.WorkspaceConditionTypeBenchmarkCompleted)); c != nil && c.Status == metav1.ConditionTrue {
 		return nil
 	}

--- a/pkg/workspace/controllers/workspace_controller_test.go
+++ b/pkg/workspace/controllers/workspace_controller_test.go
@@ -1094,6 +1094,27 @@ func TestSyncWorkspaceStatus(t *testing.T) {
 			verifySucceededCondition: true,
 			expectedSucceededStatus:  v1.ConditionTrue,
 		},
+		"legacy preset workspace without benchmark probe stays ready": {
+			// Benchmark is enabled (no disable-benchmark annotation), but the ready
+			// StatefulSet has no benchmark startup probe — i.e. a workspace created
+			// before the benchmark feature.
+			workspace: func() *v1beta1.Workspace {
+				ws := test.MockWorkspaceWithPresetVLLM.DeepCopy()
+				ws.Status.State = v1beta1.WorkspaceStatePending
+				return ws
+			}(),
+			statefulSet: &appsv1.StatefulSet{
+				ObjectMeta: v1.ObjectMeta{Name: test.MockWorkspaceWithPresetVLLM.Name, Namespace: test.MockWorkspaceWithPresetVLLM.Namespace},
+				Spec: appsv1.StatefulSetSpec{
+					Replicas: lo.ToPtr(int32(1)),
+					// No benchmark startup probe → hasBenchmarkProbe=false → benchmarkApplicable=false.
+				},
+				Status: appsv1.StatefulSetStatus{ReadyReplicas: 1},
+			},
+			expectedState:            v1beta1.WorkspaceStateReady,
+			verifySucceededCondition: true,
+			expectedSucceededStatus:  v1.ConditionTrue,
+		},
 		"inference pending during initialization": {
 			workspace:           test.MockWorkspaceDistributedModel.DeepCopy(),
 			statefulSetNotFound: true,
@@ -1244,7 +1265,7 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 	t.Run("ready when inference and resource are ready", func(t *testing.T) {
 		status := &v1beta1.WorkspaceStatus{State: v1beta1.WorkspaceStatePending}
 		wObj := &v1beta1.Workspace{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{v1beta1.AnnotationDisableBenchmark: "true"}}}
-		applyInferenceWorkspaceStatus(context.Background(), status, wObj, buildReconcileErrMessageAppender(nil), true, v1.ConditionTrue)
+		applyInferenceWorkspaceStatus(context.Background(), status, wObj, buildReconcileErrMessageAppender(nil), true, v1.ConditionTrue, false)
 
 		assert.Equal(t, v1beta1.WorkspaceStateReady, status.State)
 		inferenceCondition := meta.FindStatusCondition(status.Conditions, string(v1beta1.WorkspaceConditionTypeInferenceStatus))
@@ -1258,7 +1279,7 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 
 	t.Run("not ready after established", func(t *testing.T) {
 		status := &v1beta1.WorkspaceStatus{State: v1beta1.WorkspaceStateReady}
-		applyInferenceWorkspaceStatus(context.Background(), status, &v1beta1.Workspace{}, buildReconcileErrMessageAppender(nil), false, v1.ConditionTrue)
+		applyInferenceWorkspaceStatus(context.Background(), status, &v1beta1.Workspace{}, buildReconcileErrMessageAppender(nil), false, v1.ConditionTrue, false)
 
 		assert.Equal(t, v1beta1.WorkspaceStateNotReady, status.State)
 		inferenceCondition := meta.FindStatusCondition(status.Conditions, string(v1beta1.WorkspaceConditionTypeInferenceStatus))
@@ -1266,7 +1287,7 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 		assert.Equal(t, v1.ConditionFalse, inferenceCondition.Status)
 	})
 
-	t.Run("not-ready path clears benchmark condition and result (benchmark on by default)", func(t *testing.T) {
+	t.Run("not-ready path preserves benchmark condition and result (write-once)", func(t *testing.T) {
 		wObj := &v1beta1.Workspace{
 			ObjectMeta: v1.ObjectMeta{},
 			Inference: &v1beta1.InferenceSpec{
@@ -1292,12 +1313,72 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 			},
 		}
 
-		// kubeClient is nil — applyBenchmarkStatus must not be called on the not-ready path.
-		applyInferenceWorkspaceStatus(context.Background(), status, wObj, buildReconcileErrMessageAppender(nil), false, v1.ConditionTrue)
+		// inferenceReady=false drives the not-ready path. benchmarkApplicable=true.
+		// Write-once: the recorded result and condition must be preserved (no clear).
+		applyInferenceWorkspaceStatus(context.Background(), status, wObj, buildReconcileErrMessageAppender(nil), false, v1.ConditionTrue, true)
 
-		assert.Nil(t, status.Performance, "Performance should be cleared on not-ready")
+		assert.NotNil(t, status.Performance, "Performance must be preserved on not-ready (write-once)")
+		if status.Performance != nil {
+			m, ok := status.Performance.Metrics[BenchmarkMetricPeakTPM]
+			assert.True(t, ok)
+			assert.Equal(t, "12345", m.Value)
+		}
 		benchmarkCond := meta.FindStatusCondition(status.Conditions, string(v1beta1.WorkspaceConditionTypeBenchmarkCompleted))
-		assert.Nil(t, benchmarkCond, "BenchmarkCompleted condition should be removed on not-ready")
+		if assert.NotNil(t, benchmarkCond, "BenchmarkCompleted must be preserved on not-ready (write-once)") {
+			assert.Equal(t, v1.ConditionTrue, benchmarkCond.Status)
+		}
+	})
+
+	t.Run("write-once: recovery after flap does not re-read logs", func(t *testing.T) {
+		wObj := &v1beta1.Workspace{
+			ObjectMeta: v1.ObjectMeta{Name: "ws", Namespace: "default"},
+			Inference: &v1beta1.InferenceSpec{
+				Preset: &v1beta1.PresetSpec{PresetMeta: v1beta1.PresetMeta{Name: "test-model"}},
+			},
+		}
+		status := &v1beta1.WorkspaceStatus{
+			State: v1beta1.WorkspaceStateNotReady,
+			Performance: &v1beta1.Performance{
+				Metrics: map[string]v1beta1.Metric{BenchmarkMetricPeakTPM: {Value: "12345"}},
+			},
+			Conditions: []v1.Condition{{
+				Type:   string(v1beta1.WorkspaceConditionTypeBenchmarkCompleted),
+				Status: v1.ConditionTrue,
+				Reason: "BenchmarkCompleted",
+			}},
+		}
+
+		// Empty fake client: if the skip guard did NOT fire, applyBenchmarkStatus would
+		// try to read logs and fail. We assert it stays Ready with the result intact.
+		k8sclient.SetGlobalClientGoClient(kubefake.NewClientset())
+		applyInferenceWorkspaceStatus(context.Background(), status, wObj, buildReconcileErrMessageAppender(nil), true, v1.ConditionTrue, true)
+
+		assert.Equal(t, v1beta1.WorkspaceStateReady, status.State)
+		m, ok := status.Performance.Metrics[BenchmarkMetricPeakTPM]
+		assert.True(t, ok)
+		assert.Equal(t, "12345", m.Value)
+	})
+
+	t.Run("legacy workspace: benchmark skipped, stays ready", func(t *testing.T) {
+		wObj := &v1beta1.Workspace{
+			ObjectMeta: v1.ObjectMeta{Name: "legacy", Namespace: "default"},
+			Inference: &v1beta1.InferenceSpec{
+				Preset: &v1beta1.PresetSpec{PresetMeta: v1beta1.PresetMeta{Name: "test-model"}},
+			},
+		}
+		status := &v1beta1.WorkspaceStatus{State: v1beta1.WorkspaceStatePending}
+
+		// benchmarkApplicable=false (no probe). Empty fake client would fail a log read;
+		// asserting Ready proves applyBenchmarkStatus was not invoked.
+		k8sclient.SetGlobalClientGoClient(kubefake.NewClientset())
+		applyInferenceWorkspaceStatus(context.Background(), status, wObj, buildReconcileErrMessageAppender(nil), true, v1.ConditionTrue, false)
+
+		assert.Equal(t, v1beta1.WorkspaceStateReady, status.State)
+		succeeded := meta.FindStatusCondition(status.Conditions, string(v1beta1.WorkspaceConditionTypeSucceeded))
+		if assert.NotNil(t, succeeded) {
+			assert.Equal(t, v1.ConditionTrue, succeeded.Status)
+		}
+		assert.Nil(t, meta.FindStatusCondition(status.Conditions, string(v1beta1.WorkspaceConditionTypeBenchmarkCompleted)))
 	})
 
 	t.Run("benchmark guard skips StreamLogs when BenchmarkCompleted is already True", func(t *testing.T) {
@@ -1333,6 +1414,47 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 		benchmarkCond := meta.FindStatusCondition(status.Conditions, string(v1beta1.WorkspaceConditionTypeBenchmarkCompleted))
 		assert.Equal(t, v1.ConditionTrue, benchmarkCond.Status)
 	})
+}
+
+func Test_hasBenchmarkStartupProbe(t *testing.T) {
+	containerName := "ws"
+	mkSS := func(probe *corev1.Probe) *appsv1.StatefulSet {
+		return &appsv1.StatefulSet{
+			Spec: appsv1.StatefulSetSpec{
+				Template: corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: containerName, StartupProbe: probe},
+						},
+					},
+				},
+			},
+		}
+	}
+	execProbe := func(cmd ...string) *corev1.Probe {
+		return &corev1.Probe{ProbeHandler: corev1.ProbeHandler{Exec: &corev1.ExecAction{Command: cmd}}}
+	}
+
+	cases := map[string]struct {
+		ss   *appsv1.StatefulSet
+		want bool
+	}{
+		"benchmark non-distributed": {mkSS(execProbe("python3", "/workspace/vllm/benchmark_entrypoint.py")), true},
+		"benchmark distributed shell": {mkSS(execProbe("/bin/sh", "-c",
+			`if [ "$POD_INDEX" = "0" ]; then python3 /workspace/vllm/benchmark_entrypoint.py; else true; fi`)), true},
+		"distributed health check": {mkSS(execProbe("/bin/sh", "-c",
+			"python3 /workspace/vllm/multi-node-health-check.py readiness")), false},
+		"legacy http probe": {mkSS(&corev1.Probe{ProbeHandler: corev1.ProbeHandler{
+			HTTPGet: &corev1.HTTPGetAction{Path: "/health"}}}), false},
+		"no startup probe": {mkSS(nil), false},
+		"empty command":    {mkSS(execProbe()), false},
+		"no containers":    {&appsv1.StatefulSet{}, false},
+	}
+	for name, tc := range cases {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, hasBenchmarkStartupProbe(tc.ss))
+		})
+	}
 }
 
 func TestApplyTuningWorkspaceStatus(t *testing.T) {


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
1. Legacy workspaces created before the benchmark default enablement will fail due to it missing the benchmark result log. 2. For pods, the readiness can flip without container restart, which would remove the performance and benchmarkcompleted status and cause an attempt to re-read the benchmark result from pod log, which is no longer within the last 500 lines.
**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Fixes #2133 
**Notes for Reviewers**:

Validated the following:
1. Normal workspace: benchmark ran and recorded TPM with BenchmarkCompleted=True.
2. Legacy workspace (probe stripped): stayed Ready with the benchmark skipped, instead of failing.
3. InferenceSet (replicas=2): both children benchmarked and the aggregated TPM equaled their exact sum.
4. Benchmark result survives readiness changes (no restart): flipping a workspace NotReady and back preserved the exact same Performance.
5. Benchmark result survives container restarts: restarting the container kept the original recorded result instead of overwriting it.
6. Legacy InferenceSet (mixed children): the legacy child was skipped while the InferenceSet still went Ready and aggregated only the benchmarked child.