### PR TITLE
[WIP] test: remove redundant enableInferenceSetController feature gate from CI

### DIFF
--- a/.github/actions/e2e-base-setup/action.yaml
+++ b/.github/actions/e2e-base-setup/action.yaml
@@ -393,7 +393,7 @@ runs:
         REGISTRY: ${{ env.REGISTRY }}
         VERSION: ${{ env.VERSION }}
         TEST_SUITE: ${{ inputs.node_provisioner }}
-        HELM_INSTALL_EXTRA_ARGS: "--set featureGates.gatewayAPIInferenceExtension=true --set featureGates.enableInferenceSetController=true --set featureGates.enableMultiRoleInferenceController=true --set featureGates.enableBaseImageAutoUpgrade=true --set featureGates.ModelMirror=true --set featureGates.ModelStreaming=true --set defaultModelMirrorStorageClass=blob-fuse --set defaultStreamingServiceAccount=kaito-model-streamer --set modelMirrorDownloadCPU=2 --set modelMirrorDownloadMemory=4Gi --set nodeProvisioner=${{ inputs.node_provisioner == 'gpuprovisioner' && 'azure-gpu-provisioner' || 'karpenter' }}"
+        HELM_INSTALL_EXTRA_ARGS: "--set featureGates.gatewayAPIInferenceExtension=true --set featureGates.enableMultiRoleInferenceController=true --set featureGates.enableBaseImageAutoUpgrade=true --set featureGates.ModelMirror=true --set featureGates.ModelStreaming=true --set defaultModelMirrorStorageClass=blob-fuse --set defaultStreamingServiceAccount=kaito-model-streamer --set modelMirrorDownloadCPU=2 --set modelMirrorDownloadMemory=4Gi --set nodeProvisioner=${{ inputs.node_provisioner == 'gpuprovisioner' && 'azure-gpu-provisioner' || 'karpenter' }}"
 
     - name: Install Istio and Gateway for E2E testing
       shell: bash

--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -86,7 +86,7 @@ jobs:
           # Install via Helm
           # CSI Local Node cannot be configured to not deploy and it crashes on kind on github runners for unknown reasons
           # so we need to filter it out its components
-          helm template kaito-workspace ./charts/kaito/workspace --namespace ${{ env.KAITO_NAMESPACE }} --set nodeProvisioner="byo" --set featureGates.enableInferenceSetController="true" --set featureGates.gatewayAPIInferenceExtension="true" --include-crds --debug --wait | awk '
+          helm template kaito-workspace ./charts/kaito/workspace --namespace ${{ env.KAITO_NAMESPACE }} --set nodeProvisioner="byo" --set featureGates.gatewayAPIInferenceExtension="true" --include-crds --debug --wait | awk '
             BEGIN { RS="---\n"; ORS="---\n"; csi=0 }
             /kind: ServiceAccount/ && /name: csi-local-node/ { csi=1 }
             /kind: StorageClass/ && /name: kaito-local-nvme-disk/ { csi=1 }
@@ -250,13 +250,6 @@ jobs:
             echo "✗ gatewayAPIInferenceExtension feature gate not found"
             exit 1
           fi
-          if echo "$CONTROLLER_ARGS" | grep -q "enableInferenceSetController=true"; then
-            echo "✓ enableInferenceSetController feature gate enabled"
-          else
-            echo "✗ enableInferenceSetController feature gate not found"
-            exit 1
-          fi
-
           echo "=== Verifying GWIE not created for non-preset InferenceSet (expected) ==="
           POOL_NAME="inferenceset-aikit-test-inferencepool"
           if kubectl get ocirepository $POOL_NAME 2>/dev/null; then

--- a/.github/workflows/base-image-auto-upgrade-test.yaml
+++ b/.github/workflows/base-image-auto-upgrade-test.yaml
@@ -180,7 +180,6 @@ jobs:
           helm upgrade kaito-workspace ./charts/kaito/workspace \
             --namespace kaito-workspace \
             --set featureGates.enableBaseImageAutoUpgrade=true \
-            --set featureGates.enableInferenceSetController=true \
             --take-ownership
 
           kubectl rollout status deploy/kaito-workspace -n kaito-workspace --timeout=300s
@@ -495,7 +494,6 @@ jobs:
           helm upgrade kaito-workspace ./charts/kaito/workspace \
             --namespace kaito-workspace \
             --set featureGates.enableBaseImageAutoUpgrade=true \
-            --set featureGates.enableInferenceSetController=true \
             --take-ownership
 
           kubectl rollout status deploy/kaito-workspace -n kaito-workspace --timeout=300s


### PR DESCRIPTION
## What type of PR is this?
/kind cleanup

## What this PR does / why we need it

Since `enableInferenceSetController` now defaults to `true` starting v0.11.0 (beta promotion, #2112), the explicit `--set featureGates.enableInferenceSetController=true` in CI workflows is redundant for workflows that install/upgrade to the **current chart**.

For workflows that install an **old chart version** (e.g., `base-image-auto-upgrade-test.yaml` with v0.10.0), the flag must remain because older charts default `enableInferenceSetController` to `false`.

### Files changed

| File | Change |
|------|--------|
| `.github/actions/e2e-base-setup/action.yaml` | Remove `enableInferenceSetController=true` from `HELM_INSTALL_EXTRA_ARGS` (uses current chart) |
| `.github/workflows/aikit.yaml` | Remove from `helm template` command and the corresponding verification check (uses current chart) |
| `.github/workflows/base-image-auto-upgrade-test.yaml` | Remove from the two **Upgrade to current chart** steps only; keep the two **Install old chart** (v0.10.0) steps unchanged |

## Which issue(s) this PR fixes
N/A - CI cleanup following InferenceSet beta promotion

## Related PRs
- #2112 (InferenceSet beta promotion - changes chart default to `true`)
- #2135 (docs update for beta promotion)
