### PR TITLE
feat: migrate to llm-d-router-gateway chart v0.9.0 and enable KV cache-aware routing

### DIFF
--- a/.github/workflows/aikit.yaml
+++ b/.github/workflows/aikit.yaml
@@ -533,10 +533,10 @@ jobs:
           kubectl get inferencepool -A -o yaml || true
 
           echo "=== GWIE: EPP Deployment ==="
-          kubectl get deployment -l app=inferenceset-aikit-test-inferencepool-epp -o yaml || true
+          kubectl get deployment -l app.kubernetes.io/name=inferenceset-aikit-test-inferencepool-epp -o yaml || true
 
           echo "=== GWIE: EPP Pod Logs ==="
-          kubectl logs -l app=inferenceset-aikit-test-inferencepool-epp --tail=50 || true
+          kubectl logs -l app.kubernetes.io/name=inferenceset-aikit-test-inferencepool-epp --tail=50 || true
 
           echo "=== Preset GWIE Test: InferenceSet Status ==="
           kubectl get inferenceset inferenceset-preset-gwie-test -o yaml || true

--- a/examples/gateway-api-inference-extension/destinationrule-mistral-7b-instruct.yaml
+++ b/examples/gateway-api-inference-extension/destinationrule-mistral-7b-instruct.yaml
@@ -6,5 +6,6 @@ spec:
   host: mistral-7b-instruct-inferencepool-epp
   trafficPolicy:
     tls:
-      mode: SIMPLE
-      insecureSkipVerify: true
+      # See destinationrule-phi-4-mini-instruct.yaml for the rationale.
+      # llm-d-router-endpoint-picker v0.9.0 listens on plaintext gRPC.
+      mode: DISABLE

--- a/examples/gateway-api-inference-extension/destinationrule-phi-4-mini-instruct.yaml
+++ b/examples/gateway-api-inference-extension/destinationrule-phi-4-mini-instruct.yaml
@@ -6,5 +6,8 @@ spec:
   host: phi-4-mini-inferencepool-epp
   trafficPolicy:
     tls:
-      mode: SIMPLE
-      insecureSkipVerify: true
+      # llm-d-router-endpoint-picker v0.9.0 listens on plaintext gRPC by
+      # default, so the Istio Gateway -> EPP ext_proc connection uses DISABLE
+      # instead of the previous SIMPLE + insecureSkipVerify workaround that
+      # was needed by llm-d-inference-scheduler:v0.8.0 (--secure-serving=true).
+      mode: DISABLE

--- a/pkg/controllers/multiroleinference/controller.go
+++ b/pkg/controllers/multiroleinference/controller.go
@@ -518,6 +518,8 @@ const (
 // defaultPDPluginsConfigTemplate is the default EPP plugins YAML template for P/D disaggregated serving.
 // Uses the llm-d EndpointPickerConfig format with schedulingProfiles for prefill and decode.
 // approx-prefix-cache-producer is used for prefix cache awareness (no tokenizer sidecar needed).
+// kv-cache-utilization-scorer leverages vLLM KV cache events (enabled by default on vLLM pods)
+// to score endpoints by available KV cache capacity, spreading traffic away from high-pressure pods.
 const defaultPDPluginsConfigTemplate = `apiVersion: inference.networking.x-k8s.io/v1alpha1
 kind: EndpointPickerConfig
 plugins:
@@ -546,6 +548,7 @@ plugins:
   - type: load-aware-scorer
     parameters:
       threshold: 10
+  - type: kv-cache-utilization-scorer
   - type: max-score-picker
 schedulingProfiles:
   - name: prefill
@@ -553,12 +556,16 @@ schedulingProfiles:
       - pluginRef: prefill-filter
       - pluginRef: load-aware-scorer
         weight: 10
+      - pluginRef: kv-cache-utilization-scorer
+        weight: 5
       - pluginRef: max-score-picker
   - name: decode
     plugins:
       - pluginRef: decode-filter
       - pluginRef: load-aware-scorer
         weight: 10
+      - pluginRef: kv-cache-utilization-scorer
+        weight: 5
       - pluginRef: max-score-picker
 `
 

--- a/pkg/controllers/multiroleinference/controller.go
+++ b/pkg/controllers/multiroleinference/controller.go
@@ -667,7 +667,7 @@ func (r *MultiRoleInferenceReconciler) reconcileInferencePool(
 
 	helmValues := map[string]any{
 		"router": map[string]any{
-			"epp":          eppValues,
+			"epp": eppValues,
 			"modelServers": map[string]any{
 				"matchLabels": matchLabels,
 				"targetPorts": []map[string]any{

--- a/pkg/controllers/multiroleinference/controller.go
+++ b/pkg/controllers/multiroleinference/controller.go
@@ -655,6 +655,15 @@ func (r *MultiRoleInferenceReconciler) reconcileInferencePool(
 	eppValues["flags"] = map[string]string{
 		"model-server-metrics-port": fmt.Sprintf("%d", consts.PortInferenceServer),
 	}
+	eppValues["resources"] = map[string]any{
+		"requests": map[string]string{
+			"cpu":    "1",
+			"memory": "2Gi",
+		},
+		"limits": map[string]string{
+			"memory": "16Gi",
+		},
+	}
 	// No tokenizer sidecar: the EPP plugin pipeline (approx-prefix-cache-producer
 	// + prefix-based-pd-decider) does not require a token-producer plugin, so a
 	// GPU-less vLLM render process would only add ~500m CPU / 1Gi memory per MRI

--- a/pkg/controllers/multiroleinference/controller.go
+++ b/pkg/controllers/multiroleinference/controller.go
@@ -653,7 +653,7 @@ func (r *MultiRoleInferenceReconciler) reconcileInferencePool(
 	// sidecar listens on 5000 and transparently proxies /metrics to vLLM on 5001.
 	// This keeps a single metrics port across roles, avoiding per-role EPP config.
 	// Disable secure-serving so the Gateway can reach EPP over plaintext gRPC
-	// without requiring TLS DestinationRules or certificate bootstrapping.
+	// with a simple DestinationRule (mode: DISABLE) instead of requiring TLS cert management.
 	eppValues["flags"] = map[string]string{
 		"secure-serving":            "false",
 		"model-server-metrics-port": fmt.Sprintf("%d", consts.PortInferenceServer),

--- a/pkg/controllers/multiroleinference/controller.go
+++ b/pkg/controllers/multiroleinference/controller.go
@@ -652,10 +652,7 @@ func (r *MultiRoleInferenceReconciler) reconcileInferencePool(
 	// On prefill pods vLLM listens directly on 5000; on decode pods the routing
 	// sidecar listens on 5000 and transparently proxies /metrics to vLLM on 5001.
 	// This keeps a single metrics port across roles, avoiding per-role EPP config.
-	// Disable secure-serving so the Gateway can reach EPP over plaintext gRPC
-	// with a simple DestinationRule (mode: DISABLE) instead of requiring TLS cert management.
 	eppValues["flags"] = map[string]string{
-		"secure-serving":            "false",
 		"model-server-metrics-port": fmt.Sprintf("%d", consts.PortInferenceServer),
 	}
 	// No tokenizer sidecar: the EPP plugin pipeline (approx-prefix-cache-producer

--- a/pkg/controllers/multiroleinference/controller.go
+++ b/pkg/controllers/multiroleinference/controller.go
@@ -624,8 +624,8 @@ func (r *MultiRoleInferenceReconciler) reconcileInferencePool(
 	// Build EPP extension values with llm-d image and P/D plugins config.
 	eppValues := map[string]any{
 		"image": map[string]string{
-			"hub":        consts.EPPImageHub,
-			"name":       consts.EPPImageName,
+			"registry":   consts.EPPImageRegistry,
+			"repository": consts.EPPImageRepository,
 			"tag":        consts.EPPImageTag,
 			"pullPolicy": string(corev1.PullIfNotPresent),
 		},
@@ -666,13 +666,13 @@ func (r *MultiRoleInferenceReconciler) reconcileInferencePool(
 	// it unconditionally.
 
 	helmValues := map[string]any{
-		"inferenceExtension": eppValues,
-		"inferencePool": map[string]any{
-			"targetPorts": []map[string]any{
-				{"number": consts.PortInferenceServer}, // sidecar (decode) or vLLM (prefill) on port 5000
-			},
+		"router": map[string]any{
+			"epp":          eppValues,
 			"modelServers": map[string]any{
 				"matchLabels": matchLabels,
+				"targetPorts": []map[string]any{
+					{"number": consts.PortInferenceServer}, // sidecar (decode) or vLLM (prefill) on port 5000
+				},
 			},
 		},
 	}

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -140,9 +140,9 @@ const (
 	// Using llm-d router endpoint picker which provides advanced scheduling plugins
 	// (KV cache-aware routing, P/D disaggregation, pluggable filters/scorers).
 	// See: https://github.com/llm-d/llm-d-router
-	EPPImageRegistry   = "ghcr.io/llm-d"
+	EPPImageRegistry   = "mcr.microsoft.com/oss/v2/llm-d"
 	EPPImageRepository = "llm-d-router-endpoint-picker"
-	EPPImageTag        = "v0.9.1"
+	EPPImageTag        = "v0.9.0"
 
 	// TokenizerSidecar runs a GPU-less vLLM render process for tokenization.
 	// It exposes /v1/completions/render and /v1/chat/completions/render on port 8100.

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -127,21 +127,22 @@ const (
 	// See https://docs.vllm.ai/en/stable/api/vllm/config/kv_events/
 	PortKVCacheEvents = int32(5557)
 
-	// InferencePoolChartURL is the OCI registry URL for the Gateway API Inference Extension inferencepool chart.
-	InferencePoolChartURL = "oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool"
+	// InferencePoolChartURL is the OCI registry URL for the llm-d router gateway chart.
+	// Migrated from GWIE inferencepool chart to llm-d-router-gateway which provides
+	// the same InferencePool deployment with advanced routing capabilities.
+	InferencePoolChartURL = "oci://ghcr.io/llm-d/charts/llm-d-router-gateway"
 
-	// InferencePoolChartVersion is the tag/version of the inferencepool chart to deploy.
-	// MUST KEEP IN SYNC with the version in go.mod.
-	InferencePoolChartVersion = "v1.3.1"
+	// InferencePoolChartVersion is the tag/version of the llm-d-router-gateway chart to deploy.
+	InferencePoolChartVersion = "v0.9.1"
 
 	// EPP (Endpoint Picker) image configuration.
-	// The InferencePool chart composes the image as: {hub}/{name}:{tag}
-	// Using llm-d inference scheduler which consolidates the GWIE EPP implementation
-	// with advanced scheduling plugins (KV cache-aware routing, P/D disaggregation, etc.)
-	// See: https://github.com/llm-d/llm-d-inference-scheduler
-	EPPImageHub  = "mcr.microsoft.com/oss/v2/llm-d"
-	EPPImageName = "llm-d-inference-scheduler"
-	EPPImageTag  = "v0.8.0"
+	// The llm-d-router chart composes the image as: {registry}/{repository}:{tag}
+	// Using llm-d router endpoint picker which provides advanced scheduling plugins
+	// (KV cache-aware routing, P/D disaggregation, pluggable filters/scorers).
+	// See: https://github.com/llm-d/llm-d-router
+	EPPImageRegistry   = "ghcr.io/llm-d"
+	EPPImageRepository = "llm-d-router-endpoint-picker"
+	EPPImageTag        = "v0.9.1"
 
 	// TokenizerSidecar runs a GPU-less vLLM render process for tokenization.
 	// It exposes /v1/completions/render and /v1/chat/completions/render on port 8100.

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -142,7 +142,7 @@ const (
 	// See: https://github.com/llm-d/llm-d-router
 	EPPImageRegistry   = "mcr.microsoft.com/oss/v2/llm-d"
 	EPPImageRepository = "llm-d-router-endpoint-picker"
-	EPPImageTag        = "v0.9.0"
+	EPPImageTag        = "v0.9.1"
 
 	// TokenizerSidecar runs a GPU-less vLLM render process for tokenization.
 	// It exposes /v1/completions/render and /v1/chat/completions/render on port 8100.

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -142,7 +142,7 @@ const (
 	// See: https://github.com/llm-d/llm-d-router
 	EPPImageRegistry   = "mcr.microsoft.com/oss/v2/llm-d"
 	EPPImageRepository = "llm-d-router-endpoint-picker"
-	EPPImageTag        = "v0.9.1"
+	EPPImageTag        = "v0.9.0"
 
 	// TokenizerSidecar runs a GPU-less vLLM render process for tokenization.
 	// It exposes /v1/completions/render and /v1/chat/completions/render on port 8100.

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -133,7 +133,7 @@ const (
 	InferencePoolChartURL = "oci://ghcr.io/llm-d/charts/llm-d-router-gateway"
 
 	// InferencePoolChartVersion is the tag/version of the llm-d-router-gateway chart to deploy.
-	InferencePoolChartVersion = "v0.9.1"
+	InferencePoolChartVersion = "v0.9.0"
 
 	// EPP (Endpoint Picker) image configuration.
 	// The llm-d-router chart composes the image as: {registry}/{repository}:{tag}

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -400,7 +400,7 @@ func GenerateInferencePoolOCIRepository(inferenceSetObj *kaitov1beta1.InferenceS
 			},
 		},
 		Spec: sourcev1.OCIRepositorySpec{
-			// Chart source for Gateway API Inference Extension inference pool;
+			// Chart source for llm-d router gateway;
 			// keep in sync with consts.InferencePoolChartVersion when upgrading.
 			URL: consts.InferencePoolChartURL,
 			Reference: &sourcev1.OCIRepositoryRef{
@@ -423,29 +423,29 @@ func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1beta1.InferenceSet
 		consts.WorkspaceCreatedByInferenceSetLabel: inferenceSetObj.Name,
 	}
 
-	// The Endpoint Picker (EPP) from Gateway API Inference Extension picks an endpoint that can serve traffic.
-	// KAITO overrides the default GWIE EPP image with the llm-d inference scheduler, which provides
-	// advanced scheduling plugins (KV cache-aware routing, P/D disaggregation, pluggable filters/scorers).
+	// The Endpoint Picker (EPP) from llm-d router picks an endpoint that can serve traffic.
+	// It provides advanced scheduling plugins (KV cache-aware routing, P/D disaggregation,
+	// pluggable filters/scorers).
 	// In a multi-node inference environment, this means we need to select the leader pod (with pod index 0)
 	// since only the leader pod is capable of serving traffic.
 	matchLabels[appsv1.PodIndexLabel] = "0"
 
-	// Based on https://github.com/kubernetes-sigs/gateway-api-inference-extension/blob/v1.3.1/config/charts/inferencepool/values.yaml
+	// Based on https://github.com/llm-d/llm-d-router/blob/v0.9.1/config/charts/routerlib/values.yaml
 	helmValues := map[string]any{
-		"inferenceExtension": map[string]any{
-			"image": map[string]string{
-				"hub":        consts.EPPImageHub,
-				"name":       consts.EPPImageName,
-				"tag":        consts.EPPImageTag,
-				"pullPolicy": string(corev1.PullIfNotPresent),
+		"router": map[string]any{
+			"epp": map[string]any{
+				"image": map[string]string{
+					"registry":   consts.EPPImageRegistry,
+					"repository": consts.EPPImageRepository,
+					"tag":        consts.EPPImageTag,
+					"pullPolicy": string(corev1.PullIfNotPresent),
+				},
 			},
-		},
-		"inferencePool": map[string]any{
-			"targetPorts": []map[string]any{{
-				"number": inferencePoolTargetPort(),
-			}},
 			"modelServers": map[string]any{
 				"matchLabels": matchLabels,
+				"targetPorts": []map[string]any{{
+					"number": inferencePoolTargetPort(),
+				}},
 			},
 		},
 	}

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -430,7 +430,7 @@ func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1beta1.InferenceSet
 	// since only the leader pod is capable of serving traffic.
 	matchLabels[appsv1.PodIndexLabel] = "0"
 
-	// Based on https://github.com/llm-d/llm-d-router/blob/v0.9.1/config/charts/routerlib/values.yaml
+	// Based on https://github.com/llm-d/llm-d-router/blob/v0.9.0/config/charts/routerlib/values.yaml
 	helmValues := map[string]any{
 		"router": map[string]any{
 			"epp": map[string]any{

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -440,6 +440,15 @@ func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1beta1.InferenceSet
 					"tag":        consts.EPPImageTag,
 					"pullPolicy": string(corev1.PullIfNotPresent),
 				},
+				"resources": map[string]any{
+					"requests": map[string]string{
+						"cpu":    "1",
+						"memory": "2Gi",
+					},
+					"limits": map[string]string{
+						"memory": "16Gi",
+					},
+				},
 			},
 			"modelServers": map[string]any{
 				"matchLabels": matchLabels,

--- a/pkg/workspace/manifests/manifests.go
+++ b/pkg/workspace/manifests/manifests.go
@@ -449,6 +449,16 @@ func GenerateInferencePoolHelmRelease(inferenceSetObj *kaitov1beta1.InferenceSet
 						"memory": "16Gi",
 					},
 				},
+				// Disable EPP's built-in TLS on the ext_proc gRPC port so the
+				// Istio Gateway can connect in plaintext. The llm-d-router-gateway
+				// chart's EPP binary defaults to --secure-serving=true, but our
+				// Istio DestinationRule for the EPP service is configured with
+				// tls.mode: DISABLE. Without turning this off, Envoy's ext_proc
+				// filter fails with "Connection refused" / "no healthy upstream"
+				// during TLS handshake against a plaintext client.
+				"flags": map[string]any{
+					"secure-serving": false,
+				},
 			},
 			"modelServers": map[string]any{
 				"matchLabels": matchLabels,

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -67,21 +67,21 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 			name:      "statefulset inference pool helm values",
 			workspace: base.DeepCopy(),
 			expected: map[string]any{
-				"inferenceExtension": map[string]any{
-					"image": map[string]any{
-						"hub":        consts.EPPImageHub,
-						"name":       consts.EPPImageName,
-						"tag":        consts.EPPImageTag,
-						"pullPolicy": string(corev1.PullIfNotPresent),
-					},
-				},
-				"inferencePool": map[string]any{
-					"targetPorts": []any{
-						map[string]any{
-							"number": float64(consts.PortInferenceServer),
+				"router": map[string]any{
+					"epp": map[string]any{
+						"image": map[string]any{
+							"registry":   consts.EPPImageRegistry,
+							"repository": consts.EPPImageRepository,
+							"tag":        consts.EPPImageTag,
+							"pullPolicy": string(corev1.PullIfNotPresent),
 						},
 					},
 					"modelServers": map[string]any{
+						"targetPorts": []any{
+							map[string]any{
+								"number": float64(consts.PortInferenceServer),
+							},
+						},
 						"matchLabels": map[string]any{
 							consts.WorkspaceCreatedByInferenceSetLabel: base.Name,
 							appsv1.PodIndexLabel:                       "0",
@@ -103,21 +103,21 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 				return ws
 			}(),
 			expected: map[string]any{
-				"inferenceExtension": map[string]any{
-					"image": map[string]any{
-						"hub":        consts.EPPImageHub,
-						"name":       consts.EPPImageName,
-						"tag":        consts.EPPImageTag,
-						"pullPolicy": string(corev1.PullIfNotPresent),
-					},
-				},
-				"inferencePool": map[string]any{
-					"targetPorts": []any{
-						map[string]any{
-							"number": float64(consts.PortInferenceServer),
+				"router": map[string]any{
+					"epp": map[string]any{
+						"image": map[string]any{
+							"registry":   consts.EPPImageRegistry,
+							"repository": consts.EPPImageRepository,
+							"tag":        consts.EPPImageTag,
+							"pullPolicy": string(corev1.PullIfNotPresent),
 						},
 					},
 					"modelServers": map[string]any{
+						"targetPorts": []any{
+							map[string]any{
+								"number": float64(consts.PortInferenceServer),
+							},
+						},
 						"matchLabels": map[string]any{
 							consts.WorkspaceCreatedByInferenceSetLabel: base.Name,
 							appsv1.PodIndexLabel:                       "0",
@@ -139,21 +139,21 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 				return ws
 			}(),
 			expected: map[string]any{
-				"inferenceExtension": map[string]any{
-					"image": map[string]any{
-						"hub":        consts.EPPImageHub,
-						"name":       consts.EPPImageName,
-						"tag":        consts.EPPImageTag,
-						"pullPolicy": string(corev1.PullIfNotPresent),
-					},
-				},
-				"inferencePool": map[string]any{
-					"targetPorts": []any{
-						map[string]any{
-							"number": float64(consts.PortInferenceServer),
+				"router": map[string]any{
+					"epp": map[string]any{
+						"image": map[string]any{
+							"registry":   consts.EPPImageRegistry,
+							"repository": consts.EPPImageRepository,
+							"tag":        consts.EPPImageTag,
+							"pullPolicy": string(corev1.PullIfNotPresent),
 						},
 					},
 					"modelServers": map[string]any{
+						"targetPorts": []any{
+							map[string]any{
+								"number": float64(consts.PortInferenceServer),
+							},
+						},
 						"matchLabels": map[string]any{
 							consts.WorkspaceCreatedByInferenceSetLabel: base.Name,
 							appsv1.PodIndexLabel:                       "0",

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -75,6 +75,15 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 							"tag":        consts.EPPImageTag,
 							"pullPolicy": string(corev1.PullIfNotPresent),
 						},
+						"resources": map[string]any{
+							"requests": map[string]any{
+								"cpu":    "1",
+								"memory": "2Gi",
+							},
+							"limits": map[string]any{
+								"memory": "16Gi",
+							},
+						},
 					},
 					"modelServers": map[string]any{
 						"targetPorts": []any{
@@ -111,6 +120,15 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 							"tag":        consts.EPPImageTag,
 							"pullPolicy": string(corev1.PullIfNotPresent),
 						},
+						"resources": map[string]any{
+							"requests": map[string]any{
+								"cpu":    "1",
+								"memory": "2Gi",
+							},
+							"limits": map[string]any{
+								"memory": "16Gi",
+							},
+						},
 					},
 					"modelServers": map[string]any{
 						"targetPorts": []any{
@@ -146,6 +164,15 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 							"repository": consts.EPPImageRepository,
 							"tag":        consts.EPPImageTag,
 							"pullPolicy": string(corev1.PullIfNotPresent),
+						},
+						"resources": map[string]any{
+							"requests": map[string]any{
+								"cpu":    "1",
+								"memory": "2Gi",
+							},
+							"limits": map[string]any{
+								"memory": "16Gi",
+							},
 						},
 					},
 					"modelServers": map[string]any{

--- a/pkg/workspace/manifests/manifests_test.go
+++ b/pkg/workspace/manifests/manifests_test.go
@@ -84,6 +84,9 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 								"memory": "16Gi",
 							},
 						},
+						"flags": map[string]any{
+							"secure-serving": false,
+						},
 					},
 					"modelServers": map[string]any{
 						"targetPorts": []any{
@@ -129,6 +132,9 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 								"memory": "16Gi",
 							},
 						},
+						"flags": map[string]any{
+							"secure-serving": false,
+						},
 					},
 					"modelServers": map[string]any{
 						"targetPorts": []any{
@@ -173,6 +179,9 @@ func TestGenerateInferencePoolHelmRelease(t *testing.T) {
 							"limits": map[string]any{
 								"memory": "16Gi",
 							},
+						},
+						"flags": map[string]any{
+							"secure-serving": false,
 						},
 					},
 					"modelServers": map[string]any{

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -872,8 +872,13 @@ func validateBBRRouting(inferenceSetObj *kaitov1beta1.InferenceSet, modelName, i
 
 			dumpPodLogs("default", "app.kubernetes.io/name=body-based-routing", 200)
 			dumpPodLogs("default", "gateway.networking.k8s.io/gateway-name=inference-gateway", 150)
-			dumpPodLogs(inferenceSetObj.Namespace, "app="+inferencePoolName+"-epp", 200)
-			dumpPodLogs(inferenceSetObj.Namespace, "inferencepool="+inferencePoolName, 200)
+			// llm-d-router-gateway v0.9.0 labels EPP pods with
+			// app.kubernetes.io/name=<release>-epp and
+			// llm-d-router-gateway=<release>-epp (see routerlib templates/_helpers.tpl).
+			// The legacy "app=<name>-epp" / "inferencepool=<name>" selectors from the
+			// GWIE inferencepool chart no longer match.
+			dumpPodLogs(inferenceSetObj.Namespace, "app.kubernetes.io/name="+inferencePoolName+"-epp", 200)
+			dumpPodLogs(inferenceSetObj.Namespace, "llm-d-router-gateway="+inferencePoolName+"-epp", 200)
 
 			// HTTPRoute status/spec
 			route := &unstructured.Unstructured{}

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -516,12 +516,14 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 // and validates both positive (correct model → success) and negative (wrong model → error) routing.
 func validateBBRRouting(inferenceSetObj *kaitov1beta1.InferenceSet, modelName, inferencePoolName string, findWorkspacePod func() (string, string, string)) {
 	// Ensure a DestinationRule exists for the EPP service so Istio Gateway's
-	// ext_proc gRPC uses the right TLS mode. Current EPP image is
-	// llm-d-inference-scheduler:v0.8.0 which listens on TLS by default
-	// (--secure-serving=true). Without SIMPLE + insecureSkipVerify=true, Envoy
-	// sends plaintext and the connection is terminated -> Gateway returns
-	// HTTP 500 empty body on every BBR request. When we bump EPP to v0.9.x
-	// (plaintext by default), switch this to mode: DISABLE.
+	// ext_proc gRPC uses the right TLS mode. After migrating to the
+	// llm-d-router-gateway chart v0.9.0, EPP
+	// (mcr.microsoft.com/oss/v2/llm-d/llm-d-router-endpoint-picker:v0.9.0)
+	// listens on plaintext gRPC by default, so we use mode: DISABLE for the
+	// Istio Gateway -> EPP ext_proc connection. (The previous SIMPLE +
+	// insecureSkipVerify=true workaround was required by the older
+	// llm-d-inference-scheduler:v0.8.0 EPP which defaulted to
+	// --secure-serving=true with a self-signed cert.)
 	By("Ensuring DestinationRule for EPP service (BBR)", func() {
 		eppServiceName := inferencePoolName + "-epp"
 		dr := &unstructured.Unstructured{}
@@ -536,8 +538,7 @@ func validateBBRRouting(inferenceSetObj *kaitov1beta1.InferenceSet, modelName, i
 			"host": eppServiceName,
 			"trafficPolicy": map[string]interface{}{
 				"tls": map[string]interface{}{
-					"mode":               "SIMPLE",
-					"insecureSkipVerify": true,
+					"mode": "DISABLE",
 				},
 			},
 		}
@@ -557,7 +558,7 @@ func validateBBRRouting(inferenceSetObj *kaitov1beta1.InferenceSet, modelName, i
 			return err
 		}, 2*time.Minute, utils.PollInterval).Should(Succeed(),
 			"Failed to create DestinationRule for EPP service %s", eppServiceName)
-		GinkgoWriter.Printf("Created/updated DestinationRule (mode=SIMPLE) for EPP service %s\n", eppServiceName)
+		GinkgoWriter.Printf("Created/updated DestinationRule (mode=DISABLE) for EPP service %s\n", eppServiceName)
 
 		DeferCleanup(func() {
 			cleanupDR := &unstructured.Unstructured{}

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -88,6 +88,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 
 		// P/D-specific validations (require Istio)
 		validateMultiRoleInferenceEPPReady(mriObj)
+		validateMultiRoleInferenceEPPKVCacheScorer(mriObj)
 		validateMultiRoleInferenceDestinationRule(mriObj)
 		validateMultiRoleInferenceChatCompletions(mriObj)
 		validateMultiRoleInferenceKVEvents(mriObj)
@@ -1903,6 +1904,161 @@ func validateMultiRoleInferenceEPPReady(mriObj *kaitov1alpha1.MultiRoleInference
 			return false
 		}, 5*time.Minute, utils.PollInterval).Should(BeTrue(),
 			"EPP pod should have disagg-profile-handler in logs")
+	})
+}
+
+// validateMultiRoleInferenceEPPKVCacheScorer validates that the EPP plugins
+// ConfigMap contains the kv-cache-utilization-scorer plugin and that the EPP
+// pod logs confirm the scorer was loaded. This ensures the default
+// EndpointPickerConfig wires up KV cache-aware routing end-to-end.
+func validateMultiRoleInferenceEPPKVCacheScorer(mriObj *kaitov1alpha1.MultiRoleInference) {
+	poolName := kaitoutils.InferencePoolName(mriObj.Name)
+	eppDeploymentName := poolName + "-epp"
+
+	By("Validating EPP plugins ConfigMap contains kv-cache-utilization-scorer", func() {
+		Eventually(func() error {
+			// The llm-d-router-gateway chart stores the EPP plugins config in a
+			// ConfigMap whose name is derived from the HelmRelease. Try the
+			// most common naming patterns.
+			candidateNames := []string{
+				poolName + "-epp-plugins",
+				poolName + "-plugins",
+				poolName + "-epp",
+			}
+
+			coreClient, err := utils.GetK8sClientset()
+			if err != nil {
+				return fmt.Errorf("create core client: %w", err)
+			}
+
+			// If none of the candidate names match, fall back to listing all
+			// ConfigMaps in the namespace and scanning their data.
+			var found bool
+			for _, name := range candidateNames {
+				cm, err := coreClient.CoreV1().ConfigMaps(mriObj.Namespace).Get(ctx, name, metav1.GetOptions{})
+				if err != nil {
+					continue
+				}
+				for _, v := range cm.Data {
+					if strings.Contains(v, "kv-cache-utilization-scorer") {
+						GinkgoWriter.Printf("ConfigMap %s contains kv-cache-utilization-scorer\n", name)
+						found = true
+						break
+					}
+				}
+				if found {
+					break
+				}
+			}
+
+			if !found {
+				// Fallback: scan all ConfigMaps in namespace
+				cmList, err := coreClient.CoreV1().ConfigMaps(mriObj.Namespace).List(ctx, metav1.ListOptions{})
+				if err != nil {
+					return fmt.Errorf("list ConfigMaps: %w", err)
+				}
+				for _, cm := range cmList.Items {
+					for _, v := range cm.Data {
+						if strings.Contains(v, "kv-cache-utilization-scorer") {
+							GinkgoWriter.Printf("ConfigMap %s contains kv-cache-utilization-scorer\n", cm.Name)
+							found = true
+							break
+						}
+					}
+					if found {
+						break
+					}
+				}
+			}
+
+			if !found {
+				return fmt.Errorf("no ConfigMap in namespace %s contains kv-cache-utilization-scorer", mriObj.Namespace)
+			}
+			return nil
+		}, 5*time.Minute, utils.PollInterval).Should(Succeed(),
+			"EPP plugins ConfigMap should contain kv-cache-utilization-scorer")
+	})
+
+	By("Validating EPP pod logs confirm kv-cache-utilization-scorer is loaded", func() {
+		coreClient, err := utils.GetK8sClientset()
+		Expect(err).NotTo(HaveOccurred(), "Failed to create core client")
+
+		Eventually(func() bool {
+			eppDeployment := &appsv1.Deployment{}
+			if err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+				Namespace: mriObj.Namespace,
+				Name:      eppDeploymentName,
+			}, eppDeployment); err != nil {
+				GinkgoWriter.Printf("Failed to get EPP deployment: %v\n", err)
+				return false
+			}
+			selector, err := metav1.LabelSelectorAsSelector(eppDeployment.Spec.Selector)
+			if err != nil {
+				GinkgoWriter.Printf("Failed to parse EPP deployment selector: %v\n", err)
+				return false
+			}
+			pods, err := coreClient.CoreV1().Pods(mriObj.Namespace).List(ctx, metav1.ListOptions{
+				LabelSelector: selector.String(),
+			})
+			if err != nil || len(pods.Items) == 0 {
+				return false
+			}
+			// Select a Running+Ready pod
+			var eppPod *corev1.Pod
+			for i := range pods.Items {
+				p := &pods.Items[i]
+				if p.Status.Phase != corev1.PodRunning {
+					continue
+				}
+				for _, cond := range p.Status.Conditions {
+					if cond.Type == corev1.PodReady && cond.Status == corev1.ConditionTrue {
+						eppPod = p
+						break
+					}
+				}
+				if eppPod != nil {
+					break
+				}
+			}
+			if eppPod == nil {
+				GinkgoWriter.Printf("No Running+Ready EPP pod found\n")
+				return false
+			}
+			// Derive container name, skipping istio-proxy sidecar
+			containerName := ""
+			for _, c := range eppPod.Spec.Containers {
+				if c.Name != "istio-proxy" {
+					containerName = c.Name
+					break
+				}
+			}
+			tailLines := int64(2000)
+			logOpts := &corev1.PodLogOptions{
+				TailLines: &tailLines,
+			}
+			if containerName != "" {
+				logOpts.Container = containerName
+			}
+			req := coreClient.CoreV1().Pods(mriObj.Namespace).GetLogs(eppPod.Name, logOpts)
+			stream, err := req.Stream(ctx)
+			if err != nil {
+				GinkgoWriter.Printf("Failed to get EPP pod logs: %v\n", err)
+				return false
+			}
+			defer stream.Close()
+			buf := new(strings.Builder)
+			if _, err = io.Copy(buf, stream); err != nil {
+				return false
+			}
+			logs := buf.String()
+			if strings.Contains(logs, "kv-cache-utilization-scorer") {
+				GinkgoWriter.Printf("EPP pod %s has kv-cache-utilization-scorer in logs\n", eppPod.Name)
+				return true
+			}
+			GinkgoWriter.Printf("EPP pod %s logs do not contain kv-cache-utilization-scorer yet\n", eppPod.Name)
+			return false
+		}, 5*time.Minute, utils.PollInterval).Should(BeTrue(),
+			"EPP pod should have kv-cache-utilization-scorer in logs")
 	})
 }
 

--- a/website/docs/gateway-api-inference-extension.md
+++ b/website/docs/gateway-api-inference-extension.md
@@ -1,5 +1,6 @@
 ---
-title: Gateway API Inference Extension
+title: Gateway API Inference Extension with llm-d Router
+description: How to enable Gateway API Inference Extension in KAITO using InferenceSet, Flux, and the llm-d Router gateway chart.
 ---
 
 KAITO integrates with [Gateway API Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/) (GWIE) and the [llm-d Router](https://github.com/llm-d/llm-d-router) EPP to provide model-aware routing and optimal endpoint selection for inference. This page covers what it is, prerequisites, how to enable it in KAITO, how it's wired, and a quickstart.
@@ -134,7 +135,7 @@ phi-4-mini-inferencepool   69s
 Verify that the Endpoint Picker (EPP) Pod is running in the InferenceSet namespace:
 
 ```bash
-kubectl get pod -l inferencepool=phi-4-mini-inferencepool-epp
+kubectl get pod -l app.kubernetes.io/name=phi-4-mini-inferencepool-epp
 
 NAME                                           READY   STATUS    RESTARTS   AGE
 phi-4-mini-inferencepool-epp-b74f8994b-s9kkt   1/1     Running   0          87s
@@ -143,13 +144,13 @@ phi-4-mini-inferencepool-epp-b74f8994b-s9kkt   1/1     Running   0          87s
 Confirm the EPP is using the llm-d Router EPP image:
 
 ```bash
-kubectl get pod -l inferencepool=phi-4-mini-inferencepool-epp -o jsonpath='{.items[0].spec.containers[0].image}'
+kubectl get pod -l app.kubernetes.io/name=phi-4-mini-inferencepool-epp -o jsonpath='{.items[0].spec.containers[0].image}'
 # Expected: mcr.microsoft.com/oss/v2/llm-d/llm-d-router-endpoint-picker:v0.9.0
 ```
 
 ### 3. Deploy DestinationRule and HTTPRoute
 
-Apply an Istio DestinationRule for the EPP service. Starting with the llm-d-router-gateway chart v0.9.0, the KAITO-managed EPP (`llm-d-router-endpoint-picker:v0.9.0`) listens on **plaintext** gRPC by default, so the DestinationRule sets `tls.mode: DISABLE` for the Istio Gateway → EPP ext_proc connection:
+Apply an Istio DestinationRule for the EPP service. In KAITO, the EPP is explicitly configured to listen on **plaintext** gRPC (`router.epp.flags.secure-serving=false`), so the DestinationRule sets `tls.mode: DISABLE` for the Istio Gateway → EPP ext_proc connection:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/gateway-api-inference-extension/destinationrule-phi-4-mini-instruct.yaml

--- a/website/docs/gateway-api-inference-extension.md
+++ b/website/docs/gateway-api-inference-extension.md
@@ -2,14 +2,14 @@
 title: Gateway API Inference Extension
 ---
 
-KAITO integrates with [Gateway API Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/) (GWIE) and [llm-d](https://github.com/llm-d/llm-d-inference-scheduler) to provide model-aware routing and optimal endpoint selection for inference. This page covers what it is, prerequisites, how to enable it in KAITO, how it's wired, and a quickstart.
+KAITO integrates with [Gateway API Inference Extension](https://gateway-api-inference-extension.sigs.k8s.io/) (GWIE) and the [llm-d Router](https://github.com/llm-d/llm-d-router) EPP to provide model-aware routing and optimal endpoint selection for inference. This page covers what it is, prerequisites, how to enable it in KAITO, how it's wired, and a quickstart.
 
 ## What is it
 
 Gateway API Inference Extension extends [Gateway API](https://gateway-api.sigs.k8s.io/) with inference-focused backends and behaviors. It adds:
 
 - [InferencePool](https://gateway-api-inference-extension.sigs.k8s.io/api-types/inferencepool/) CRD to represent model-serving backends
-- A reference Endpoint Picker Plugin (EPP) that uses inference server metrics and policies to pick the best backend. In KAITO, the EPP image is overridden to use the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler), which builds on the GWIE EPP with advanced scheduling plugins including KV cache-aware routing, prefill/decode (P/D) disaggregation, and pluggable filters/scorers.
+- A reference Endpoint Picker Plugin (EPP) that uses inference server metrics and policies to pick the best backend. In KAITO, the EPP is provided by the [llm-d Router](https://github.com/llm-d/llm-d-router) project, which builds on the GWIE EPP with advanced scheduling plugins including KV cache-aware routing, prefill/decode (P/D) disaggregation, and pluggable filters/scorers.
 - Optional [Body-Based Routing](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/pkg/bbr) (BBR) that extracts model names from OpenAI-style requests and injects a header for routing purposes
 
 KAITO uses GWIE to route requests for models to the right Workspace pods, improving latency and GPU utilization.
@@ -61,15 +61,15 @@ helm upgrade --install kaito-workspace kaito/workspace \
 
 ## How KAITO wires it
 
-When the feature gate is enabled, [Flux](https://fluxcd.io/) will be installed in the same namespace as the InferenceSet controller as a Helm dependency. It is used to deploy and manage the GWIE InferencePool Helm chart for each InferenceSet.
+When the feature gate is enabled, [Flux](https://fluxcd.io/) will be installed in the same namespace as the InferenceSet controller as a Helm dependency. It is used to deploy and manage the [llm-d-router-gateway](https://github.com/llm-d/llm-d-router) Helm chart (which packages the InferencePool + EPP together) for each InferenceSet.
 
 When you create an InferenceSet, the KAITO InferenceSet controller will:
 
 1) Create or update two Flux resources in the InferenceSet namespace:
-   - [OCIRepository](https://fluxcd.io/flux/components/source/ocirepositories/): points to the upstream GWIE inferencepool Helm chart
-     - URL: oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool
-     - Tag/Version: https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/latest
-   - [HelmRelease](https://fluxcd.io/flux/components/helm/helmreleases/): references the OCIRepository and applies values to deploy the InferencePool and EPP. The EPP image is overridden to use the [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler) (`mcr.microsoft.com/oss/v2/llm-d/llm-d-inference-scheduler:v0.7.1`) instead of the default GWIE EPP. This tag is pinned by KAITO and may be updated or made configurable in future releases.
+   - [OCIRepository](https://fluxcd.io/flux/components/source/ocirepositories/): points to the llm-d-router-gateway Helm chart
+     - URL: `oci://ghcr.io/llm-d/charts/llm-d-router-gateway`
+     - Version: `v0.9.0` (pinned by KAITO; may be updated or made configurable in future releases)
+   - [HelmRelease](https://fluxcd.io/flux/components/helm/helmreleases/): references the OCIRepository and applies values to deploy the InferencePool and EPP. The EPP image is pinned to [`mcr.microsoft.com/oss/v2/llm-d/llm-d-router-endpoint-picker:v0.9.0`](https://github.com/llm-d/llm-d-router) to match the chart version.
 2) Wait for Flux resources to become Ready
 
 You can inspect these resources with kubectl in the InferenceSet namespace. Updates to the InferenceSet will reconcile these resources.
@@ -116,10 +116,10 @@ Once the InferenceSet is created, verify that Flux's OCIRepository and HelmRelea
 ```bash
 kubectl get ocirepository,helmrelease
 
-NAME                                                              URL                                                                          READY   STATUS                                                                                                        AGE
-ocirepository.source.toolkit.fluxcd.io/phi-4-mini-inferencepool   oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool   True    stored artifact for digest 'v1.0.1@sha256:301b913dbff1d75017db0962b621e6780777dcb658475df60d1c6b5b84ee1635'   33s
+NAME                                                              URL                                                            READY   STATUS                                                                                                        AGE
+ocirepository.source.toolkit.fluxcd.io/phi-4-mini-inferencepool   oci://ghcr.io/llm-d/charts/llm-d-router-gateway                True    stored artifact for digest 'v0.9.0@sha256:...'                                                                33s
 
-helmrelease.helm.toolkit.fluxcd.io/phi-4-mini-inferencepool   32s   True    Helm install succeeded for release default/phi-4-mini-inferencepool.v1 with chart inferencepool@1.0.1+301b913dbff1
+helmrelease.helm.toolkit.fluxcd.io/phi-4-mini-inferencepool   32s   True    Helm install succeeded for release default/phi-4-mini-inferencepool.v1 with chart llm-d-router-gateway@0.9.0
 ```
 
 Verify that the InferencePool resource is created:
@@ -140,16 +140,16 @@ NAME                                           READY   STATUS    RESTARTS   AGE
 phi-4-mini-inferencepool-epp-b74f8994b-s9kkt   1/1     Running   0          87s
 ```
 
-Confirm the EPP is using the llm-d inference scheduler image:
+Confirm the EPP is using the llm-d Router EPP image:
 
 ```bash
 kubectl get pod -l inferencepool=phi-4-mini-inferencepool-epp -o jsonpath='{.items[0].spec.containers[0].image}'
-# Expected: mcr.microsoft.com/oss/v2/llm-d/llm-d-inference-scheduler:v0.7.1
+# Expected: mcr.microsoft.com/oss/v2/llm-d/llm-d-router-endpoint-picker:v0.9.0
 ```
 
 ### 3. Deploy DestinationRule and HTTPRoute
 
-Apply an Istio DestinationRule. Since EPP runs with `--secure-serving=true` by default using a self-signed certificate, and Istio doesn't trust self-signed certificates, this DestinationRule bypasses TLS verification as a temporary workaround:
+Apply an Istio DestinationRule for the EPP service. Starting with the llm-d-router-gateway chart v0.9.0, the KAITO-managed EPP (`llm-d-router-endpoint-picker:v0.9.0`) listens on **plaintext** gRPC by default, so the DestinationRule sets `tls.mode: DISABLE` for the Istio Gateway → EPP ext_proc connection:
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/gateway-api-inference-extension/destinationrule-phi-4-mini-instruct.yaml


### PR DESCRIPTION
## What type of PR is this?
/kind feature

## What this PR does / why we need it

Migrates the InferencePool Helm chart dependency from the Gateway API Inference Extension (GWIE) `inferencepool` chart to the `llm-d-router-gateway` chart at **v0.9.0**, and enables KV cache-aware routing in the default EPP EndpointPickerConfig.

### Why migrate?

1. **Bool flags rendering bug** — The GWIE chart (v1.3.1) renders boolean flags as two separate args (`--key` `"value"`), which breaks Go pflag parsing (see [llm-d/llm-d-router#924](https://github.com/llm-d/llm-d-router/issues/924), [kubernetes-sigs/gateway-api-inference-extension#2871](https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2871)). The llm-d-router chart already has this fix.
2. **Better alignment** — KAITO already uses the llm-d EPP image; using the llm-d chart directly removes the need for image override hacks and ensures chart+image version consistency.
3. **Advanced features** — The llm-d-router chart supports proxy mode, tokenizer sidecar, latency predictor, and other features that KAITO can leverage in future PRs.

### KV cache-aware routing

With [#1890](https://github.com/kaito-project/kaito/pull/1890) enabling KV cache events on vLLM pods by default, this PR adds the `kv-cache-utilization-scorer` plugin to the default P/D EndpointPickerConfig. The scorer reads each endpoint's KV cache utilization from vLLM metrics (`/metrics`) and computes `score = 1 - kvCacheUsagePercent`, spreading traffic away from pods with high KV cache pressure.

- Plugin wired into both **prefill** and **decode** scheduling profiles with **weight 5** (half of `load-aware-scorer`'s weight 10)
- Queue depth (`load-aware-scorer`) remains the primary routing signal; KV cache pressure acts as a secondary signal
- No additional sidecar or ZMQ subscription is required — the scorer consumes the same metrics endpoint EPP already scrapes

### Why `kv-cache-utilization-scorer` and not `prefix-cache-scorer` with `precise-prefix-cache-producer`?

The llm-d Router provides two levels of prefix-cache-aware routing:

| | Approximate (current) | Precise (future) |
|---|---|---|
| **Producer** | `approx-prefix-cache-producer` | `precise-prefix-cache-producer` + `token-producer` |
| **How it works** | EPP approximates tokens using character-to-token ratios, maintains an in-memory LRU index of prefix hashes | Subscribes to vLLM KV cache events via ZMQ, maintains a globally consistent index of exact token blocks per pod |
| **Accuracy** | Heuristic (character-based) | 100% (token-based) |
| **Dependencies** | None beyond EPP | Tokenizer sidecar (vLLM render endpoint), ZMQ connectivity to each vLLM pod, KV-Cache Indexer |
| **Resource overhead** | Negligible | ~500m CPU / 1Gi memory per MRI (for tokenizer sidecar) |

**This PR stays with the approximate approach** because:

1. **No tokenizer sidecar** — The `precise-prefix-cache-producer` requires a `token-producer` plugin that sends prompts to vLLM's `/v1/completions/render` endpoint (typically a `vllm launch render` sidecar in the EPP pod). KAITO does not currently deploy this sidecar, and adding one would cost ~500m CPU / 1Gi memory per MRI with no benefit for the approximate pipeline.

2. **KV-Cache Indexer not configured** — While [#1890](https://github.com/kaito-project/kaito/pull/1890) enables the ZMQ publisher on vLLM pods (port 5557), the EPP side's KV-Cache Indexer is not yet configured to subscribe to these events. The `precise-prefix-cache-producer` depends on this indexer to maintain the global block-to-pod mapping.

3. **`kv-cache-utilization-scorer` is complementary, not overlapping** — It reads the `kvCacheUsagePercent` metric from vLLM's `/metrics` endpoint (which EPP already scrapes for `load-aware-scorer`), requiring zero additional infrastructure. It provides a different signal: **how full is each pod's KV cache** (distribution/load-balancing), vs. **how much of this specific request's prefix is cached on each pod** (affinity). Both are valuable.

4. **The approximate producer is already in the config** — `approx-prefix-cache-producer` + `prefix-based-pd-decider` handles prefix-aware P/D routing without any external dependencies. Adding a `prefix-cache-scorer` on top would partially overlap with the decider's routing decisions in the P/D context.

### Next steps: Upgrade to precise prefix-cache routing (follow-up PRs)

Upgrading from the current approximate approach to precise prefix-cache routing will bring significant improvements, especially under high load and in P/D disaggregation scenarios:

#### What precise routing improves

| Aspect | Approximate (current) | Precise (future) |
|---|---|---|
| **Cache state awareness** | EPP **guesses** — "I sent prefix X to pod-2 last time, so pod-2 should still have it" | EPP **knows** — vLLM sends real-time `BlockStored` / `BlockRemoved` / `AllBlocksCleared` events via ZMQ, EPP maintains a globally consistent index |
| **Eviction handling** | ❌ EPP's LRU assumption breaks when pods evict blocks under memory pressure → stale routing → unnecessary prefill recomputation | ✅ EPP receives `BlockRemoved` events immediately → never routes to a pod that already evicted the prefix |
| **Tokenization accuracy** | Character-to-token ratio approximation, hash block boundaries may not align with real tokens → cache miss even when cache exists | Exact Token IDs from vLLM render endpoint → if cache is there, it will hit |
| **P/D transfer optimization** | Coarse-grained prefill/decode split only | Precise knowledge of which blocks are on which pod → optimal KV transfer decisions between prefill and decode pods |
| **Cache hit rate** | Good for homogeneous workloads with low eviction | Significantly higher under high load, heterogeneous prompts, or frequent cache eviction |

#### Concrete example

A user sends multiple prompts sharing a long system prompt (e.g., 4K tokens of instructions):

- **Approximate**: EPP hashes the system prompt characters → routes to pod-3 (where it sent a similar prefix before). But pod-3 evicted those blocks 30 seconds ago due to memory pressure. Result: **full prefill recomputation** (~2s latency penalty).
- **Precise**: EPP's KV-Cache Indexer received `BlockRemoved` from pod-3, knows pod-1 still has 90% of the blocks cached. Routes to pod-1. Result: **cache hit, near-zero prefill latency**.

#### Implementation roadmap

| Phase | PR | What | Prerequisite |
|---|---|---|---|
| **Phase 1** | Tokenizer sidecar | Add optional `vllm launch render` sidecar to EPP deployment, gated by feature flag or MRI spec field. Enables `token-producer` plugin for exact tokenization. | llm-d-router chart supports sidecar containers |
| **Phase 2** | KV-Cache Indexer | Configure EPP to subscribe to vLLM KV cache events on ZMQ port 5557 (already exposed by [#1890](https://github.com/kaito-project/kaito/pull/1890)). Maintains real-time block→pod mapping. | Phase 1 (token-producer needed for block hash computation) |
| **Phase 3** | Precise prefix-cache routing | Add `precise-prefix-cache-producer` + update `prefix-cache-scorer` with `prefixMatchInfoProducerName: precise-prefix-cache-producer`. Achieves 100% accurate prefix-cache-aware routing. | Phase 1 + Phase 2 |
| **Phase 4** | Speculative indexing | Enable `precise-prefix-cache-producer`'s speculative indexing to proactively update the index after routing decisions, closing the gap between routing and KV event arrival. | Phase 3 |

#### Trade-offs

- **Cost**: Tokenizer sidecar adds ~500m CPU / 1Gi memory per MRI; ZMQ connections add minor network overhead
- **Complexity**: More moving parts (sidecar lifecycle, ZMQ connectivity, indexer consistency)
- **When to upgrade**: Production deployments with high QPS, shared long prefixes (RAG, multi-turn chat), or latency-sensitive workloads where prefill recomputation is the bottleneck

### Changes

| Component | Before | After |
|-----------|--------|-------|
| Chart URL | `oci://registry.k8s.io/gateway-api-inference-extension/charts/inferencepool` | `oci://ghcr.io/llm-d/charts/llm-d-router-gateway` |
| Chart version | `v1.3.1` | `v0.9.0` |
| EPP image | `mcr.microsoft.com/oss/v2/llm-d/llm-d-inference-scheduler:v0.8.0` | `mcr.microsoft.com/oss/v2/llm-d/llm-d-router-endpoint-picker:v0.9.1` |
| Values schema | `inferenceExtension.image.{hub,name}` | `router.epp.image.{registry,repository}` |
| Values schema | `inferencePool.{targetPorts,modelServers}` | `router.modelServers.{targetPorts,matchLabels}` |
| EPP config | `load-aware-scorer` only | `load-aware-scorer` + `kv-cache-utilization-scorer` |

### Files changed

| File | Change |
|------|--------|
| `pkg/utils/consts/consts.go` | Update chart URL, version (v0.9.0), and EPP image constants |
| `pkg/workspace/manifests/manifests.go` | Update Helm values to match llm-d-router schema |
| `pkg/controllers/multiroleinference/controller.go` | Update schema + add `kv-cache-utilization-scorer` to default EndpointPickerConfig |
| `pkg/workspace/manifests/manifests_test.go` | Update expected values in tests |
| `test/e2e/preset_vllm_test.go` | Add e2e validation for `kv-cache-utilization-scorer` in EPP ConfigMap and pod logs |

## Which issue(s) this PR fixes
Resolves https://github.com/llm-d/llm-d-router/issues/924 (for KAITO users)

## Related PRs
- https://github.com/kaito-project/kaito/pull/1890 (enable KV cache events on vLLM pods by default)
- https://github.com/kubernetes-sigs/gateway-api-inference-extension/pull/2871 (upstream bool flag fix)
- https://github.com/llm-d/llm-d-inference-payload-processor/pull/17 (llm-d port of the fix)