### PR TITLE
[WIP] fix: relax httpx pin to avoid pip resolver downgrading huggingface-hub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,12 +164,12 @@ tuning-metrics-server-test: ## Run Tuning Metrics Server tests with pytest.
 
 .PHONY: inference-api-e2e
 inference-api-e2e: ## Run inference API e2e tests with pytest.
-	pip install -r ./presets/workspace/dependencies/requirements-test.txt --upgrade
+	pip install --no-cache-dir -r ./presets/workspace/dependencies/requirements-test.txt --upgrade
 	pip install pytest-cov
 	pytest --cov -o log_cli=true -o log_cli_level=INFO presets/workspace/inference/vllm
 	pytest --cov -o log_cli=true -o log_cli_level=INFO presets/workspace/inference/text-generation
 
-	pip install -r ./presets/workspace/generator/requirements.txt --upgrade
+	pip install --no-cache-dir -r ./presets/workspace/generator/requirements.txt --upgrade
 	pytest --cov -o log_cli=true -o log_cli_level=INFO presets/workspace/generator/
 
 # Ginkgo configurations

--- a/presets/workspace/dependencies/requirements-test.txt
+++ b/presets/workspace/dependencies/requirements-test.txt
@@ -3,5 +3,5 @@
 
 # Test dependencies
 pytest==8.3.4
-httpx==0.27.0
+httpx>=0.27.0,<1.0
 requests==2.32.4


### PR DESCRIPTION
## What type of PR is this?
/kind bug

## What this PR does / why we need it

Fixes CI `unit-tests` job failure where all Python inference-api tests fail with:

```
ImportError: huggingface-hub>=1.5.0,<2.0 is required for a normal functioning
of this module, but found huggingface-hub==0.36.2.
```

### Root cause

The strict `httpx==0.27.0` pin in `requirements-test.txt` causes pip's dependency resolver (when used with `--upgrade`) to incorrectly downgrade `huggingface-hub` from `1.11.0` to `0.36.2` on self-hosted runners with pre-installed packages.

The resolution sequence:
1. pip collects `huggingface-hub==1.11.0` (correct)
2. `httpx==0.27.0` forces downgrade from pre-installed `httpx==0.28.1`
3. pip's backtracking resolver gets confused and installs `huggingface-hub==0.36.2`
4. `transformers==5.6.0` requires `huggingface-hub>=1.5.0,<2.0` → ImportError

### Fix

Relax `httpx==0.27.0` to `httpx>=0.27.0,<1.0`, which is compatible with:
- `huggingface-hub==1.11.0` (requires `httpx<1,>=0.23.0`)
- The test suite (needs httpx for async HTTP testing)

This avoids the forced downgrade that triggers pip's resolver bug.

## Which issue(s) this PR fixes
Fixes CI flake affecting all PRs on main.
