### PR TITLE
ci: automate release on tag push

### DIFF
--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -1,4 +1,4 @@
-name: Create release
+name: GitHub release
 on:
   workflow_dispatch:
     inputs:
@@ -10,6 +10,17 @@ on:
         description: 'Release branch (e.g., release-0.6)'
         required: true
         type: string
+  workflow_call:
+    inputs:
+      release_version:
+        description: 'Release version (e.g., v0.2.2 or v0.2.2-rc.0)'
+        required: true
+        type: string
+      release_branch:
+        description: 'Release branch (e.g., release-0.6). Optional when called from a tag push.'
+        required: false
+        type: string
+        default: ''
 
 permissions:
   id-token: write
@@ -40,16 +51,16 @@ jobs:
         with:
           submodules: true
           fetch-depth: 0
-          ref: ${{ github.event.inputs.release_version }}
+          ref: ${{ inputs.release_version }}
 
       - name: Validate inputs
         run: |
-          echo "Creating release ${{ github.event.inputs.release_version }} from branch ${{ github.event.inputs.release_branch }}"
-          if [[ ! "${{ github.event.inputs.release_version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
+          echo "Creating release ${{ inputs.release_version }} from branch ${{ inputs.release_branch }}"
+          if [[ ! "${{ inputs.release_version }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]; then
             echo "Error: Release version must follow format vX.Y.Z or vX.Y.Z-rc.W"
             exit 1
           fi
-          if [[ ! "${{ github.event.inputs.release_branch }}" =~ ^release- ]]; then
+          if [[ -n "${{ inputs.release_branch }}" && ! "${{ inputs.release_branch }}" =~ ^release- ]]; then
             echo "Error: Release branch must start with 'release-'"
             exit 1
           fi
@@ -57,7 +68,7 @@ jobs:
       - name: Check if release already exists
         id: check-release
         run: |
-          TAG="${{ github.event.inputs.release_version }}"
+          TAG="${{ inputs.release_version }}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
             echo "Release $TAG already exists, skipping creation"
@@ -76,9 +87,9 @@ jobs:
           args: release --clean --timeout 60m --verbose
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GORELEASER_CURRENT_TAG: ${{ github.event.inputs.release_version }}
+          GORELEASER_CURRENT_TAG: ${{ inputs.release_version }}
 
       - name: Release already exists
         if: steps.check-release.outputs.exists == 'true'
         run: |
-          echo "Release ${{ github.event.inputs.release_version }} already exists."
+          echo "Release ${{ inputs.release_version }} already exists."

--- a/.github/workflows/publish-rag-controller-gh-image.yaml
+++ b/.github/workflows/publish-rag-controller-gh-image.yaml
@@ -5,6 +5,12 @@ on:
       release_version:
         description: 'tag to be created for this image (i.e. vxx.xx.xx)'
         required: true
+  workflow_call:
+    inputs:
+      release_version:
+        description: 'tag to be published'
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -25,12 +31,12 @@ jobs:
     steps:
       - name: validate version
         run: |
-          echo "${{ github.event.inputs.release_version }}" | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'
+          echo "${{ inputs.release_version }}" | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'
 
       - id: get-tag
         name: Get tag
         run: |
-          echo "tag=$(echo ${{ github.event.inputs.release_version }})" >> $GITHUB_OUTPUT
+          echo "tag=$(echo ${{ inputs.release_version }})" >> $GITHUB_OUTPUT
 
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1

--- a/.github/workflows/publish-rag-service-gh-image.yaml
+++ b/.github/workflows/publish-rag-service-gh-image.yaml
@@ -5,6 +5,12 @@ on:
       release_version:
         description: 'tag to be created for this image (i.e. vxx.xx.xx)'
         required: true
+  workflow_call:
+    inputs:
+      release_version:
+        description: 'tag to be published'
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -25,12 +31,12 @@ jobs:
     steps:
       - name: validate version
         run: |
-          echo "${{ github.event.inputs.release_version }}" | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'
+          echo "${{ inputs.release_version }}" | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'
 
       - id: get-tag
         name: Get tag
         run: |
-          echo "tag=$(echo ${{ github.event.inputs.release_version }})" >> $GITHUB_OUTPUT
+          echo "tag=$(echo ${{ inputs.release_version }})" >> $GITHUB_OUTPUT
 
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1

--- a/.github/workflows/publish-workspace-gh-image.yaml
+++ b/.github/workflows/publish-workspace-gh-image.yaml
@@ -5,6 +5,12 @@ on:
       release_version:
         description: 'tag to be created for this image (i.e. vxx.xx.xx)'
         required: true
+  workflow_call:
+    inputs:
+      release_version:
+        description: 'tag to be published'
+        required: true
+        type: string
 
 permissions:
   id-token: write
@@ -25,12 +31,12 @@ jobs:
     steps:
       - name: validate version
         run: |
-          echo "${{ github.event.inputs.release_version }}" | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'
+          echo "${{ inputs.release_version }}" | grep -E 'v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$'
 
       - id: get-tag
         name: Get tag
         run: |
-            echo "tag=$(echo ${{ github.event.inputs.release_version }})" >> $GITHUB_OUTPUT
+            echo "tag=$(echo ${{ inputs.release_version }})" >> $GITHUB_OUTPUT
 
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,68 @@
+name: Release
+
+# Push a semver tag (e.g. v0.8.0 or v0.8.0-rc.1) on a release branch and
+# this workflow will:
+#   1. Build, scan and publish all GH container images (workspace,
+#      rag-controller, rag-service) in parallel. Each of those then
+#      cascades, via repository_dispatch, to the matching MCR build job
+#      and helm-chart publish job (existing chain, unchanged).
+#   2. Once all GH image jobs succeed, run goreleaser to create the
+#      GitHub Release with auto-generated changelog.
+#
+# Manual fallback: the individual publish-*-gh-image.yaml and
+# github-release.yaml workflows still expose workflow_dispatch so they
+# can be re-run individually if a step needs to be retried.
+
+on:
+  push:
+    tags:
+      - 'v[0-9]+.[0-9]+.[0-9]+'
+      - 'v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+'
+
+permissions:
+  id-token: write
+  contents: write
+  packages: write
+
+jobs:
+  resolve-version:
+    runs-on: ubuntu-latest
+    outputs:
+      release_version: ${{ steps.resolve.outputs.release_version }}
+    steps:
+      - id: resolve
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          echo "release_version=${TAG}" >> "$GITHUB_OUTPUT"
+
+  publish-workspace:
+    needs: resolve-version
+    uses: ./.github/workflows/publish-workspace-gh-image.yaml
+    with:
+      release_version: ${{ needs.resolve-version.outputs.release_version }}
+    secrets: inherit
+
+  publish-rag-controller:
+    needs: resolve-version
+    uses: ./.github/workflows/publish-rag-controller-gh-image.yaml
+    with:
+      release_version: ${{ needs.resolve-version.outputs.release_version }}
+    secrets: inherit
+
+  publish-rag-service:
+    needs: resolve-version
+    uses: ./.github/workflows/publish-rag-service-gh-image.yaml
+    with:
+      release_version: ${{ needs.resolve-version.outputs.release_version }}
+    secrets: inherit
+
+  create-release:
+    needs:
+      - resolve-version
+      - publish-workspace
+      - publish-rag-controller
+      - publish-rag-service
+    uses: ./.github/workflows/github-release.yaml
+    with:
+      release_version: ${{ needs.resolve-version.outputs.release_version }}
+    secrets: inherit


### PR DESCRIPTION

**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Push a semver tag (e.g. v0.8.0) on a release branch and the new release.yaml orchestrator fans out to the 3 image-publish workflows in parallel, then runs goreleaser once they all succeed. The existing repository_dispatch cascade to MCR builds and helm-chart publishing is unchanged.

The 3 publish-*-gh-image workflows and github-release.yaml (renamed from create-release.yaml) now expose workflow_call alongside workflow_dispatch, so they can still be run individually as a manual fallback.

    push tag v0.8.0
      └─ release.yaml
            ├─ publish-workspace-gh-image (workflow_call)
            │     └─ dispatches → publish-workspace-mcr-image
            │           └─ dispatches → publish-workspace-helm-chart
            ├─ publish-rag-controller-gh-image (workflow_call)
            │     └─ dispatches → publish-rag-controller-mcr-image
            │           └─ dispatches → publish-ragengine-helm-chart
            ├─ publish-rag-service-gh-image (workflow_call)
            │     └─ dispatches → publish-rag-service-mcr-image
            │           └─ dispatches → publish-ragengine-helm-chart
            └─ github-release (after all 3 GH images succeed)

