### PR TITLE
fix: [breaking] harden max-model-len and node estimation

### DIFF
--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -129,6 +129,11 @@ type Metadata struct {
 	// +optional
 	BytesPerToken int `yaml:"bytesPerToken,omitempty"`
 
+	// AttnType specifies the attention implementation (e.g., MHA, GQA, MQA, MLA),
+	// computed by the preset generator from the model config.
+	// +optional
+	AttnType string `yaml:"attnType,omitempty"`
+
 	// ModelTokenLimit is the maximum number of tokens (context window) supported by the model.
 	// This field is only for best effort supported vLLM models.
 	// +optional
@@ -199,10 +204,6 @@ type PresetParam struct {
 	// To determine TotalSafeTensorFileSize and BytesPerToken values for a new model,
 	// run the presets/workspace/generator/preset_generator.py script
 	// with the model's Hugging Face repository ID as an argument.
-
-	// AttnType specifies the attention implementation (e.g., MHA, GQA, MLA).
-	// Calculated by the preset generator based on model config.
-	AttnType string `yaml:"attn_type,omitempty"`
 
 	RuntimeParam
 

--- a/pkg/workspace/estimator/max_model_len.go
+++ b/pkg/workspace/estimator/max_model_len.go
@@ -32,19 +32,19 @@ const (
 	// loaded by vLLM relative to the on-disk safetensor size.
 	weightExpansionFactor = 1.02
 
-	// baseOverheadGiB is the model-independent part of vLLM's fixed per-GPU
+	// BaseOverheadGiB is the model-independent part of vLLM's fixed per-GPU
 	// overhead: non-torch allocations such as the CUDA context and NCCL buffers
 	// (~0.6 GiB) plus a baseline for small-model activations and CUDA graphs
-	// (~1.7 GiB). Larger models add to this via overheadWeightFactor below.
-	baseOverheadGiB = 2.3
+	// (~1.7 GiB). Larger models add to this via OverheadWeightFactor below.
+	BaseOverheadGiB = 2.3
 
-	// overheadWeightFactor scales the runtime overhead with the per-GPU model
-	// weight share (modelWeightOverhead). Peak activation memory and CUDA graph
-	// capture both grow with hidden size / layer count and are sharded across TP
-	// ranks the same way weights are, so the per-GPU weight share is a good proxy
-	// for them. vLLM measures these empirically in determine_available_memory() and
+	// OverheadWeightFactor scales the runtime overhead with the per-GPU model
+	// weight share. Peak activation memory and CUDA graph capture both grow with
+	// hidden size / layer count and are sharded across TP ranks the same way
+	// weights are, so the per-GPU weight share is a good proxy for them. vLLM
+	// measures these empirically in determine_available_memory() and
 	// profile_cudagraph_memory(). We approximate at best effort here.
-	overheadWeightFactor = 0.05
+	OverheadWeightFactor = 0.05
 )
 
 // MaxModelLenInput contains the inputs required to compute the optimal
@@ -160,7 +160,7 @@ func calculateMemoryParameters(in MaxModelLenInput, weightGiB float64) (float64,
 	// Fixed runtime overhead per GPU: a model-independent base plus a term that
 	// scales with the per-GPU model weight share, approximating the activation and
 	// CUDA-graph memory that grow with model size (see constant docs).
-	staticOverhead := baseOverheadGiB + overheadWeightFactor*modelWeightOverhead
+	staticOverhead := BaseOverheadGiB + OverheadWeightFactor*modelWeightOverhead
 
 	availableMemoryGiB := usableMemoryPerGPU - modelWeightOverhead - staticOverhead
 	availableMemoryBytes := availableMemoryGiB * (1 << 30)

--- a/pkg/workspace/estimator/max_model_len.go
+++ b/pkg/workspace/estimator/max_model_len.go
@@ -165,16 +165,26 @@ func calculateMemoryParameters(in MaxModelLenInput, weightGiB float64) (float64,
 	availableMemoryGiB := usableMemoryPerGPU - modelWeightOverhead - staticOverhead
 	availableMemoryBytes := availableMemoryGiB * (1 << 30)
 
+	// Per-GPU per-token KV footprint. The KV cache is distributed across GPUs by
+	// the parallelism strategy, mirroring how the model weights are sharded above
+	// (weights are divided by nodes*gpuCount):
+	//   - Tensor parallelism shards the KV heads across the gpuCount GPUs within a
+	//     pipeline stage. MLA is the exception: its compressed latent KV is
+	//     replicated on every TP rank, so it is NOT divided by gpuCount.
+	//   - Pipeline parallelism (multi-node) splits the model's layers across the
+	//     `nodes` stages, so each GPU holds only 1/nodes of the layers' KV.
 	var adjustedBytesPerToken float64
 	if in.DisableTensorParallelism {
+		// Falcon-style models replicate the full model on each GPU (no TP/PP
+		// sharding), so the per-GPU KV footprint is the full per-token size.
 		adjustedBytesPerToken = bytesPerToken
 	} else if in.MLAReplicatedKVCache {
-		// MLA stores a single compressed latent KV per token that is replicated on
-		// every tensor-parallel rank rather than sharded across them, so the per-GPU
-		// footprint is not divided by gpuCount.
-		adjustedBytesPerToken = bytesPerToken * nodes
+		// MLA: latent KV replicated across TP ranks (no /gpuCount), but pipeline
+		// parallelism still splits layers across nodes (/nodes).
+		adjustedBytesPerToken = bytesPerToken / nodes
 	} else {
-		adjustedBytesPerToken = bytesPerToken / gpuCount * nodes
+		// Standard attention: sharded by TP (/gpuCount) and split by PP (/nodes).
+		adjustedBytesPerToken = bytesPerToken / gpuCount / nodes
 	}
 
 	return availableMemoryBytes, adjustedBytesPerToken

--- a/pkg/workspace/estimator/max_model_len.go
+++ b/pkg/workspace/estimator/max_model_len.go
@@ -20,6 +20,33 @@ import (
 	"k8s.io/klog/v2"
 )
 
+const (
+	// gpuMemoryUtilization mirrors the --gpu-memory-utilization value vLLM is
+	// launched with (see buildVLLMInferenceCommand in pkg/model/interface.go).
+	// vLLM treats it as the hard cap on the fraction of total GPU memory used for
+	// weights + activations + CUDA graphs + KV cache, so the estimator must use
+	// the same value to predict the KV-cache budget vLLM will actually have.
+	gpuMemoryUtilization = 0.84
+
+	// weightExpansionFactor accounts for the ~2% expansion of model weights once
+	// loaded by vLLM relative to the on-disk safetensor size.
+	weightExpansionFactor = 1.02
+
+	// baseOverheadGiB is the model-independent part of vLLM's fixed per-GPU
+	// overhead: non-torch allocations such as the CUDA context and NCCL buffers
+	// (~0.6 GiB) plus a baseline for small-model activations and CUDA graphs
+	// (~1.7 GiB). Larger models add to this via overheadWeightFactor below.
+	baseOverheadGiB = 2.3
+
+	// overheadWeightFactor scales the runtime overhead with the per-GPU model
+	// weight share (modelWeightOverhead). Peak activation memory and CUDA graph
+	// capture both grow with hidden size / layer count and are sharded across TP
+	// ranks the same way weights are, so the per-GPU weight share is a good proxy
+	// for them. vLLM measures these empirically in determine_available_memory() and
+	// profile_cudagraph_memory(). We approximate at best effort here.
+	overheadWeightFactor = 0.05
+)
+
 // MaxModelLenInput contains the inputs required to compute the optimal
 // max model length for GPU memory efficiency. The struct is intentionally
 // self-contained so that external callers do not have to depend on any
@@ -36,6 +63,13 @@ type MaxModelLenInput struct {
 	// DisableTensorParallelism indicates the model does not shard weights
 	// or KV cache across GPUs/nodes (e.g. Falcon-style models).
 	DisableTensorParallelism bool
+	// MLAReplicatedKVCache indicates the model uses Multi-head Latent Attention
+	// (MLA), whose compressed latent KV cache is replicated on every tensor-parallel
+	// rank rather than sharded across them. When true, the per-GPU KV footprint per
+	// token is NOT divided by GPUCount. Mis-modeling this as sharded under-counts the
+	// per-token KV by a factor of GPUCount and inflates the computed max-model-len
+	// past what vLLM can honor (deterministic startup ValueError / crash-loop).
+	MLAReplicatedKVCache bool
 	// GPUMemoryBytes is the memory of a single GPU, in bytes.
 	GPUMemoryBytes int64
 	// GPUCount is the number of GPUs per node.
@@ -109,23 +143,24 @@ func calculateMemoryParameters(in MaxModelLenInput, weightGiB float64) (float64,
 	nodes := float64(in.NumRequiredNodes)
 	bytesPerToken := float64(in.BytesPerToken)
 
-	// availableMemoryGiB = (gpuMemGB * 0.84) / gpuCount - (weightGiB * 1.02) / (nodes * gpuCount) - 2.3
+	// Available GPU memory per GPU. vLLM caps total usage at gpuMemoryUtilization;
+	// within that budget the weights, KV cache, and the fixed runtime overhead
+	// (staticOverheadGiB) must all fit.
+	usableMemoryPerGPU := (gpuMemGB * gpuMemoryUtilization) / gpuCount
 
-	// Available GPU memory per GPU with 84% utilization factor.
-	usableMemoryPerGPU := (gpuMemGB * 0.84) / gpuCount
-
-	// Model weight overhead per GPU with 2% safety margin.
+	// Model weight overhead per GPU with the weight expansion factor.
 	var modelWeightOverhead float64
 	if in.DisableTensorParallelism {
 		// Falcon-style models: don't distribute weight across nodes/GPUs.
-		modelWeightOverhead = weightGiB * 1.02
+		modelWeightOverhead = weightGiB * weightExpansionFactor
 	} else {
-		modelWeightOverhead = (weightGiB * 1.02) / (nodes * gpuCount)
+		modelWeightOverhead = (weightGiB * weightExpansionFactor) / (nodes * gpuCount)
 	}
 
-	// Static overhead for activations and non-torch components
-	// (max activations 1.7 GiB + max non-torch overhead 0.6 GiB).
-	staticOverhead := 2.3
+	// Fixed runtime overhead per GPU: a model-independent base plus a term that
+	// scales with the per-GPU model weight share, approximating the activation and
+	// CUDA-graph memory that grow with model size (see constant docs).
+	staticOverhead := baseOverheadGiB + overheadWeightFactor*modelWeightOverhead
 
 	availableMemoryGiB := usableMemoryPerGPU - modelWeightOverhead - staticOverhead
 	availableMemoryBytes := availableMemoryGiB * (1 << 30)
@@ -133,6 +168,11 @@ func calculateMemoryParameters(in MaxModelLenInput, weightGiB float64) (float64,
 	var adjustedBytesPerToken float64
 	if in.DisableTensorParallelism {
 		adjustedBytesPerToken = bytesPerToken
+	} else if in.MLAReplicatedKVCache {
+		// MLA stores a single compressed latent KV per token that is replicated on
+		// every tensor-parallel rank rather than sharded across them, so the per-GPU
+		// footprint is not divided by gpuCount.
+		adjustedBytesPerToken = bytesPerToken * nodes
 	} else {
 		adjustedBytesPerToken = bytesPerToken / gpuCount * nodes
 	}

--- a/pkg/workspace/estimator/max_model_len_test.go
+++ b/pkg/workspace/estimator/max_model_len_test.go
@@ -106,7 +106,11 @@ func TestComputeMaxModelLen(t *testing.T) {
 				GPUCount:             1,
 				NumRequiredNodes:     3,
 			},
-			expected:    19456, // base 2.3Gi + 0.05*per-GPU weight overhead
+			// Multi-node: pipeline parallelism splits the 80 layers across the 3
+			// nodes, so per-GPU KV is bytes/token / (gpuCount * nodes). With the
+			// layers split, KV room is ample and the candidate clamps to the model
+			// token limit.
+			expected:    131072,
 			description: "llama-3.3-70b-instruct with vLLM on 3 nodes x Standard_NC24ads_A100_v4",
 		},
 		{
@@ -125,6 +129,23 @@ func TestComputeMaxModelLen(t *testing.T) {
 			// mis-computed as >1M and clamped to ModelTokenLimit without the MLA flag).
 			expected:    761600,
 			description: "mistral-small-4-119b (MLA) with vLLM on Standard_NC80adis_H100_v5",
+		},
+		{
+			name: "minimax-m2.7 multi-node TP2xPP2 on Standard_NC80adis_H100_v5",
+			input: MaxModelLenInput{
+				ModelTokenLimit:      204800,
+				BytesPerToken:        253952, // GQA: 2 * 8 kv-heads * 128 headDim * 62 layers
+				TotalModelWeightSize: "214.34Gi",
+				GPUMemoryBytes:       gib("188Gi"),
+				GPUCount:             2,
+				NumRequiredNodes:     2,
+			},
+			// TP=2 (shard KV heads) x PP=2 (split 62 layers across nodes) => per-GPU
+			// bytes/token = 253952 / (2*2) = 63488, matching vLLM's measured ~63503.
+			// KV room then exceeds the model token limit, so it clamps to 204800.
+			// (Before the PP fix, KAITO computed 81408 and lost ~60% of context.)
+			expected:    204800,
+			description: "minimax-m2.7 (GQA) with vLLM on 2 nodes x Standard_NC80adis_H100_v5 (TP2xPP2)",
 		},
 	}
 

--- a/pkg/workspace/estimator/max_model_len_test.go
+++ b/pkg/workspace/estimator/max_model_len_test.go
@@ -45,6 +45,19 @@ func TestComputeMaxModelLen(t *testing.T) {
 			description: "should return 0 for invalid BytesPerToken",
 		},
 		{
+			name: "model weights exceed available GPU memory",
+			input: MaxModelLenInput{
+				ModelTokenLimit:      131072,
+				BytesPerToken:        131072,
+				TotalModelWeightSize: "40Gi", // exceeds usable memory on a 24Gi GPU
+				GPUMemoryBytes:       gib("24Gi"),
+				GPUCount:             1,
+				NumRequiredNodes:     1,
+			},
+			expected:    0,
+			description: "should return 0 when weights plus overhead leave no KV cache room",
+		},
+		{
 			name: "deepseek-r1-distill-llama-8b on Standard_NV36ads_A10_v5",
 			input: MaxModelLenInput{
 				ModelTokenLimit:      131072,
@@ -54,7 +67,7 @@ func TestComputeMaxModelLen(t *testing.T) {
 				GPUCount:             1,
 				NumRequiredNodes:     1,
 			},
-			expected:    21248,
+			expected:    14848, // base 2.3Gi + 0.05*per-GPU weight overhead (small model => low overhead)
 			description: "deepseek-r1-distill-llama-8b with vLLM on Standard_NV36ads_A10_v5",
 		},
 		{
@@ -67,7 +80,7 @@ func TestComputeMaxModelLen(t *testing.T) {
 				GPUCount:             2,
 				NumRequiredNodes:     1,
 			},
-			expected:    41728,
+			expected:    34048, // base 2.3Gi + 0.05*per-GPU weight overhead
 			description: "deepseek-r1-distill-qwen-14b with vLLM on Standard_NV72ads_A10_v5",
 		},
 		{
@@ -93,8 +106,25 @@ func TestComputeMaxModelLen(t *testing.T) {
 				GPUCount:             1,
 				NumRequiredNodes:     3,
 			},
-			expected:    22016,
+			expected:    19456, // base 2.3Gi + 0.05*per-GPU weight overhead
 			description: "llama-3.3-70b-instruct with vLLM on 3 nodes x Standard_NC24ads_A100_v4",
+		},
+		{
+			name: "mistral-small-4-119b MLA on Standard_NC80adis_H100_v5",
+			input: MaxModelLenInput{
+				ModelTokenLimit:      1048576,
+				BytesPerToken:        23040, // MLA: 2 * (kvLoraRank 256 + qkRopeHeadDim 64) * 36 layers
+				TotalModelWeightSize: "112.63Gi",
+				MLAReplicatedKVCache: true,
+				GPUMemoryBytes:       gib("188Gi"),
+				GPUCount:             2,
+				NumRequiredNodes:     1,
+			},
+			// MLA KV is replicated across the 2 TP ranks, so bytes/token is NOT
+			// divided by GPUCount. Must stay under vLLM's ~810208 limit (would be
+			// mis-computed as >1M and clamped to ModelTokenLimit without the MLA flag).
+			expected:    761600,
+			description: "mistral-small-4-119b (MLA) with vLLM on Standard_NC80adis_H100_v5",
 		},
 	}
 

--- a/pkg/workspace/estimator/nodesestimator/estimator.go
+++ b/pkg/workspace/estimator/nodesestimator/estimator.go
@@ -105,26 +105,38 @@ func (c *NodeEstimator) EstimateNodeCount(ctx context.Context, req estimator.Nod
 		gpuMemPerGPU := float64(gpuConfig.GPUMem.Value() / int64(gpuConfig.GPUCount))
 		availGPUMem := gpuMemPerGPU * 0.84 // utilization is set to default 0.84
 
-		// Overhead: fixed base (2.3GB) + KV cache for context length
+		// Overhead: a fixed base plus the KV cache for the
+		// context length, plus a term that scales with the per-GPU model weight
+		// share (estimator.OverheadWeightFactor). For the tensor-parallel (sharded)
+		// case the weight-scaled term folds into the (1 + OverheadWeightFactor)
+		// divisor below, keeping the solve non-circular.
+		baseOverhead := estimator.BaseOverheadGiB * float64(consts.GiBToBytes)
 		kvCache := float64(maxModelLen*inferParams.BytesPerToken) / float64(gpuConfig.GPUCount)
-		overhead := 2.3*consts.GiBToBytes + kvCache
+		fixedReserve := baseOverhead + kvCache
 
-		if inferParams.DisableTensorParallelism && modelSize+overhead > availGPUMem {
-			return 0, fmt.Errorf("GPU memory %.0f bytes is too small for model, needs %.0f bytes (model: %.0f + overhead: %.0f)",
-				gpuMemPerGPU, modelSize+overhead, modelSize, overhead)
+		// Tensor-parallelism-disabled models place the full model on each GPU, so
+		// the weight-scaled overhead uses the full model size.
+		if inferParams.DisableTensorParallelism {
+			overhead := fixedReserve + estimator.OverheadWeightFactor*modelSize
+			if modelSize+overhead > availGPUMem {
+				return 0, fmt.Errorf("GPU memory %.0f bytes is too small for model, needs %.0f bytes (model: %.0f + overhead: %.0f)",
+					gpuMemPerGPU, modelSize+overhead, modelSize, overhead)
+			}
 		}
 
-		if availGPUMem <= overhead {
-			return 0, fmt.Errorf("GPU memory %.0f bytes is too small, needs at least %.1f GB overhead (base: 2.3GB + KV Cache: %.1f GB)",
-				gpuMemPerGPU, overhead/float64(consts.GiBToBytes), kvCache/float64(consts.GiBToBytes))
+		if availGPUMem <= fixedReserve {
+			return 0, fmt.Errorf("GPU memory %.0f bytes is too small, needs at least %.1f GB overhead (base: %.1fGB + KV Cache: %.1f GB)",
+				gpuMemPerGPU, fixedReserve/float64(consts.GiBToBytes), estimator.BaseOverheadGiB, kvCache/float64(consts.GiBToBytes))
 		}
 
-		availMemPerGPU := availGPUMem - overhead
+		// Per-GPU memory available for model weights. The weight-scaled overhead
+		// (OverheadWeightFactor x per-GPU weight) folds into the (1 + factor) divisor.
+		availMemPerGPU := (availGPUMem - fixedReserve) / (1 + estimator.OverheadWeightFactor)
 		minGPUs := int(modelSize/availMemPerGPU) + 1
 		nodeCountPerReplica = (minGPUs + gpuConfig.GPUCount - 1) / gpuConfig.GPUCount
 
-		klog.Infof("modelSize(%.0f), gpuMemPerGPU(%.0f), availGPUMem(%.0f), overhead(%.0f), availMemPerGPU(%.0f), minGPUs(%d) => nodeCountPerReplica(%d) for workspace %s",
-			modelSize, gpuMemPerGPU, availGPUMem, overhead, availMemPerGPU, minGPUs, nodeCountPerReplica, req.WorkspaceName)
+		klog.Infof("modelSize(%.0f), gpuMemPerGPU(%.0f), availGPUMem(%.0f), fixedReserve(%.0f), availMemPerGPU(%.0f), minGPUs(%d) => nodeCountPerReplica(%d) for workspace %s",
+			modelSize, gpuMemPerGPU, availGPUMem, fixedReserve, availMemPerGPU, minGPUs, nodeCountPerReplica, req.WorkspaceName)
 
 		if nodeCountPerReplica > 1 && inferParams.DisableTensorParallelism {
 			return 0, fmt.Errorf("models with disabled tensor parallelism cannot be distributed across more than 1 GPU node, calculated nodes: %d", nodeCountPerReplica)

--- a/pkg/workspace/estimator/nodesestimator/estimator_test.go
+++ b/pkg/workspace/estimator/nodesestimator/estimator_test.go
@@ -575,7 +575,7 @@ func TestNodeEstimator_EstimateNodeCount_Qwen25Coder32B(t *testing.T) {
 		errorContains string
 	}{
 		{
-			name: "Should optimize qwen2.5-coder-32b with A100 GPU - single node sufficient",
+			name: "Should optimize qwen2.5-coder-32b with A100 GPU - two nodes sufficient",
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test-qwen25-coder-32b-workspace",
@@ -593,7 +593,7 @@ func TestNodeEstimator_EstimateNodeCount_Qwen25Coder32B(t *testing.T) {
 					},
 				},
 			},
-			expectedCount: 1, // Should optimize to 1 node (62.5Gi fits in 80GB A100 GPU with 0.84 utilization)
+			expectedCount: 2, // Should optimize to 2 nodes
 			expectedError: false,
 		},
 	}

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -512,15 +512,28 @@ func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int, streamingM
 						//klog.Infof("[RuntimeContext] workspace=%s using user explicit max-model-len=%d", ctx.Workspace.Name, maxModelLen)
 						//} else {
 						// If no user value, compute planned value
-						maxModelLen = estimator.ComputeMaxModelLen(estimator.MaxModelLenInput{
+						computedMaxModelLen := estimator.ComputeMaxModelLen(estimator.MaxModelLenInput{
 							ModelTokenLimit:          presetParams.ModelTokenLimit,
 							BytesPerToken:            presetParams.BytesPerToken,
 							TotalModelWeightSize:     presetParams.TotalSafeTensorFileSize,
 							DisableTensorParallelism: presetParams.DisableTensorParallelism,
+							MLAReplicatedKVCache:     presetParams.AttnType == "MLA",
 							GPUMemoryBytes:           gpuConfig.GPUMem.Value(),
 							GPUCount:                 gpuConfig.GPUCount,
 							NumRequiredNodes:         numNodes,
 						})
+						// A zero result with valid sizing inputs means the model
+						// weights plus runtime overhead leave no room for the KV
+						// cache. Fail fast with an actionable error instead of
+						// omitting --max-model-len, which would let vLLM fall back to
+						// the model's full context and crash-loop at startup.
+						if computedMaxModelLen <= 0 && presetParams.BytesPerToken > 0 && gpuConfig.GPUMem.Value() > 0 {
+							return fmt.Errorf("unable to fit model %q on the requested resources: weights (%s) plus runtime overhead exceed the available GPU memory (gpuConfig=%s, nodes=%d). Use a larger GPU SKU, add nodes, or set an explicit max-model-len in the inference config",
+								presetParams.Name, presetParams.TotalSafeTensorFileSize, gpuConfig.String(), numNodes)
+						}
+						if computedMaxModelLen > 0 {
+							maxModelLen = computedMaxModelLen
+						}
 						klog.Infof("[RuntimeContext] workspace=%s using computed max-model-len=%d (gpuConfig=%s, numNodes=%d)", ctx.Workspace.Name, maxModelLen, gpuConfig.String(), numNodes)
 						//}
 					}

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -235,7 +235,7 @@ func TestGeneratePresetInference(t *testing.T) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Service{}), mock.Anything).Return(nil)
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
 			},
-			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=6 --ray_port=6379; python3 /workspace/vllm/inference_api.py --distributed-executor-backend=ray --model=test-repo/test-model --code-revision=test-revision --download-dir=/workspace/weights --dtype=float16 --gpu-memory-utilization=0.84 --max-model-len=2048 --kaito-config-file=/mnt/config/inference_config.yaml --kaito-kv-cache-cpu-memory-utilization=0 --pipeline-parallel-size=6 --tensor-parallel-size=1; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
+			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=7 --ray_port=6379; python3 /workspace/vllm/inference_api.py --distributed-executor-backend=ray --model=test-repo/test-model --code-revision=test-revision --download-dir=/workspace/weights --dtype=float16 --gpu-memory-utilization=0.84 --max-model-len=2048 --kaito-config-file=/mnt/config/inference_config.yaml --kaito-kv-cache-cpu-memory-utilization=0 --pipeline-parallel-size=7 --tensor-parallel-size=1; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
 
 			expectedEnvVars: []corev1.EnvVar{flashInferSamplerEnvVar, {
 				Name: "HF_TOKEN",
@@ -260,9 +260,9 @@ func TestGeneratePresetInference(t *testing.T) {
 
 		"test-model-download-distributed/vllm (more nodes than required)": {
 			// Using Standard_NC4as_T4_v3, which has 16GB GPU memory per node.
-			// The preset requires 64GB GPU memory for the model; estimator computes 6 nodes needed.
+			// The preset requires 64GB GPU memory for the model; estimator computes 7 nodes needed.
 			workspace: test.MockWorkspaceWithPresetDownloadVLLM,
-			nodeCount: 8, // 8 nodes requested; model requires 6, so 6 pipeline stages are used
+			nodeCount: 8, // 8 nodes requested; model requires 7, so 7 pipeline stages are used
 			modelName: "test-model-download",
 			callMocks: func(c *test.MockClient) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
@@ -272,7 +272,7 @@ func TestGeneratePresetInference(t *testing.T) {
 				// Mock node list for BYO node discovery
 				c.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
 			},
-			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=6 --ray_port=6379; python3 /workspace/vllm/inference_api.py --distributed-executor-backend=ray --model=test-repo/test-model --code-revision=test-revision --download-dir=/workspace/weights --dtype=float16 --gpu-memory-utilization=0.84 --max-model-len=2048 --kaito-config-file=/mnt/config/inference_config.yaml --kaito-kv-cache-cpu-memory-utilization=0 --pipeline-parallel-size=6 --tensor-parallel-size=1; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
+			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=7 --ray_port=6379; python3 /workspace/vllm/inference_api.py --distributed-executor-backend=ray --model=test-repo/test-model --code-revision=test-revision --download-dir=/workspace/weights --dtype=float16 --gpu-memory-utilization=0.84 --max-model-len=2048 --kaito-config-file=/mnt/config/inference_config.yaml --kaito-kv-cache-cpu-memory-utilization=0 --pipeline-parallel-size=7 --tensor-parallel-size=1; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
 
 			expectedEnvVars: []corev1.EnvVar{flashInferSamplerEnvVar, {
 				Name: "HF_TOKEN",

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -705,7 +705,7 @@ func (g *Generator) FinalizeParams() {
 
 	bpt, attnType := g.calculateKVCacheTokenSize()
 	g.Param.Metadata.BytesPerToken = bpt
-	g.Param.AttnType = attnType
+	g.Param.Metadata.AttnType = attnType
 }
 
 // loadFromCatalog checks whether the model repo exists in the embedded catalog.

--- a/presets/workspace/generator/generator_test.go
+++ b/presets/workspace/generator/generator_test.go
@@ -45,8 +45,8 @@ func TestGeneratePreset(t *testing.T) {
 					BytesPerToken:          131072,
 					ModelTokenLimit:        131072,
 					DiskStorageRequirement: "87Gi", // 7.15 + 80
+					AttnType:               "GQA",
 				},
-				AttnType: "GQA",
 			},
 			expectedVLLM: model.VLLMParam{
 				ModelName: "phi-4-mini-instruct",
@@ -72,8 +72,8 @@ func TestGeneratePreset(t *testing.T) {
 					BytesPerToken:          8192,
 					ModelTokenLimit:        2048,
 					DiskStorageRequirement: "93Gi", // 13.44 + 80
+					AttnType:               "MQA",
 				},
-				AttnType: "MQA",
 			},
 			expectedVLLM: model.VLLMParam{
 				ModelName: "falcon-7b-instruct",
@@ -100,8 +100,8 @@ func TestGeneratePreset(t *testing.T) {
 					ModelTokenLimit:        262144,
 					DiskStorageRequirement: "89Gi", // 9.70 + 80
 					QuantMethod:            "fp8",
+					AttnType:               "GQA",
 				},
-				AttnType: "GQA",
 			},
 			expectedVLLM: model.VLLMParam{
 				ModelName: "ministral-3-8b-instruct-2512",
@@ -129,8 +129,8 @@ func TestGeneratePreset(t *testing.T) {
 					DiskStorageRequirement: "714Gi", // 634.70 + 80
 					ToolCallParser:         "mistral",
 					QuantMethod:            "compressed-tensors",
+					AttnType:               "MLA",
 				},
-				AttnType: "MLA",
 			},
 			expectedVLLM: model.VLLMParam{
 				ModelName: "mistral-large-3-675b-instruct-2512",
@@ -158,8 +158,8 @@ func TestGeneratePreset(t *testing.T) {
 					DiskStorageRequirement: "136Gi", // 56.87 + 80
 					ReasoningParser:        "qwen3",
 					ToolCallParser:         "qwen3_xml",
+					AttnType:               "GQA",
 				},
-				AttnType: "GQA",
 			},
 			expectedVLLM: model.VLLMParam{
 				ModelName: "qwen3-coder-30b-a3b-instruct",
@@ -187,8 +187,8 @@ func TestGeneratePreset(t *testing.T) {
 					DiskStorageRequirement: "95Gi", // 15.26 + 80
 					ReasoningParser:        "qwen3",
 					ToolCallParser:         "hermes",
+					AttnType:               "GQA",
 				},
-				AttnType: "GQA",
 			},
 			expectedVLLM: model.VLLMParam{
 				ModelName: "qwen3-8b",
@@ -217,8 +217,8 @@ func TestGeneratePreset(t *testing.T) {
 					ReasoningParser:        "deepseek_v3",
 					ToolCallParser:         "deepseek_v31",
 					QuantMethod:            "fp8",
+					AttnType:               "MLA",
 				},
-				AttnType: "MLA",
 			},
 			expectedVLLM: model.VLLMParam{
 				ModelName: "deepseek-v3.1",
@@ -247,8 +247,8 @@ func TestGeneratePreset(t *testing.T) {
 					ReasoningParser:        "deepseek_v3",
 					ToolCallParser:         "deepseek_v3",
 					QuantMethod:            "fp8",
+					AttnType:               "MLA",
 				},
-				AttnType: "MLA",
 			},
 			expectedVLLM: model.VLLMParam{
 				ModelName: "deepseek-v3",
@@ -276,8 +276,8 @@ func TestGeneratePreset(t *testing.T) {
 					DiskStorageRequirement: "110Gi", // 30.51 + 80
 					ReasoningParser:        "qwen3",
 					ToolCallParser:         "hermes",
+					AttnType:               "GQA",
 				},
-				AttnType: "GQA",
 			},
 			expectedVLLM: model.VLLMParam{
 				ModelName: "nemotron-orchestrator-8b",
@@ -307,8 +307,8 @@ func TestGeneratePreset(t *testing.T) {
 					ToolCallParser:         "hermes",
 					QuantMethod:            "awq",
 					QuantBits:              4,
+					AttnType:               "GQA",
 				},
-				AttnType: "GQA",
 			},
 			expectedVLLM: model.VLLMParam{
 				ModelName: "qwen3-8b-awq",
@@ -490,8 +490,8 @@ func TestLoadFromCatalog(t *testing.T) {
 					BytesPerToken:          131072,
 					ModelTokenLimit:        131072,
 					DiskStorageRequirement: "87Gi",
+					AttnType:               "GQA",
 				},
-				AttnType: "GQA",
 			},
 		},
 		{
@@ -508,8 +508,8 @@ func TestLoadFromCatalog(t *testing.T) {
 					BytesPerToken:          204800,
 					ModelTokenLimit:        16384,
 					DiskStorageRequirement: "107Gi",
+					AttnType:               "GQA",
 				},
-				AttnType: "GQA",
 			},
 		},
 		{
@@ -527,8 +527,8 @@ func TestLoadFromCatalog(t *testing.T) {
 					ModelTokenLimit:        131072,
 					DiskStorageRequirement: "88Gi",
 					ToolCallParser:         "functiongemma",
+					AttnType:               "GQA",
 				},
-				AttnType: "GQA",
 			},
 		},
 		{
@@ -546,8 +546,8 @@ func TestLoadFromCatalog(t *testing.T) {
 					ModelTokenLimit:        32768,
 					DiskStorageRequirement: "93Gi",
 					ToolCallParser:         "mistral",
+					AttnType:               "GQA",
 				},
-				AttnType: "GQA",
 			},
 		},
 		{
@@ -564,8 +564,8 @@ func TestLoadFromCatalog(t *testing.T) {
 					BytesPerToken:          139264,
 					ModelTokenLimit:        262144,
 					DiskStorageRequirement: "89Gi",
+					AttnType:               "GQA",
 				},
-				AttnType: "GQA",
 			},
 		},
 		{

--- a/presets/workspace/models/vllm_model.go
+++ b/presets/workspace/models/vllm_model.go
@@ -173,6 +173,7 @@ func (m *vLLMCompatibleModel) GetInferenceParameters() *model.PresetParam {
 		Architectures:        m.model.Architectures,
 		QuantMethod:          m.model.QuantMethod,
 		QuantBits:            m.model.QuantBits,
+		AttnType:             m.model.AttnType,
 	}
 
 	runParamsVLLM := make(map[string]string)

--- a/presets/workspace/models/vllm_model_test.go
+++ b/presets/workspace/models/vllm_model_test.go
@@ -122,6 +122,20 @@ func TestVLLMCompatibleModel_GetInferenceParameters(t *testing.T) {
 			},
 		},
 		{
+			name: "MLA model surfaces AttnType at the PresetParam level",
+			model: model.Metadata{
+				Name:          "mla-model",
+				Version:       "https://huggingface.co/test/model",
+				ModelFileSize: "2Gi",
+				AttnType:      "MLA",
+			},
+			expectedName:  "mla-model",
+			expectedDType: "bfloat16",
+			checkParams: func(t *testing.T, params *model.PresetParam) {
+				assert.Equal(t, "MLA", params.AttnType)
+			},
+		},
+		{
 			name: "model with reasoning parser",
 			model: model.Metadata{
 				Name:            "reasoning-model",

--- a/website/docs/memory-estimator.md
+++ b/website/docs/memory-estimator.md
@@ -70,11 +70,25 @@ The total KV cache scales linearly with both context length and concurrency:
 Total KV Cache = BytesPerToken × Context Length × Concurrent Requests
 ```
 
-When tensor parallelism splits the model across N GPUs, each GPU only holds 1/N of the KV cache — the attention heads are partitioned, and each GPU stores the cache for its assigned heads only.
+When the model is distributed across multiple GPUs, each GPU holds only a fraction of the KV cache. How the cache is partitioned depends on the parallelism strategy and the attention type:
+
+- **Tensor parallelism (within a node):** the attention heads are partitioned across the GPUs, so each of the `N` GPUs stores the KV cache for only its assigned heads — `1/N` of the per-token cost.
+- **Pipeline parallelism (across nodes):** the transformer *layers* are split across the pipeline stages (one per node), so each GPU holds the KV cache for only its share of the layers — an additional `1/nodes` factor.
+- **Multi-head Latent Attention (MLA):** models such as DeepSeek and Kimi compress the KV cache into a single shared latent vector per token. This latent cache is **replicated on every tensor-parallel rank** rather than partitioned, so it is *not* divided by the tensor-parallel size (pipeline parallelism still splits it by layer across nodes).
+
+KAITO folds these into a single **adjusted bytes per token** that mirrors how the model weights are distributed.
 
 ### Runtime Overhead
 
-Activation memory — the intermediate results from each transformer layer during the forward pass — and other runtime allocations (CUDA context, memory allocator fragmentation) also consume VRAM. A common rule of thumb estimates activation memory at around 25% of model weight memory. During inference, however, the activation footprint is much smaller than during training because only one token is processed at a time rather than entire batches. KAITO reserves a small fixed overhead for these costs.
+Activation memory — the intermediate results from each transformer layer during the forward pass — together with CUDA graph capture buffers and other runtime allocations (CUDA context, memory allocator fragmentation) also consume VRAM. vLLM measures these empirically at startup; KAITO has to estimate them ahead of time.
+
+Because activation and CUDA graph memory grow with model size (more layers and a wider hidden dimension produce larger intermediate tensors), KAITO does not use a single flat number. Instead it reserves a **base overhead plus a term that scales with the per-GPU model weight share**:
+
+```
+Runtime Overhead per GPU = baseOverhead + scaleFactor × (model weight share per GPU)
+```
+
+The base covers model-independent costs (CUDA context, NCCL buffers, and a small-model activation/CUDA-graph baseline); the weight-scaled term approximates the larger activation and CUDA graph footprints of bigger models. Because activations and CUDA graphs are sharded across tensor-parallel ranks the same way weights are, the per-GPU weight share is a good proxy.
 
 Beyond this, not all of a GPU's physical VRAM is available to the application. The GPU driver, CUDA runtime, and memory allocator fragmentation all claim a portion. KAITO accounts for this by applying a **GPU utilization factor** — treating only a fraction of the advertised VRAM as usable.
 
@@ -101,8 +115,8 @@ The estimator runs at Workspace creation time, before any GPU nodes are provisio
 The logic, in plain terms:
 
 1. **Per-GPU usable memory** = physical VRAM × utilization factor
-2. **Per-GPU overhead** = fixed runtime overhead + KV cache per GPU (= `contextLength × BytesPerToken / totalGPUs`)
-3. **Per-GPU memory left for weights** = usable memory − overhead
+2. **Fixed per-GPU reserve** = base runtime overhead + KV cache per GPU (= `contextLength × BytesPerToken / totalGPUs`)
+3. **Per-GPU memory left for weights** = (usable memory − fixed reserve) ÷ (1 + weightOverheadFactor). The weight-scaled part of the runtime overhead (activations, CUDA graphs) is proportional to the weight that lands on each GPU, so it folds into a `(1 + factor)` divisor rather than a fixed subtraction — this keeps the solve non-circular when the GPU count is still unknown.
 4. **Minimum GPUs needed** = model weight size ÷ per-GPU memory left for weights (rounded up)
 5. **Minimum nodes** = minimum GPUs ÷ GPUs per node (rounded up)
 
@@ -187,9 +201,9 @@ Using the default context size (2,048 tokens) for initial estimation:
 1. `modelSize = 7.15 × 1.02 = 7.29 GiB`
 2. `availablePerGPU = 80 × 0.84 = 67.2 GiB`
 3. `kvCachePerGPU = 2048 × 128 KB / 1 = 0.25 GiB`
-4. `overhead = fixedOverhead + 0.25 GiB`
-5. `memForWeightsPerGPU = 67.2 − overhead ≈ 64.7 GiB`
-6. `minGPUs = ⌊7.29 / 64.7⌋ + 1 = 1`
+4. `fixedReserve = 2.3 (base) + 0.25 (KV) = 2.55 GiB`
+5. `memForWeightsPerGPU = (67.2 − 2.55) / (1 + 0.05) = 64.65 / 1.05 = 61.57 GiB` — the `(1 + 0.05)` divisor accounts for the weight-scaled runtime overhead (activations + CUDA graphs)
+6. `minGPUs = ⌈7.29 / 61.57⌉ = 1`
 7. `minNodes = ⌈1 / 1⌉ = 1`
 
 **Result: 1 node** (1 GPU) is sufficient — the model is small enough to fit easily.
@@ -200,11 +214,12 @@ Now compute the longest context window on that 1 GPU:
 
 1. `modelWeightPerGPU = 7.29 GiB` (single GPU, no distribution)
 2. `availablePerGPU = 67.2 GiB`
-3. `remainingPerGPU = 67.2 − 7.29 − fixedOverhead ≈ 57.61 GiB`
-4. `adjustedBytesPerToken = 128 KB` (single GPU)
-5. `rawCandidate = 57.61 GiB / 128 KB ≈ 471941 tokens`
-6. Clamp to model limit: `min(471941, 131072) = 131,072`
-7. Align to 256: `131,072` (already aligned)
+3. `overhead = 2.3 + 0.05 × 7.29 = 2.66 GiB`
+4. `remainingPerGPU = 67.2 − 7.29 − 2.66 = 57.25 GiB`
+5. `adjustedBytesPerToken = 128 KB` (single GPU, GQA)
+6. `rawCandidate = 57.25 GiB × 8,192 tokens/GiB ≈ 469,000 tokens`
+7. Clamp to model limit: `min(469000, 131072) = 131,072`
+8. Align to 256: `131,072` (already aligned)
 
 **Result: vLLM launches with `--max-model-len 131072`** — the full 128K context the model architecture supports.
 
@@ -214,11 +229,12 @@ On a `Standard_NV36ads_A10_v5` node (1× A10 24 GiB GPU):
 
 1. `availablePerGPU = 24 × 0.84 ≈ 20.16 GiB`
 2. `modelSize = 7.29 GiB` (actual SafeTensor size × 1.02)
-3. `remainingPerGPU = 20.16 − 7.29 − fixedOverhead ≈ 10.57 GiB`
-4. `rawCandidate = 10.57 GiB / 128 KB ≈ 86,589 tokens`
-5. Clamp to model limit: `min(86589, 131072) = 86,589`
-6. Align to 256: `86,528`
+3. `overhead = 2.3 + 0.05 × 7.29 = 2.66 GiB` (base + weight-scaled term)
+4. `remainingPerGPU = 20.16 − 7.29 − 2.66 = 10.21 GiB`
+5. `rawCandidate = 10.21 GiB × 8,192 tokens/GiB ≈ 83,640 tokens`
+6. Clamp to model limit: `min(83640, 131072) = 83,640`
+7. Align to 256: `83,456`
 
-The model still fits on 1 node, but the context window drops to ~77K tokens — well below the model's 128K architectural limit. To get the full context, you'd need a GPU with more memory.
+The model still fits on 1 node, but the context window drops to ~83K tokens — well below the model's 128K architectural limit. To get the full context, you'd need a GPU with more memory.
 
 </details>


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
This PR fixed multiple issues in KAITO's `max-model-len` estimation:

## 1. Estimation on runtime overhead is over-optimistic
**Problem:** The estimator reserved a **flat `2.3 GiB`** per GPU for non-KV runtime memory (activations + non-torch). vLLM actually reserves much more for large models — it *measures* this at startup in `determine_available_memory()` (peak activation forward pass) and `profile_cudagraph_memory()` (CUDA-graph capture, ~1.5–1.9 GiB on H100). For a big model like Mistral-Medium the real overhead is ~5.5 GiB/GPU, so the flat 2.3 over-counted available KV by ~3 GiB → the estimator computed a `max-model-len` (1,048,576) larger than vLLM could honor → deterministic `ValueError` at KV-cache init → crash-loop.

**Fix:** Replaced the flat constant with `baseOverheadGiB(2.3) + overheadWeightFactor(0.05) × per-GPU-weight-share`. The per-GPU weight share is a good proxy because activation + CUDA-graph memory grow with hidden-size/layer-count and are sharded across TP ranks the same way weights are.

## 2. KV cache size is underestimated for MLA models
**Problem:** The estimator computed per-token KV as `bytesPerToken / gpuCount`, assuming tensor parallelism **shards** the KV cache across GPUs. That's true for GQA/MHA, but **MLA (Multi-head Latent Attention) replicates its single compressed latent KV on every TP rank** — it isn't sharded. Using Mistral-Small-4-119B (MLA, TP=2) as an example, KAITO under-counted per-token KV by 2× (predicted 11,520, real 23,040), computed ~1.5M tokens, clamped to the 1M model limit, and the inference pod crash-looped because vLLM's real KV only fit ~810K.

**Fix:** Plumbed `AttnType` through to the estimator (`MLAReplicatedKVCache` input) and, for MLA, **don't divide by gpuCount**.

## 3. max-model-len calculation is buggy for pipeline-parallelism scenarios
**Problem:** The multi-node formula was `bytesPerToken / gpuCount * nodes` — it **multiplied** by node count. But pipeline parallelism (PP = nodes) **splits the model's layers across stages**, so each GPU holds only `1/nodes` of the layers' KV. Multiplying instead of dividing over-counted per-token KV by `nodes²` relative to truth. For MiniMax-M2.7 (TP2×PP2) KAITO computed 253,952 B/tok/GPU when the real value was ~63,488 — a 4× over-count — yielding `max-model-len=81,408` and silently throwing away ~60% of the model's usable 204,800 context. This was also internally inconsistent: weights in the same function are already divided by `nodes × gpuCount`, but KV wasn't.

**Fix:** Changed the standard-attention multi-node path to `bytesPerToken / gpuCount / nodes` (shard by TP, split layers by PP) and the MLA path to `bytesPerToken / nodes` (replicated on TP, still split by PP).

## TODOs
1. Per-token KV is greatly over-counted for models using sliding-window attention or hybrid attention 
(gemma4 6.2×, gpt-oss-120b 3.8×, qwen3.6 7.9×) because right now every layer is modeled as full-context. We should enhance KAITO memory estimator to handle such models accurately.
2. max-model-len estimation is too conservative on small GPUs. For example, when deploying model `Qwen3-8b` (16.4 GB) on an A10 GPU, KAITO estimated `max-model-len=11,008` while the actual max context len was 20,272. In future we may take GPU size into account in max-model-len estimation.

**Requirements**:
- [ ] added unit tests and e2e tests (if applicable).
- [x] verified the max-model-len estimation for the following models on Azure SKU Standard_NC80adis_H100_v5:

| Models | Attn / topology | bytes per-tok KV /GPU (KAITO) | bytes per-tok KV /GPU (vLLM) | avail KV (KAITO) | avail KV (vLLM) | max-model-len (KAITO) | KV-cache size (vLLM)
|---|---|---|---|---|---|---|---|
| Mistral-Small-4-119B-2603 | MLA, TP2 | 23,040 | 23,040 | 16.4 GiB | 17.39 GiB | 761,600 | 810,176 |
| MiniMax-M2.7 | GQA, TP2×PP2 | 63,488 | 63,503 | 19.27 GiB | 19.97 GiB | 204,800 (clamped) | 337,664 |
| Llama-3.3-70B-Instruct | GQA, TP2 | 163,840 | 163,917 | 6.29 GiB | 8.48 GiB | 40,960 | 55,296 |
| gemma-4-31B-it | sliding-window, TP2 | 491,520 | 79,128 | 45.5 GiB | 39.45 GiB | **99,072** | 535,346 |
| gpt-oss-120b | sliding-window, TP2 | 73,728 | 19,602 | — | 40.84 GiB | 131,072 (clamped) | 131,072 |
| Qwen3.6-35B-A3B | hybrid GDN, TP2 | 81,920 | 10,395 | — | 40.04 GiB | 262,144 (clamped) | 2,236,798 |
| DeepSeek-R1 | MLA, TP8×PP2 | 35,136 | 34,560 | — | 19.7 GiB | 163,840 (clamped) | 612,144 |
| Kimi-2.6 | MLA, TP8×PP2 | 35,136 | 34,557 | — | 26.4 GiB | 262,144 (clamped) | 820,304 |
| Qwen3-8b | GQA, TP1 (1 node, A10) | 147,456 | 147,789 | 1.52 Gib | 2.79 GiB | **11,008** | 20,272 |

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Fixes #2132

**Notes for Reviewers**: