### PR TITLE
fix: use unique LabelSelector per workspace to prevent cross-workspace node sharing

### DIFF
--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/rand"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -275,7 +276,12 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 		klog.InfoS("Need to create more workspaces...", "current", len(wsList.Items), "desired", desiredReplicas)
 		for i := range replicaNumToCreate {
 			workspaceObj := &kaitov1beta1.Workspace{}
-			workspaceObj.GenerateName = iObj.Name + "-"
+			// Generate the workspace name client-side so the value is available
+			// when we build the unique label selector below. Using GenerateName
+			// would leave Name empty until the server assigns it on Create, which
+			// would cause uniqueWorkspaceLabelSelector to embed an empty string
+			// and defeat the per-workspace uniqueness fix.
+			workspaceObj.Name = iObj.Name + "-" + rand.String(5)
 			workspaceObj.Namespace = iObj.Namespace
 
 			// Start with labels from the template metadata, then add controller labels.

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -283,13 +283,14 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 			// would cause uniqueWorkspaceLabelSelector to embed an empty string
 			// and defeat the per-workspace uniqueness fix.
 			//
-			// Workspace names must satisfy the DNS1123 subdomain limit of 253
-			// chars. The InferenceSet name itself is already a DNS1123 subdomain
-			// (<=253), so when it is close to the limit we truncate the prefix to
-			// leave room for the "-" separator and the 5-char random suffix
-			// (matching kube-apiserver's GenerateName behavior).
+			// Workspace names must satisfy the DNS1123 *label* limit of 63 chars
+			// (validated in api/v1beta1/workspace_validation.go via
+			// validation.IsDNS1123Label). The InferenceSet name itself is also a
+			// DNS1123 label (<=63), so when it is close to the limit we truncate
+			// the prefix to leave room for the "-" separator and the 5-char
+			// random suffix (matching kube-apiserver's GenerateName behavior).
 			const randSuffixLen = 5
-			const maxNameLen = validation.DNS1123SubdomainMaxLength // 253
+			const maxNameLen = validation.DNS1123LabelMaxLength // 63
 			prefix := iObj.Name
 			if len(prefix) > maxNameLen-randSuffixLen-1 {
 				prefix = prefix[:maxNameLen-randSuffixLen-1]
@@ -327,9 +328,20 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 			workspaceObj.OwnerReferences = []metav1.OwnerReference{
 				*metav1.NewControllerRef(iObj, kaitov1beta1.GroupVersion.WithKind("InferenceSet")),
 			}
+			// Build the workspace's resource label selector. For auto-provisioning
+			// (InstanceType set), each workspace gets a unique label so its
+			// NodePool provisions dedicated nodes and concurrent scale up/down
+			// does not share nodes across workspaces. For BYO mode
+			// (InstanceType empty), pre-existing user nodes will not carry the
+			// generated label, so we must leave the user's selector untouched
+			// or no nodes would match.
+			resourceSelector := iObj.Spec.Selector
+			if iObj.Spec.Template.Resource.InstanceType != "" {
+				resourceSelector = uniqueWorkspaceLabelSelector(iObj.Spec.Selector, workspaceObj.Name)
+			}
 			workspaceObj.Resource = kaitov1beta1.ResourceSpec{
 				InstanceType:  iObj.Spec.Template.Resource.InstanceType,
-				LabelSelector: uniqueWorkspaceLabelSelector(iObj.Spec.Selector, workspaceObj.Name),
+				LabelSelector: resourceSelector,
 			}
 			workspaceObj.Inference = &iObj.Spec.Template.Inference
 

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -32,6 +32,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -281,7 +282,19 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 			// would leave Name empty until the server assigns it on Create, which
 			// would cause uniqueWorkspaceLabelSelector to embed an empty string
 			// and defeat the per-workspace uniqueness fix.
-			workspaceObj.Name = iObj.Name + "-" + rand.String(5)
+			//
+			// Workspace names must satisfy the DNS1123 subdomain limit of 253
+			// chars. The InferenceSet name itself is already a DNS1123 subdomain
+			// (<=253), so when it is close to the limit we truncate the prefix to
+			// leave room for the "-" separator and the 5-char random suffix
+			// (matching kube-apiserver's GenerateName behavior).
+			const randSuffixLen = 5
+			const maxNameLen = validation.DNS1123SubdomainMaxLength // 253
+			prefix := iObj.Name
+			if len(prefix) > maxNameLen-randSuffixLen-1 {
+				prefix = prefix[:maxNameLen-randSuffixLen-1]
+			}
+			workspaceObj.Name = prefix + "-" + rand.String(randSuffixLen)
 			workspaceObj.Namespace = iObj.Namespace
 
 			// Start with labels from the template metadata, then add controller labels.

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -309,7 +309,7 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 				*metav1.NewControllerRef(iObj, kaitov1beta1.GroupVersion.WithKind("InferenceSet")),
 			}
 			workspaceObj.Resource = kaitov1beta1.ResourceSpec{
-				InstanceType: iObj.Spec.Template.Resource.InstanceType,
+				InstanceType:  iObj.Spec.Template.Resource.InstanceType,
 				LabelSelector: uniqueWorkspaceLabelSelector(iObj.Spec.Selector, workspaceObj.Name),
 			}
 			workspaceObj.Inference = &iObj.Spec.Template.Inference

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -53,7 +53,6 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/inferenceset"
-	"github.com/kaito-project/kaito/pkg/utils/nodes"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/utils/workspace"
 	"github.com/kaito-project/kaito/pkg/workspace/controllers"
@@ -331,29 +330,16 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 			workspaceObj.OwnerReferences = []metav1.OwnerReference{
 				*metav1.NewControllerRef(iObj, kaitov1beta1.GroupVersion.WithKind("InferenceSet")),
 			}
-			// Build the workspace's resource label selector. Each workspace gets a
-			// unique label ("<ns>.<wsName>") so its Resource.LabelSelector only
-			// matches its own dedicated node(s), preventing cross-workspace node
-			// sharing and the lifecycle conflicts that causes during concurrent
-			// scale-up/scale-down operations.
-			//
-			// For Karpenter auto-provisioning (InstanceType set), the unique label
-			// is propagated onto newly-provisioned NodeClaims/Nodes via the NodePool
-			// template (see pkg/nodeprovision/karpenter/nodepool.go), so the
-			// constraint is satisfied automatically.
-			//
-			// For BYO mode (InstanceType empty), nodes are pre-provisioned by the
-			// user and do not carry the generated label. We therefore claim an
-			// unlabeled, ready node that matches the user's selector and patch the
-			// unique label onto it before creating the workspace, so its BYO
-			// provisioner can locate at least one matching node.
-			resourceSelector := uniqueWorkspaceLabelSelector(iObj.Spec.Selector, workspaceObj.Namespace, workspaceObj.Name)
-			uniqueValue := resourceSelector.MatchLabels[consts.InferenceSetWorkspaceNodeLabel]
-			if iObj.Spec.Template.Resource.InstanceType == "" {
-				if err := c.claimBYONode(ctx, iObj.Spec.Selector, uniqueValue); err != nil {
-					klog.ErrorS(err, "failed to claim BYO node for workspace", "workspace", workspaceObj.Name)
-					return reconcile.Result{}, err
-				}
+			// Build the workspace's resource label selector. For auto-provisioning
+			// (InstanceType set), each workspace gets a unique label so its
+			// NodePool provisions dedicated nodes and concurrent scale up/down
+			// does not share nodes across workspaces. For BYO mode
+			// (InstanceType empty), pre-existing user nodes will not carry the
+			// generated label, so we must leave the user's selector untouched
+			// or no nodes would match.
+			resourceSelector := iObj.Spec.Selector
+			if iObj.Spec.Template.Resource.InstanceType != "" {
+				resourceSelector = uniqueWorkspaceLabelSelector(iObj.Spec.Selector, workspaceObj.Namespace, workspaceObj.Name)
 			}
 			workspaceObj.Resource = kaitov1beta1.ResourceSpec{
 				InstanceType:  iObj.Spec.Template.Resource.InstanceType,
@@ -797,56 +783,4 @@ func uniqueWorkspaceLabelSelector(base *metav1.LabelSelector, namespace, workspa
 	}
 	selector.MatchLabels[consts.InferenceSetWorkspaceNodeLabel] = uniqueWorkspaceLabelValue(namespace, workspaceName)
 	return selector
-}
-
-// claimBYONode reserves a pre-provisioned node for a BYO-mode workspace by
-// patching consts.InferenceSetWorkspaceNodeLabel=<uniqueValue> onto the first
-// ready node that matches the user's selector and is not already claimed by
-// another InferenceSet workspace. This is the BYO equivalent of the Karpenter
-// NodePool template-label propagation, and is what makes the augmented
-// workspace LabelSelector resolvable in BYO mode.
-//
-// userSelector is the InferenceSet's Spec.Selector before sanitization; only
-// non-reserved entries actually constrain which nodes are candidates.
-func (c *InferenceSetReconciler) claimBYONode(ctx context.Context, userSelector *metav1.LabelSelector, uniqueValue string) error {
-	matchLabels := client.MatchingLabels(kaitov1beta1.SanitizedMatchLabels(userSelector))
-	nodeList, err := nodes.ListNodes(ctx, c.Client, matchLabels)
-	if err != nil {
-		return fmt.Errorf("failed to list candidate BYO nodes: %w", err)
-	}
-
-	for i := range nodeList.Items {
-		node := &nodeList.Items[i]
-		if !nodes.NodeIsReadyAndNotDeleting(node) {
-			continue
-		}
-		// Skip nodes already claimed by some workspace; the candidate must be
-		// either unlabeled or already carry our exact unique value (idempotent
-		// retries).
-		if existing, ok := node.Labels[consts.InferenceSetWorkspaceNodeLabel]; ok && existing != uniqueValue {
-			continue
-		}
-
-		if node.Labels[consts.InferenceSetWorkspaceNodeLabel] == uniqueValue {
-			return nil
-		}
-
-		patch := client.MergeFrom(node.DeepCopy())
-		if node.Labels == nil {
-			node.Labels = map[string]string{}
-		}
-		node.Labels[consts.InferenceSetWorkspaceNodeLabel] = uniqueValue
-		if err := c.Client.Patch(ctx, node, patch); err != nil {
-			// Another reconcile (or the user) may have just labeled the node;
-			// fall through and try the next candidate.
-			klog.V(2).InfoS("failed to patch BYO node, trying next candidate",
-				"node", node.Name, "error", err.Error())
-			continue
-		}
-		klog.InfoS("claimed BYO node for workspace",
-			"node", node.Name, "label", consts.InferenceSetWorkspaceNodeLabel, "value", uniqueValue)
-		return nil
-	}
-
-	return fmt.Errorf("no unclaimed ready node matches selector %v for BYO workspace", matchLabels)
 }

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -15,6 +15,8 @@ package inferenceset
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"maps"
 	"slices"
@@ -337,7 +339,7 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 			// or no nodes would match.
 			resourceSelector := iObj.Spec.Selector
 			if iObj.Spec.Template.Resource.InstanceType != "" {
-				resourceSelector = uniqueWorkspaceLabelSelector(iObj.Spec.Selector, workspaceObj.Name)
+				resourceSelector = uniqueWorkspaceLabelSelector(iObj.Spec.Selector, workspaceObj.Namespace, workspaceObj.Name)
 			}
 			workspaceObj.Resource = kaitov1beta1.ResourceSpec{
 				InstanceType:  iObj.Spec.Template.Resource.InstanceType,
@@ -723,11 +725,53 @@ func (c *InferenceSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return builder.Complete(c)
 }
 
+// uniqueWorkspaceLabelValue builds a label value that uniquely identifies a
+// workspace across namespaces. Node labels are cluster-scoped, so embedding
+// only the workspace name (which itself only encodes the InferenceSet name +
+// a 5-char random suffix) is ambiguous when two InferenceSets in different
+// namespaces share the same name.
+//
+// The format is "<namespace>.<workspaceName>". To satisfy the Kubernetes label
+// value constraint (max 63 chars, [a-z0-9A-Z]([-_.a-z0-9A-Z]*[a-z0-9A-Z])?),
+// we fall back to a deterministic short hash of the full "<ns>.<name>" string
+// when the joined value would exceed the limit; that hash is still unique per
+// (namespace, workspaceName) tuple because the random suffix in workspaceName
+// makes the full input unique.
+func uniqueWorkspaceLabelValue(namespace, workspaceName string) string {
+	full := namespace + "." + workspaceName
+	if len(full) <= validation.LabelValueMaxLength {
+		return full
+	}
+	// Truncated form: keep a human-readable prefix and append a short hash
+	// of the full identifier so different (ns, name) pairs never collide.
+	sum := sha256.Sum256([]byte(full))
+	const hashLen = 10 // hex chars from sha256, ~40 bits of entropy
+	hash := hex.EncodeToString(sum[:])[:hashLen]
+	// Reserve room for "-" + hash, then truncate the prefix.
+	prefixBudget := validation.LabelValueMaxLength - hashLen - 1
+	prefix := full
+	if len(prefix) > prefixBudget {
+		prefix = prefix[:prefixBudget]
+	}
+	// Make sure the prefix ends with an alphanumeric so the resulting value
+	// still satisfies the label value regex ("-" is fine inside, just not as
+	// the last char before the appended "-<hash>").
+	for len(prefix) > 0 {
+		last := prefix[len(prefix)-1]
+		if (last >= 'a' && last <= 'z') || (last >= 'A' && last <= 'Z') || (last >= '0' && last <= '9') {
+			break
+		}
+		prefix = prefix[:len(prefix)-1]
+	}
+	return prefix + "-" + hash
+}
+
 // uniqueWorkspaceLabelSelector creates a deep copy of the InferenceSet's selector
-// and adds the workspace name as a unique label. This ensures each workspace
-// targets only its own dedicated node(s), preventing cross-workspace node sharing
-// that causes lifecycle conflicts during concurrent scale-up/scale-down operations.
-func uniqueWorkspaceLabelSelector(base *metav1.LabelSelector, workspaceName string) *metav1.LabelSelector {
+// and adds a namespace-qualified workspace identifier as a unique label. This
+// ensures each workspace targets only its own dedicated node(s), preventing
+// cross-workspace node sharing that causes lifecycle conflicts during concurrent
+// scale-up/scale-down operations and avoids collisions across namespaces.
+func uniqueWorkspaceLabelSelector(base *metav1.LabelSelector, namespace, workspaceName string) *metav1.LabelSelector {
 	var selector *metav1.LabelSelector
 	if base != nil {
 		selector = base.DeepCopy()
@@ -737,6 +781,6 @@ func uniqueWorkspaceLabelSelector(base *metav1.LabelSelector, workspaceName stri
 	if selector.MatchLabels == nil {
 		selector.MatchLabels = make(map[string]string)
 	}
-	selector.MatchLabels[consts.InferenceSetWorkspaceNodeLabel] = workspaceName
+	selector.MatchLabels[consts.InferenceSetWorkspaceNodeLabel] = uniqueWorkspaceLabelValue(namespace, workspaceName)
 	return selector
 }

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -53,6 +53,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/inferenceset"
+	"github.com/kaito-project/kaito/pkg/utils/nodes"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/utils/workspace"
 	"github.com/kaito-project/kaito/pkg/workspace/controllers"
@@ -330,16 +331,29 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 			workspaceObj.OwnerReferences = []metav1.OwnerReference{
 				*metav1.NewControllerRef(iObj, kaitov1beta1.GroupVersion.WithKind("InferenceSet")),
 			}
-			// Build the workspace's resource label selector. For auto-provisioning
-			// (InstanceType set), each workspace gets a unique label so its
-			// NodePool provisions dedicated nodes and concurrent scale up/down
-			// does not share nodes across workspaces. For BYO mode
-			// (InstanceType empty), pre-existing user nodes will not carry the
-			// generated label, so we must leave the user's selector untouched
-			// or no nodes would match.
-			resourceSelector := iObj.Spec.Selector
-			if iObj.Spec.Template.Resource.InstanceType != "" {
-				resourceSelector = uniqueWorkspaceLabelSelector(iObj.Spec.Selector, workspaceObj.Namespace, workspaceObj.Name)
+			// Build the workspace's resource label selector. Each workspace gets a
+			// unique label ("<ns>.<wsName>") so its Resource.LabelSelector only
+			// matches its own dedicated node(s), preventing cross-workspace node
+			// sharing and the lifecycle conflicts that causes during concurrent
+			// scale-up/scale-down operations.
+			//
+			// For Karpenter auto-provisioning (InstanceType set), the unique label
+			// is propagated onto newly-provisioned NodeClaims/Nodes via the NodePool
+			// template (see pkg/nodeprovision/karpenter/nodepool.go), so the
+			// constraint is satisfied automatically.
+			//
+			// For BYO mode (InstanceType empty), nodes are pre-provisioned by the
+			// user and do not carry the generated label. We therefore claim an
+			// unlabeled, ready node that matches the user's selector and patch the
+			// unique label onto it before creating the workspace, so its BYO
+			// provisioner can locate at least one matching node.
+			resourceSelector := uniqueWorkspaceLabelSelector(iObj.Spec.Selector, workspaceObj.Namespace, workspaceObj.Name)
+			uniqueValue := resourceSelector.MatchLabels[consts.InferenceSetWorkspaceNodeLabel]
+			if iObj.Spec.Template.Resource.InstanceType == "" {
+				if err := c.claimBYONode(ctx, iObj.Spec.Selector, uniqueValue); err != nil {
+					klog.ErrorS(err, "failed to claim BYO node for workspace", "workspace", workspaceObj.Name)
+					return reconcile.Result{}, err
+				}
 			}
 			workspaceObj.Resource = kaitov1beta1.ResourceSpec{
 				InstanceType:  iObj.Spec.Template.Resource.InstanceType,
@@ -783,4 +797,56 @@ func uniqueWorkspaceLabelSelector(base *metav1.LabelSelector, namespace, workspa
 	}
 	selector.MatchLabels[consts.InferenceSetWorkspaceNodeLabel] = uniqueWorkspaceLabelValue(namespace, workspaceName)
 	return selector
+}
+
+// claimBYONode reserves a pre-provisioned node for a BYO-mode workspace by
+// patching consts.InferenceSetWorkspaceNodeLabel=<uniqueValue> onto the first
+// ready node that matches the user's selector and is not already claimed by
+// another InferenceSet workspace. This is the BYO equivalent of the Karpenter
+// NodePool template-label propagation, and is what makes the augmented
+// workspace LabelSelector resolvable in BYO mode.
+//
+// userSelector is the InferenceSet's Spec.Selector before sanitization; only
+// non-reserved entries actually constrain which nodes are candidates.
+func (c *InferenceSetReconciler) claimBYONode(ctx context.Context, userSelector *metav1.LabelSelector, uniqueValue string) error {
+	matchLabels := client.MatchingLabels(kaitov1beta1.SanitizedMatchLabels(userSelector))
+	nodeList, err := nodes.ListNodes(ctx, c.Client, matchLabels)
+	if err != nil {
+		return fmt.Errorf("failed to list candidate BYO nodes: %w", err)
+	}
+
+	for i := range nodeList.Items {
+		node := &nodeList.Items[i]
+		if !nodes.NodeIsReadyAndNotDeleting(node) {
+			continue
+		}
+		// Skip nodes already claimed by some workspace; the candidate must be
+		// either unlabeled or already carry our exact unique value (idempotent
+		// retries).
+		if existing, ok := node.Labels[consts.InferenceSetWorkspaceNodeLabel]; ok && existing != uniqueValue {
+			continue
+		}
+
+		if node.Labels[consts.InferenceSetWorkspaceNodeLabel] == uniqueValue {
+			return nil
+		}
+
+		patch := client.MergeFrom(node.DeepCopy())
+		if node.Labels == nil {
+			node.Labels = map[string]string{}
+		}
+		node.Labels[consts.InferenceSetWorkspaceNodeLabel] = uniqueValue
+		if err := c.Client.Patch(ctx, node, patch); err != nil {
+			// Another reconcile (or the user) may have just labeled the node;
+			// fall through and try the next candidate.
+			klog.V(2).InfoS("failed to patch BYO node, trying next candidate",
+				"node", node.Name, "error", err.Error())
+			continue
+		}
+		klog.InfoS("claimed BYO node for workspace",
+			"node", node.Name, "label", consts.InferenceSetWorkspaceNodeLabel, "value", uniqueValue)
+		return nil
+	}
+
+	return fmt.Errorf("no unclaimed ready node matches selector %v for BYO workspace", matchLabels)
 }

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -309,8 +309,8 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 				*metav1.NewControllerRef(iObj, kaitov1beta1.GroupVersion.WithKind("InferenceSet")),
 			}
 			workspaceObj.Resource = kaitov1beta1.ResourceSpec{
-				InstanceType:  iObj.Spec.Template.Resource.InstanceType,
-				LabelSelector: iObj.Spec.Selector,
+				InstanceType: iObj.Spec.Template.Resource.InstanceType,
+				LabelSelector: uniqueWorkspaceLabelSelector(iObj.Spec.Selector, workspaceObj.Name),
 			}
 			workspaceObj.Inference = &iObj.Spec.Template.Inference
 
@@ -690,4 +690,22 @@ func (c *InferenceSetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	go monitorInferenceSets(context.Background(), c.Client)
 	return builder.Complete(c)
+}
+
+// uniqueWorkspaceLabelSelector creates a deep copy of the InferenceSet's selector
+// and adds the workspace name as a unique label. This ensures each workspace
+// targets only its own dedicated node(s), preventing cross-workspace node sharing
+// that causes lifecycle conflicts during concurrent scale-up/scale-down operations.
+func uniqueWorkspaceLabelSelector(base *metav1.LabelSelector, workspaceName string) *metav1.LabelSelector {
+	var selector *metav1.LabelSelector
+	if base != nil {
+		selector = base.DeepCopy()
+	} else {
+		selector = &metav1.LabelSelector{}
+	}
+	if selector.MatchLabels == nil {
+		selector.MatchLabels = make(map[string]string)
+	}
+	selector.MatchLabels[consts.InferenceSetWorkspaceNodeLabel] = workspaceName
+	return selector
 }

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -510,13 +510,13 @@ func TestInferenceSetBenchmarkAggregation(t *testing.T) {
 func TestUniqueWorkspaceLabelSelector(t *testing.T) {
 	tests := []struct {
 		name          string
-		base          *metav1.LabelSelector
+		base          *v1.LabelSelector
 		workspaceName string
 		wantLabels    map[string]string
 	}{
 		{
 			name: "adds workspace label to existing selector",
-			base: &metav1.LabelSelector{
+			base: &v1.LabelSelector{
 				MatchLabels: map[string]string{
 					"apps": "my-model",
 				},
@@ -537,7 +537,7 @@ func TestUniqueWorkspaceLabelSelector(t *testing.T) {
 		},
 		{
 			name: "creates selector with empty matchLabels",
-			base: &metav1.LabelSelector{},
+			base: &v1.LabelSelector{},
 			workspaceName: "ws-1",
 			wantLabels: map[string]string{
 				consts.InferenceSetWorkspaceNodeLabel: "ws-1",
@@ -545,7 +545,7 @@ func TestUniqueWorkspaceLabelSelector(t *testing.T) {
 		},
 		{
 			name: "does not mutate original selector",
-			base: &metav1.LabelSelector{
+			base: &v1.LabelSelector{
 				MatchLabels: map[string]string{
 					"apps": "shared-model",
 				},

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -506,3 +506,93 @@ func TestInferenceSetBenchmarkAggregation(t *testing.T) {
 		})
 	}
 }
+
+func TestUniqueWorkspaceLabelSelector(t *testing.T) {
+	tests := []struct {
+		name          string
+		base          *metav1.LabelSelector
+		workspaceName string
+		wantLabels    map[string]string
+	}{
+		{
+			name: "adds workspace label to existing selector",
+			base: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"apps": "my-model",
+				},
+			},
+			workspaceName: "my-model-abc123",
+			wantLabels: map[string]string{
+				"apps":                              "my-model",
+				consts.InferenceSetWorkspaceNodeLabel: "my-model-abc123",
+			},
+		},
+		{
+			name:          "creates selector from nil base",
+			base:          nil,
+			workspaceName: "my-model-xyz",
+			wantLabels: map[string]string{
+				consts.InferenceSetWorkspaceNodeLabel: "my-model-xyz",
+			},
+		},
+		{
+			name: "creates selector with empty matchLabels",
+			base: &metav1.LabelSelector{},
+			workspaceName: "ws-1",
+			wantLabels: map[string]string{
+				consts.InferenceSetWorkspaceNodeLabel: "ws-1",
+			},
+		},
+		{
+			name: "does not mutate original selector",
+			base: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"apps": "shared-model",
+				},
+			},
+			workspaceName: "ws-unique",
+			wantLabels: map[string]string{
+				"apps":                              "shared-model",
+				consts.InferenceSetWorkspaceNodeLabel: "ws-unique",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var originalLabels map[string]string
+			if tt.base != nil && tt.base.MatchLabels != nil {
+				originalLabels = make(map[string]string)
+				for k, v := range tt.base.MatchLabels {
+					originalLabels[k] = v
+				}
+			}
+
+			got := uniqueWorkspaceLabelSelector(tt.base, tt.workspaceName)
+
+			if got == nil {
+				t.Fatal("expected non-nil selector")
+			}
+			if len(got.MatchLabels) != len(tt.wantLabels) {
+				t.Errorf("got %d labels, want %d: got=%v", len(got.MatchLabels), len(tt.wantLabels), got.MatchLabels)
+			}
+			for k, v := range tt.wantLabels {
+				if got.MatchLabels[k] != v {
+					t.Errorf("label %q = %q, want %q", k, got.MatchLabels[k], v)
+				}
+			}
+
+			// Verify original selector was not mutated
+			if tt.base != nil && originalLabels != nil {
+				for k, v := range originalLabels {
+					if tt.base.MatchLabels[k] != v {
+						t.Errorf("original selector mutated: key %q changed from %q to %q", k, v, tt.base.MatchLabels[k])
+					}
+				}
+				if _, exists := tt.base.MatchLabels[consts.InferenceSetWorkspaceNodeLabel]; exists {
+					t.Error("original selector should not contain the workspace node label")
+				}
+			}
+		})
+	}
+}

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
@@ -658,5 +659,103 @@ func TestUniqueWorkspaceLabelValue(t *testing.T) {
 	second := uniqueWorkspaceLabelValue(ns1, name)
 	if first != second {
 		t.Errorf("label value is not deterministic: %q vs %q", first, second)
+	}
+}
+
+func fakeClientWithObjects(t *testing.T, scheme *runtime.Scheme, objs ...client.Object) client.Client {
+	t.Helper()
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}
+
+func TestClaimBYONode(t *testing.T) {
+	scheme := runtime.NewScheme()
+	if err := corev1.AddToScheme(scheme); err != nil {
+		t.Fatalf("add corev1 to scheme: %v", err)
+	}
+
+	readyNode := func(name string, labels map[string]string) *corev1.Node {
+		n := &corev1.Node{
+			ObjectMeta: v1.ObjectMeta{Name: name, Labels: labels},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
+			},
+		}
+		return n
+	}
+
+	tests := []struct {
+		name         string
+		nodes        []client.Object
+		userSelector *v1.LabelSelector
+		wantClaimed  string // node name we expect to be labeled, "" if expecting error
+		wantErr      bool
+	}{
+		{
+			name: "labels first unclaimed ready matching node",
+			nodes: []client.Object{
+				readyNode("n1", map[string]string{"apps": "m"}),
+				readyNode("n2", map[string]string{"apps": "m"}),
+			},
+			userSelector: &v1.LabelSelector{MatchLabels: map[string]string{"apps": "m"}},
+			wantClaimed:  "n1",
+		},
+		{
+			name: "skips node already claimed by another workspace",
+			nodes: []client.Object{
+				readyNode("n1", map[string]string{
+					"apps":                                "m",
+					consts.InferenceSetWorkspaceNodeLabel: "default.other-ws",
+				}),
+				readyNode("n2", map[string]string{"apps": "m"}),
+			},
+			userSelector: &v1.LabelSelector{MatchLabels: map[string]string{"apps": "m"}},
+			wantClaimed:  "n2",
+		},
+		{
+			name: "idempotent when node already labeled with the same value",
+			nodes: []client.Object{
+				readyNode("n1", map[string]string{
+					"apps":                                "m",
+					consts.InferenceSetWorkspaceNodeLabel: "default.ws-xyz",
+				}),
+			},
+			userSelector: &v1.LabelSelector{MatchLabels: map[string]string{"apps": "m"}},
+			wantClaimed:  "n1",
+		},
+		{
+			name: "no candidate nodes returns error",
+			nodes: []client.Object{
+				readyNode("n1", map[string]string{
+					"apps":                                "m",
+					consts.InferenceSetWorkspaceNodeLabel: "default.other-ws",
+				}),
+			},
+			userSelector: &v1.LabelSelector{MatchLabels: map[string]string{"apps": "m"}},
+			wantErr:      true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fakeClient := fakeClientWithObjects(t, scheme, tt.nodes...)
+			r := &InferenceSetReconciler{Client: fakeClient}
+			err := r.claimBYONode(context.Background(), tt.userSelector, "default.ws-xyz")
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			node := &corev1.Node{}
+			if err := fakeClient.Get(context.Background(), client.ObjectKey{Name: tt.wantClaimed}, node); err != nil {
+				t.Fatalf("get node %s: %v", tt.wantClaimed, err)
+			}
+			if got := node.Labels[consts.InferenceSetWorkspaceNodeLabel]; got != "default.ws-xyz" {
+				t.Errorf("node %s label = %q, want %q", tt.wantClaimed, got, "default.ws-xyz")
+			}
+		})
 	}
 }

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -31,6 +31,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kaito-project/kaito/api/v1beta1"
@@ -511,36 +512,40 @@ func TestUniqueWorkspaceLabelSelector(t *testing.T) {
 	tests := []struct {
 		name          string
 		base          *v1.LabelSelector
+		namespace     string
 		workspaceName string
 		wantLabels    map[string]string
 	}{
 		{
-			name: "adds workspace label to existing selector",
+			name: "adds namespace-qualified workspace label to existing selector",
 			base: &v1.LabelSelector{
 				MatchLabels: map[string]string{
 					"apps": "my-model",
 				},
 			},
-			workspaceName: "my-model-abc123",
+			namespace:     "default",
+			workspaceName: "my-model-abc12",
 			wantLabels: map[string]string{
 				"apps":                                "my-model",
-				consts.InferenceSetWorkspaceNodeLabel: "my-model-abc123",
+				consts.InferenceSetWorkspaceNodeLabel: "default.my-model-abc12",
 			},
 		},
 		{
 			name:          "creates selector from nil base",
 			base:          nil,
-			workspaceName: "my-model-xyz",
+			namespace:     "ns-a",
+			workspaceName: "my-model-xyz12",
 			wantLabels: map[string]string{
-				consts.InferenceSetWorkspaceNodeLabel: "my-model-xyz",
+				consts.InferenceSetWorkspaceNodeLabel: "ns-a.my-model-xyz12",
 			},
 		},
 		{
 			name:          "creates selector with empty matchLabels",
 			base:          &v1.LabelSelector{},
-			workspaceName: "ws-1",
+			namespace:     "default",
+			workspaceName: "ws-1-aaaaa",
 			wantLabels: map[string]string{
-				consts.InferenceSetWorkspaceNodeLabel: "ws-1",
+				consts.InferenceSetWorkspaceNodeLabel: "default.ws-1-aaaaa",
 			},
 		},
 		{
@@ -550,10 +555,11 @@ func TestUniqueWorkspaceLabelSelector(t *testing.T) {
 					"apps": "shared-model",
 				},
 			},
-			workspaceName: "ws-unique",
+			namespace:     "team-a",
+			workspaceName: "ws-unique-aaaaa",
 			wantLabels: map[string]string{
 				"apps":                                "shared-model",
-				consts.InferenceSetWorkspaceNodeLabel: "ws-unique",
+				consts.InferenceSetWorkspaceNodeLabel: "team-a.ws-unique-aaaaa",
 			},
 		},
 	}
@@ -568,7 +574,7 @@ func TestUniqueWorkspaceLabelSelector(t *testing.T) {
 				}
 			}
 
-			got := uniqueWorkspaceLabelSelector(tt.base, tt.workspaceName)
+			got := uniqueWorkspaceLabelSelector(tt.base, tt.namespace, tt.workspaceName)
 
 			if got == nil {
 				t.Fatal("expected non-nil selector")
@@ -594,5 +600,61 @@ func TestUniqueWorkspaceLabelSelector(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestUniqueWorkspaceLabelValue(t *testing.T) {
+	const labelMax = 63
+
+	tests := []struct {
+		name          string
+		namespace     string
+		workspaceName string
+	}{
+		{
+			name:          "short namespace and name",
+			namespace:     "default",
+			workspaceName: "ws-aaaaa",
+		},
+		{
+			name:          "long namespace",
+			namespace:     "a-very-long-namespace-name-used-in-multi-tenant-clusters",
+			workspaceName: "my-model-abcde",
+		},
+		{
+			name:      "max-length workspace name",
+			namespace: "ns-with-long-name",
+			// 63-char workspace name (DNS1123 label max).
+			workspaceName: "abcdefghij1234567890abcdefghij1234567890abcdefghij1234567abcde",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := uniqueWorkspaceLabelValue(tt.namespace, tt.workspaceName)
+			if len(got) == 0 {
+				t.Fatal("empty label value")
+			}
+			if len(got) > labelMax {
+				t.Errorf("label value %q is %d chars, exceeds %d", got, len(got), labelMax)
+			}
+			if errs := validation.IsValidLabelValue(got); len(errs) > 0 {
+				t.Errorf("label value %q is invalid: %v", got, errs)
+			}
+		})
+	}
+
+	// Distinctness: same workspace name in different namespaces must yield
+	// different label values.
+	ns1 := "team-a"
+	ns2 := "team-b"
+	name := "foo-abcde"
+	if uniqueWorkspaceLabelValue(ns1, name) == uniqueWorkspaceLabelValue(ns2, name) {
+		t.Errorf("label value collided across namespaces for same workspace name")
+	}
+
+	// Determinism: same input must yield the same output.
+	if uniqueWorkspaceLabelValue(ns1, name) != uniqueWorkspaceLabelValue(ns1, name) {
+		t.Errorf("label value is not deterministic")
 	}
 }

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -654,7 +654,9 @@ func TestUniqueWorkspaceLabelValue(t *testing.T) {
 	}
 
 	// Determinism: same input must yield the same output.
-	if uniqueWorkspaceLabelValue(ns1, name) != uniqueWorkspaceLabelValue(ns1, name) {
-		t.Errorf("label value is not deterministic")
+	first := uniqueWorkspaceLabelValue(ns1, name)
+	second := uniqueWorkspaceLabelValue(ns1, name)
+	if first != second {
+		t.Errorf("label value is not deterministic: %q vs %q", first, second)
 	}
 }

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -33,7 +33,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
@@ -659,103 +658,5 @@ func TestUniqueWorkspaceLabelValue(t *testing.T) {
 	second := uniqueWorkspaceLabelValue(ns1, name)
 	if first != second {
 		t.Errorf("label value is not deterministic: %q vs %q", first, second)
-	}
-}
-
-func fakeClientWithObjects(t *testing.T, scheme *runtime.Scheme, objs ...client.Object) client.Client {
-	t.Helper()
-	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
-}
-
-func TestClaimBYONode(t *testing.T) {
-	scheme := runtime.NewScheme()
-	if err := corev1.AddToScheme(scheme); err != nil {
-		t.Fatalf("add corev1 to scheme: %v", err)
-	}
-
-	readyNode := func(name string, labels map[string]string) *corev1.Node {
-		n := &corev1.Node{
-			ObjectMeta: v1.ObjectMeta{Name: name, Labels: labels},
-			Status: corev1.NodeStatus{
-				Conditions: []corev1.NodeCondition{{Type: corev1.NodeReady, Status: corev1.ConditionTrue}},
-			},
-		}
-		return n
-	}
-
-	tests := []struct {
-		name         string
-		nodes        []client.Object
-		userSelector *v1.LabelSelector
-		wantClaimed  string // node name we expect to be labeled, "" if expecting error
-		wantErr      bool
-	}{
-		{
-			name: "labels first unclaimed ready matching node",
-			nodes: []client.Object{
-				readyNode("n1", map[string]string{"apps": "m"}),
-				readyNode("n2", map[string]string{"apps": "m"}),
-			},
-			userSelector: &v1.LabelSelector{MatchLabels: map[string]string{"apps": "m"}},
-			wantClaimed:  "n1",
-		},
-		{
-			name: "skips node already claimed by another workspace",
-			nodes: []client.Object{
-				readyNode("n1", map[string]string{
-					"apps":                                "m",
-					consts.InferenceSetWorkspaceNodeLabel: "default.other-ws",
-				}),
-				readyNode("n2", map[string]string{"apps": "m"}),
-			},
-			userSelector: &v1.LabelSelector{MatchLabels: map[string]string{"apps": "m"}},
-			wantClaimed:  "n2",
-		},
-		{
-			name: "idempotent when node already labeled with the same value",
-			nodes: []client.Object{
-				readyNode("n1", map[string]string{
-					"apps":                                "m",
-					consts.InferenceSetWorkspaceNodeLabel: "default.ws-xyz",
-				}),
-			},
-			userSelector: &v1.LabelSelector{MatchLabels: map[string]string{"apps": "m"}},
-			wantClaimed:  "n1",
-		},
-		{
-			name: "no candidate nodes returns error",
-			nodes: []client.Object{
-				readyNode("n1", map[string]string{
-					"apps":                                "m",
-					consts.InferenceSetWorkspaceNodeLabel: "default.other-ws",
-				}),
-			},
-			userSelector: &v1.LabelSelector{MatchLabels: map[string]string{"apps": "m"}},
-			wantErr:      true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			fakeClient := fakeClientWithObjects(t, scheme, tt.nodes...)
-			r := &InferenceSetReconciler{Client: fakeClient}
-			err := r.claimBYONode(context.Background(), tt.userSelector, "default.ws-xyz")
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("expected error, got nil")
-				}
-				return
-			}
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			node := &corev1.Node{}
-			if err := fakeClient.Get(context.Background(), client.ObjectKey{Name: tt.wantClaimed}, node); err != nil {
-				t.Fatalf("get node %s: %v", tt.wantClaimed, err)
-			}
-			if got := node.Labels[consts.InferenceSetWorkspaceNodeLabel]; got != "default.ws-xyz" {
-				t.Errorf("node %s label = %q, want %q", tt.wantClaimed, got, "default.ws-xyz")
-			}
-		})
 	}
 }

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -523,7 +523,7 @@ func TestUniqueWorkspaceLabelSelector(t *testing.T) {
 			},
 			workspaceName: "my-model-abc123",
 			wantLabels: map[string]string{
-				"apps":                              "my-model",
+				"apps":                                "my-model",
 				consts.InferenceSetWorkspaceNodeLabel: "my-model-abc123",
 			},
 		},
@@ -536,8 +536,8 @@ func TestUniqueWorkspaceLabelSelector(t *testing.T) {
 			},
 		},
 		{
-			name: "creates selector with empty matchLabels",
-			base: &v1.LabelSelector{},
+			name:          "creates selector with empty matchLabels",
+			base:          &v1.LabelSelector{},
 			workspaceName: "ws-1",
 			wantLabels: map[string]string{
 				consts.InferenceSetWorkspaceNodeLabel: "ws-1",
@@ -552,7 +552,7 @@ func TestUniqueWorkspaceLabelSelector(t *testing.T) {
 			},
 			workspaceName: "ws-unique",
 			wantLabels: map[string]string{
-				"apps":                              "shared-model",
+				"apps":                                "shared-model",
 				consts.InferenceSetWorkspaceNodeLabel: "ws-unique",
 			},
 		},

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -182,6 +182,12 @@ const (
 
 	WorkspaceCreatedByInferenceSetLabel = "inferenceset.kaito.sh/created-by"
 
+	// InferenceSetWorkspaceNodeLabel is applied to the workspace's LabelSelector
+	// and propagated to provisioned nodes. It ensures each workspace created by an
+	// InferenceSet targets only its own dedicated node(s), preventing cross-workspace
+	// node sharing that causes lifecycle conflicts during scale-up/scale-down.
+	InferenceSetWorkspaceNodeLabel = "inferenceset.kaito.sh/workspace"
+
 	NodeImageFamilyUbuntu     = "ubuntu"
 	NodeImageFamilyAzureLinux = "azurelinux"
 	SpotInstanceKey           = "kubernetes.azure.com/scalesetpriority"


### PR DESCRIPTION
## Problem

When InferenceSet controller creates multiple workspaces (during scale-up), they all share the same `Resource.LabelSelector` from the InferenceSet spec. This causes multiple workspaces to target the same nodes via nodeAffinity, leading to lifecycle conflicts:

1. Two workspaces' pods get scheduled on the same node
2. During scale-down, a terminating pod blocks node deletion because another workspace's pending pod depends on it
3. The system enters a deadlock: node can't be deleted (valid pod depends on it) and pod can't schedule (node is being drained)

This was observed with frequent scale-up/scale-down behavior where workspaces were created and deleted in rapid succession.

## Root Cause

In `pkg/inferenceset/inferenceset_controller.go`, line 313:
```go
workspaceObj.Resource = kaitov1beta1.ResourceSpec{
    InstanceType:  iObj.Spec.Template.Resource.InstanceType,
    LabelSelector: iObj.Spec.Selector,  // <-- shared across all workspaces!
}
```

All workspaces created by the same InferenceSet use the identical `LabelSelector`, which means:
- Their NodePools provision nodes with the same labels
- Their pods' nodeAffinity matches ANY node from the same InferenceSet
- Node-to-workspace binding is not enforced

## Fix

1. Deep-copy the InferenceSet's selector and add a workspace-specific label (`inferenceset.kaito.sh/workspace: <workspace-name>`)
2. Each workspace now has a unique `Resource.LabelSelector`
3. Nodes provisioned for workspace A only match pods from workspace A

### Files Changed
- `pkg/utils/consts/consts.go` — New constant `InferenceSetWorkspaceNodeLabel`
- `pkg/inferenceset/inferenceset_controller.go` — Use `uniqueWorkspaceLabelSelector()` helper
- `pkg/inferenceset/inferenceset_controller_test.go` — Unit tests for the new function

## P/D Disaggregation Compatibility

This fix does **NOT** affect P/D (Prefill/Decode) disaggregation because:
- InferencePool endpoint selection uses **pod-level labels** (`kaito.sh/inference-role`, `multiroleinference.kaito.sh/created-by`)
- Node-level selectors are independent of the EPP routing logic
- The `inferenceset.kaito.sh/workspace` label is only used for node affinity, not for InferencePool matching

## Severity

This is a **0.11.0 release blocker** — the issue manifests with any InferenceSet that has `replicas > 1` or undergoes scale-up/scale-down operations.