### PR TITLE
feat: derive NodeClass RBAC from karpenterProvider config

### DIFF
--- a/charts/kaito/workspace/templates/clusterrole.yaml
+++ b/charts/kaito/workspace/templates/clusterrole.yaml
@@ -51,15 +51,16 @@ rules:
   - apiGroups: ["karpenter.sh"]
     resources: ["nodepools", "nodepools/status"]
     verbs: ["get","list","watch","create", "delete", "update", "patch"]
-  {{- if eq .Values.cloudProviderName "azure" }}
-  - apiGroups: [ "karpenter.azure.com" ]
-    resources: [ "aksnodeclasses"]
-    verbs: [ "get","list","watch","create", "delete", "update", "patch" ]
-  {{- else if eq .Values.cloudProviderName "aws" }}
-  - apiGroups: [ "karpenter.k8s.aws" ]
-    resources: [ "ec2nodeclasses"]
-    verbs: [ "get","list","watch","create", "delete", "update", "patch" ]
+  {{- $provider := index .Values.karpenterProviders .Values.karpenterProvider }}
+  {{- if not $provider }}
+  {{- fail (printf "karpenterProviders.%s is not defined in values.yaml" .Values.karpenterProvider) }}
   {{- end }}
+  {{- if or (not $provider.group) (not $provider.resourceName) }}
+  {{- fail (printf "karpenterProviders.%s must define both 'group' and 'resourceName'" .Values.karpenterProvider) }}
+  {{- end }}
+  - apiGroups: [ "{{ $provider.group }}" ]
+    resources: [ "{{ $provider.resourceName }}" ]
+    verbs: [ "get","list","watch","create", "delete", "update", "patch" ]
   {{- end }}
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Replace hardcoded azure/aws cloudProviderName branches with the selected karpenterProviders entry's group and resourceName, mirroring the nodeclass-configmap template. Add value validation that fails rendering with a clear message when the provider or its group/resourceName is missing.

Btw: I will add a MockNodeClass in producation-stack for co-existence with azure karpenter.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: