### PR TITLE
docs: add prefill/decode disaggregation guide for GWIE + MultiRoleInference

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The details of the service APIs can be found in this [document](https://kaito-pr
 - **CPU models**: Please check this [doc](https://kaito-project.github.io/kaito/docs/aikit) for running CPU models using [aikit](https://github.com/kaito-project/aikit/).
 - **RAGEngine**: Please check the installation guidance and usage documents [here](https://kaito-project.github.io/kaito/docs/rag).
 - **RAGEngine Output Guardrails**: Please check the current behavior, configuration, and limitations [here](https://kaito-project.github.io/kaito/docs/rag-output-guardrails).
+- **Prefill/Decode Disaggregation**: Please check this [doc](https://kaito-project.github.io/kaito/docs/prefill-decode-disaggregation) for deploying models with P/D disaggregation using MultiRoleInference and Gateway API Inference Extension.
 
 
 ## Contributing

--- a/website/docs/prefill-decode-disaggregation.md
+++ b/website/docs/prefill-decode-disaggregation.md
@@ -1,0 +1,217 @@
+---
+title: Prefill/Decode Disaggregation
+---
+
+# Prefill/Decode (P/D) Disaggregation
+
+Prefill/Decode disaggregation separates the two phases of LLM inference into independently scalable pod groups, improving throughput and GPU utilization for large models.
+
+## Overview
+
+In standard LLM inference, a single pod handles both phases:
+
+- **Prefill** — the compute-intensive phase where all input tokens are processed in parallel to build the KV cache
+- **Decode** — the memory-bandwidth-intensive phase where tokens are generated autoregressively one at a time
+
+With P/D disaggregation via **MultiRoleInference (MRI)**, KAITO creates separate workloads for each role, allowing you to:
+
+- **Scale independently** — adjust prefill and decode replicas based on workload patterns
+- **Optimize GPU selection** — use compute-optimized instances for prefill and memory-bandwidth-optimized instances for decode
+- **Improve throughput** — prefill pods process new prompts while decode pods generate tokens for previous requests
+- **Transfer KV cache transparently** — NIXL handles direct pod-to-pod KV cache movement without gateway involvement
+
+## Prerequisites
+
+- **KAITO v0.11.0+** with the `enableMultiRoleInferenceController` feature gate enabled
+- **Istio** installed as the Gateway API provider
+- **Gateway API CRDs** v1.4.1+
+- A GPU node pool with sufficient capacity for both prefill and decode pods
+
+### Enable the Feature Gate
+
+```bash
+helm upgrade --install kaito-workspace kaito/workspace \
+  --namespace kaito-workspace \
+  --set featureGates.enableMultiRoleInferenceController=true
+```
+
+## Architecture
+
+### How MRI Works
+
+When you create a MultiRoleInference resource, KAITO will:
+
+1. Provision separate pod groups for each role (prefill and decode) via child InferenceSets
+2. **Inject a routing sidecar** into decode pods — the [`llm-d-routing-sidecar`](https://github.com/llm-d/llm-d-router) container is automatically injected, listening on port 5000 and proxying to vLLM on port 5001
+3. **Set `VLLM_NIXL_SIDE_CHANNEL_HOST`** to the Pod IP on both prefill and decode pods, enabling cross-pod KV cache transfer via vLLM's NIXL connector
+4. Create a single InferencePool with an EPP (Endpoint Picker) deployment that uses llm-d scheduling plugins for P/D-aware routing
+5. The EPP uses scheduling profiles (`prefill` and `decode`) with a `prefix-based-pd-decider` plugin to decide which role handles each request
+
+### Port Architecture
+
+| Component | Prefill Pod | Decode Pod |
+|-----------|-------------|------------|
+| vLLM | port 5000 (default) | port 5001 (moved) |
+| Routing sidecar | — | port 5000 |
+| InferencePool targetPort | 5000 (vLLM directly) | 5000 (via sidecar → vLLM:5001) |
+
+### Request Flow
+
+1. The Gateway routes the request to the llm-d EPP scheduler
+2. The EPP's `prefix-based-pd-decider` plugin determines whether to route to prefill or decode based on the request's prefix cache status
+3. For a new prompt: the request goes to a **prefill pod** (port 5000, vLLM directly), which processes all input tokens in parallel and builds the KV cache
+4. The **decode pod's routing sidecar** (port 5000) receives the decode request and forwards it to vLLM (port 5001). The decode pod uses NIXL (`VLLM_NIXL_SIDE_CHANNEL_HOST`) to transfer the KV cache directly from the prefill pod
+5. The decode pod performs autoregressive token generation using the transferred KV cache
+6. The response streams back through the Gateway to the client
+
+## Quickstart
+
+### 1. Install Istio and Deploy Gateway
+
+Install Istio with Gateway API Inference Extension support:
+
+```bash
+helm install istio-base istio/base -n istio-system --create-namespace --wait
+helm install istiod istio/istiod -n istio-system --wait \
+  --set pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION_DATAPLANE_SUPPORT=true \
+  --set pilot.env.PILOT_ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true
+```
+
+Install Gateway API CRDs and deploy the Gateway:
+
+```bash
+kubectl apply -k "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.4.1"
+kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/gateway-api-inference-extension/gateway.yaml
+```
+
+### 2. Deploy MultiRoleInference
+
+Create a MultiRoleInference resource with prefill/decode roles:
+
+```bash
+kubectl apply -f - <<EOF
+apiVersion: kaito.sh/v1alpha1
+kind: MultiRoleInference
+metadata:
+  name: phi-4-mini
+  namespace: kaito-workspace
+spec:
+  labelSelector:
+    matchLabels:
+      apps: phi-4-mini
+  model:
+    name: phi-4-mini-instruct
+  roles:
+  - type: prefill
+    replicas: 1
+    instanceType: Standard_NC24ads_A100_v4
+  - type: decode
+    replicas: 1
+    instanceType: Standard_NC24ads_A100_v4
+EOF
+```
+
+### 3. Verify Resources
+
+Verify that both prefill and decode pods are running:
+
+```bash
+kubectl get pods -l multiroleinference.kaito.sh/created-by=phi-4-mini -n kaito-workspace
+```
+
+Expected output:
+
+```
+NAME                              READY   STATUS    RESTARTS   AGE
+phi-4-mini-decode-25x54-0         2/2     Running   0          10h
+phi-4-mini-prefill-qkrzk-0        1/1     Running   0          10h
+```
+
+> **Note:** Decode pods show `2/2` because they have both the vLLM container and the automatically injected `llm-d-routing-sidecar` container. Prefill pods show `1/1` with only the vLLM container.
+
+Verify the InferencePool and EPP:
+
+```bash
+kubectl get inferencepool -n kaito-workspace
+kubectl get pods -l inferencepool=phi-4-mini-inferencepool-epp -n kaito-workspace
+```
+
+### 4. Deploy DestinationRule and HTTPRoute
+
+Since EPP runs with `--secure-serving=true` using a self-signed certificate, apply a DestinationRule to bypass TLS verification:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/gateway-api-inference-extension/destinationrule-phi-4-mini.yaml
+```
+
+Create the HTTPRoute that targets the InferencePool:
+
+```bash
+kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/gateway-api-inference-extension/httproute.yaml
+```
+
+### 5. Test Inference
+
+Get the Gateway IP:
+
+```bash
+export GATEWAY_IP=$(kubectl get gateway inference-gateway -o jsonpath='{.status.addresses[0].value}')
+```
+
+Send a request:
+
+```bash
+curl -s "http://${GATEWAY_IP}:8080/v1/chat/completions" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "phi-4-mini-instruct",
+    "messages": [{"role": "user", "content": "Explain prefill/decode disaggregation in LLM inference"}],
+    "max_tokens": 100,
+    "temperature": 0
+  }' | jq .
+```
+
+With P/D disaggregation active, the prefill pod processes the input tokens and builds the KV cache, then the decode pod receives the KV cache via NIXL and generates the output tokens.
+
+### 6. Validate P/D Disaggregation
+
+To confirm that disaggregation is working, check the EPP logs for the `disagg-profile-handler` scheduling profile:
+
+```bash
+kubectl logs -l inferencepool=phi-4-mini-inferencepool-epp -n kaito-workspace | grep "disagg-profile-handler"
+```
+
+Check prefill pod logs for prompt throughput:
+
+```bash
+kubectl logs phi-4-mini-prefill-<id>-0 -n kaito-workspace | grep "Avg prompt throughput"
+```
+
+Check decode pod logs for KV cache transfer metrics:
+
+```bash
+kubectl logs phi-4-mini-decode-<id>-0 -c <container> -n kaito-workspace | grep "Num successful transfers"
+```
+
+## Scaling Recommendations
+
+| Workload Pattern | Prefill Replicas | Decode Replicas | Notes |
+|-----------------|-----------------|-----------------|-------|
+| Long prompts, short responses | More prefill | Fewer decode | Prefill is the bottleneck |
+| Short prompts, long responses | Fewer prefill | More decode | Decode is the bottleneck |
+| Balanced | Equal | Equal | Good starting point |
+| High concurrency | Scale both | Scale both | Monitor EPP routing metrics |
+
+## Limitations
+
+- **Alpha feature** — API may change in future releases
+- Requires Istio as the Gateway API provider
+- KV cache transfer via NIXL requires GPU-to-GPU connectivity between prefill and decode pods
+- Currently supports vLLM runtime only
+
+## Related Resources
+
+- [Gateway API Inference Extension](./gateway-api-inference-extension.md) — Full GWIE documentation including InferenceSet
+- [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler) — The EPP scheduling plugins used for P/D routing
+- [NIXL](https://github.com/ai-dynamo/nixl) — The KV cache transfer library
+- [llm-d routing sidecar](https://github.com/llm-d/llm-d-router) — The sidecar injected into decode pods

--- a/website/docs/prefill-decode-disaggregation.md
+++ b/website/docs/prefill-decode-disaggregation.md
@@ -30,6 +30,8 @@ With P/D disaggregation via **MultiRoleInference (MRI)**, KAITO creates separate
 ```bash
 helm repo add kaito https://kaito-project.github.io/kaito/charts/kaito
 helm repo update
+
+export CLUSTER_NAME="<your-aks-cluster-name>"
 helm upgrade --install kaito-workspace kaito/workspace \
   --namespace kaito-workspace \
   --create-namespace \

--- a/website/docs/prefill-decode-disaggregation.md
+++ b/website/docs/prefill-decode-disaggregation.md
@@ -2,8 +2,6 @@
 title: Prefill/Decode Disaggregation
 ---
 
-# Prefill/Decode (P/D) Disaggregation
-
 Prefill/Decode disaggregation separates the two phases of LLM inference into independently scalable pod groups, improving throughput and GPU utilization for large models.
 
 ## Overview

--- a/website/docs/prefill-decode-disaggregation.md
+++ b/website/docs/prefill-decode-disaggregation.md
@@ -31,7 +31,7 @@ With P/D disaggregation via **MultiRoleInference (MRI)**, KAITO creates separate
 helm repo add kaito https://kaito-project.github.io/kaito/charts/kaito
 helm repo update
 
-export CLUSTER_NAME="<your-aks-cluster-name>"
+export CLUSTER_NAME="<your-cluster-name>"
 helm upgrade --install kaito-workspace kaito/workspace \
   --namespace kaito-workspace \
   --create-namespace \

--- a/website/docs/prefill-decode-disaggregation.md
+++ b/website/docs/prefill-decode-disaggregation.md
@@ -32,6 +32,7 @@ With P/D disaggregation via **MultiRoleInference (MRI)**, KAITO creates separate
 ```bash
 helm upgrade --install kaito-workspace kaito/workspace \
   --namespace kaito-workspace \
+  --create-namespace \
   --set featureGates.enableMultiRoleInferenceController=true
 ```
 
@@ -42,7 +43,7 @@ helm upgrade --install kaito-workspace kaito/workspace \
 When you create a MultiRoleInference resource, KAITO will:
 
 1. Provision separate pod groups for each role (prefill and decode) via child InferenceSets
-2. **Inject a routing sidecar** into decode pods — the [`llm-d-routing-sidecar`](https://github.com/llm-d/llm-d-router) container is automatically injected, listening on port 5000 and proxying to vLLM on port 5001
+2. **Inject a routing sidecar** into decode pods — the [`llm-d-routing-sidecar`](https://github.com/llm-d/llm-d-routing-sidecar) container is automatically injected, listening on port 5000 and proxying to vLLM on port 5001
 3. **Set `VLLM_NIXL_SIDE_CHANNEL_HOST`** to the Pod IP on both prefill and decode pods, enabling cross-pod KV cache transfer via vLLM's NIXL connector
 4. Create a single InferencePool with an EPP (Endpoint Picker) deployment that uses llm-d scheduling plugins for P/D-aware routing
 5. The EPP uses scheduling profiles (`prefill` and `decode`) with a `prefix-based-pd-decider` plugin to decide which role handles each request
@@ -66,22 +67,31 @@ When you create a MultiRoleInference resource, KAITO will:
 
 ## Quickstart
 
+> **Note:** This quickstart deploys all resources in the `kaito-workspace` namespace. Adjust the namespace if your setup differs.
+
 ### 1. Install Istio and Deploy Gateway
 
-Install Istio with Gateway API Inference Extension support:
+Add the Istio Helm repo and install Istio with Gateway API Inference Extension support:
 
 ```bash
-helm install istio-base istio/base -n istio-system --create-namespace --wait
-helm install istiod istio/istiod -n istio-system --wait \
-  --set pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION_DATAPLANE_SUPPORT=true \
-  --set pilot.env.PILOT_ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true
+helm repo add istio https://istio-release.storage.googleapis.com/charts
+helm repo update
+helm upgrade -i istio-base istio/base \
+  --version 1.28.3 \
+  --namespace istio-system \
+  --create-namespace
+helm upgrade -i istiod istio/istiod \
+  --version 1.28.3 \
+  --namespace istio-system \
+  --set pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION="true" \
+  --wait
 ```
 
 Install Gateway API CRDs and deploy the Gateway:
 
 ```bash
 kubectl apply -k "github.com/kubernetes-sigs/gateway-api/config/crd?ref=v1.4.1"
-kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/gateway-api-inference-extension/gateway.yaml
+kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/gateway-api-inference-extension/gateway.yaml -n kaito-workspace
 ```
 
 ### 2. Deploy MultiRoleInference
@@ -141,13 +151,13 @@ kubectl get pods -l inferencepool=phi-4-mini-inferencepool-epp -n kaito-workspac
 Since EPP runs with `--secure-serving=true` using a self-signed certificate, apply a DestinationRule to bypass TLS verification:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/gateway-api-inference-extension/destinationrule-phi-4-mini.yaml
+kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/gateway-api-inference-extension/destinationrule-phi-4-mini-instruct.yaml -n kaito-workspace
 ```
 
 Create the HTTPRoute that targets the InferencePool:
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/gateway-api-inference-extension/httproute.yaml
+kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/gateway-api-inference-extension/httproute.yaml -n kaito-workspace
 ```
 
 ### 5. Test Inference
@@ -155,13 +165,13 @@ kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/head
 Get the Gateway IP:
 
 ```bash
-export GATEWAY_IP=$(kubectl get gateway inference-gateway -o jsonpath='{.status.addresses[0].value}')
+export GATEWAY_IP=$(kubectl get gateway inference-gateway -n kaito-workspace -o jsonpath='{.status.addresses[0].value}')
 ```
 
-Send a request:
+Send a request (the Gateway listens on port 80):
 
 ```bash
-curl -s "http://${GATEWAY_IP}:8080/v1/chat/completions" \
+curl -s "http://${GATEWAY_IP}/v1/chat/completions" \
   -H "Content-Type: application/json" \
   -d '{
     "model": "phi-4-mini-instruct",
@@ -190,7 +200,7 @@ kubectl logs phi-4-mini-prefill-<id>-0 -n kaito-workspace | grep "Avg prompt thr
 Check decode pod logs for KV cache transfer metrics:
 
 ```bash
-kubectl logs phi-4-mini-decode-<id>-0 -c <container> -n kaito-workspace | grep "Num successful transfers"
+kubectl logs phi-4-mini-decode-<id>-0 -n kaito-workspace | grep "Num successful transfers"
 ```
 
 ## Scaling Recommendations
@@ -214,4 +224,4 @@ kubectl logs phi-4-mini-decode-<id>-0 -c <container> -n kaito-workspace | grep "
 - [Gateway API Inference Extension](./gateway-api-inference-extension.md) — Full GWIE documentation including InferenceSet
 - [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler) — The EPP scheduling plugins used for P/D routing
 - [NIXL](https://github.com/ai-dynamo/nixl) — The KV cache transfer library
-- [llm-d routing sidecar](https://github.com/llm-d/llm-d-router) — The sidecar injected into decode pods
+- [llm-d routing sidecar](https://github.com/llm-d/llm-d-routing-sidecar) — The sidecar injected into decode pods

--- a/website/docs/prefill-decode-disaggregation.md
+++ b/website/docs/prefill-decode-disaggregation.md
@@ -65,10 +65,10 @@ When you create a MultiRoleInference resource, KAITO will:
 ### Request Flow
 
 1. The Gateway routes the incoming user request to the llm-d EPP scheduler
-2. The EPP routes user requests to a **decode pod** — the routing sidecar on port 5000 receives the request
-3. The routing sidecar forwards the request to the local vLLM instance (port 5001), which coordinates with the EPP's scheduling plugins to determine if a prefill is needed
-4. If the KV cache is not already available, the decode pod triggers a **prefill pod** to process the input tokens in parallel and build the KV cache. The prefill pod transfers the KV cache directly to the decode pod via NIXL (`VLLM_NIXL_SIDE_CHANNEL_HOST`)
-5. The decode pod performs autoregressive token generation using the transferred KV cache
+2. The EPP's `disagg-profile-handler` and `prefix-based-pd-decider` plugins determine whether the request needs prefill (based on prefix cache status) and communicate the decision via headers (set by `disagg-headers-handler`)
+3. The EPP routes the request to a **decode pod** — the routing sidecar on port 5000 receives the request along with headers indicating the selected prefill pod
+4. The routing sidecar orchestrates the prefill call: it contacts the designated **prefill pod** to process the input tokens and build the KV cache, then the prefill pod transfers the KV cache directly to the decode pod via NIXL (`VLLM_NIXL_SIDE_CHANNEL_HOST`)
+5. Once the KV cache is available, the routing sidecar forwards the request to the local vLLM instance (port 5001) for autoregressive token generation
 6. The response streams back through the Gateway to the client
 
 > **Note:** The InferencePool targets port 5000 on all pods (prefill + decode). The EPP's internal `prefill-filter` / `decode-filter` plugins handle role-based selection, routing user traffic to decode pods while prefill pods are coordinated internally.
@@ -157,6 +157,8 @@ kubectl get pods -l inferencepool=phi-4-mini-inferencepool-epp -n kaito-workspac
 ### 4. Deploy DestinationRule and HTTPRoute
 
 Since EPP runs with `--secure-serving=true` using a self-signed certificate, apply a DestinationRule to bypass TLS verification:
+
+> ⚠️ **Security warning:** This DestinationRule uses `insecureSkipVerify: true`, which disables server identity verification. This is acceptable for **development and testing only**. For production, configure a trusted CA certificate or use cert-manager to provision proper TLS certificates for the EPP service.
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/kaito-project/kaito/refs/heads/main/examples/gateway-api-inference-extension/destinationrule-phi-4-mini-instruct.yaml -n kaito-workspace

--- a/website/docs/prefill-decode-disaggregation.md
+++ b/website/docs/prefill-decode-disaggregation.md
@@ -27,7 +27,7 @@ With P/D disaggregation via **MultiRoleInference (MRI)**, KAITO creates separate
 - **Gateway API CRDs** v1.4.1+
 - A GPU node pool with sufficient capacity for both prefill and decode pods
 
-### Enable the Feature Gates
+### Enable this feature
 
 ```bash
 helm repo add kaito https://kaito-project.github.io/kaito/charts/kaito
@@ -35,8 +35,11 @@ helm repo update
 helm upgrade --install kaito-workspace kaito/workspace \
   --namespace kaito-workspace \
   --create-namespace \
+  --set clusterName="$CLUSTER_NAME" \
   --set featureGates.enableMultiRoleInferenceController=true \
-  --set featureGates.gatewayAPIInferenceExtension=true
+  --set featureGates.gatewayAPIInferenceExtension=true \
+  --wait \
+  --take-ownership
 ```
 
 ## Architecture

--- a/website/docs/prefill-decode-disaggregation.md
+++ b/website/docs/prefill-decode-disaggregation.md
@@ -27,13 +27,16 @@ With P/D disaggregation via **MultiRoleInference (MRI)**, KAITO creates separate
 - **Gateway API CRDs** v1.4.1+
 - A GPU node pool with sufficient capacity for both prefill and decode pods
 
-### Enable the Feature Gate
+### Enable the Feature Gates
 
 ```bash
+helm repo add kaito https://kaito-project.github.io/kaito/charts
+helm repo update
 helm upgrade --install kaito-workspace kaito/workspace \
   --namespace kaito-workspace \
   --create-namespace \
-  --set featureGates.enableMultiRoleInferenceController=true
+  --set featureGates.enableMultiRoleInferenceController=true \
+  --set featureGates.gatewayAPIInferenceExtension=true
 ```
 
 ## Architecture

--- a/website/docs/prefill-decode-disaggregation.md
+++ b/website/docs/prefill-decode-disaggregation.md
@@ -30,7 +30,7 @@ With P/D disaggregation via **MultiRoleInference (MRI)**, KAITO creates separate
 ### Enable the Feature Gates
 
 ```bash
-helm repo add kaito https://kaito-project.github.io/kaito/charts
+helm repo add kaito https://kaito-project.github.io/kaito/charts/kaito
 helm repo update
 helm upgrade --install kaito-workspace kaito/workspace \
   --namespace kaito-workspace \
@@ -61,12 +61,14 @@ When you create a MultiRoleInference resource, KAITO will:
 
 ### Request Flow
 
-1. The Gateway routes the request to the llm-d EPP scheduler
-2. The EPP's `prefix-based-pd-decider` plugin determines whether to route to prefill or decode based on the request's prefix cache status
-3. For a new prompt: the request goes to a **prefill pod** (port 5000, vLLM directly), which processes all input tokens in parallel and builds the KV cache
-4. The **decode pod's routing sidecar** (port 5000) receives the decode request and forwards it to vLLM (port 5001). The decode pod uses NIXL (`VLLM_NIXL_SIDE_CHANNEL_HOST`) to transfer the KV cache directly from the prefill pod
+1. The Gateway routes the incoming user request to the llm-d EPP scheduler
+2. The EPP routes user requests to a **decode pod** — the routing sidecar on port 5000 receives the request
+3. The routing sidecar forwards the request to the local vLLM instance (port 5001), which coordinates with the EPP's scheduling plugins to determine if a prefill is needed
+4. If the KV cache is not already available, the decode pod triggers a **prefill pod** to process the input tokens in parallel and build the KV cache. The prefill pod transfers the KV cache directly to the decode pod via NIXL (`VLLM_NIXL_SIDE_CHANNEL_HOST`)
 5. The decode pod performs autoregressive token generation using the transferred KV cache
 6. The response streams back through the Gateway to the client
+
+> **Note:** The InferencePool targets port 5000 on all pods (prefill + decode). The EPP's internal `prefill-filter` / `decode-filter` plugins handle role-based selection, routing user traffic to decode pods while prefill pods are coordinated internally.
 
 ## Quickstart
 

--- a/website/docs/prefill-decode-disaggregation.md
+++ b/website/docs/prefill-decode-disaggregation.md
@@ -230,6 +230,5 @@ kubectl logs phi-4-mini-decode-<id>-0 -n kaito-workspace | grep "Num successful 
 ## Related Resources
 
 - [Gateway API Inference Extension](./gateway-api-inference-extension.md) — Full GWIE documentation including InferenceSet
-- [llm-d inference scheduler](https://github.com/llm-d/llm-d-inference-scheduler) — The EPP scheduling plugins used for P/D routing
-- [NIXL](https://github.com/ai-dynamo/nixl) — The KV cache transfer library
+- [llm-d router](https://github.com/llm-d/llm-d-router) — The EPP scheduling plugins used for P/D routing
 - [llm-d routing sidecar](https://github.com/llm-d/llm-d-routing-sidecar) — The sidecar injected into decode pods

--- a/website/docs/prefill-decode-disaggregation.md
+++ b/website/docs/prefill-decode-disaggregation.md
@@ -231,4 +231,3 @@ kubectl logs phi-4-mini-decode-<id>-0 -n kaito-workspace | grep "Num successful 
 
 - [Gateway API Inference Extension](./gateway-api-inference-extension.md) — Full GWIE documentation including InferenceSet
 - [llm-d router](https://github.com/llm-d/llm-d-router) — The EPP scheduling plugins used for P/D routing
-- [llm-d routing sidecar](https://github.com/llm-d/llm-d-routing-sidecar) — The sidecar injected into decode pods

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -72,6 +72,7 @@ const sidebars = {
             items: [
                 'aikit',
                 'gateway-api-inference-extension',
+                'prefill-decode-disaggregation',
             ],
         },
         {


### PR DESCRIPTION
## Description

Add a standalone document (`website/docs/prefill-decode-disaggregation.md`) explaining how to use Gateway API Inference Extension (GWIE) with MultiRoleInference (MRI) to create prefill/decode disaggregated inference workloads.

### Contents

- **Overview** — What P/D disaggregation is and why it matters
- **Architecture** — How MRI provisions resources, port layout, routing sidecar injection, NIXL KV cache transfer
- **Request flow** — Step-by-step explanation of how a request flows through the system
- **Quickstart** — End-to-end steps to deploy and test P/D disaggregated inference
- **Scaling recommendations** — Guidance on replica ratios for different workload patterns
- **Limitations** — Current alpha constraints

### Related

- Builds on context from #2051
- Complements existing `gateway-api-inference-extension.md` docs

Signed-off-by: Andy Zhang <andyzhangx@live.com>