### PR TITLE
feat: support surge-based auto upgrade for base serving image

### DIFF
--- a/.github/workflows/base-image-auto-upgrade-test.yaml
+++ b/.github/workflows/base-image-auto-upgrade-test.yaml
@@ -570,11 +570,25 @@ jobs:
           NEW_TAG=$(yq '.models[] | select(.name == "base") | .tag' presets/workspace/models/supported_models.yaml)
           echo "Blue: $BLUE_WS  Green: $GREEN_WS"
 
-          # The green surge should run the NEW base image.
-          GREEN_IMAGE=$(kubectl get statefulset "$GREEN_WS" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
-          echo "Green StatefulSet image: $GREEN_IMAGE"
+          # The green surge should run the NEW base image. The Workspace controller
+          # creates the green StatefulSet asynchronously after the Workspace object,
+          # so poll until the image is populated rather than checking once.
+          echo "Waiting for green StatefulSet to be created on the new base tag $NEW_TAG..."
+          end=$((SECONDS+300))
+          GREEN_IMAGE=""
+          while [ $SECONDS -lt $end ]; do
+            GREEN_IMAGE=$(kubectl get statefulset "$GREEN_WS" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+            if echo "$GREEN_IMAGE" | grep -q "$NEW_TAG"; then
+              echo "Green StatefulSet image: $GREEN_IMAGE"
+              break
+            fi
+            echo "Waiting for green StatefulSet image... (current: '${GREEN_IMAGE:-<none>}')"
+            sleep 10
+          done
           if ! echo "$GREEN_IMAGE" | grep -q "$NEW_TAG"; then
-            echo "ERROR: green workspace is not on the new base tag $NEW_TAG"
+            echo "ERROR: green workspace is not on the new base tag $NEW_TAG (image: '${GREEN_IMAGE:-<none>}')"
+            kubectl get workspace -L kaito.sh/upgrade-surge-for
+            kubectl get statefulset "$GREEN_WS" -o yaml 2>/dev/null || true
             exit 1
           fi
 

--- a/.github/workflows/base-image-auto-upgrade-test.yaml
+++ b/.github/workflows/base-image-auto-upgrade-test.yaml
@@ -352,7 +352,7 @@ jobs:
       contents: read
       id-token: write
     env:
-      INFERENCESET_NAME: auto-upgrade-bg-test
+      INFERENCESET_NAME: auto-upgrade-surge-test
 
     steps:
       - name: Harden Runner
@@ -466,8 +466,8 @@ jobs:
                 echo "Workspace $WS_NAME is ready"
                 SS_IMAGE=$(kubectl get statefulset "$WS_NAME" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
                 echo "Current workload image: $SS_IMAGE"
-                # Record the original (blue) workspace name for later comparison.
-                echo "BLUE_WS=$WS_NAME" >> "$GITHUB_ENV"
+                # Record the original (old) workspace name for later comparison.
+                echo "OLD_WS=$WS_NAME" >> "$GITHUB_ENV"
                 break
               fi
               POD_STATUS=$(kubectl get pods -l kaito.sh/workspace="$WS_NAME" -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)
@@ -516,179 +516,242 @@ jobs:
             exit 1
           fi
 
-      - name: Verify a surge (green) workspace is created
+      - name: Verify a surge workspace is created
         shell: bash
         run: |
           NEW_TAG=$(yq '.models[] | select(.name == "base") | .tag' presets/workspace/models/supported_models.yaml)
           echo "Expected new base tag: $NEW_TAG"
-          echo "Blue (old) workspace: $BLUE_WS"
+          echo "Old workspace: $OLD_WS"
           echo "Waiting for the surge workspace to be created..."
 
           end=$((SECONDS+600))
-          GREEN_WS=""
+          SURGE_WS=""
           while [ $SECONDS -lt $end ]; do
-            # The surge (green) workspace carries the upgrade-surge-for label.
-            GREEN_WS=$(kubectl get workspace -l kaito.sh/upgrade-surge-for -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-            if [ -n "$GREEN_WS" ]; then
-              SURGE_FOR=$(kubectl get workspace "$GREEN_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
-              echo "Surge workspace created: $GREEN_WS (surge-for=$SURGE_FOR)"
+            # The surge workspace carries the upgrade-surge-for label.
+            SURGE_WS=$(kubectl get workspace -l kaito.sh/upgrade-surge-for -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+            if [ -n "$SURGE_WS" ]; then
+              SURGE_FOR=$(kubectl get workspace "$SURGE_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
+              echo "Surge workspace created: $SURGE_WS (surge-for=$SURGE_FOR)"
 
-              # The surge must replace the blue workspace and must NOT be the blue one.
-              if [ "$GREEN_WS" = "$BLUE_WS" ]; then
-                echo "ERROR: surge workspace is the same as blue workspace"
+              # The surge must replace the old workspace and must NOT be the old one.
+              if [ "$SURGE_WS" = "$OLD_WS" ]; then
+                echo "ERROR: surge workspace is the same as the old workspace"
                 exit 1
               fi
-              if [ "$SURGE_FOR" != "$BLUE_WS" ]; then
-                echo "ERROR: surge-for=$SURGE_FOR does not point to blue workspace $BLUE_WS"
+              if [ "$SURGE_FOR" != "$OLD_WS" ]; then
+                echo "ERROR: surge-for=$SURGE_FOR does not point to old workspace $OLD_WS"
                 exit 1
               fi
-              echo "GREEN_WS=$GREEN_WS" >> "$GITHUB_ENV"
+              echo "SURGE_WS=$SURGE_WS" >> "$GITHUB_ENV"
               break
             fi
             echo "Waiting for surge workspace... (none yet)"
             sleep 10
           done
 
-          if [ -z "$GREEN_WS" ]; then
+          if [ -z "$SURGE_WS" ]; then
             echo "Timeout: surge workspace was not created"
             kubectl get workspace -L kaito.sh/upgrade-surge-for
             kubectl logs deploy/kaito-workspace -n kaito-workspace --tail=200
             exit 1
           fi
 
-          # Blue must still exist and must NOT carry the surge label.
-          kubectl get workspace "$BLUE_WS" >/dev/null
-          BLUE_SURGE=$(kubectl get workspace "$BLUE_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
-          if [ -n "$BLUE_SURGE" ]; then
-            echo "ERROR: blue workspace unexpectedly has surge label"
+          # Old workspace must still exist and must NOT carry the surge label.
+          kubectl get workspace "$OLD_WS" >/dev/null
+          OLD_SURGE_LABEL=$(kubectl get workspace "$OLD_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
+          if [ -n "$OLD_SURGE_LABEL" ]; then
+            echo "ERROR: old workspace unexpectedly has surge label"
             exit 1
           fi
 
-      - name: Verify no downtime - blue stays ready until green is ready
+      - name: Scale up during in-flight upgrade
+        shell: bash
+        run: |
+          # The surge for OLD_WS is now in flight (SURGE_WS created, not yet
+          # promoted). Scale the InferenceSet from 1 to 2 and verify the controller
+          # creates an additional (stable) replica DURING the upgrade. This proves
+          # an in-flight surge no longer blocks scaling: the runner owns the surge
+          # and the old workspace it replaces, while the InferenceSet controller is
+          # free to reconcile the remaining replica slots.
+          echo "Scaling ${INFERENCESET_NAME} from 1 to 2 while the surge is in flight..."
+          kubectl patch inferenceset ${INFERENCESET_NAME} --type=merge -p '{"spec":{"replicas":2}}'
+
+          echo "Waiting for a new stable replica (neither the old workspace nor the surge) to be created..."
+          end=$((SECONDS+600))
+          SCALED_WS=""
+          while [ $SECONDS -lt $end ]; do
+            for w in $(kubectl get workspace -l inferenceset.kaito.sh/created-by=${INFERENCESET_NAME} -o jsonpath='{.items[*].metadata.name}'); do
+              if [ "$w" != "$OLD_WS" ] && [ "$w" != "$SURGE_WS" ]; then
+                W_SURGE=$(kubectl get workspace "$w" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
+                if [ -z "$W_SURGE" ]; then
+                  SCALED_WS="$w"
+                  break
+                fi
+              fi
+            done
+            if [ -n "$SCALED_WS" ]; then
+              echo "New stable replica created during upgrade: $SCALED_WS"
+              echo "SCALED_WS=$SCALED_WS" >> "$GITHUB_ENV"
+              break
+            fi
+            # The in-flight surge must not vanish while we wait for the scale-up.
+            if ! kubectl get workspace "$SURGE_WS" >/dev/null 2>&1; then
+              echo "NOTE: surge $SURGE_WS already completed before scale-up was observed"
+            fi
+            echo "Waiting for scaled replica... (none yet)"
+            sleep 10
+          done
+
+          if [ -z "$SCALED_WS" ]; then
+            echo "ERROR: scaling was blocked during the in-flight upgrade (no new replica created)"
+            kubectl get workspace -L kaito.sh/upgrade-surge-for
+            kubectl logs deploy/kaito-workspace -n kaito-workspace --tail=200
+            exit 1
+          fi
+
+          # Old workspace must still be present and serving: scaling must not disturb
+          # the in-flight upgrade or cause downtime on the old replica.
+          OLD_DELETING=$(kubectl get workspace "$OLD_WS" -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true)
+          if [ -n "$OLD_DELETING" ]; then
+            echo "ERROR: old workspace was deleted as a side effect of scaling (downtime!)"
+            exit 1
+          fi
+
+      - name: Verify no downtime - old stays ready until surge is ready
         shell: bash
         run: |
           NEW_TAG=$(yq '.models[] | select(.name == "base") | .tag' presets/workspace/models/supported_models.yaml)
-          echo "Blue: $BLUE_WS  Green: $GREEN_WS"
+          echo "Old: $OLD_WS  Surge: $SURGE_WS"
 
-          # The green surge should run the NEW base image. The Workspace controller
-          # creates the green StatefulSet asynchronously after the Workspace object,
+          # The surge should run the NEW base image. The Workspace controller
+          # creates the surge StatefulSet asynchronously after the Workspace object,
           # so poll until the image is populated rather than checking once.
-          echo "Waiting for green StatefulSet to be created on the new base tag $NEW_TAG..."
+          echo "Waiting for surge StatefulSet to be created on the new base tag $NEW_TAG..."
           end=$((SECONDS+300))
-          GREEN_IMAGE=""
+          SURGE_IMAGE=""
           while [ $SECONDS -lt $end ]; do
-            GREEN_IMAGE=$(kubectl get statefulset "$GREEN_WS" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
-            if echo "$GREEN_IMAGE" | grep -q "$NEW_TAG"; then
-              echo "Green StatefulSet image: $GREEN_IMAGE"
+            SURGE_IMAGE=$(kubectl get statefulset "$SURGE_WS" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+            if echo "$SURGE_IMAGE" | grep -q "$NEW_TAG"; then
+              echo "Surge StatefulSet image: $SURGE_IMAGE"
               break
             fi
-            echo "Waiting for green StatefulSet image... (current: '${GREEN_IMAGE:-<none>}')"
+            echo "Waiting for surge StatefulSet image... (current: '${SURGE_IMAGE:-<none>}')"
             sleep 10
           done
-          if ! echo "$GREEN_IMAGE" | grep -q "$NEW_TAG"; then
-            echo "ERROR: green workspace is not on the new base tag $NEW_TAG (image: '${GREEN_IMAGE:-<none>}')"
+          if ! echo "$SURGE_IMAGE" | grep -q "$NEW_TAG"; then
+            echo "ERROR: surge workspace is not on the new base tag $NEW_TAG (image: '${SURGE_IMAGE:-<none>}')"
             kubectl get workspace -L kaito.sh/upgrade-surge-for
-            kubectl get statefulset "$GREEN_WS" -o yaml 2>/dev/null || true
+            kubectl get statefulset "$SURGE_WS" -o yaml 2>/dev/null || true
             exit 1
           fi
 
-          # While the green workspace comes up (and downloads weights), the blue
+          # While the surge workspace comes up (and downloads weights), the old
           # workspace MUST keep serving (InferenceReady=True). This is the core
-          # no-downtime guarantee of surge-based upgrades. Poll until green is ready, and on
-          # every poll assert blue is still ready and not being deleted.
-          echo "Waiting for green to become ready while asserting blue stays ready..."
+          # no-downtime guarantee of surge-based upgrades. Poll until the surge is
+          # ready, and on every poll assert the old workspace is still ready and not
+          # being deleted.
+          echo "Waiting for the surge to become ready while asserting the old workspace stays ready..."
           end=$((SECONDS+2400))
           while [ $SECONDS -lt $end ]; do
-            GREEN_READY=$(kubectl get workspace "$GREEN_WS" -o jsonpath='{.status.conditions[?(@.type=="InferenceReady")].status}' 2>/dev/null || true)
-            if [ "$GREEN_READY" = "True" ]; then
-              echo "Green workspace $GREEN_WS is ready"
+            SURGE_READY=$(kubectl get workspace "$SURGE_WS" -o jsonpath='{.status.conditions[?(@.type=="InferenceReady")].status}' 2>/dev/null || true)
+            if [ "$SURGE_READY" = "True" ]; then
+              echo "Surge workspace $SURGE_WS is ready"
               break
             fi
 
-            # Blue must still be present and serving during the surge bring-up.
-            BLUE_DELETING=$(kubectl get workspace "$BLUE_WS" -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true)
-            BLUE_READY=$(kubectl get workspace "$BLUE_WS" -o jsonpath='{.status.conditions[?(@.type=="InferenceReady")].status}' 2>/dev/null || true)
-            if [ -n "$BLUE_DELETING" ]; then
-              echo "ERROR: blue workspace is being deleted before green is ready (downtime!)"
+            # Old workspace must still be present and serving during the surge bring-up.
+            OLD_DELETING=$(kubectl get workspace "$OLD_WS" -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true)
+            OLD_READY=$(kubectl get workspace "$OLD_WS" -o jsonpath='{.status.conditions[?(@.type=="InferenceReady")].status}' 2>/dev/null || true)
+            if [ -n "$OLD_DELETING" ]; then
+              echo "ERROR: old workspace is being deleted before the surge is ready (downtime!)"
               kubectl get workspace -L kaito.sh/upgrade-surge-for
               exit 1
             fi
-            if [ "$BLUE_READY" != "True" ]; then
-              echo "ERROR: blue workspace lost readiness before green is ready (downtime!) - InferenceReady=$BLUE_READY"
-              kubectl get workspace "$BLUE_WS" -o yaml
+            if [ "$OLD_READY" != "True" ]; then
+              echo "ERROR: old workspace lost readiness before the surge is ready (downtime!) - InferenceReady=$OLD_READY"
+              kubectl get workspace "$OLD_WS" -o yaml
               exit 1
             fi
 
-            echo "Waiting... (green ready: ${GREEN_READY:-False}, blue ready: $BLUE_READY)"
+            echo "Waiting... (surge ready: ${SURGE_READY:-False}, old ready: $OLD_READY)"
             sleep 20
           done
 
           if [ $SECONDS -ge $end ]; then
-            echo "Timeout: green workspace did not become ready"
+            echo "Timeout: surge workspace did not become ready"
             kubectl get workspace -L kaito.sh/upgrade-surge-for
-            kubectl describe pods -l kaito.sh/workspace="$GREEN_WS" 2>/dev/null | tail -60 || true
-            kubectl logs -l kaito.sh/workspace="$GREEN_WS" --tail=100 2>/dev/null || true
+            kubectl describe pods -l kaito.sh/workspace="$SURGE_WS" 2>/dev/null | tail -60 || true
+            kubectl logs -l kaito.sh/workspace="$SURGE_WS" --tail=100 2>/dev/null || true
             kubectl logs deploy/kaito-workspace -n kaito-workspace --tail=200
             exit 1
           fi
 
-      - name: Verify cutover - blue deleted and green promoted
+      - name: Verify cutover - old deleted and surge promoted
         shell: bash
         run: |
-          echo "Waiting for blue ($BLUE_WS) to be deleted after green became ready..."
+          echo "Waiting for the old workspace ($OLD_WS) to be deleted after the surge became ready..."
           end=$((SECONDS+600))
           while [ $SECONDS -lt $end ]; do
-            if ! kubectl get workspace "$BLUE_WS" >/dev/null 2>&1; then
-              echo "Blue workspace $BLUE_WS deleted (cutover complete)"
+            if ! kubectl get workspace "$OLD_WS" >/dev/null 2>&1; then
+              echo "Old workspace $OLD_WS deleted (cutover complete)"
               break
             fi
-            echo "Waiting for blue deletion..."
+            echo "Waiting for old workspace deletion..."
             sleep 10
           done
-          if kubectl get workspace "$BLUE_WS" >/dev/null 2>&1; then
-            echo "Timeout: blue workspace was not deleted"
+          if kubectl get workspace "$OLD_WS" >/dev/null 2>&1; then
+            echo "Timeout: old workspace was not deleted"
             kubectl get workspace -L kaito.sh/upgrade-surge-for
             kubectl logs deploy/kaito-workspace -n kaito-workspace --tail=200
             exit 1
           fi
 
-          echo "Waiting for green ($GREEN_WS) to be promoted (surge label removed)..."
+          echo "Waiting for the surge ($SURGE_WS) to be promoted (surge label removed)..."
           end=$((SECONDS+600))
           while [ $SECONDS -lt $end ]; do
-            SURGE_LABEL=$(kubectl get workspace "$GREEN_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
+            SURGE_LABEL=$(kubectl get workspace "$SURGE_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
             if [ -z "$SURGE_LABEL" ]; then
-              echo "Green workspace promoted (surge label removed)"
+              echo "Surge workspace promoted (surge label removed)"
               break
             fi
             echo "Waiting for promotion... (surge-for still: $SURGE_LABEL)"
             sleep 10
           done
-          SURGE_LABEL=$(kubectl get workspace "$GREEN_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
+          SURGE_LABEL=$(kubectl get workspace "$SURGE_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
           if [ -n "$SURGE_LABEL" ]; then
-            echo "Timeout: green workspace was not promoted"
-            kubectl get workspace "$GREEN_WS" -o yaml
+            echo "Timeout: surge workspace was not promoted"
+            kubectl get workspace "$SURGE_WS" -o yaml
             exit 1
           fi
 
-          # Exactly one managed workspace should remain, on the new tag, ready.
+          # After cutover + scale-up, exactly two replicas should remain: the
+          # promoted surge and the replica added during the upgrade. Both must be
+          # on the new tag and ready, with no surge labels left.
           NEW_TAG=$(yq '.models[] | select(.name == "base") | .tag' presets/workspace/models/supported_models.yaml)
-          COUNT=$(kubectl get workspace -l inferenceset.kaito.sh/created-by=${INFERENCESET_NAME} -o json | jq '.items | length')
-          echo "Workspace count for InferenceSet: $COUNT"
-          if [ "$COUNT" != "1" ]; then
-            echo "ERROR: expected exactly 1 workspace after cutover, got $COUNT"
+          echo "Waiting for the InferenceSet to settle at 2 ready replicas on $NEW_TAG..."
+          end=$((SECONDS+2400))
+          while [ $SECONDS -lt $end ]; do
+            data=$(kubectl get workspace -l inferenceset.kaito.sh/created-by=${INFERENCESET_NAME} -o json)
+            COUNT=$(echo "$data" | jq '.items | length')
+            SURGES=$(echo "$data" | jq '[.items[]|select(.metadata.labels["kaito.sh/upgrade-surge-for"])]|length')
+            READY=$(echo "$data" | jq '[.items[]|select(.status.conditions[]?|select(.type=="InferenceReady" and .status=="True"))]|length')
+            # Count workspaces whose StatefulSet image is on the new tag.
+            ONNEW=0
+            for w in $(echo "$data" | jq -r '.items[].metadata.name'); do
+              IMG=$(kubectl get statefulset "$w" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+              if echo "$IMG" | grep -q "$NEW_TAG"; then ONNEW=$((ONNEW+1)); fi
+            done
+            echo "count=$COUNT surges=$SURGES ready=$READY onNewTag=$ONNEW"
+            if [ "$COUNT" = "2" ] && [ "$SURGES" = "0" ] && [ "$READY" = "2" ] && [ "$ONNEW" = "2" ]; then
+              echo "Upgrade + scale-up settled: 2 replicas, both ready on $NEW_TAG, no surges."
+              break
+            fi
+            sleep 20
+          done
+          if [ $SECONDS -ge $end ]; then
+            echo "ERROR: InferenceSet did not settle at 2 ready replicas on the new tag"
             kubectl get workspace -L kaito.sh/upgrade-surge-for
-            exit 1
-          fi
-
-          GREEN_IMAGE=$(kubectl get statefulset "$GREEN_WS" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
-          GREEN_READY=$(kubectl get workspace "$GREEN_WS" -o jsonpath='{.status.conditions[?(@.type=="InferenceReady")].status}' 2>/dev/null || true)
-          echo "Final workspace $GREEN_WS image: $GREEN_IMAGE, InferenceReady: $GREEN_READY"
-          if ! echo "$GREEN_IMAGE" | grep -q "$NEW_TAG"; then
-            echo "ERROR: final workspace is not on the new base tag $NEW_TAG"
-            exit 1
-          fi
-          if [ "$GREEN_READY" != "True" ]; then
-            echo "ERROR: final workspace is not ready"
+            kubectl logs deploy/kaito-workspace -n kaito-workspace --tail=200
             exit 1
           fi
 

--- a/.github/workflows/base-image-auto-upgrade-test.yaml
+++ b/.github/workflows/base-image-auto-upgrade-test.yaml
@@ -4,8 +4,11 @@ on:
   pull_request:
     paths:
       - "pkg/controllers/autoupgrade/**"
+      - "pkg/inferenceset/**"
+      - "pkg/utils/inferenceset/**"
       - "pkg/workspace/controllers/workspace_controller.go"
       - "api/v1alpha1/inferenceset_types.go"
+      - "api/v1beta1/inferenceset_types.go"
       - "charts/kaito/workspace/**"
       - ".github/workflows/base-image-auto-upgrade-test.yaml"
   workflow_dispatch:
@@ -25,7 +28,7 @@ env:
   GO_VERSION: "1.26.4"
 
 jobs:
-  auto-upgrade-test:
+  in-place-auto-upgrade-test:
     runs-on: ["self-hosted", "hostname:kaito-e2e-github-runner"]
     environment: e2e-test
     permissions:
@@ -331,6 +334,370 @@ jobs:
           echo "NumDriftedWorkspaces: $DRIFT"
           echo "LastSuccessfulUpgradeTime: $LAST_SUCCESS"
           kubectl get inferenceset auto-upgrade-test -o yaml
+          exit 1
+
+      - name: Cleanup
+        if: always()
+        shell: bash
+        run: |
+          az group delete --name "${{ env.CLUSTER_NAME }}" --yes --no-wait || true
+
+  # Blue-green strategy: the controller creates a NEW (green) Workspace on the new
+  # base image, waits for it to become ready, then deletes the OLD (blue) one. This
+  # verifies the no-downtime upgrade path, in contrast to the in-place job above.
+  bluegreen-auto-upgrade-test:
+    runs-on: ["self-hosted", "hostname:kaito-e2e-github-runner"]
+    environment: e2e-test
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      INFERENCESET_NAME: auto-upgrade-bg-test
+
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Run e2e-base-setup composite action
+        uses: ./.github/actions/e2e-base-setup
+        with:
+          git_sha: ${{ github.event.pull_request.head.sha || github.sha }}
+          skip_helm_install: true
+
+      - name: Build base image with semantic version tag
+        shell: bash
+        run: |
+          # Build the base image directly with the actual version tag (e.g. 0.3.2)
+          # so the auto-upgrade label shows the real version instead of a random CI ID.
+          BASE_TAG=$(git show HEAD:presets/workspace/models/supported_models.yaml | yq '.models[] | select(.name == "base") | .tag')
+          echo "Building base image: $REGISTRY/kaito-base:$BASE_TAG"
+
+          docker buildx build \
+            --builder img-builder \
+            --build-arg VERSION="$BASE_TAG" \
+            --build-arg MODEL_TYPE=text-generation \
+            --output "type=image,name=$REGISTRY/kaito-base:$BASE_TAG,push=true,compression=zstd" \
+            -f ./docker/presets/models/tfs/Dockerfile .
+
+          # Ensure supported_models.yaml points to test ACR with the semantic tag
+          yq -i "(.models[] | select(.name == \"base\") | .tag) = \"$BASE_TAG\"" presets/workspace/models/supported_models.yaml
+          yq -i "(.models[] | select(.name == \"base\") | .registry) = \"$REGISTRY\"" presets/workspace/models/supported_models.yaml
+          echo "Base model config: registry=$REGISTRY, tag=$BASE_TAG"
+
+      - name: Build workspace controller
+        run: |
+          make docker-build-workspace
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+          IMG_NAME: "workspace"
+          IMG_TAG: "test"
+          OUTPUT_TYPE: "type=registry"
+          ARCH: "amd64"
+
+      - name: Install old chart (${{ env.OLD_CHART_VERSION }})
+        shell: bash
+        run: |
+          helm repo add kaito https://kaito-project.github.io/kaito/charts/kaito
+          helm repo update
+          helm install kaito-workspace kaito/workspace \
+            --version ${{ env.OLD_CHART_VERSION }} \
+            --namespace kaito-workspace \
+            --create-namespace \
+            --set featureGates.enableInferenceSetController=true
+
+          kubectl wait --for=condition=available deploy "kaito-workspace" -n kaito-workspace --timeout=300s
+
+      - name: Wait for webhook endpoints
+        shell: bash
+        run: |
+          echo "Waiting for webhook service endpoints..."
+          end=$((SECONDS+120))
+          while [ $SECONDS -lt $end ]; do
+            EP=$(kubectl get endpoints kaito-workspace-svc -n kaito-workspace -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null || true)
+            if [ -n "$EP" ]; then
+              echo "Webhook endpoint ready: $EP"
+              break
+            fi
+            sleep 5
+          done
+
+          if [ $SECONDS -ge $end ]; then
+            echo "Timeout waiting for webhook endpoints"
+            exit 1
+          fi
+
+      - name: Create InferenceSet (without autoUpgrade)
+        shell: bash
+        run: |
+          # Old chart CRD does not have autoUpgrade field, so create without it.
+          cat <<EOF | kubectl apply -f -
+          apiVersion: kaito.sh/v1alpha1
+          kind: InferenceSet
+          metadata:
+            name: ${INFERENCESET_NAME}
+          spec:
+            replicas: 1
+            labelSelector:
+              matchLabels:
+                apps: ${INFERENCESET_NAME}
+            template:
+              resource:
+                instanceType: "Standard_NV36ads_A10_v5"
+              inference:
+                preset:
+                  name: mistral-7b-instruct
+          EOF
+
+      - name: Wait for workspace readiness (old controller)
+        shell: bash
+        run: |
+          echo "Waiting for InferenceSet workspace to become ready..."
+          end=$((SECONDS+2400))
+          while [ $SECONDS -lt $end ]; do
+            WS_NAME=$(kubectl get workspace -l inferenceset.kaito.sh/created-by=${INFERENCESET_NAME} -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+            if [ -n "$WS_NAME" ]; then
+              READY=$(kubectl get workspace "$WS_NAME" -o jsonpath='{.status.conditions[?(@.type=="InferenceReady")].status}' 2>/dev/null || true)
+              if [ "$READY" = "True" ]; then
+                echo "Workspace $WS_NAME is ready"
+                SS_IMAGE=$(kubectl get statefulset "$WS_NAME" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+                echo "Current workload image: $SS_IMAGE"
+                # Record the original (blue) workspace name for later comparison.
+                echo "BLUE_WS=$WS_NAME" >> "$GITHUB_ENV"
+                break
+              fi
+              POD_STATUS=$(kubectl get pods -l kaito.sh/workspace="$WS_NAME" -o jsonpath='{.items[0].status.phase}' 2>/dev/null || true)
+              echo "Waiting... (workspace: $WS_NAME, pod: ${POD_STATUS:-unknown})"
+            else
+              echo "Waiting... (workspace: not yet created)"
+            fi
+            sleep 30
+          done
+
+          if [ $SECONDS -ge $end ]; then
+            echo "Timeout waiting for workspace readiness"
+            kubectl get workspace -o yaml
+            kubectl logs deploy/kaito-workspace -n kaito-workspace --tail=100 2>/dev/null || true
+            exit 1
+          fi
+
+      - name: Upgrade to current chart
+        shell: bash
+        run: |
+          yq -i '(.image.repository) = "'"${REGISTRY}"'/workspace"' ./charts/kaito/workspace/values.yaml
+          yq -i '(.image.tag) = "test"' ./charts/kaito/workspace/values.yaml
+
+          helm upgrade kaito-workspace ./charts/kaito/workspace \
+            --namespace kaito-workspace \
+            --set featureGates.enableBaseImageAutoUpgrade=true \
+            --set featureGates.enableInferenceSetController=true \
+            --take-ownership
+
+          kubectl rollout status deploy/kaito-workspace -n kaito-workspace --timeout=300s
+        env:
+          REGISTRY: ${{ env.REGISTRY }}
+
+      - name: Patch InferenceSet to enable blue-green autoUpgrade
+        shell: bash
+        run: |
+          # The old CRD did not have autoUpgrade; now that the chart (and CRD) is
+          # upgraded, enable autoUpgrade with the BlueGreen strategy.
+          kubectl patch inferenceset ${INFERENCESET_NAME} --type=merge \
+            -p '{"spec":{"autoUpgrade":{"enabled":true,"strategy":"BlueGreen"}}}'
+
+          STRATEGY=$(kubectl get inferenceset ${INFERENCESET_NAME} -o jsonpath='{.spec.autoUpgrade.strategy}')
+          echo "AutoUpgrade strategy: $STRATEGY"
+          if [ "$STRATEGY" != "BlueGreen" ]; then
+            echo "ERROR: expected strategy BlueGreen, got '$STRATEGY'"
+            exit 1
+          fi
+
+      - name: Verify a surge (green) workspace is created
+        shell: bash
+        run: |
+          NEW_TAG=$(yq '.models[] | select(.name == "base") | .tag' presets/workspace/models/supported_models.yaml)
+          echo "Expected new base tag: $NEW_TAG"
+          echo "Blue (old) workspace: $BLUE_WS"
+          echo "Waiting for the blue-green surge workspace to be created..."
+
+          end=$((SECONDS+600))
+          GREEN_WS=""
+          while [ $SECONDS -lt $end ]; do
+            # The surge (green) workspace carries the upgrade-surge-for label.
+            GREEN_WS=$(kubectl get workspace -l kaito.sh/upgrade-surge-for -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+            if [ -n "$GREEN_WS" ]; then
+              SURGE_FOR=$(kubectl get workspace "$GREEN_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
+              echo "Surge workspace created: $GREEN_WS (surge-for=$SURGE_FOR)"
+
+              # The surge must replace the blue workspace and must NOT be the blue one.
+              if [ "$GREEN_WS" = "$BLUE_WS" ]; then
+                echo "ERROR: surge workspace is the same as blue workspace"
+                exit 1
+              fi
+              if [ "$SURGE_FOR" != "$BLUE_WS" ]; then
+                echo "ERROR: surge-for=$SURGE_FOR does not point to blue workspace $BLUE_WS"
+                exit 1
+              fi
+              echo "GREEN_WS=$GREEN_WS" >> "$GITHUB_ENV"
+              break
+            fi
+            echo "Waiting for surge workspace... (none yet)"
+            sleep 10
+          done
+
+          if [ -z "$GREEN_WS" ]; then
+            echo "Timeout: surge workspace was not created"
+            kubectl get workspace -L kaito.sh/upgrade-surge-for
+            kubectl logs deploy/kaito-workspace -n kaito-workspace --tail=200
+            exit 1
+          fi
+
+          # Blue must still exist and must NOT carry the surge label.
+          kubectl get workspace "$BLUE_WS" >/dev/null
+          BLUE_SURGE=$(kubectl get workspace "$BLUE_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
+          if [ -n "$BLUE_SURGE" ]; then
+            echo "ERROR: blue workspace unexpectedly has surge label"
+            exit 1
+          fi
+
+      - name: Verify no downtime - blue stays ready until green is ready
+        shell: bash
+        run: |
+          NEW_TAG=$(yq '.models[] | select(.name == "base") | .tag' presets/workspace/models/supported_models.yaml)
+          echo "Blue: $BLUE_WS  Green: $GREEN_WS"
+
+          # The green surge should run the NEW base image.
+          GREEN_IMAGE=$(kubectl get statefulset "$GREEN_WS" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+          echo "Green StatefulSet image: $GREEN_IMAGE"
+          if ! echo "$GREEN_IMAGE" | grep -q "$NEW_TAG"; then
+            echo "ERROR: green workspace is not on the new base tag $NEW_TAG"
+            exit 1
+          fi
+
+          # While the green workspace comes up (and downloads weights), the blue
+          # workspace MUST keep serving (InferenceReady=True). This is the core
+          # no-downtime guarantee of blue-green. Poll until green is ready, and on
+          # every poll assert blue is still ready and not being deleted.
+          echo "Waiting for green to become ready while asserting blue stays ready..."
+          end=$((SECONDS+2400))
+          while [ $SECONDS -lt $end ]; do
+            GREEN_READY=$(kubectl get workspace "$GREEN_WS" -o jsonpath='{.status.conditions[?(@.type=="InferenceReady")].status}' 2>/dev/null || true)
+            if [ "$GREEN_READY" = "True" ]; then
+              echo "Green workspace $GREEN_WS is ready"
+              break
+            fi
+
+            # Blue must still be present and serving during the surge bring-up.
+            BLUE_DELETING=$(kubectl get workspace "$BLUE_WS" -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true)
+            BLUE_READY=$(kubectl get workspace "$BLUE_WS" -o jsonpath='{.status.conditions[?(@.type=="InferenceReady")].status}' 2>/dev/null || true)
+            if [ -n "$BLUE_DELETING" ]; then
+              echo "ERROR: blue workspace is being deleted before green is ready (downtime!)"
+              kubectl get workspace -L kaito.sh/upgrade-surge-for
+              exit 1
+            fi
+            if [ "$BLUE_READY" != "True" ]; then
+              echo "ERROR: blue workspace lost readiness before green is ready (downtime!) - InferenceReady=$BLUE_READY"
+              kubectl get workspace "$BLUE_WS" -o yaml
+              exit 1
+            fi
+
+            echo "Waiting... (green ready: ${GREEN_READY:-False}, blue ready: $BLUE_READY)"
+            sleep 20
+          done
+
+          if [ $SECONDS -ge $end ]; then
+            echo "Timeout: green workspace did not become ready"
+            kubectl get workspace -L kaito.sh/upgrade-surge-for
+            kubectl describe pods -l kaito.sh/workspace="$GREEN_WS" 2>/dev/null | tail -60 || true
+            kubectl logs -l kaito.sh/workspace="$GREEN_WS" --tail=100 2>/dev/null || true
+            kubectl logs deploy/kaito-workspace -n kaito-workspace --tail=200
+            exit 1
+          fi
+
+      - name: Verify cutover - blue deleted and green promoted
+        shell: bash
+        run: |
+          echo "Waiting for blue ($BLUE_WS) to be deleted after green became ready..."
+          end=$((SECONDS+600))
+          while [ $SECONDS -lt $end ]; do
+            if ! kubectl get workspace "$BLUE_WS" >/dev/null 2>&1; then
+              echo "Blue workspace $BLUE_WS deleted (cutover complete)"
+              break
+            fi
+            echo "Waiting for blue deletion..."
+            sleep 10
+          done
+          if kubectl get workspace "$BLUE_WS" >/dev/null 2>&1; then
+            echo "Timeout: blue workspace was not deleted"
+            kubectl get workspace -L kaito.sh/upgrade-surge-for
+            kubectl logs deploy/kaito-workspace -n kaito-workspace --tail=200
+            exit 1
+          fi
+
+          echo "Waiting for green ($GREEN_WS) to be promoted (surge label removed)..."
+          end=$((SECONDS+600))
+          while [ $SECONDS -lt $end ]; do
+            SURGE_LABEL=$(kubectl get workspace "$GREEN_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
+            if [ -z "$SURGE_LABEL" ]; then
+              echo "Green workspace promoted (surge label removed)"
+              break
+            fi
+            echo "Waiting for promotion... (surge-for still: $SURGE_LABEL)"
+            sleep 10
+          done
+          SURGE_LABEL=$(kubectl get workspace "$GREEN_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
+          if [ -n "$SURGE_LABEL" ]; then
+            echo "Timeout: green workspace was not promoted"
+            kubectl get workspace "$GREEN_WS" -o yaml
+            exit 1
+          fi
+
+          # Exactly one managed workspace should remain, on the new tag, ready.
+          NEW_TAG=$(yq '.models[] | select(.name == "base") | .tag' presets/workspace/models/supported_models.yaml)
+          COUNT=$(kubectl get workspace -l inferenceset.kaito.sh/created-by=${INFERENCESET_NAME} -o json | jq '.items | length')
+          echo "Workspace count for InferenceSet: $COUNT"
+          if [ "$COUNT" != "1" ]; then
+            echo "ERROR: expected exactly 1 workspace after cutover, got $COUNT"
+            kubectl get workspace -L kaito.sh/upgrade-surge-for
+            exit 1
+          fi
+
+          GREEN_IMAGE=$(kubectl get statefulset "$GREEN_WS" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+          GREEN_READY=$(kubectl get workspace "$GREEN_WS" -o jsonpath='{.status.conditions[?(@.type=="InferenceReady")].status}' 2>/dev/null || true)
+          echo "Final workspace $GREEN_WS image: $GREEN_IMAGE, InferenceReady: $GREEN_READY"
+          if ! echo "$GREEN_IMAGE" | grep -q "$NEW_TAG"; then
+            echo "ERROR: final workspace is not on the new base tag $NEW_TAG"
+            exit 1
+          fi
+          if [ "$GREEN_READY" != "True" ]; then
+            echo "ERROR: final workspace is not ready"
+            exit 1
+          fi
+
+      - name: Verify InferenceSet status reports zero drift
+        shell: bash
+        run: |
+          end=$((SECONDS+600))
+          while [ $SECONDS -lt $end ]; do
+            DRIFT=$(kubectl get inferenceset ${INFERENCESET_NAME} -o jsonpath='{.status.autoUpgrade.numDriftedWorkspaces}' 2>/dev/null || true)
+            LAST_SUCCESS=$(kubectl get inferenceset ${INFERENCESET_NAME} -o jsonpath='{.status.autoUpgrade.lastSuccessfulUpgradeTime}' 2>/dev/null || true)
+
+            if [ "$DRIFT" = "0" ] && [ -n "$LAST_SUCCESS" ]; then
+              echo "NumDriftedWorkspaces: $DRIFT"
+              echo "LastSuccessfulUpgradeTime: $LAST_SUCCESS"
+              echo "InferenceSet blue-green auto-upgrade status verified successfully."
+              exit 0
+            fi
+            echo "Waiting for status update... (drift: ${DRIFT:-unknown}, lastSuccess: ${LAST_SUCCESS:-<none>})"
+            sleep 15
+          done
+
+          echo "Timeout: InferenceSet status not updated"
+          kubectl get inferenceset ${INFERENCESET_NAME} -o yaml
           exit 1
 
       - name: Cleanup

--- a/.github/workflows/base-image-auto-upgrade-test.yaml
+++ b/.github/workflows/base-image-auto-upgrade-test.yaml
@@ -342,9 +342,10 @@ jobs:
         run: |
           az group delete --name "${{ env.CLUSTER_NAME }}" --yes --no-wait || true
 
-  # Surge-based strategy: the controller creates a NEW (surge) Workspace on the new
-  # base image, waits for it to become ready, then deletes the OLD one. This
-  # verifies the no-downtime upgrade path, in contrast to the in-place job above.
+  # Surge-based strategy: the auto-upgrade runner adds a NEW Workspace on the new
+  # base image; the InferenceSet controller keeps the OLD one serving until the new
+  # one is Ready, then retires the old one during scale-down. This verifies the
+  # no-downtime upgrade path, in contrast to the in-place job above.
   surge-based-auto-upgrade-test:
     runs-on: ["self-hosted", "hostname:kaito-e2e-github-runner"]
     environment: e2e-test
@@ -516,180 +517,121 @@ jobs:
             exit 1
           fi
 
-      - name: Verify a surge workspace is created
+      - name: Verify a new workspace is created on the new base image
         shell: bash
         run: |
           NEW_TAG=$(yq '.models[] | select(.name == "base") | .tag' presets/workspace/models/supported_models.yaml)
           echo "Expected new base tag: $NEW_TAG"
           echo "Old workspace: $OLD_WS"
-          echo "Waiting for the surge workspace to be created..."
+          echo "Waiting for the auto-upgrade runner to create a new (surge) workspace..."
 
+          # The runner adds one new-image workspace with no special label; it is simply
+          # the workspace belonging to this InferenceSet that is not the original one.
           end=$((SECONDS+600))
-          SURGE_WS=""
-          while [ $SECONDS -lt $end ]; do
-            # The surge workspace carries the upgrade-surge-for label.
-            SURGE_WS=$(kubectl get workspace -l kaito.sh/upgrade-surge-for -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
-            if [ -n "$SURGE_WS" ]; then
-              SURGE_FOR=$(kubectl get workspace "$SURGE_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
-              echo "Surge workspace created: $SURGE_WS (surge-for=$SURGE_FOR)"
-
-              # The surge must replace the old workspace and must NOT be the old one.
-              if [ "$SURGE_WS" = "$OLD_WS" ]; then
-                echo "ERROR: surge workspace is the same as the old workspace"
-                exit 1
-              fi
-              if [ "$SURGE_FOR" != "$OLD_WS" ]; then
-                echo "ERROR: surge-for=$SURGE_FOR does not point to old workspace $OLD_WS"
-                exit 1
-              fi
-              echo "SURGE_WS=$SURGE_WS" >> "$GITHUB_ENV"
-              break
-            fi
-            echo "Waiting for surge workspace... (none yet)"
-            sleep 10
-          done
-
-          if [ -z "$SURGE_WS" ]; then
-            echo "Timeout: surge workspace was not created"
-            kubectl get workspace -L kaito.sh/upgrade-surge-for
-            kubectl logs deploy/kaito-workspace -n kaito-workspace --tail=200
-            exit 1
-          fi
-
-          # Old workspace must still exist and must NOT carry the surge label.
-          kubectl get workspace "$OLD_WS" >/dev/null
-          OLD_SURGE_LABEL=$(kubectl get workspace "$OLD_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
-          if [ -n "$OLD_SURGE_LABEL" ]; then
-            echo "ERROR: old workspace unexpectedly has surge label"
-            exit 1
-          fi
-
-      - name: Scale up during in-flight upgrade
-        shell: bash
-        run: |
-          # The surge for OLD_WS is now in flight (SURGE_WS created, not yet
-          # promoted). Scale the InferenceSet from 1 to 2 and verify the controller
-          # creates an additional (stable) replica DURING the upgrade. This proves
-          # an in-flight surge no longer blocks scaling: the runner owns the surge
-          # and the old workspace it replaces, while the InferenceSet controller is
-          # free to reconcile the remaining replica slots.
-          echo "Scaling ${INFERENCESET_NAME} from 1 to 2 while the surge is in flight..."
-          kubectl patch inferenceset ${INFERENCESET_NAME} --type=merge -p '{"spec":{"replicas":2}}'
-
-          echo "Waiting for a new stable replica (neither the old workspace nor the surge) to be created..."
-          end=$((SECONDS+600))
-          SCALED_WS=""
+          NEW_WS=""
           while [ $SECONDS -lt $end ]; do
             for w in $(kubectl get workspace -l inferenceset.kaito.sh/created-by=${INFERENCESET_NAME} -o jsonpath='{.items[*].metadata.name}'); do
-              if [ "$w" != "$OLD_WS" ] && [ "$w" != "$SURGE_WS" ]; then
-                W_SURGE=$(kubectl get workspace "$w" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
-                if [ -z "$W_SURGE" ]; then
-                  SCALED_WS="$w"
-                  break
-                fi
+              if [ "$w" != "$OLD_WS" ]; then
+                NEW_WS="$w"
+                break
               fi
             done
-            if [ -n "$SCALED_WS" ]; then
-              echo "New stable replica created during upgrade: $SCALED_WS"
-              echo "SCALED_WS=$SCALED_WS" >> "$GITHUB_ENV"
+            if [ -n "$NEW_WS" ]; then
+              echo "New workspace created: $NEW_WS"
+              echo "NEW_WS=$NEW_WS" >> "$GITHUB_ENV"
               break
             fi
-            # The in-flight surge must not vanish while we wait for the scale-up.
-            if ! kubectl get workspace "$SURGE_WS" >/dev/null 2>&1; then
-              echo "NOTE: surge $SURGE_WS already completed before scale-up was observed"
-            fi
-            echo "Waiting for scaled replica... (none yet)"
+            echo "Waiting for new workspace... (none yet)"
             sleep 10
           done
 
-          if [ -z "$SCALED_WS" ]; then
-            echo "ERROR: scaling was blocked during the in-flight upgrade (no new replica created)"
-            kubectl get workspace -L kaito.sh/upgrade-surge-for
+          if [ -z "$NEW_WS" ]; then
+            echo "Timeout: new workspace was not created"
+            kubectl get workspace -l inferenceset.kaito.sh/created-by=${INFERENCESET_NAME}
             kubectl logs deploy/kaito-workspace -n kaito-workspace --tail=200
             exit 1
           fi
 
-          # Old workspace must still be present and serving: scaling must not disturb
-          # the in-flight upgrade or cause downtime on the old replica.
+          # Old workspace must still exist and keep serving (no downtime / not deleted yet).
+          kubectl get workspace "$OLD_WS" >/dev/null
           OLD_DELETING=$(kubectl get workspace "$OLD_WS" -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true)
           if [ -n "$OLD_DELETING" ]; then
-            echo "ERROR: old workspace was deleted as a side effect of scaling (downtime!)"
+            echo "ERROR: old workspace is being deleted before the new one is ready (downtime!)"
             exit 1
           fi
 
-      - name: Verify no downtime - old stays ready until surge is ready
+      - name: Verify no downtime - old stays ready until the new workspace is ready
         shell: bash
         run: |
           NEW_TAG=$(yq '.models[] | select(.name == "base") | .tag' presets/workspace/models/supported_models.yaml)
-          echo "Old: $OLD_WS  Surge: $SURGE_WS"
+          echo "Old: $OLD_WS  New: $NEW_WS"
 
-          # The surge should run the NEW base image. The Workspace controller
-          # creates the surge StatefulSet asynchronously after the Workspace object,
-          # so poll until the image is populated rather than checking once.
-          echo "Waiting for surge StatefulSet to be created on the new base tag $NEW_TAG..."
+          # The new workspace should run the NEW base image. The Workspace controller
+          # creates its StatefulSet asynchronously after the Workspace object, so poll
+          # until the image is populated rather than checking once.
+          echo "Waiting for the new StatefulSet to be created on the new base tag $NEW_TAG..."
           end=$((SECONDS+300))
-          SURGE_IMAGE=""
+          NEW_IMAGE=""
           while [ $SECONDS -lt $end ]; do
-            SURGE_IMAGE=$(kubectl get statefulset "$SURGE_WS" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
-            if echo "$SURGE_IMAGE" | grep -q "$NEW_TAG"; then
-              echo "Surge StatefulSet image: $SURGE_IMAGE"
+            NEW_IMAGE=$(kubectl get statefulset "$NEW_WS" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
+            if echo "$NEW_IMAGE" | grep -q "$NEW_TAG"; then
+              echo "New StatefulSet image: $NEW_IMAGE"
               break
             fi
-            echo "Waiting for surge StatefulSet image... (current: '${SURGE_IMAGE:-<none>}')"
+            echo "Waiting for new StatefulSet image... (current: '${NEW_IMAGE:-<none>}')"
             sleep 10
           done
-          if ! echo "$SURGE_IMAGE" | grep -q "$NEW_TAG"; then
-            echo "ERROR: surge workspace is not on the new base tag $NEW_TAG (image: '${SURGE_IMAGE:-<none>}')"
-            kubectl get workspace -L kaito.sh/upgrade-surge-for
-            kubectl get statefulset "$SURGE_WS" -o yaml 2>/dev/null || true
+          if ! echo "$NEW_IMAGE" | grep -q "$NEW_TAG"; then
+            echo "ERROR: new workspace is not on the new base tag $NEW_TAG (image: '${NEW_IMAGE:-<none>}')"
+            kubectl get workspace -l inferenceset.kaito.sh/created-by=${INFERENCESET_NAME}
+            kubectl get statefulset "$NEW_WS" -o yaml 2>/dev/null || true
             exit 1
           fi
 
-          # While the surge workspace comes up (and downloads weights), the old
-          # workspace MUST keep serving (InferenceReady=True). This is the core
-          # no-downtime guarantee of surge-based upgrades. Poll until the surge is
-          # ready, and on every poll assert the old workspace is still ready and not
-          # being deleted.
-          echo "Waiting for the surge to become ready while asserting the old workspace stays ready..."
+          # While the new workspace comes up (and downloads weights), the old workspace
+          # MUST keep serving (InferenceReady=True). This is the core no-downtime
+          # guarantee. Poll until the new one is ready, and on every poll assert the old
+          # workspace is still ready and not being deleted.
+          echo "Waiting for the new workspace to become ready while asserting the old one stays ready..."
           end=$((SECONDS+2400))
           while [ $SECONDS -lt $end ]; do
-            SURGE_READY=$(kubectl get workspace "$SURGE_WS" -o jsonpath='{.status.conditions[?(@.type=="InferenceReady")].status}' 2>/dev/null || true)
-            if [ "$SURGE_READY" = "True" ]; then
-              echo "Surge workspace $SURGE_WS is ready"
+            NEW_READY=$(kubectl get workspace "$NEW_WS" -o jsonpath='{.status.conditions[?(@.type=="InferenceReady")].status}' 2>/dev/null || true)
+            if [ "$NEW_READY" = "True" ]; then
+              echo "New workspace $NEW_WS is ready"
               break
             fi
 
-            # Old workspace must still be present and serving during the surge bring-up.
+            # Old workspace must still be present and serving during the new one's bring-up.
             OLD_DELETING=$(kubectl get workspace "$OLD_WS" -o jsonpath='{.metadata.deletionTimestamp}' 2>/dev/null || true)
             OLD_READY=$(kubectl get workspace "$OLD_WS" -o jsonpath='{.status.conditions[?(@.type=="InferenceReady")].status}' 2>/dev/null || true)
             if [ -n "$OLD_DELETING" ]; then
-              echo "ERROR: old workspace is being deleted before the surge is ready (downtime!)"
-              kubectl get workspace -L kaito.sh/upgrade-surge-for
+              echo "ERROR: old workspace is being deleted before the new one is ready (downtime!)"
+              kubectl get workspace -l inferenceset.kaito.sh/created-by=${INFERENCESET_NAME}
               exit 1
             fi
             if [ "$OLD_READY" != "True" ]; then
-              echo "ERROR: old workspace lost readiness before the surge is ready (downtime!) - InferenceReady=$OLD_READY"
+              echo "ERROR: old workspace lost readiness before the new one is ready (downtime!) - InferenceReady=$OLD_READY"
               kubectl get workspace "$OLD_WS" -o yaml
               exit 1
             fi
 
-            echo "Waiting... (surge ready: ${SURGE_READY:-False}, old ready: $OLD_READY)"
+            echo "Waiting... (new ready: ${NEW_READY:-False}, old ready: $OLD_READY)"
             sleep 20
           done
 
           if [ $SECONDS -ge $end ]; then
-            echo "Timeout: surge workspace did not become ready"
-            kubectl get workspace -L kaito.sh/upgrade-surge-for
-            kubectl describe pods -l kaito.sh/workspace="$SURGE_WS" 2>/dev/null | tail -60 || true
-            kubectl logs -l kaito.sh/workspace="$SURGE_WS" --tail=100 2>/dev/null || true
+            echo "Timeout: new workspace did not become ready"
+            kubectl get workspace -l inferenceset.kaito.sh/created-by=${INFERENCESET_NAME}
+            kubectl describe pods -l kaito.sh/workspace="$NEW_WS" 2>/dev/null | tail -60 || true
+            kubectl logs -l kaito.sh/workspace="$NEW_WS" --tail=100 2>/dev/null || true
             kubectl logs deploy/kaito-workspace -n kaito-workspace --tail=200
             exit 1
           fi
 
-      - name: Verify cutover - old deleted and surge promoted
+      - name: Verify cutover - old workspace deleted
         shell: bash
         run: |
-          echo "Waiting for the old workspace ($OLD_WS) to be deleted after the surge became ready..."
+          echo "Waiting for the old workspace ($OLD_WS) to be deleted after the new one became ready..."
           end=$((SECONDS+600))
           while [ $SECONDS -lt $end ]; do
             if ! kubectl get workspace "$OLD_WS" >/dev/null 2>&1; then
@@ -701,39 +643,19 @@ jobs:
           done
           if kubectl get workspace "$OLD_WS" >/dev/null 2>&1; then
             echo "Timeout: old workspace was not deleted"
-            kubectl get workspace -L kaito.sh/upgrade-surge-for
+            kubectl get workspace -l inferenceset.kaito.sh/created-by=${INFERENCESET_NAME}
             kubectl logs deploy/kaito-workspace -n kaito-workspace --tail=200
             exit 1
           fi
 
-          echo "Waiting for the surge ($SURGE_WS) to be promoted (surge label removed)..."
-          end=$((SECONDS+600))
-          while [ $SECONDS -lt $end ]; do
-            SURGE_LABEL=$(kubectl get workspace "$SURGE_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
-            if [ -z "$SURGE_LABEL" ]; then
-              echo "Surge workspace promoted (surge label removed)"
-              break
-            fi
-            echo "Waiting for promotion... (surge-for still: $SURGE_LABEL)"
-            sleep 10
-          done
-          SURGE_LABEL=$(kubectl get workspace "$SURGE_WS" -o json | jq -r '.metadata.labels["kaito.sh/upgrade-surge-for"] // empty')
-          if [ -n "$SURGE_LABEL" ]; then
-            echo "Timeout: surge workspace was not promoted"
-            kubectl get workspace "$SURGE_WS" -o yaml
-            exit 1
-          fi
-
-          # After cutover + scale-up, exactly two replicas should remain: the
-          # promoted surge and the replica added during the upgrade. Both must be
-          # on the new tag and ready, with no surge labels left.
+          # After cutover, exactly one replica should remain: the new workspace,
+          # on the new tag and ready.
           NEW_TAG=$(yq '.models[] | select(.name == "base") | .tag' presets/workspace/models/supported_models.yaml)
-          echo "Waiting for the InferenceSet to settle at 2 ready replicas on $NEW_TAG..."
+          echo "Waiting for the InferenceSet to settle at 1 ready replica on $NEW_TAG..."
           end=$((SECONDS+2400))
           while [ $SECONDS -lt $end ]; do
             data=$(kubectl get workspace -l inferenceset.kaito.sh/created-by=${INFERENCESET_NAME} -o json)
             COUNT=$(echo "$data" | jq '.items | length')
-            SURGES=$(echo "$data" | jq '[.items[]|select(.metadata.labels["kaito.sh/upgrade-surge-for"])]|length')
             READY=$(echo "$data" | jq '[.items[]|select(.status.conditions[]?|select(.type=="InferenceReady" and .status=="True"))]|length')
             # Count workspaces whose StatefulSet image is on the new tag.
             ONNEW=0
@@ -741,16 +663,16 @@ jobs:
               IMG=$(kubectl get statefulset "$w" -o jsonpath='{.spec.template.spec.containers[0].image}' 2>/dev/null || true)
               if echo "$IMG" | grep -q "$NEW_TAG"; then ONNEW=$((ONNEW+1)); fi
             done
-            echo "count=$COUNT surges=$SURGES ready=$READY onNewTag=$ONNEW"
-            if [ "$COUNT" = "2" ] && [ "$SURGES" = "0" ] && [ "$READY" = "2" ] && [ "$ONNEW" = "2" ]; then
-              echo "Upgrade + scale-up settled: 2 replicas, both ready on $NEW_TAG, no surges."
+            echo "count=$COUNT ready=$READY onNewTag=$ONNEW"
+            if [ "$COUNT" = "1" ] && [ "$READY" = "1" ] && [ "$ONNEW" = "1" ]; then
+              echo "Upgrade settled: 1 replica, ready on $NEW_TAG."
               break
             fi
             sleep 20
           done
           if [ $SECONDS -ge $end ]; then
-            echo "ERROR: InferenceSet did not settle at 2 ready replicas on the new tag"
-            kubectl get workspace -L kaito.sh/upgrade-surge-for
+            echo "ERROR: InferenceSet did not settle at 1 ready replica on the new tag"
+            kubectl get workspace -l inferenceset.kaito.sh/created-by=${INFERENCESET_NAME}
             kubectl logs deploy/kaito-workspace -n kaito-workspace --tail=200
             exit 1
           fi

--- a/.github/workflows/base-image-auto-upgrade-test.yaml
+++ b/.github/workflows/base-image-auto-upgrade-test.yaml
@@ -342,10 +342,10 @@ jobs:
         run: |
           az group delete --name "${{ env.CLUSTER_NAME }}" --yes --no-wait || true
 
-  # Blue-green strategy: the controller creates a NEW (green) Workspace on the new
-  # base image, waits for it to become ready, then deletes the OLD (blue) one. This
+  # Surge-based strategy: the controller creates a NEW (surge) Workspace on the new
+  # base image, waits for it to become ready, then deletes the OLD one. This
   # verifies the no-downtime upgrade path, in contrast to the in-place job above.
-  bluegreen-auto-upgrade-test:
+  surge-based-auto-upgrade-test:
     runs-on: ["self-hosted", "hostname:kaito-e2e-github-runner"]
     environment: e2e-test
     permissions:
@@ -501,18 +501,18 @@ jobs:
         env:
           REGISTRY: ${{ env.REGISTRY }}
 
-      - name: Patch InferenceSet to enable blue-green autoUpgrade
+      - name: Patch InferenceSet to enable surge-based autoUpgrade
         shell: bash
         run: |
           # The old CRD did not have autoUpgrade; now that the chart (and CRD) is
-          # upgraded, enable autoUpgrade with the BlueGreen strategy.
+          # upgraded, enable autoUpgrade with the Surge strategy.
           kubectl patch inferenceset ${INFERENCESET_NAME} --type=merge \
-            -p '{"spec":{"autoUpgrade":{"enabled":true,"strategy":"BlueGreen"}}}'
+            -p '{"spec":{"autoUpgrade":{"enabled":true,"strategy":"Surge"}}}'
 
           STRATEGY=$(kubectl get inferenceset ${INFERENCESET_NAME} -o jsonpath='{.spec.autoUpgrade.strategy}')
           echo "AutoUpgrade strategy: $STRATEGY"
-          if [ "$STRATEGY" != "BlueGreen" ]; then
-            echo "ERROR: expected strategy BlueGreen, got '$STRATEGY'"
+          if [ "$STRATEGY" != "Surge" ]; then
+            echo "ERROR: expected strategy Surge, got '$STRATEGY'"
             exit 1
           fi
 
@@ -522,7 +522,7 @@ jobs:
           NEW_TAG=$(yq '.models[] | select(.name == "base") | .tag' presets/workspace/models/supported_models.yaml)
           echo "Expected new base tag: $NEW_TAG"
           echo "Blue (old) workspace: $BLUE_WS"
-          echo "Waiting for the blue-green surge workspace to be created..."
+          echo "Waiting for the surge workspace to be created..."
 
           end=$((SECONDS+600))
           GREEN_WS=""
@@ -594,7 +594,7 @@ jobs:
 
           # While the green workspace comes up (and downloads weights), the blue
           # workspace MUST keep serving (InferenceReady=True). This is the core
-          # no-downtime guarantee of blue-green. Poll until green is ready, and on
+          # no-downtime guarantee of surge-based upgrades. Poll until green is ready, and on
           # every poll assert blue is still ready and not being deleted.
           echo "Waiting for green to become ready while asserting blue stays ready..."
           end=$((SECONDS+2400))
@@ -703,7 +703,7 @@ jobs:
             if [ "$DRIFT" = "0" ] && [ -n "$LAST_SUCCESS" ]; then
               echo "NumDriftedWorkspaces: $DRIFT"
               echo "LastSuccessfulUpgradeTime: $LAST_SUCCESS"
-              echo "InferenceSet blue-green auto-upgrade status verified successfully."
+              echo "InferenceSet surge-based auto-upgrade status verified successfully."
               exit 0
             fi
             echo "Waiting for status update... (drift: ${DRIFT:-unknown}, lastSuccess: ${LAST_SUCCESS:-<none>})"

--- a/api/v1alpha1/inferenceset_types.go
+++ b/api/v1alpha1/inferenceset_types.go
@@ -43,7 +43,7 @@ type InferenceSetTemplate struct {
 
 // AutoUpgradeStrategy describes how the controller replaces Workspaces when a
 // newer base image version is detected.
-// +kubebuilder:validation:Enum=InPlace;BlueGreen
+// +kubebuilder:validation:Enum=InPlace;Surge
 type AutoUpgradeStrategy string
 
 const (
@@ -52,11 +52,11 @@ const (
 	// while the pod is recreated and the model is reloaded.
 	InPlaceUpgradeStrategy AutoUpgradeStrategy = "InPlace"
 
-	// BlueGreenUpgradeStrategy creates a new Workspace on the new base image,
+	// SurgeBasedUpgradeStrategy creates a new Workspace on the new base image,
 	// waits for it to become inference-ready, then deletes the old Workspace.
-	// This avoids downtime at the cost of temporarily running both Workspaces
+	// This avoids downtime at the cost of temporarily running an extra Workspace
 	// (extra GPU capacity) during the rollout.
-	BlueGreenUpgradeStrategy AutoUpgradeStrategy = "BlueGreen"
+	SurgeBasedUpgradeStrategy AutoUpgradeStrategy = "Surge"
 )
 
 // AutoUpgradePolicy configures automatic base image upgrade behavior.
@@ -70,7 +70,7 @@ type AutoUpgradePolicy struct {
 
 	// Strategy selects how Workspaces are replaced during an upgrade.
 	// "InPlace" (default) rolls the existing Workspace's StatefulSet, incurring
-	// downtime. "BlueGreen" creates a new Workspace, waits for it to become
+	// downtime. "Surge" creates a new Workspace, waits for it to become
 	// ready, then deletes the old one, avoiding downtime.
 	// +optional
 	// +kubebuilder:default:=InPlace

--- a/api/v1alpha1/inferenceset_types.go
+++ b/api/v1alpha1/inferenceset_types.go
@@ -41,6 +41,24 @@ type InferenceSetTemplate struct {
 	Inference kaitov1beta1.InferenceSpec `json:"inference"`
 }
 
+// AutoUpgradeStrategy describes how the controller replaces Workspaces when a
+// newer base image version is detected.
+// +kubebuilder:validation:Enum=InPlace;BlueGreen
+type AutoUpgradeStrategy string
+
+const (
+	// InPlaceUpgradeStrategy upgrades the existing Workspace's StatefulSet in place
+	// (rolling update of the pod template image). This is fast but incurs downtime
+	// while the pod is recreated and the model is reloaded.
+	InPlaceUpgradeStrategy AutoUpgradeStrategy = "InPlace"
+
+	// BlueGreenUpgradeStrategy creates a new Workspace on the new base image,
+	// waits for it to become inference-ready, then deletes the old Workspace.
+	// This avoids downtime at the cost of temporarily running both Workspaces
+	// (extra GPU capacity) during the rollout.
+	BlueGreenUpgradeStrategy AutoUpgradeStrategy = "BlueGreen"
+)
+
 // AutoUpgradePolicy configures automatic base image upgrade behavior.
 type AutoUpgradePolicy struct {
 	// Enabled controls whether the controller automatically upgrades
@@ -49,6 +67,14 @@ type AutoUpgradePolicy struct {
 	// +optional
 	// +kubebuilder:default:=false
 	Enabled bool `json:"enabled"`
+
+	// Strategy selects how Workspaces are replaced during an upgrade.
+	// "InPlace" (default) rolls the existing Workspace's StatefulSet, incurring
+	// downtime. "BlueGreen" creates a new Workspace, waits for it to become
+	// ready, then deletes the old one, avoiding downtime.
+	// +optional
+	// +kubebuilder:default:=InPlace
+	Strategy AutoUpgradeStrategy `json:"strategy,omitempty"`
 
 	// MaintenanceWindow restricts when upgrades may be applied.
 	// If not specified, upgrades may be applied at any time.

--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -76,6 +76,12 @@ const (
 	// should be upgraded to the specified base image version. Set by the AutoUpgradeRunner;
 	// retained after upgrade completes as an audit trail.
 	LabelUpgradeToVersion = KAITOPrefix + "upgrade-to-version"
+
+	// LabelUpgradeSurgeFor marks a Workspace created by the blue-green auto-upgrade
+	// strategy as a surge replacement for the named (old) Workspace. The value is the
+	// name of the Workspace being replaced. The label is removed once the old Workspace
+	// has been deleted, promoting the surge Workspace to a normal managed replica.
+	LabelUpgradeSurgeFor = KAITOPrefix + "upgrade-surge-for"
 )
 
 // GetWorkspaceRuntimeName returns the runtime name of the workspace.

--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -76,12 +76,6 @@ const (
 	// should be upgraded to the specified base image version. Set by the AutoUpgradeRunner;
 	// retained after upgrade completes as an audit trail.
 	LabelUpgradeToVersion = KAITOPrefix + "upgrade-to-version"
-
-	// LabelUpgradeSurgeFor marks a Workspace created by the surge-based auto-upgrade
-	// strategy as a surge replacement for the named (old) Workspace. The value is the
-	// name of the Workspace being replaced. The label is removed once the old Workspace
-	// has been deleted, promoting the surge Workspace to a normal managed replica.
-	LabelUpgradeSurgeFor = KAITOPrefix + "upgrade-surge-for"
 )
 
 // GetWorkspaceRuntimeName returns the runtime name of the workspace.

--- a/api/v1alpha1/labels.go
+++ b/api/v1alpha1/labels.go
@@ -77,7 +77,7 @@ const (
 	// retained after upgrade completes as an audit trail.
 	LabelUpgradeToVersion = KAITOPrefix + "upgrade-to-version"
 
-	// LabelUpgradeSurgeFor marks a Workspace created by the blue-green auto-upgrade
+	// LabelUpgradeSurgeFor marks a Workspace created by the surge-based auto-upgrade
 	// strategy as a surge replacement for the named (old) Workspace. The value is the
 	// name of the Workspace being replaced. The label is removed once the old Workspace
 	// has been deleted, promoting the surge Workspace to a normal managed replica.

--- a/api/v1beta1/inferenceset_types.go
+++ b/api/v1beta1/inferenceset_types.go
@@ -47,7 +47,7 @@ type InferenceSetTemplate struct {
 
 // AutoUpgradeStrategy describes how the controller replaces Workspaces when a
 // newer base image version is detected.
-// +kubebuilder:validation:Enum=InPlace;BlueGreen
+// +kubebuilder:validation:Enum=InPlace;Surge
 type AutoUpgradeStrategy string
 
 const (
@@ -56,11 +56,11 @@ const (
 	// while the pod is recreated and the model is reloaded.
 	InPlaceUpgradeStrategy AutoUpgradeStrategy = "InPlace"
 
-	// BlueGreenUpgradeStrategy creates a new Workspace on the new base image,
+	// SurgeBasedUpgradeStrategy creates a new Workspace on the new base image,
 	// waits for it to become inference-ready, then deletes the old Workspace.
-	// This avoids downtime at the cost of temporarily running both Workspaces
+	// This avoids downtime at the cost of temporarily running an extra Workspace
 	// (extra GPU capacity) during the rollout.
-	BlueGreenUpgradeStrategy AutoUpgradeStrategy = "BlueGreen"
+	SurgeBasedUpgradeStrategy AutoUpgradeStrategy = "Surge"
 )
 
 // AutoUpgradePolicy configures automatic base image upgrade behavior.
@@ -74,7 +74,7 @@ type AutoUpgradePolicy struct {
 
 	// Strategy selects how Workspaces are replaced during an upgrade.
 	// "InPlace" (default) rolls the existing Workspace's StatefulSet, incurring
-	// downtime. "BlueGreen" creates a new Workspace, waits for it to become
+	// downtime. "Surge" creates a new Workspace, waits for it to become
 	// ready, then deletes the old one, avoiding downtime.
 	// +optional
 	// +kubebuilder:default:=InPlace

--- a/api/v1beta1/inferenceset_types.go
+++ b/api/v1beta1/inferenceset_types.go
@@ -45,6 +45,24 @@ type InferenceSetTemplate struct {
 	Inference InferenceSpec            `json:"inference"`
 }
 
+// AutoUpgradeStrategy describes how the controller replaces Workspaces when a
+// newer base image version is detected.
+// +kubebuilder:validation:Enum=InPlace;BlueGreen
+type AutoUpgradeStrategy string
+
+const (
+	// InPlaceUpgradeStrategy upgrades the existing Workspace's StatefulSet in place
+	// (rolling update of the pod template image). This is fast but incurs downtime
+	// while the pod is recreated and the model is reloaded.
+	InPlaceUpgradeStrategy AutoUpgradeStrategy = "InPlace"
+
+	// BlueGreenUpgradeStrategy creates a new Workspace on the new base image,
+	// waits for it to become inference-ready, then deletes the old Workspace.
+	// This avoids downtime at the cost of temporarily running both Workspaces
+	// (extra GPU capacity) during the rollout.
+	BlueGreenUpgradeStrategy AutoUpgradeStrategy = "BlueGreen"
+)
+
 // AutoUpgradePolicy configures automatic base image upgrade behavior.
 type AutoUpgradePolicy struct {
 	// Enabled controls whether the controller automatically upgrades
@@ -53,6 +71,14 @@ type AutoUpgradePolicy struct {
 	// +optional
 	// +kubebuilder:default:=false
 	Enabled bool `json:"enabled"`
+
+	// Strategy selects how Workspaces are replaced during an upgrade.
+	// "InPlace" (default) rolls the existing Workspace's StatefulSet, incurring
+	// downtime. "BlueGreen" creates a new Workspace, waits for it to become
+	// ready, then deletes the old one, avoiding downtime.
+	// +optional
+	// +kubebuilder:default:=InPlace
+	Strategy AutoUpgradeStrategy `json:"strategy,omitempty"`
 
 	// MaintenanceWindow restricts when upgrades may be applied.
 	// If not specified, upgrades may be applied at any time.

--- a/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
+++ b/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
@@ -98,11 +98,11 @@ spec:
                     description: |-
                       Strategy selects how Workspaces are replaced during an upgrade.
                       "InPlace" (default) rolls the existing Workspace's StatefulSet, incurring
-                      downtime. "BlueGreen" creates a new Workspace, waits for it to become
+                      downtime. "Surge" creates a new Workspace, waits for it to become
                       ready, then deletes the old one, avoiding downtime.
                     enum:
                     - InPlace
-                    - BlueGreen
+                    - Surge
                     type: string
                 type: object
               labelSelector:
@@ -504,11 +504,11 @@ spec:
                     description: |-
                       Strategy selects how Workspaces are replaced during an upgrade.
                       "InPlace" (default) rolls the existing Workspace's StatefulSet, incurring
-                      downtime. "BlueGreen" creates a new Workspace, waits for it to become
+                      downtime. "Surge" creates a new Workspace, waits for it to become
                       ready, then deletes the old one, avoiding downtime.
                     enum:
                     - InPlace
-                    - BlueGreen
+                    - Surge
                     type: string
                 type: object
               labelSelector:

--- a/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
+++ b/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
@@ -93,6 +93,17 @@ spec:
                     required:
                     - schedule
                     type: object
+                  strategy:
+                    default: InPlace
+                    description: |-
+                      Strategy selects how Workspaces are replaced during an upgrade.
+                      "InPlace" (default) rolls the existing Workspace's StatefulSet, incurring
+                      downtime. "BlueGreen" creates a new Workspace, waits for it to become
+                      ready, then deletes the old one, avoiding downtime.
+                    enum:
+                    - InPlace
+                    - BlueGreen
+                    type: string
                 type: object
               labelSelector:
                 description: workspace created by InferenceSet controller would use
@@ -488,6 +499,17 @@ spec:
                     required:
                     - schedule
                     type: object
+                  strategy:
+                    default: InPlace
+                    description: |-
+                      Strategy selects how Workspaces are replaced during an upgrade.
+                      "InPlace" (default) rolls the existing Workspace's StatefulSet, incurring
+                      downtime. "BlueGreen" creates a new Workspace, waits for it to become
+                      ready, then deletes the old one, avoiding downtime.
+                    enum:
+                    - InPlace
+                    - BlueGreen
+                    type: string
                 type: object
               labelSelector:
                 description: workspace created by InferenceSet controller would use

--- a/config/crd/bases/kaito.sh_inferencesets.yaml
+++ b/config/crd/bases/kaito.sh_inferencesets.yaml
@@ -98,11 +98,11 @@ spec:
                     description: |-
                       Strategy selects how Workspaces are replaced during an upgrade.
                       "InPlace" (default) rolls the existing Workspace's StatefulSet, incurring
-                      downtime. "BlueGreen" creates a new Workspace, waits for it to become
+                      downtime. "Surge" creates a new Workspace, waits for it to become
                       ready, then deletes the old one, avoiding downtime.
                     enum:
                     - InPlace
-                    - BlueGreen
+                    - Surge
                     type: string
                 type: object
               labelSelector:
@@ -504,11 +504,11 @@ spec:
                     description: |-
                       Strategy selects how Workspaces are replaced during an upgrade.
                       "InPlace" (default) rolls the existing Workspace's StatefulSet, incurring
-                      downtime. "BlueGreen" creates a new Workspace, waits for it to become
+                      downtime. "Surge" creates a new Workspace, waits for it to become
                       ready, then deletes the old one, avoiding downtime.
                     enum:
                     - InPlace
-                    - BlueGreen
+                    - Surge
                     type: string
                 type: object
               labelSelector:

--- a/config/crd/bases/kaito.sh_inferencesets.yaml
+++ b/config/crd/bases/kaito.sh_inferencesets.yaml
@@ -93,6 +93,17 @@ spec:
                     required:
                     - schedule
                     type: object
+                  strategy:
+                    default: InPlace
+                    description: |-
+                      Strategy selects how Workspaces are replaced during an upgrade.
+                      "InPlace" (default) rolls the existing Workspace's StatefulSet, incurring
+                      downtime. "BlueGreen" creates a new Workspace, waits for it to become
+                      ready, then deletes the old one, avoiding downtime.
+                    enum:
+                    - InPlace
+                    - BlueGreen
+                    type: string
                 type: object
               labelSelector:
                 description: workspace created by InferenceSet controller would use
@@ -488,6 +499,17 @@ spec:
                     required:
                     - schedule
                     type: object
+                  strategy:
+                    default: InPlace
+                    description: |-
+                      Strategy selects how Workspaces are replaced during an upgrade.
+                      "InPlace" (default) rolls the existing Workspace's StatefulSet, incurring
+                      downtime. "BlueGreen" creates a new Workspace, waits for it to become
+                      ready, then deletes the old one, avoiding downtime.
+                    enum:
+                    - InPlace
+                    - BlueGreen
+                    type: string
                 type: object
               labelSelector:
                 description: workspace created by InferenceSet controller would use

--- a/pkg/controllers/autoupgrade/runner.go
+++ b/pkg/controllers/autoupgrade/runner.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/robfig/cron/v3"
 	appsv1 "k8s.io/api/apps/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"k8s.io/klog/v2"
@@ -31,6 +32,7 @@ import (
 	inferencesetutil "github.com/kaito-project/kaito/pkg/utils/inferenceset"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/utils/workspace"
+	workspacecontrollers "github.com/kaito-project/kaito/pkg/workspace/controllers"
 	"github.com/kaito-project/kaito/pkg/workspace/inference"
 )
 
@@ -97,6 +99,21 @@ func (r *AutoUpgradeRunner) reconcileInferenceSet(ctx context.Context, inference
 		return
 	}
 
+	switch inferenceSetObj.Spec.AutoUpgrade.Strategy {
+	case kaitov1beta1.BlueGreenUpgradeStrategy:
+		r.reconcileBlueGreen(ctx, inferenceSetObj)
+	case kaitov1beta1.InPlaceUpgradeStrategy:
+		r.reconcileInPlace(ctx, inferenceSetObj)
+	default:
+		klog.ErrorS(fmt.Errorf("unsupported auto-upgrade strategy"), "AutoUpgradeRunner: unsupported strategy", "inferenceset", klog.KObj(inferenceSetObj))
+	}
+}
+
+// reconcileInPlace handles a single InferenceSet's auto-upgrade lifecycle using the
+// in-place strategy: it tags the next drifted Workspace with the upgrade label so the
+// Workspace controller rolls that Workspace's StatefulSet to the new base image in
+// place. Only one Workspace is upgraded at a time.
+func (r *AutoUpgradeRunner) reconcileInPlace(ctx context.Context, inferenceSetObj *kaitov1beta1.InferenceSet) {
 	// Get the current controller-embedded base image tag.
 	desiredImage := inference.GetBaseImageName()
 	desiredTag := inference.GetBaseImageTag()
@@ -290,6 +307,169 @@ func (r *AutoUpgradeRunner) tagWorkspaceForUpgrade(ctx context.Context, isObj *k
 	}
 	klog.InfoS("AutoUpgradeRunner: tagged workspace for upgrade",
 		"workspace", klog.KObj(ws), "targetVersion", desiredTag, "inferenceset", klog.KObj(isObj))
+}
+
+// reconcileBlueGreen handles a single InferenceSet's auto-upgrade lifecycle using
+// the blue-green strategy: for each drifted ("blue") Workspace, create a new
+// ("green") Workspace on the new base image, wait for it to become inference-ready,
+// then delete the blue Workspace. Only one upgrade is in flight per InferenceSet
+// at a time. The new Workspace automatically picks up the controller's current
+// base image because it is generated fresh from GetBaseImageName().
+func (r *AutoUpgradeRunner) reconcileBlueGreen(ctx context.Context, inferenceSetObj *kaitov1beta1.InferenceSet) {
+	desiredImage := inference.GetBaseImageName()
+	desiredTag := inference.GetBaseImageTag()
+
+	wsList, err := inferencesetutil.ListWorkspaces(ctx, inferenceSetObj, r.Client)
+	if err != nil {
+		klog.ErrorS(err, "AutoUpgradeRunner: failed to list workspaces", "inferenceset", klog.KObj(inferenceSetObj))
+		return
+	}
+	// Deterministic ordering so we always pick the same blue Workspace to upgrade next.
+	sort.SliceStable(wsList.Items, func(i, j int) bool {
+		return wsList.Items[i].UID < wsList.Items[j].UID
+	})
+
+	// Classify Workspaces:
+	//   - surge: the in-flight green Workspace (carries the upgrade-surge-for label).
+	//   - drifted: blue Workspaces still running an old base image.
+	var surge *kaitov1beta1.Workspace
+	var drifted []kaitov1beta1.Workspace
+	byName := make(map[string]*kaitov1beta1.Workspace, len(wsList.Items))
+	for i := range wsList.Items {
+		ws := &wsList.Items[i]
+		byName[ws.Name] = ws
+		if ws.DeletionTimestamp != nil {
+			continue
+		}
+		if _, ok := ws.Labels[kaitov1alpha1.LabelUpgradeSurgeFor]; ok {
+			surge = ws
+			continue
+		}
+		ss := &appsv1.StatefulSet{}
+		if err := resources.GetResource(ctx, ws.Name, ws.Namespace, r.Client, ss); err != nil {
+			if apierrors.IsNotFound(err) {
+				// StatefulSet not created yet; treat as not-yet-drifted and skip this tick.
+				continue
+			}
+			klog.ErrorS(err, "AutoUpgradeRunner: failed to get StatefulSet", "workspace", klog.KObj(ws))
+			return
+		}
+		if !isWorkspaceInDesiredState(ss, desiredImage) {
+			drifted = append(drifted, wsList.Items[i])
+		}
+	}
+
+	// Drift count = blue Workspaces not yet on the desired image (the surge itself
+	// is excluded; the blue it replaces remains counted until deleted).
+	newDriftCount := len(drifted)
+	if r.statusNeedsUpdate(inferenceSetObj, newDriftCount) {
+		markSuccess := newDriftCount == 0 && r.previousDriftCount(inferenceSetObj) > 0
+		if err := r.updateStatus(ctx, inferenceSetObj, newDriftCount, markSuccess); err != nil {
+			return
+		}
+	}
+
+	// An upgrade is already in flight: drive it toward completion before starting another.
+	if surge != nil {
+		r.advanceBlueGreen(ctx, inferenceSetObj, surge, byName)
+		return
+	}
+
+	if len(drifted) == 0 {
+		klog.V(4).InfoS("AutoUpgradeRunner: no drifted workspaces, skipping", "inferenceset", klog.KObj(inferenceSetObj))
+		return
+	}
+
+	if !r.isWithinMaintenanceWindow(inferenceSetObj) {
+		klog.V(4).InfoS("AutoUpgradeRunner: outside maintenance window, skipping", "inferenceset", klog.KObj(inferenceSetObj))
+		return
+	}
+
+	// Start a new upgrade: create a green Workspace for the first drifted blue Workspace.
+	r.createSurgeWorkspace(ctx, inferenceSetObj, &drifted[0], desiredTag)
+}
+
+// advanceBlueGreen drives an in-flight blue-green upgrade forward by one step:
+// wait for the green Workspace to become ready, then delete the blue Workspace,
+// and finally promote the green Workspace (remove its surge label) once the blue
+// Workspace is fully gone.
+func (r *AutoUpgradeRunner) advanceBlueGreen(ctx context.Context, inferenceSetObj *kaitov1beta1.InferenceSet, surge *kaitov1beta1.Workspace, byName map[string]*kaitov1beta1.Workspace) {
+	blueName := surge.Labels[kaitov1alpha1.LabelUpgradeSurgeFor]
+
+	// Wait for the green Workspace to become inference-ready before cutting over.
+	if workspacecontrollers.DetermineWorkspacePhase(surge) != "succeeded" {
+		klog.V(4).InfoS("AutoUpgradeRunner: waiting for surge workspace to become ready",
+			"surge", klog.KObj(surge), "blue", blueName, "inferenceset", klog.KObj(inferenceSetObj))
+		return
+	}
+
+	blue, blueExists := byName[blueName]
+	if blueExists && blue.DeletionTimestamp == nil {
+		// Green is ready: delete the blue Workspace to cut traffic over.
+		klog.InfoS("AutoUpgradeRunner: surge workspace ready, deleting old workspace",
+			"surge", klog.KObj(surge), "blue", klog.KObj(blue), "inferenceset", klog.KObj(inferenceSetObj))
+		if err := r.Client.Delete(ctx, blue, &client.DeleteOptions{}); err != nil {
+			klog.ErrorS(err, "AutoUpgradeRunner: failed to delete old workspace", "blue", klog.KObj(blue))
+		}
+		return
+	}
+	if blueExists && blue.DeletionTimestamp != nil {
+		// Blue is terminating; wait for it to fully disappear before promoting green.
+		klog.V(4).InfoS("AutoUpgradeRunner: waiting for old workspace to be deleted",
+			"blue", klog.KObj(blue), "inferenceset", klog.KObj(inferenceSetObj))
+		return
+	}
+
+	// Blue is gone: promote the green Workspace by removing its surge label so the
+	// InferenceSet controller resumes managing it as a normal replica.
+	r.promoteSurgeWorkspace(ctx, surge)
+}
+
+// createSurgeWorkspace creates a new ("green") Workspace as a surge replacement for
+// the given drifted ("blue") Workspace. The green Workspace is generated from the
+// InferenceSet template (so it picks up the controller's current base image) and is
+// labeled with upgrade-surge-for=<blue name> and the upgrade-start-time annotation.
+func (r *AutoUpgradeRunner) createSurgeWorkspace(ctx context.Context, inferenceSetObj *kaitov1beta1.InferenceSet, blue *kaitov1beta1.Workspace, desiredTag string) {
+	green := inferencesetutil.NewWorkspaceForInferenceSet(inferenceSetObj)
+	if green.Labels == nil {
+		green.Labels = make(map[string]string)
+	}
+	green.Labels[kaitov1alpha1.LabelUpgradeSurgeFor] = blue.Name
+	green.Labels[kaitov1alpha1.LabelUpgradeToVersion] = desiredTag
+	if green.Annotations == nil {
+		green.Annotations = make(map[string]string)
+	}
+	green.Annotations[AnnotationUpgradeStartTime] = time.Now().UTC().Format(time.RFC3339)
+
+	if err := r.Client.Create(ctx, green); err != nil {
+		klog.ErrorS(err, "AutoUpgradeRunner: failed to create surge workspace",
+			"blue", klog.KObj(blue), "inferenceset", klog.KObj(inferenceSetObj))
+		return
+	}
+	klog.InfoS("AutoUpgradeRunner: created surge workspace for blue-green upgrade",
+		"blue", klog.KObj(blue), "targetVersion", desiredTag, "inferenceset", klog.KObj(inferenceSetObj))
+}
+
+// promoteSurgeWorkspace removes the upgrade-surge-for label from a green Workspace,
+// handing it back to the InferenceSet controller as a normal managed replica.
+func (r *AutoUpgradeRunner) promoteSurgeWorkspace(ctx context.Context, surge *kaitov1beta1.Workspace) {
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		latest := &kaitov1beta1.Workspace{}
+		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(surge), latest); err != nil {
+			return err
+		}
+		if _, ok := latest.Labels[kaitov1alpha1.LabelUpgradeSurgeFor]; !ok {
+			return nil
+		}
+		patch := client.MergeFrom(latest.DeepCopy())
+		delete(latest.Labels, kaitov1alpha1.LabelUpgradeSurgeFor)
+		return r.Client.Patch(ctx, latest, patch)
+	})
+	if err != nil {
+		klog.ErrorS(err, "AutoUpgradeRunner: failed to promote surge workspace", "surge", klog.KObj(surge))
+		return
+	}
+	klog.InfoS("AutoUpgradeRunner: blue-green upgrade complete, promoted surge workspace", "surge", klog.KObj(surge))
 }
 
 // isWorkspaceInDesiredState returns true if the workspace's StatefulSet is running

--- a/pkg/controllers/autoupgrade/runner.go
+++ b/pkg/controllers/autoupgrade/runner.go
@@ -102,7 +102,9 @@ func (r *AutoUpgradeRunner) reconcileInferenceSet(ctx context.Context, inference
 	switch inferenceSetObj.Spec.AutoUpgrade.Strategy {
 	case kaitov1beta1.BlueGreenUpgradeStrategy:
 		r.reconcileBlueGreen(ctx, inferenceSetObj)
-	case kaitov1beta1.InPlaceUpgradeStrategy:
+	case kaitov1beta1.InPlaceUpgradeStrategy, "":
+		// Empty strategy defaults to in-place (the CRD default is InPlace; the
+		// empty value also covers objects created before the field existed).
 		r.reconcileInPlace(ctx, inferenceSetObj)
 	default:
 		klog.ErrorS(fmt.Errorf("unsupported auto-upgrade strategy"), "AutoUpgradeRunner: unsupported strategy", "inferenceset", klog.KObj(inferenceSetObj))

--- a/pkg/controllers/autoupgrade/runner.go
+++ b/pkg/controllers/autoupgrade/runner.go
@@ -32,7 +32,6 @@ import (
 	inferencesetutil "github.com/kaito-project/kaito/pkg/utils/inferenceset"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/utils/workspace"
-	workspacecontrollers "github.com/kaito-project/kaito/pkg/workspace/controllers"
 	"github.com/kaito-project/kaito/pkg/workspace/inference"
 )
 
@@ -311,12 +310,19 @@ func (r *AutoUpgradeRunner) tagWorkspaceForUpgrade(ctx context.Context, isObj *k
 		"workspace", klog.KObj(ws), "targetVersion", desiredTag, "inferenceset", klog.KObj(isObj))
 }
 
-// reconcileSurge handles a single InferenceSet's auto-upgrade lifecycle using
-// the surge-based strategy: for each drifted (old) Workspace, create a new
-// surge Workspace on the new base image, wait for it to become inference-ready,
-// then delete the old Workspace. Only one upgrade is in flight per InferenceSet
-// at a time. The new Workspace automatically picks up the controller's current
-// base image because it is generated fresh from GetBaseImageName().
+// reconcileSurge handles a single InferenceSet's auto-upgrade lifecycle using the
+// surge-based strategy. The runner's only responsibility is to add capacity: when at
+// least one Workspace is drifted (running an old base image) and the InferenceSet is
+// currently at its desired replica count, it creates ONE new Workspace on the new base
+// image (generated fresh from the InferenceSet template, so it picks up the controller's
+// current base image).
+//
+// The InferenceSet controller performs the cutover: when it scales back down to the
+// desired count it prefers deleting old-image Workspaces, and only retires a Ready old
+// Workspace once enough Ready replicas remain (i.e. after the new Workspace becomes
+// Ready), preserving availability. This one-in / one-out handoff — driven purely by the
+// replica count, with no explicit surge bookkeeping — repeats until no drifted Workspaces
+// remain.
 func (r *AutoUpgradeRunner) reconcileSurge(ctx context.Context, inferenceSetObj *kaitov1beta1.InferenceSet) {
 	desiredImage := inference.GetBaseImageName()
 	desiredTag := inference.GetBaseImageTag()
@@ -326,59 +332,57 @@ func (r *AutoUpgradeRunner) reconcileSurge(ctx context.Context, inferenceSetObj 
 		klog.ErrorS(err, "AutoUpgradeRunner: failed to list workspaces", "inferenceset", klog.KObj(inferenceSetObj))
 		return
 	}
-	// Deterministic ordering so we always pick the same old Workspace to upgrade next.
-	sort.SliceStable(wsList.Items, func(i, j int) bool {
-		return wsList.Items[i].UID < wsList.Items[j].UID
-	})
 
-	// Classify Workspaces:
-	//   - surge: the in-flight new Workspace (carries the upgrade-surge-for label).
-	//   - drifted: old Workspaces still running an old base image.
-	var surge *kaitov1beta1.Workspace
-	var drifted []kaitov1beta1.Workspace
-	byName := make(map[string]*kaitov1beta1.Workspace, len(wsList.Items))
+	// Count live Workspaces and how many are drifted (still on an old base image). A
+	// Workspace whose StatefulSet does not exist yet is a freshly created new-image
+	// Workspace coming up; it counts toward the live total but not toward drift.
+	liveCount := 0
+	driftCount := 0
 	for i := range wsList.Items {
 		ws := &wsList.Items[i]
-		byName[ws.Name] = ws
 		if ws.DeletionTimestamp != nil {
 			continue
 		}
-		if _, ok := ws.Labels[kaitov1alpha1.LabelUpgradeSurgeFor]; ok {
-			surge = ws
-			continue
-		}
+		liveCount++
+
 		ss := &appsv1.StatefulSet{}
 		if err := resources.GetResource(ctx, ws.Name, ws.Namespace, r.Client, ss); err != nil {
 			if apierrors.IsNotFound(err) {
-				// StatefulSet not created yet; treat as not-yet-drifted and skip this tick.
-				continue
+				continue // StatefulSet not created yet; treat as new-image, not drifted.
 			}
 			klog.ErrorS(err, "AutoUpgradeRunner: failed to get StatefulSet", "workspace", klog.KObj(ws))
 			return
 		}
 		if !isWorkspaceInDesiredState(ss, desiredImage) {
-			drifted = append(drifted, wsList.Items[i])
+			driftCount++
 		}
 	}
 
-	// Drift count = old Workspaces not yet on the desired image (the surge itself
-	// is excluded; the old one it replaces remains counted until deleted).
-	newDriftCount := len(drifted)
-	if r.statusNeedsUpdate(inferenceSetObj, newDriftCount) {
-		markSuccess := newDriftCount == 0 && r.previousDriftCount(inferenceSetObj) > 0
-		if err := r.updateStatus(ctx, inferenceSetObj, newDriftCount, markSuccess); err != nil {
+	// Report drift and mark success when the fleet has fully converged onto the new image.
+	if r.statusNeedsUpdate(inferenceSetObj, driftCount) {
+		markSuccess := driftCount == 0 && r.previousDriftCount(inferenceSetObj) > 0
+		if err := r.updateStatus(ctx, inferenceSetObj, driftCount, markSuccess); err != nil {
 			return
 		}
 	}
 
-	// An upgrade is already in flight: drive it toward completion before starting another.
-	if surge != nil {
-		r.advanceSurge(ctx, inferenceSetObj, surge, byName)
+	if driftCount == 0 {
+		klog.V(4).InfoS("AutoUpgradeRunner: no drifted workspaces, skipping", "inferenceset", klog.KObj(inferenceSetObj))
 		return
 	}
 
-	if len(drifted) == 0 {
-		klog.V(4).InfoS("AutoUpgradeRunner: no drifted workspaces, skipping", "inferenceset", klog.KObj(inferenceSetObj))
+	// Only add a surge Workspace when the InferenceSet is exactly at its desired count:
+	//   - liveCount > desired: a surge is already in flight; wait for the controller to
+	//     retire an old Workspace (returning the count to desired) before adding another.
+	//   - liveCount < desired: the controller is still scaling up and will create new-image
+	//     Workspaces on its own, so no surge is needed.
+	desiredReplicas := int32(1)
+	if inferenceSetObj.Spec.Replicas != nil {
+		desiredReplicas = *inferenceSetObj.Spec.Replicas
+	}
+	if liveCount != int(desiredReplicas) {
+		klog.V(4).InfoS("AutoUpgradeRunner: upgrade surge in flight or scaling, skipping",
+			"inferenceset", klog.KObj(inferenceSetObj), "live", liveCount, "desired", desiredReplicas)
 		return
 	}
 
@@ -387,91 +391,22 @@ func (r *AutoUpgradeRunner) reconcileSurge(ctx context.Context, inferenceSetObj 
 		return
 	}
 
-	// Start a new upgrade: create a surge Workspace for the first drifted Workspace.
-	r.createSurgeWorkspace(ctx, inferenceSetObj, &drifted[0], desiredTag)
+	// Add one new-image Workspace. The controller retires an old one once this is Ready.
+	r.createUpgradeWorkspace(ctx, inferenceSetObj, desiredTag)
 }
 
-// advanceSurge drives an in-flight surge-based upgrade forward by one step:
-// wait for the surge Workspace to become ready, then delete the old Workspace,
-// and finally promote the surge Workspace (remove its surge label) once the old
-// Workspace is fully gone.
-func (r *AutoUpgradeRunner) advanceSurge(ctx context.Context, inferenceSetObj *kaitov1beta1.InferenceSet, surge *kaitov1beta1.Workspace, byName map[string]*kaitov1beta1.Workspace) {
-	oldName := surge.Labels[kaitov1alpha1.LabelUpgradeSurgeFor]
+// createUpgradeWorkspace creates a new Workspace for the InferenceSet on the current base
+// image. It is generated fresh from the InferenceSet template, so it picks up the
+// controller's current base image.
+func (r *AutoUpgradeRunner) createUpgradeWorkspace(ctx context.Context, inferenceSetObj *kaitov1beta1.InferenceSet, desiredTag string) {
+	ws := inferencesetutil.NewWorkspaceForInferenceSet(inferenceSetObj)
 
-	// Wait for the surge Workspace to become inference-ready before cutting over.
-	if workspacecontrollers.DetermineWorkspacePhase(surge) != "succeeded" {
-		klog.V(4).InfoS("AutoUpgradeRunner: waiting for surge workspace to become ready",
-			"surge", klog.KObj(surge), "old", oldName, "inferenceset", klog.KObj(inferenceSetObj))
+	if err := r.Client.Create(ctx, ws); err != nil {
+		klog.ErrorS(err, "AutoUpgradeRunner: failed to create upgrade workspace", "inferenceset", klog.KObj(inferenceSetObj))
 		return
 	}
-
-	old, oldExists := byName[oldName]
-	if oldExists && old.DeletionTimestamp == nil {
-		// Surge is ready: delete the old Workspace to cut traffic over.
-		klog.InfoS("AutoUpgradeRunner: surge workspace ready, deleting old workspace",
-			"surge", klog.KObj(surge), "old", klog.KObj(old), "inferenceset", klog.KObj(inferenceSetObj))
-		if err := r.Client.Delete(ctx, old, &client.DeleteOptions{}); err != nil {
-			klog.ErrorS(err, "AutoUpgradeRunner: failed to delete old workspace", "old", klog.KObj(old))
-		}
-		return
-	}
-	if oldExists && old.DeletionTimestamp != nil {
-		// Old Workspace is terminating; wait for it to fully disappear before promoting the surge.
-		klog.V(4).InfoS("AutoUpgradeRunner: waiting for old workspace to be deleted",
-			"old", klog.KObj(old), "inferenceset", klog.KObj(inferenceSetObj))
-		return
-	}
-
-	// Old Workspace is gone: promote the surge Workspace by removing its surge label so the
-	// InferenceSet controller resumes managing it as a normal replica.
-	r.promoteSurgeWorkspace(ctx, surge)
-}
-
-// createSurgeWorkspace creates a new surge Workspace as a replacement for the
-// given drifted (old) Workspace. The surge Workspace is generated from the
-// InferenceSet template (so it picks up the controller's current base image) and is
-// labeled with upgrade-surge-for=<old name> and the upgrade-start-time annotation.
-func (r *AutoUpgradeRunner) createSurgeWorkspace(ctx context.Context, inferenceSetObj *kaitov1beta1.InferenceSet, old *kaitov1beta1.Workspace, desiredTag string) {
-	surge := inferencesetutil.NewWorkspaceForInferenceSet(inferenceSetObj)
-	if surge.Labels == nil {
-		surge.Labels = make(map[string]string)
-	}
-	surge.Labels[kaitov1alpha1.LabelUpgradeSurgeFor] = old.Name
-	surge.Labels[kaitov1alpha1.LabelUpgradeToVersion] = desiredTag
-	if surge.Annotations == nil {
-		surge.Annotations = make(map[string]string)
-	}
-	surge.Annotations[AnnotationUpgradeStartTime] = time.Now().UTC().Format(time.RFC3339)
-
-	if err := r.Client.Create(ctx, surge); err != nil {
-		klog.ErrorS(err, "AutoUpgradeRunner: failed to create surge workspace",
-			"old", klog.KObj(old), "inferenceset", klog.KObj(inferenceSetObj))
-		return
-	}
-	klog.InfoS("AutoUpgradeRunner: created surge workspace for surge-based upgrade",
-		"old", klog.KObj(old), "targetVersion", desiredTag, "inferenceset", klog.KObj(inferenceSetObj))
-}
-
-// promoteSurgeWorkspace removes the upgrade-surge-for label from a surge Workspace,
-// handing it back to the InferenceSet controller as a normal managed replica.
-func (r *AutoUpgradeRunner) promoteSurgeWorkspace(ctx context.Context, surge *kaitov1beta1.Workspace) {
-	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		latest := &kaitov1beta1.Workspace{}
-		if err := r.Client.Get(ctx, client.ObjectKeyFromObject(surge), latest); err != nil {
-			return err
-		}
-		if _, ok := latest.Labels[kaitov1alpha1.LabelUpgradeSurgeFor]; !ok {
-			return nil
-		}
-		patch := client.MergeFrom(latest.DeepCopy())
-		delete(latest.Labels, kaitov1alpha1.LabelUpgradeSurgeFor)
-		return r.Client.Patch(ctx, latest, patch)
-	})
-	if err != nil {
-		klog.ErrorS(err, "AutoUpgradeRunner: failed to promote surge workspace", "surge", klog.KObj(surge))
-		return
-	}
-	klog.InfoS("AutoUpgradeRunner: surge-based upgrade complete, promoted surge workspace", "surge", klog.KObj(surge))
+	klog.InfoS("AutoUpgradeRunner: created new workspace for surge-based upgrade",
+		"targetVersion", desiredTag, "inferenceset", klog.KObj(inferenceSetObj))
 }
 
 // isWorkspaceInDesiredState returns true if the workspace's StatefulSet is running

--- a/pkg/controllers/autoupgrade/runner.go
+++ b/pkg/controllers/autoupgrade/runner.go
@@ -100,8 +100,8 @@ func (r *AutoUpgradeRunner) reconcileInferenceSet(ctx context.Context, inference
 	}
 
 	switch inferenceSetObj.Spec.AutoUpgrade.Strategy {
-	case kaitov1beta1.BlueGreenUpgradeStrategy:
-		r.reconcileBlueGreen(ctx, inferenceSetObj)
+	case kaitov1beta1.SurgeBasedUpgradeStrategy:
+		r.reconcileSurge(ctx, inferenceSetObj)
 	case kaitov1beta1.InPlaceUpgradeStrategy, "":
 		// Empty strategy defaults to in-place (the CRD default is InPlace; the
 		// empty value also covers objects created before the field existed).
@@ -311,13 +311,13 @@ func (r *AutoUpgradeRunner) tagWorkspaceForUpgrade(ctx context.Context, isObj *k
 		"workspace", klog.KObj(ws), "targetVersion", desiredTag, "inferenceset", klog.KObj(isObj))
 }
 
-// reconcileBlueGreen handles a single InferenceSet's auto-upgrade lifecycle using
-// the blue-green strategy: for each drifted ("blue") Workspace, create a new
-// ("green") Workspace on the new base image, wait for it to become inference-ready,
-// then delete the blue Workspace. Only one upgrade is in flight per InferenceSet
+// reconcileSurge handles a single InferenceSet's auto-upgrade lifecycle using
+// the surge-based strategy: for each drifted (old) Workspace, create a new
+// surge Workspace on the new base image, wait for it to become inference-ready,
+// then delete the old Workspace. Only one upgrade is in flight per InferenceSet
 // at a time. The new Workspace automatically picks up the controller's current
 // base image because it is generated fresh from GetBaseImageName().
-func (r *AutoUpgradeRunner) reconcileBlueGreen(ctx context.Context, inferenceSetObj *kaitov1beta1.InferenceSet) {
+func (r *AutoUpgradeRunner) reconcileSurge(ctx context.Context, inferenceSetObj *kaitov1beta1.InferenceSet) {
 	desiredImage := inference.GetBaseImageName()
 	desiredTag := inference.GetBaseImageTag()
 
@@ -326,14 +326,14 @@ func (r *AutoUpgradeRunner) reconcileBlueGreen(ctx context.Context, inferenceSet
 		klog.ErrorS(err, "AutoUpgradeRunner: failed to list workspaces", "inferenceset", klog.KObj(inferenceSetObj))
 		return
 	}
-	// Deterministic ordering so we always pick the same blue Workspace to upgrade next.
+	// Deterministic ordering so we always pick the same old Workspace to upgrade next.
 	sort.SliceStable(wsList.Items, func(i, j int) bool {
 		return wsList.Items[i].UID < wsList.Items[j].UID
 	})
 
 	// Classify Workspaces:
-	//   - surge: the in-flight green Workspace (carries the upgrade-surge-for label).
-	//   - drifted: blue Workspaces still running an old base image.
+	//   - surge: the in-flight new Workspace (carries the upgrade-surge-for label).
+	//   - drifted: old Workspaces still running an old base image.
 	var surge *kaitov1beta1.Workspace
 	var drifted []kaitov1beta1.Workspace
 	byName := make(map[string]*kaitov1beta1.Workspace, len(wsList.Items))
@@ -361,8 +361,8 @@ func (r *AutoUpgradeRunner) reconcileBlueGreen(ctx context.Context, inferenceSet
 		}
 	}
 
-	// Drift count = blue Workspaces not yet on the desired image (the surge itself
-	// is excluded; the blue it replaces remains counted until deleted).
+	// Drift count = old Workspaces not yet on the desired image (the surge itself
+	// is excluded; the old one it replaces remains counted until deleted).
 	newDriftCount := len(drifted)
 	if r.statusNeedsUpdate(inferenceSetObj, newDriftCount) {
 		markSuccess := newDriftCount == 0 && r.previousDriftCount(inferenceSetObj) > 0
@@ -373,7 +373,7 @@ func (r *AutoUpgradeRunner) reconcileBlueGreen(ctx context.Context, inferenceSet
 
 	// An upgrade is already in flight: drive it toward completion before starting another.
 	if surge != nil {
-		r.advanceBlueGreen(ctx, inferenceSetObj, surge, byName)
+		r.advanceSurge(ctx, inferenceSetObj, surge, byName)
 		return
 	}
 
@@ -387,72 +387,72 @@ func (r *AutoUpgradeRunner) reconcileBlueGreen(ctx context.Context, inferenceSet
 		return
 	}
 
-	// Start a new upgrade: create a green Workspace for the first drifted blue Workspace.
+	// Start a new upgrade: create a surge Workspace for the first drifted Workspace.
 	r.createSurgeWorkspace(ctx, inferenceSetObj, &drifted[0], desiredTag)
 }
 
-// advanceBlueGreen drives an in-flight blue-green upgrade forward by one step:
-// wait for the green Workspace to become ready, then delete the blue Workspace,
-// and finally promote the green Workspace (remove its surge label) once the blue
+// advanceSurge drives an in-flight surge-based upgrade forward by one step:
+// wait for the surge Workspace to become ready, then delete the old Workspace,
+// and finally promote the surge Workspace (remove its surge label) once the old
 // Workspace is fully gone.
-func (r *AutoUpgradeRunner) advanceBlueGreen(ctx context.Context, inferenceSetObj *kaitov1beta1.InferenceSet, surge *kaitov1beta1.Workspace, byName map[string]*kaitov1beta1.Workspace) {
-	blueName := surge.Labels[kaitov1alpha1.LabelUpgradeSurgeFor]
+func (r *AutoUpgradeRunner) advanceSurge(ctx context.Context, inferenceSetObj *kaitov1beta1.InferenceSet, surge *kaitov1beta1.Workspace, byName map[string]*kaitov1beta1.Workspace) {
+	oldName := surge.Labels[kaitov1alpha1.LabelUpgradeSurgeFor]
 
-	// Wait for the green Workspace to become inference-ready before cutting over.
+	// Wait for the surge Workspace to become inference-ready before cutting over.
 	if workspacecontrollers.DetermineWorkspacePhase(surge) != "succeeded" {
 		klog.V(4).InfoS("AutoUpgradeRunner: waiting for surge workspace to become ready",
-			"surge", klog.KObj(surge), "blue", blueName, "inferenceset", klog.KObj(inferenceSetObj))
+			"surge", klog.KObj(surge), "old", oldName, "inferenceset", klog.KObj(inferenceSetObj))
 		return
 	}
 
-	blue, blueExists := byName[blueName]
-	if blueExists && blue.DeletionTimestamp == nil {
-		// Green is ready: delete the blue Workspace to cut traffic over.
+	old, oldExists := byName[oldName]
+	if oldExists && old.DeletionTimestamp == nil {
+		// Surge is ready: delete the old Workspace to cut traffic over.
 		klog.InfoS("AutoUpgradeRunner: surge workspace ready, deleting old workspace",
-			"surge", klog.KObj(surge), "blue", klog.KObj(blue), "inferenceset", klog.KObj(inferenceSetObj))
-		if err := r.Client.Delete(ctx, blue, &client.DeleteOptions{}); err != nil {
-			klog.ErrorS(err, "AutoUpgradeRunner: failed to delete old workspace", "blue", klog.KObj(blue))
+			"surge", klog.KObj(surge), "old", klog.KObj(old), "inferenceset", klog.KObj(inferenceSetObj))
+		if err := r.Client.Delete(ctx, old, &client.DeleteOptions{}); err != nil {
+			klog.ErrorS(err, "AutoUpgradeRunner: failed to delete old workspace", "old", klog.KObj(old))
 		}
 		return
 	}
-	if blueExists && blue.DeletionTimestamp != nil {
-		// Blue is terminating; wait for it to fully disappear before promoting green.
+	if oldExists && old.DeletionTimestamp != nil {
+		// Old Workspace is terminating; wait for it to fully disappear before promoting the surge.
 		klog.V(4).InfoS("AutoUpgradeRunner: waiting for old workspace to be deleted",
-			"blue", klog.KObj(blue), "inferenceset", klog.KObj(inferenceSetObj))
+			"old", klog.KObj(old), "inferenceset", klog.KObj(inferenceSetObj))
 		return
 	}
 
-	// Blue is gone: promote the green Workspace by removing its surge label so the
+	// Old Workspace is gone: promote the surge Workspace by removing its surge label so the
 	// InferenceSet controller resumes managing it as a normal replica.
 	r.promoteSurgeWorkspace(ctx, surge)
 }
 
-// createSurgeWorkspace creates a new ("green") Workspace as a surge replacement for
-// the given drifted ("blue") Workspace. The green Workspace is generated from the
+// createSurgeWorkspace creates a new surge Workspace as a replacement for the
+// given drifted (old) Workspace. The surge Workspace is generated from the
 // InferenceSet template (so it picks up the controller's current base image) and is
-// labeled with upgrade-surge-for=<blue name> and the upgrade-start-time annotation.
-func (r *AutoUpgradeRunner) createSurgeWorkspace(ctx context.Context, inferenceSetObj *kaitov1beta1.InferenceSet, blue *kaitov1beta1.Workspace, desiredTag string) {
-	green := inferencesetutil.NewWorkspaceForInferenceSet(inferenceSetObj)
-	if green.Labels == nil {
-		green.Labels = make(map[string]string)
+// labeled with upgrade-surge-for=<old name> and the upgrade-start-time annotation.
+func (r *AutoUpgradeRunner) createSurgeWorkspace(ctx context.Context, inferenceSetObj *kaitov1beta1.InferenceSet, old *kaitov1beta1.Workspace, desiredTag string) {
+	surge := inferencesetutil.NewWorkspaceForInferenceSet(inferenceSetObj)
+	if surge.Labels == nil {
+		surge.Labels = make(map[string]string)
 	}
-	green.Labels[kaitov1alpha1.LabelUpgradeSurgeFor] = blue.Name
-	green.Labels[kaitov1alpha1.LabelUpgradeToVersion] = desiredTag
-	if green.Annotations == nil {
-		green.Annotations = make(map[string]string)
+	surge.Labels[kaitov1alpha1.LabelUpgradeSurgeFor] = old.Name
+	surge.Labels[kaitov1alpha1.LabelUpgradeToVersion] = desiredTag
+	if surge.Annotations == nil {
+		surge.Annotations = make(map[string]string)
 	}
-	green.Annotations[AnnotationUpgradeStartTime] = time.Now().UTC().Format(time.RFC3339)
+	surge.Annotations[AnnotationUpgradeStartTime] = time.Now().UTC().Format(time.RFC3339)
 
-	if err := r.Client.Create(ctx, green); err != nil {
+	if err := r.Client.Create(ctx, surge); err != nil {
 		klog.ErrorS(err, "AutoUpgradeRunner: failed to create surge workspace",
-			"blue", klog.KObj(blue), "inferenceset", klog.KObj(inferenceSetObj))
+			"old", klog.KObj(old), "inferenceset", klog.KObj(inferenceSetObj))
 		return
 	}
-	klog.InfoS("AutoUpgradeRunner: created surge workspace for blue-green upgrade",
-		"blue", klog.KObj(blue), "targetVersion", desiredTag, "inferenceset", klog.KObj(inferenceSetObj))
+	klog.InfoS("AutoUpgradeRunner: created surge workspace for surge-based upgrade",
+		"old", klog.KObj(old), "targetVersion", desiredTag, "inferenceset", klog.KObj(inferenceSetObj))
 }
 
-// promoteSurgeWorkspace removes the upgrade-surge-for label from a green Workspace,
+// promoteSurgeWorkspace removes the upgrade-surge-for label from a surge Workspace,
 // handing it back to the InferenceSet controller as a normal managed replica.
 func (r *AutoUpgradeRunner) promoteSurgeWorkspace(ctx context.Context, surge *kaitov1beta1.Workspace) {
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -471,7 +471,7 @@ func (r *AutoUpgradeRunner) promoteSurgeWorkspace(ctx context.Context, surge *ka
 		klog.ErrorS(err, "AutoUpgradeRunner: failed to promote surge workspace", "surge", klog.KObj(surge))
 		return
 	}
-	klog.InfoS("AutoUpgradeRunner: blue-green upgrade complete, promoted surge workspace", "surge", klog.KObj(surge))
+	klog.InfoS("AutoUpgradeRunner: surge-based upgrade complete, promoted surge workspace", "surge", klog.KObj(surge))
 }
 
 // isWorkspaceInDesiredState returns true if the workspace's StatefulSet is running

--- a/pkg/controllers/autoupgrade/runner.go
+++ b/pkg/controllers/autoupgrade/runner.go
@@ -353,7 +353,7 @@ func (r *AutoUpgradeRunner) reconcileSurge(ctx context.Context, inferenceSetObj 
 			klog.ErrorS(err, "AutoUpgradeRunner: failed to get StatefulSet", "workspace", klog.KObj(ws))
 			return
 		}
-		if !isWorkspaceInDesiredState(ss, desiredImage) {
+		if workspace.GetInferenceContainerImage(ss) != desiredImage {
 			driftCount++
 		}
 	}

--- a/pkg/controllers/autoupgrade/runner_test.go
+++ b/pkg/controllers/autoupgrade/runner_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -748,4 +749,210 @@ func TestReconcileInferenceSet_NoSuccessWhenPreviousDriftWasZero(t *testing.T) {
 	require.NotNil(t, updated.Status.AutoUpgrade)
 	assert.Equal(t, 0, *updated.Status.AutoUpgrade.NumDriftedWorkspaces)
 	assert.Nil(t, updated.Status.AutoUpgrade.LastSuccessfulUpgradeTime)
+}
+
+// makeBlueGreenInferenceSet builds an InferenceSet with auto-upgrade enabled and
+// the BlueGreen strategy, plus a minimal template/selector so the surge Workspace
+// can be generated.
+func makeBlueGreenInferenceSet(name, namespace string) *kaitov1beta1.InferenceSet {
+	is := makeInferenceSet(name, namespace, true, nil)
+	is.Spec.AutoUpgrade.Strategy = kaitov1beta1.BlueGreenUpgradeStrategy
+	is.Spec.Selector = &metav1.LabelSelector{
+		MatchLabels: map[string]string{"app": name},
+	}
+	is.Spec.Template = kaitov1beta1.InferenceSetTemplate{
+		Inference: kaitov1beta1.InferenceSpec{
+			Preset: &kaitov1beta1.PresetSpec{
+				PresetMeta: kaitov1beta1.PresetMeta{Name: kaitov1beta1.ModelName("phi-3-mini-128k-instruct")},
+			},
+		},
+	}
+	return is
+}
+
+// markWorkspaceSucceeded sets the WorkspaceSucceeded=True condition so
+// DetermineWorkspacePhase reports "succeeded".
+func markWorkspaceSucceeded(ws *kaitov1beta1.Workspace) {
+	ws.Status.Conditions = append(ws.Status.Conditions, metav1.Condition{
+		Type:               string(kaitov1beta1.WorkspaceConditionTypeSucceeded),
+		Status:             metav1.ConditionTrue,
+		Reason:             "ready",
+		LastTransitionTime: metav1.Now(),
+	})
+}
+
+func listSurgeWorkspaces(t *testing.T, cl client.Client, ns string) []kaitov1beta1.Workspace {
+	t.Helper()
+	all := &kaitov1beta1.WorkspaceList{}
+	require.NoError(t, cl.List(context.Background(), all, client.InNamespace(ns)))
+	var surges []kaitov1beta1.Workspace
+	for i := range all.Items {
+		if _, ok := all.Items[i].Labels[kaitov1alpha1.LabelUpgradeSurgeFor]; ok {
+			surges = append(surges, all.Items[i])
+		}
+	}
+	return surges
+}
+
+// TestReconcileBlueGreen_CreatesSurge verifies that a drifted Workspace triggers
+// the creation of a new surge (green) Workspace, without touching the blue one.
+func TestReconcileBlueGreen_CreatesSurge(t *testing.T) {
+	const (
+		ns       = "default"
+		isName   = "bg-is"
+		oldImage = "mcr.microsoft.com/aks/kaito/kaito-base:0.3.0"
+	)
+	desiredTag := inference.GetBaseImageTag()
+	setTestRegistry(t)
+
+	is := makeBlueGreenInferenceSet(isName, ns)
+	blue := makeWorkspace("blue-1", ns, isName, kaitov1beta1.WorkspaceStateReady, nil)
+	blueSS := makeStatefulSet("blue-1", ns, oldImage)
+
+	cl := newFakeClient(is, blue, blueSS)
+	r := &AutoUpgradeRunner{Client: cl}
+
+	r.reconcileInferenceSet(context.Background(), is)
+
+	// A surge workspace should have been created, pointing at the blue one.
+	surges := listSurgeWorkspaces(t, cl, ns)
+	require.Len(t, surges, 1)
+	assert.Equal(t, "blue-1", surges[0].Labels[kaitov1alpha1.LabelUpgradeSurgeFor])
+	assert.Equal(t, desiredTag, surges[0].Labels[kaitov1alpha1.LabelUpgradeToVersion])
+	assert.Equal(t, isName, surges[0].Labels[consts.WorkspaceCreatedByInferenceSetLabel])
+
+	// Blue must still exist (no downtime / not deleted yet).
+	stillThere := &kaitov1beta1.Workspace{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(blue), stillThere))
+	assert.True(t, stillThere.DeletionTimestamp.IsZero())
+}
+
+// TestReconcileBlueGreen_WaitsForSurgeReady verifies that the blue Workspace is
+// NOT deleted while the surge is still coming up, and that a second reconcile does
+// not create another surge (one-at-a-time).
+func TestReconcileBlueGreen_WaitsForSurgeReady(t *testing.T) {
+	const (
+		ns       = "default"
+		isName   = "bg-is"
+		oldImage = "mcr.microsoft.com/aks/kaito/kaito-base:0.3.0"
+		newImage = "mcr.microsoft.com/aks/kaito/kaito-base:0.4.0"
+	)
+	desiredTag := inference.GetBaseImageTag()
+	setTestRegistry(t)
+
+	is := makeBlueGreenInferenceSet(isName, ns)
+	blue := makeWorkspace("blue-1", ns, isName, kaitov1beta1.WorkspaceStateReady, nil)
+	blueSS := makeStatefulSet("blue-1", ns, oldImage)
+	// Surge exists but is not yet succeeded (no condition set).
+	green := makeWorkspace("green-1", ns, isName, kaitov1beta1.WorkspaceStatePending, map[string]string{
+		kaitov1alpha1.LabelUpgradeSurgeFor:  "blue-1",
+		kaitov1alpha1.LabelUpgradeToVersion: desiredTag,
+	})
+	greenSS := makeStatefulSet("green-1", ns, newImage)
+	greenSS.Status.ReadyReplicas = 0
+
+	cl := newFakeClient(is, blue, blueSS, green, greenSS)
+	r := &AutoUpgradeRunner{Client: cl}
+
+	r.reconcileInferenceSet(context.Background(), is)
+
+	// Blue not deleted; no second surge created.
+	stillThere := &kaitov1beta1.Workspace{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(blue), stillThere))
+	assert.True(t, stillThere.DeletionTimestamp.IsZero())
+	assert.Len(t, listSurgeWorkspaces(t, cl, ns), 1)
+}
+
+// TestReconcileBlueGreen_DeletesBlueWhenSurgeReady verifies cutover: once the
+// surge is ready, the blue Workspace is deleted.
+func TestReconcileBlueGreen_DeletesBlueWhenSurgeReady(t *testing.T) {
+	const (
+		ns       = "default"
+		isName   = "bg-is"
+		oldImage = "mcr.microsoft.com/aks/kaito/kaito-base:0.3.0"
+		newImage = "mcr.microsoft.com/aks/kaito/kaito-base:0.4.0"
+	)
+	desiredTag := inference.GetBaseImageTag()
+	setTestRegistry(t)
+
+	is := makeBlueGreenInferenceSet(isName, ns)
+	blue := makeWorkspace("blue-1", ns, isName, kaitov1beta1.WorkspaceStateReady, nil)
+	blueSS := makeStatefulSet("blue-1", ns, oldImage)
+	green := makeWorkspace("green-1", ns, isName, kaitov1beta1.WorkspaceStateReady, map[string]string{
+		kaitov1alpha1.LabelUpgradeSurgeFor:  "blue-1",
+		kaitov1alpha1.LabelUpgradeToVersion: desiredTag,
+	})
+	markWorkspaceSucceeded(green)
+	greenSS := makeStatefulSet("green-1", ns, newImage)
+
+	cl := newFakeClient(is, blue, blueSS, green, greenSS)
+	r := &AutoUpgradeRunner{Client: cl}
+
+	r.reconcileInferenceSet(context.Background(), is)
+
+	// Blue should be gone (fake client deletes immediately, no finalizer).
+	err := cl.Get(context.Background(), client.ObjectKeyFromObject(blue), &kaitov1beta1.Workspace{})
+	assert.True(t, apierrors.IsNotFound(err), "blue workspace should be deleted")
+}
+
+// TestReconcileBlueGreen_PromotesSurgeAfterBlueGone verifies the final step: once
+// blue is gone, the surge label is removed, promoting green to a normal replica.
+func TestReconcileBlueGreen_PromotesSurgeAfterBlueGone(t *testing.T) {
+	const (
+		ns       = "default"
+		isName   = "bg-is"
+		newImage = "mcr.microsoft.com/aks/kaito/kaito-base:0.4.0"
+	)
+	desiredTag := inference.GetBaseImageTag()
+	setTestRegistry(t)
+
+	is := makeBlueGreenInferenceSet(isName, ns)
+	// Blue already gone; only the surge (green) remains, ready, still labeled.
+	green := makeWorkspace("green-1", ns, isName, kaitov1beta1.WorkspaceStateReady, map[string]string{
+		kaitov1alpha1.LabelUpgradeSurgeFor:  "blue-1",
+		kaitov1alpha1.LabelUpgradeToVersion: desiredTag,
+	})
+	markWorkspaceSucceeded(green)
+	greenSS := makeStatefulSet("green-1", ns, newImage)
+
+	cl := newFakeClient(is, green, greenSS)
+	r := &AutoUpgradeRunner{Client: cl}
+
+	r.reconcileInferenceSet(context.Background(), is)
+
+	// Surge label should be removed (promoted to managed replica).
+	updated := &kaitov1beta1.Workspace{}
+	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(green), updated))
+	_, ok := updated.Labels[kaitov1alpha1.LabelUpgradeSurgeFor]
+	assert.False(t, ok, "surge label should be removed after blue is gone")
+	assert.Empty(t, listSurgeWorkspaces(t, cl, ns))
+}
+
+// TestReconcileBlueGreen_OutsideMaintenanceWindow verifies no surge is created
+// outside the maintenance window.
+func TestReconcileBlueGreen_OutsideMaintenanceWindow(t *testing.T) {
+	const (
+		ns       = "default"
+		isName   = "bg-is"
+		oldImage = "mcr.microsoft.com/aks/kaito/kaito-base:0.3.0"
+	)
+	setTestRegistry(t)
+
+	is := makeBlueGreenInferenceSet(isName, ns)
+	// A window that is effectively never open around "now": every Jan 1 at 00:00,
+	// 1 minute long. Extremely unlikely to be within the window during tests.
+	dur := metav1.Duration{Duration: time.Minute}
+	is.Spec.AutoUpgrade.MaintenanceWindow = &kaitov1beta1.MaintenanceWindow{
+		Schedule: "0 0 1 1 *",
+		Duration: &dur,
+	}
+	blue := makeWorkspace("blue-1", ns, isName, kaitov1beta1.WorkspaceStateReady, nil)
+	blueSS := makeStatefulSet("blue-1", ns, oldImage)
+
+	cl := newFakeClient(is, blue, blueSS)
+	r := &AutoUpgradeRunner{Client: cl}
+
+	r.reconcileInferenceSet(context.Background(), is)
+
+	assert.Empty(t, listSurgeWorkspaces(t, cl, ns), "no surge should be created outside the window")
 }

--- a/pkg/controllers/autoupgrade/runner_test.go
+++ b/pkg/controllers/autoupgrade/runner_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -770,42 +769,26 @@ func makeSurgeInferenceSet(name, namespace string) *kaitov1beta1.InferenceSet {
 	return is
 }
 
-// markWorkspaceSucceeded sets the WorkspaceSucceeded=True condition so
-// DetermineWorkspacePhase reports "succeeded".
-func markWorkspaceSucceeded(ws *kaitov1beta1.Workspace) {
-	ws.Status.Conditions = append(ws.Status.Conditions, metav1.Condition{
-		Type:               string(kaitov1beta1.WorkspaceConditionTypeSucceeded),
-		Status:             metav1.ConditionTrue,
-		Reason:             "ready",
-		LastTransitionTime: metav1.Now(),
-	})
-}
-
-func listSurgeWorkspaces(t *testing.T, cl client.Client, ns string) []kaitov1beta1.Workspace {
+// listWorkspacesInNamespace returns all Workspaces in the namespace.
+func listWorkspacesInNamespace(t *testing.T, cl client.Client, ns string) []kaitov1beta1.Workspace {
 	t.Helper()
 	all := &kaitov1beta1.WorkspaceList{}
 	require.NoError(t, cl.List(context.Background(), all, client.InNamespace(ns)))
-	var surges []kaitov1beta1.Workspace
-	for i := range all.Items {
-		if _, ok := all.Items[i].Labels[kaitov1alpha1.LabelUpgradeSurgeFor]; ok {
-			surges = append(surges, all.Items[i])
-		}
-	}
-	return surges
+	return all.Items
 }
 
-// TestReconcileSurge_CreatesSurge verifies that a drifted Workspace triggers
-// the creation of a new surge Workspace, without touching the old one.
-func TestReconcileSurge_CreatesSurge(t *testing.T) {
+// TestReconcileSurge_CreatesWorkspaceWhenDrifted verifies that a drifted Workspace at the
+// desired replica count triggers creation of one new Workspace on the new base image,
+// without deleting the old one (the InferenceSet controller performs the cutover).
+func TestReconcileSurge_CreatesWorkspaceWhenDrifted(t *testing.T) {
 	const (
 		ns       = "default"
 		isName   = "bg-is"
 		oldImage = "mcr.microsoft.com/aks/kaito/kaito-base:0.3.0"
 	)
-	desiredTag := inference.GetBaseImageTag()
 	setTestRegistry(t)
 
-	is := makeSurgeInferenceSet(isName, ns)
+	is := makeSurgeInferenceSet(isName, ns) // desired replicas defaults to 1
 	blue := makeWorkspace("blue-1", ns, isName, kaitov1beta1.WorkspaceStateReady, nil)
 	blueSS := makeStatefulSet("blue-1", ns, oldImage)
 
@@ -814,41 +797,41 @@ func TestReconcileSurge_CreatesSurge(t *testing.T) {
 
 	r.reconcileInferenceSet(context.Background(), is)
 
-	// A surge workspace should have been created, pointing at the blue one.
-	surges := listSurgeWorkspaces(t, cl, ns)
-	require.Len(t, surges, 1)
-	assert.Equal(t, "blue-1", surges[0].Labels[kaitov1alpha1.LabelUpgradeSurgeFor])
-	assert.Equal(t, desiredTag, surges[0].Labels[kaitov1alpha1.LabelUpgradeToVersion])
-	assert.Equal(t, isName, surges[0].Labels[consts.WorkspaceCreatedByInferenceSetLabel])
+	// A new Workspace should have been created on the new image, stamped with the version label.
+	all := listWorkspacesInNamespace(t, cl, ns)
+	require.Len(t, all, 2)
+	var newWs *kaitov1beta1.Workspace
+	for i := range all {
+		if all[i].Name != "blue-1" {
+			newWs = &all[i]
+		}
+	}
+	require.NotNil(t, newWs, "a new workspace should have been created")
+	assert.Equal(t, isName, newWs.Labels[consts.WorkspaceCreatedByInferenceSetLabel])
 
-	// Blue must still exist (no downtime / not deleted yet).
+	// Blue must still exist (no downtime / not deleted by the runner).
 	stillThere := &kaitov1beta1.Workspace{}
 	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(blue), stillThere))
 	assert.True(t, stillThere.DeletionTimestamp.IsZero())
 }
 
-// TestReconcileSurge_WaitsForSurgeReady verifies that the old Workspace is
-// NOT deleted while the surge is still coming up, and that a second reconcile does
-// not create another surge (one-at-a-time).
-func TestReconcileSurge_WaitsForSurgeReady(t *testing.T) {
+// TestReconcileSurge_NoCreateWhileSurgeInFlight verifies the runner does not add a second
+// new Workspace while an upgrade surge is already in flight (live count above desired). It
+// waits for the InferenceSet controller to retire an old Workspace first.
+func TestReconcileSurge_NoCreateWhileSurgeInFlight(t *testing.T) {
 	const (
 		ns       = "default"
 		isName   = "bg-is"
 		oldImage = "mcr.microsoft.com/aks/kaito/kaito-base:0.3.0"
-		newImage = "mcr.microsoft.com/aks/kaito/kaito-base:0.4.0"
 	)
-	desiredTag := inference.GetBaseImageTag()
-	setTestRegistry(t)
+	desiredImage := setTestRegistry(t)
 
-	is := makeSurgeInferenceSet(isName, ns)
+	is := makeSurgeInferenceSet(isName, ns) // desired replicas defaults to 1
 	blue := makeWorkspace("blue-1", ns, isName, kaitov1beta1.WorkspaceStateReady, nil)
 	blueSS := makeStatefulSet("blue-1", ns, oldImage)
-	// Surge exists but is not yet succeeded (no condition set).
-	green := makeWorkspace("green-1", ns, isName, kaitov1beta1.WorkspaceStatePending, map[string]string{
-		kaitov1alpha1.LabelUpgradeSurgeFor:  "blue-1",
-		kaitov1alpha1.LabelUpgradeToVersion: desiredTag,
-	})
-	greenSS := makeStatefulSet("green-1", ns, newImage)
+	// A new-image workspace already exists (the in-flight surge), so the live count is 2 > 1.
+	green := makeWorkspace("green-1", ns, isName, kaitov1beta1.WorkspaceStatePending, nil)
+	greenSS := makeStatefulSet("green-1", ns, desiredImage)
 	greenSS.Status.ReadyReplicas = 0
 
 	cl := newFakeClient(is, blue, blueSS, green, greenSS)
@@ -856,79 +839,36 @@ func TestReconcileSurge_WaitsForSurgeReady(t *testing.T) {
 
 	r.reconcileInferenceSet(context.Background(), is)
 
-	// Blue not deleted; no second surge created.
+	// No third workspace; runner waits for the controller to retire the old one.
+	assert.Len(t, listWorkspacesInNamespace(t, cl, ns), 2)
+	// Blue not deleted by the runner.
 	stillThere := &kaitov1beta1.Workspace{}
 	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(blue), stillThere))
 	assert.True(t, stillThere.DeletionTimestamp.IsZero())
-	assert.Len(t, listSurgeWorkspaces(t, cl, ns), 1)
 }
 
-// TestReconcileSurge_DeletesOldWhenSurgeReady verifies cutover: once the
-// surge is ready, the old Workspace is deleted.
-func TestReconcileSurge_DeletesOldWhenSurgeReady(t *testing.T) {
+// TestReconcileSurge_NoCreateWhenAllUpToDate verifies no new Workspace is created when the
+// fleet has already converged onto the desired base image.
+func TestReconcileSurge_NoCreateWhenAllUpToDate(t *testing.T) {
 	const (
-		ns       = "default"
-		isName   = "bg-is"
-		oldImage = "mcr.microsoft.com/aks/kaito/kaito-base:0.3.0"
-		newImage = "mcr.microsoft.com/aks/kaito/kaito-base:0.4.0"
+		ns     = "default"
+		isName = "bg-is"
 	)
-	desiredTag := inference.GetBaseImageTag()
-	setTestRegistry(t)
+	desiredImage := setTestRegistry(t)
 
 	is := makeSurgeInferenceSet(isName, ns)
 	blue := makeWorkspace("blue-1", ns, isName, kaitov1beta1.WorkspaceStateReady, nil)
-	blueSS := makeStatefulSet("blue-1", ns, oldImage)
-	green := makeWorkspace("green-1", ns, isName, kaitov1beta1.WorkspaceStateReady, map[string]string{
-		kaitov1alpha1.LabelUpgradeSurgeFor:  "blue-1",
-		kaitov1alpha1.LabelUpgradeToVersion: desiredTag,
-	})
-	markWorkspaceSucceeded(green)
-	greenSS := makeStatefulSet("green-1", ns, newImage)
+	blueSS := makeStatefulSet("blue-1", ns, desiredImage)
 
-	cl := newFakeClient(is, blue, blueSS, green, greenSS)
+	cl := newFakeClient(is, blue, blueSS)
 	r := &AutoUpgradeRunner{Client: cl}
 
 	r.reconcileInferenceSet(context.Background(), is)
 
-	// Old workspace should be gone (fake client deletes immediately, no finalizer).
-	err := cl.Get(context.Background(), client.ObjectKeyFromObject(blue), &kaitov1beta1.Workspace{})
-	assert.True(t, apierrors.IsNotFound(err), "old workspace should be deleted")
+	assert.Len(t, listWorkspacesInNamespace(t, cl, ns), 1)
 }
 
-// TestReconcileSurge_PromotesSurgeAfterOldGone verifies the final step: once
-// the old Workspace is gone, the surge label is removed, promoting it to a normal replica.
-func TestReconcileSurge_PromotesSurgeAfterOldGone(t *testing.T) {
-	const (
-		ns       = "default"
-		isName   = "bg-is"
-		newImage = "mcr.microsoft.com/aks/kaito/kaito-base:0.4.0"
-	)
-	desiredTag := inference.GetBaseImageTag()
-	setTestRegistry(t)
-
-	is := makeSurgeInferenceSet(isName, ns)
-	// Blue already gone; only the surge (green) remains, ready, still labeled.
-	green := makeWorkspace("green-1", ns, isName, kaitov1beta1.WorkspaceStateReady, map[string]string{
-		kaitov1alpha1.LabelUpgradeSurgeFor:  "blue-1",
-		kaitov1alpha1.LabelUpgradeToVersion: desiredTag,
-	})
-	markWorkspaceSucceeded(green)
-	greenSS := makeStatefulSet("green-1", ns, newImage)
-
-	cl := newFakeClient(is, green, greenSS)
-	r := &AutoUpgradeRunner{Client: cl}
-
-	r.reconcileInferenceSet(context.Background(), is)
-
-	// Surge label should be removed (promoted to managed replica).
-	updated := &kaitov1beta1.Workspace{}
-	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(green), updated))
-	_, ok := updated.Labels[kaitov1alpha1.LabelUpgradeSurgeFor]
-	assert.False(t, ok, "surge label should be removed after old workspace is gone")
-	assert.Empty(t, listSurgeWorkspaces(t, cl, ns))
-}
-
-// TestReconcileSurge_OutsideMaintenanceWindow verifies no surge is created
+// TestReconcileSurge_OutsideMaintenanceWindow verifies no new Workspace is created
 // outside the maintenance window.
 func TestReconcileSurge_OutsideMaintenanceWindow(t *testing.T) {
 	const (
@@ -954,5 +894,5 @@ func TestReconcileSurge_OutsideMaintenanceWindow(t *testing.T) {
 
 	r.reconcileInferenceSet(context.Background(), is)
 
-	assert.Empty(t, listSurgeWorkspaces(t, cl, ns), "no surge should be created outside the window")
+	assert.Len(t, listWorkspacesInNamespace(t, cl, ns), 1, "no new workspace should be created outside the window")
 }

--- a/pkg/controllers/autoupgrade/runner_test.go
+++ b/pkg/controllers/autoupgrade/runner_test.go
@@ -751,12 +751,12 @@ func TestReconcileInferenceSet_NoSuccessWhenPreviousDriftWasZero(t *testing.T) {
 	assert.Nil(t, updated.Status.AutoUpgrade.LastSuccessfulUpgradeTime)
 }
 
-// makeBlueGreenInferenceSet builds an InferenceSet with auto-upgrade enabled and
-// the BlueGreen strategy, plus a minimal template/selector so the surge Workspace
+// makeSurgeInferenceSet builds an InferenceSet with auto-upgrade enabled and
+// the Surge strategy, plus a minimal template/selector so the surge Workspace
 // can be generated.
-func makeBlueGreenInferenceSet(name, namespace string) *kaitov1beta1.InferenceSet {
+func makeSurgeInferenceSet(name, namespace string) *kaitov1beta1.InferenceSet {
 	is := makeInferenceSet(name, namespace, true, nil)
-	is.Spec.AutoUpgrade.Strategy = kaitov1beta1.BlueGreenUpgradeStrategy
+	is.Spec.AutoUpgrade.Strategy = kaitov1beta1.SurgeBasedUpgradeStrategy
 	is.Spec.Selector = &metav1.LabelSelector{
 		MatchLabels: map[string]string{"app": name},
 	}
@@ -794,9 +794,9 @@ func listSurgeWorkspaces(t *testing.T, cl client.Client, ns string) []kaitov1bet
 	return surges
 }
 
-// TestReconcileBlueGreen_CreatesSurge verifies that a drifted Workspace triggers
-// the creation of a new surge (green) Workspace, without touching the blue one.
-func TestReconcileBlueGreen_CreatesSurge(t *testing.T) {
+// TestReconcileSurge_CreatesSurge verifies that a drifted Workspace triggers
+// the creation of a new surge Workspace, without touching the old one.
+func TestReconcileSurge_CreatesSurge(t *testing.T) {
 	const (
 		ns       = "default"
 		isName   = "bg-is"
@@ -805,7 +805,7 @@ func TestReconcileBlueGreen_CreatesSurge(t *testing.T) {
 	desiredTag := inference.GetBaseImageTag()
 	setTestRegistry(t)
 
-	is := makeBlueGreenInferenceSet(isName, ns)
+	is := makeSurgeInferenceSet(isName, ns)
 	blue := makeWorkspace("blue-1", ns, isName, kaitov1beta1.WorkspaceStateReady, nil)
 	blueSS := makeStatefulSet("blue-1", ns, oldImage)
 
@@ -827,10 +827,10 @@ func TestReconcileBlueGreen_CreatesSurge(t *testing.T) {
 	assert.True(t, stillThere.DeletionTimestamp.IsZero())
 }
 
-// TestReconcileBlueGreen_WaitsForSurgeReady verifies that the blue Workspace is
+// TestReconcileSurge_WaitsForSurgeReady verifies that the old Workspace is
 // NOT deleted while the surge is still coming up, and that a second reconcile does
 // not create another surge (one-at-a-time).
-func TestReconcileBlueGreen_WaitsForSurgeReady(t *testing.T) {
+func TestReconcileSurge_WaitsForSurgeReady(t *testing.T) {
 	const (
 		ns       = "default"
 		isName   = "bg-is"
@@ -840,7 +840,7 @@ func TestReconcileBlueGreen_WaitsForSurgeReady(t *testing.T) {
 	desiredTag := inference.GetBaseImageTag()
 	setTestRegistry(t)
 
-	is := makeBlueGreenInferenceSet(isName, ns)
+	is := makeSurgeInferenceSet(isName, ns)
 	blue := makeWorkspace("blue-1", ns, isName, kaitov1beta1.WorkspaceStateReady, nil)
 	blueSS := makeStatefulSet("blue-1", ns, oldImage)
 	// Surge exists but is not yet succeeded (no condition set).
@@ -863,9 +863,9 @@ func TestReconcileBlueGreen_WaitsForSurgeReady(t *testing.T) {
 	assert.Len(t, listSurgeWorkspaces(t, cl, ns), 1)
 }
 
-// TestReconcileBlueGreen_DeletesBlueWhenSurgeReady verifies cutover: once the
-// surge is ready, the blue Workspace is deleted.
-func TestReconcileBlueGreen_DeletesBlueWhenSurgeReady(t *testing.T) {
+// TestReconcileSurge_DeletesOldWhenSurgeReady verifies cutover: once the
+// surge is ready, the old Workspace is deleted.
+func TestReconcileSurge_DeletesOldWhenSurgeReady(t *testing.T) {
 	const (
 		ns       = "default"
 		isName   = "bg-is"
@@ -875,7 +875,7 @@ func TestReconcileBlueGreen_DeletesBlueWhenSurgeReady(t *testing.T) {
 	desiredTag := inference.GetBaseImageTag()
 	setTestRegistry(t)
 
-	is := makeBlueGreenInferenceSet(isName, ns)
+	is := makeSurgeInferenceSet(isName, ns)
 	blue := makeWorkspace("blue-1", ns, isName, kaitov1beta1.WorkspaceStateReady, nil)
 	blueSS := makeStatefulSet("blue-1", ns, oldImage)
 	green := makeWorkspace("green-1", ns, isName, kaitov1beta1.WorkspaceStateReady, map[string]string{
@@ -890,14 +890,14 @@ func TestReconcileBlueGreen_DeletesBlueWhenSurgeReady(t *testing.T) {
 
 	r.reconcileInferenceSet(context.Background(), is)
 
-	// Blue should be gone (fake client deletes immediately, no finalizer).
+	// Old workspace should be gone (fake client deletes immediately, no finalizer).
 	err := cl.Get(context.Background(), client.ObjectKeyFromObject(blue), &kaitov1beta1.Workspace{})
-	assert.True(t, apierrors.IsNotFound(err), "blue workspace should be deleted")
+	assert.True(t, apierrors.IsNotFound(err), "old workspace should be deleted")
 }
 
-// TestReconcileBlueGreen_PromotesSurgeAfterBlueGone verifies the final step: once
-// blue is gone, the surge label is removed, promoting green to a normal replica.
-func TestReconcileBlueGreen_PromotesSurgeAfterBlueGone(t *testing.T) {
+// TestReconcileSurge_PromotesSurgeAfterOldGone verifies the final step: once
+// the old Workspace is gone, the surge label is removed, promoting it to a normal replica.
+func TestReconcileSurge_PromotesSurgeAfterOldGone(t *testing.T) {
 	const (
 		ns       = "default"
 		isName   = "bg-is"
@@ -906,7 +906,7 @@ func TestReconcileBlueGreen_PromotesSurgeAfterBlueGone(t *testing.T) {
 	desiredTag := inference.GetBaseImageTag()
 	setTestRegistry(t)
 
-	is := makeBlueGreenInferenceSet(isName, ns)
+	is := makeSurgeInferenceSet(isName, ns)
 	// Blue already gone; only the surge (green) remains, ready, still labeled.
 	green := makeWorkspace("green-1", ns, isName, kaitov1beta1.WorkspaceStateReady, map[string]string{
 		kaitov1alpha1.LabelUpgradeSurgeFor:  "blue-1",
@@ -924,13 +924,13 @@ func TestReconcileBlueGreen_PromotesSurgeAfterBlueGone(t *testing.T) {
 	updated := &kaitov1beta1.Workspace{}
 	require.NoError(t, cl.Get(context.Background(), client.ObjectKeyFromObject(green), updated))
 	_, ok := updated.Labels[kaitov1alpha1.LabelUpgradeSurgeFor]
-	assert.False(t, ok, "surge label should be removed after blue is gone")
+	assert.False(t, ok, "surge label should be removed after old workspace is gone")
 	assert.Empty(t, listSurgeWorkspaces(t, cl, ns))
 }
 
-// TestReconcileBlueGreen_OutsideMaintenanceWindow verifies no surge is created
+// TestReconcileSurge_OutsideMaintenanceWindow verifies no surge is created
 // outside the maintenance window.
-func TestReconcileBlueGreen_OutsideMaintenanceWindow(t *testing.T) {
+func TestReconcileSurge_OutsideMaintenanceWindow(t *testing.T) {
 	const (
 		ns       = "default"
 		isName   = "bg-is"
@@ -938,7 +938,7 @@ func TestReconcileBlueGreen_OutsideMaintenanceWindow(t *testing.T) {
 	)
 	setTestRegistry(t)
 
-	is := makeBlueGreenInferenceSet(isName, ns)
+	is := makeSurgeInferenceSet(isName, ns)
 	// A window that is effectively never open around "now": every Jan 1 at 00:00,
 	// 1 minute long. Extremely unlikely to be within the window during tests.
 	dur := metav1.Duration{Duration: time.Minute}

--- a/pkg/controllers/autoupgrade/runner_test.go
+++ b/pkg/controllers/autoupgrade/runner_test.go
@@ -868,6 +868,31 @@ func TestReconcileSurge_NoCreateWhenAllUpToDate(t *testing.T) {
 	assert.Len(t, listWorkspacesInNamespace(t, cl, ns), 1)
 }
 
+// TestReconcileSurge_NoSurgeWhenDesiredImageButNotReady verifies that a Workspace already
+// running the desired base image but still doing its first-time model load (StatefulSet not
+// yet Ready) is NOT treated as drifted. Drift is determined by image mismatch only, so no
+// spurious surge is created during initial startup.
+func TestReconcileSurge_NoSurgeWhenDesiredImageButNotReady(t *testing.T) {
+	const (
+		ns     = "default"
+		isName = "bg-is"
+	)
+	desiredImage := setTestRegistry(t)
+
+	is := makeSurgeInferenceSet(isName, ns) // desired replicas defaults to 1
+	blue := makeWorkspace("blue-1", ns, isName, kaitov1beta1.WorkspaceStatePending, nil)
+	blueSS := makeStatefulSet("blue-1", ns, desiredImage)
+	blueSS.Status.ReadyReplicas = 0 // on the desired image, but not Ready yet (still loading)
+
+	cl := newFakeClient(is, blue, blueSS)
+	r := &AutoUpgradeRunner{Client: cl}
+
+	r.reconcileInferenceSet(context.Background(), is)
+
+	// Still exactly one workspace: the loading replica must not be surged/replaced.
+	assert.Len(t, listWorkspacesInNamespace(t, cl, ns), 1)
+}
+
 // TestReconcileSurge_OutsideMaintenanceWindow verifies no new Workspace is created
 // outside the maintenance window.
 func TestReconcileSurge_OutsideMaintenanceWindow(t *testing.T) {

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -191,23 +191,61 @@ func aggregateBenchmarkResults(workspaces []kaitov1beta1.Workspace) (totalTPM fl
 	return
 }
 
-// partitionManagedWorkspaces splits the given workspaces into those managed by
-// the InferenceSet's normal replica accounting (returned in managed) and detects
-// whether a surge-based auto-upgrade is in progress.
+// classifyWorkspaces separates the given workspaces for the InferenceSet controller
+// during a possible in-flight surge-based auto-upgrade.
 //
-// Workspaces carrying the upgrade-surge-for label are surge replacements owned by
-// the AutoUpgradeRunner; they are excluded from managed and their presence sets
-// upgradeInProgress to true so the InferenceSet controller pauses scaling for the
-// duration of the rollout.
-func partitionManagedWorkspaces(workspaces []kaitov1beta1.Workspace) (managed []kaitov1beta1.Workspace, upgradeInProgress bool) {
+// The AutoUpgradeRunner owns a set of Workspaces while a surge upgrade is running:
+// each "surge" Workspace (carrying the upgrade-surge-for label) and the old Workspace
+// it is replacing (named by that label). These runner-owned Workspaces must not be
+// created or deleted by the InferenceSet controller.
+//
+// Returns:
+//   - managed: all non-surge Workspaces (used for readiness/benchmark status). Includes
+//     the old Workspaces currently being replaced, which keep serving during a surge.
+//   - stable: managed Workspaces that are NOT being replaced by an in-flight surge; these
+//     are the Workspaces the controller freely scales up/down.
+//   - numSurges: number of in-flight surges. Each occupies one replica slot (its paired
+//     old Workspace is the outgoing instance of that same slot), so the controller
+//     reconciles stable toward (desiredReplicas - numSurges).
+//
+// Reserving a slot per surge — rather than pausing all scaling while any surge exists —
+// lets users scale up or down even while an upgrade is in progress or stuck, without the
+// controller ever creating or deleting the runner-owned surge or its paired old Workspace.
+func classifyWorkspaces(workspaces []kaitov1beta1.Workspace) (managed, stable []kaitov1beta1.Workspace, numSurges int) {
+	// First pass: find in-flight surges and the names of the old Workspaces they replace.
+	replacedOld := make(map[string]struct{})
+	for i := range workspaces {
+		if old, ok := workspaces[i].Labels[kaitov1alpha1.LabelUpgradeSurgeFor]; ok {
+			numSurges++
+			if old != "" {
+				replacedOld[old] = struct{}{}
+			}
+		}
+	}
+	// Second pass: managed = all non-surge Workspaces; stable additionally excludes the
+	// old Workspaces currently being replaced by a surge.
 	for i := range workspaces {
 		if _, ok := workspaces[i].Labels[kaitov1alpha1.LabelUpgradeSurgeFor]; ok {
-			upgradeInProgress = true
-			continue
+			continue // surge Workspace (runner-owned)
 		}
 		managed = append(managed, workspaces[i])
+		if _, ok := replacedOld[workspaces[i].Name]; !ok {
+			stable = append(stable, workspaces[i])
+		}
 	}
 	return
+}
+
+// stableTargetForReplicas returns the number of stable Workspaces the controller should
+// maintain given the desired replica count and the number of in-flight surges. Each surge
+// reserves one replica slot, so the controller only manages the leftover slots. Clamped to
+// be non-negative.
+func stableTargetForReplicas(desiredReplicas int32, numSurges int) int {
+	target := int(desiredReplicas) - numSurges
+	if target < 0 {
+		target = 0
+	}
+	return target
 }
 
 func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iObj *kaitov1beta1.InferenceSet) (reconcile.Result, error) {
@@ -233,25 +271,29 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 
 	// Workspaces created by the surge-based auto-upgrade strategy carry the
 	// upgrade-surge-for label and are owned by the AutoUpgradeRunner for the
-	// duration of the rollout. Exclude them from replica accounting so the
-	// InferenceSet controller does not fight the runner (e.g. delete the surge
-	// or create extra replicas). While an upgrade is in progress, the runner
-	// owns the workspace pool entirely; the InferenceSet controller pauses
-	// scaling until the rollout completes (surge label removed).
-	managed, upgradeInProgress := partitionManagedWorkspaces(wsList.Items)
-	klog.InfoS("Found workspaces for inference set", "name", iObj.Name, "current", len(managed), "desired", desiredReplicas, "upgradeInProgress", upgradeInProgress)
+	// duration of the rollout. Each surge (together with the old Workspace it is
+	// replacing) reserves one replica slot; the InferenceSet controller manages
+	// only the remaining "stable" Workspaces, reconciling them toward
+	// (desiredReplicas - numSurges). This keeps the controller from fighting the
+	// runner over the surge or its paired old Workspace, while still allowing
+	// scale up/down even while an upgrade is in progress or stuck.
+	managed, stable, numSurges := classifyWorkspaces(wsList.Items)
+	stableTarget := stableTargetForReplicas(desiredReplicas, numSurges)
+	klog.InfoS("Found workspaces for inference set", "name", iObj.Name,
+		"managed", len(managed), "stable", len(stable), "surges", numSurges,
+		"desired", desiredReplicas, "stableTarget", stableTarget)
 
-	replicaNumToDelete := len(managed) - int(desiredReplicas)
-	if !upgradeInProgress && replicaNumToDelete > 0 {
-		klog.InfoS("Found extra workspaces, deleting...", "current", len(managed), "desired", desiredReplicas)
+	replicaNumToDelete := len(stable) - stableTarget
+	if replicaNumToDelete > 0 {
+		klog.InfoS("Found extra workspaces, deleting...", "stable", len(stable), "stableTarget", stableTarget)
 
 		// Partition workspaces into those already being deleted, those that are
 		// not ready, and those that are ready. Workspaces already being deleted
 		// count toward the target without issuing a new delete; among the rest,
 		// prefer deleting non-ready workspaces before ready ones.
 		var notReady, ready []*kaitov1beta1.Workspace
-		for i := range managed {
-			ws := &managed[i]
+		for i := range stable {
+			ws := &stable[i]
 			if !ws.DeletionTimestamp.IsZero() {
 				replicaNumToDelete--
 				klog.InfoS("Skipping workspace that is already being deleted...", "workspace", klog.KObj(ws))
@@ -299,12 +341,13 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 		if wsList, err = inferenceset.ListWorkspaces(ctx, iObj, c.Client); err != nil {
 			return ctrl.Result{}, err
 		}
-		managed, upgradeInProgress = partitionManagedWorkspaces(wsList.Items)
+		managed, stable, numSurges = classifyWorkspaces(wsList.Items)
+		stableTarget = stableTargetForReplicas(desiredReplicas, numSurges)
 	}
 
-	replicaNumToCreate := int(desiredReplicas) - len(managed)
-	if !upgradeInProgress && replicaNumToCreate > 0 {
-		klog.InfoS("Need to create more workspaces...", "current", len(managed), "desired", desiredReplicas)
+	replicaNumToCreate := stableTarget - len(stable)
+	if replicaNumToCreate > 0 {
+		klog.InfoS("Need to create more workspaces...", "stable", len(stable), "stableTarget", stableTarget)
 		// Set creation expectations before issuing any create so that a stale
 		// cache read in a subsequent reconcile does not create duplicate
 		// workspaces. The expectation is lowered when the create event is

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -50,6 +50,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/utils/workspace"
 	"github.com/kaito-project/kaito/pkg/workspace/controllers"
+	"github.com/kaito-project/kaito/pkg/workspace/inference"
 	"github.com/kaito-project/kaito/pkg/workspace/manifests"
 )
 
@@ -191,61 +192,111 @@ func aggregateBenchmarkResults(workspaces []kaitov1beta1.Workspace) (totalTPM fl
 	return
 }
 
-// classifyWorkspaces separates the given workspaces for the InferenceSet controller
-// during a possible in-flight surge-based auto-upgrade.
-//
-// The AutoUpgradeRunner owns a set of Workspaces while a surge upgrade is running:
-// each "surge" Workspace (carrying the upgrade-surge-for label) and the old Workspace
-// it is replacing (named by that label). These runner-owned Workspaces must not be
-// created or deleted by the InferenceSet controller.
-//
-// Returns:
-//   - managed: all non-surge Workspaces (used for readiness/benchmark status). Includes
-//     the old Workspaces currently being replaced, which keep serving during a surge.
-//   - stable: managed Workspaces that are NOT being replaced by an in-flight surge; these
-//     are the Workspaces the controller freely scales up/down.
-//   - numSurges: number of in-flight surges. Each occupies one replica slot (its paired
-//     old Workspace is the outgoing instance of that same slot), so the controller
-//     reconciles stable toward (desiredReplicas - numSurges).
-//
-// Reserving a slot per surge — rather than pausing all scaling while any surge exists —
-// lets users scale up or down even while an upgrade is in progress or stuck, without the
-// controller ever creating or deleting the runner-owned surge or its paired old Workspace.
-func classifyWorkspaces(workspaces []kaitov1beta1.Workspace) (managed, stable []kaitov1beta1.Workspace, numSurges int) {
-	// First pass: find in-flight surges and the names of the old Workspaces they replace.
-	replacedOld := make(map[string]struct{})
-	for i := range workspaces {
-		if old, ok := workspaces[i].Labels[kaitov1alpha1.LabelUpgradeSurgeFor]; ok {
-			numSurges++
-			if old != "" {
-				replacedOld[old] = struct{}{}
-			}
+// isWorkspaceOnOldImage reports whether the Workspace's StatefulSet is running a base
+// image other than the controller's current desired image. A Workspace whose StatefulSet
+// does not exist yet is treated as new (not old), so a freshly created incoming replica
+// is never preferentially deleted during a scale-down.
+func (c *InferenceSetReconciler) isWorkspaceOnOldImage(ctx context.Context, ws *kaitov1beta1.Workspace, desiredImage string) (bool, error) {
+	ss := &appsv1.StatefulSet{}
+	if err := resources.GetResource(ctx, ws.Name, ws.Namespace, c.Client, ss); err != nil {
+		if apierrors.IsNotFound(err) {
+			return false, nil
 		}
+		return false, err
 	}
-	// Second pass: managed = all non-surge Workspaces; stable additionally excludes the
-	// old Workspaces currently being replaced by a surge.
-	for i := range workspaces {
-		if _, ok := workspaces[i].Labels[kaitov1alpha1.LabelUpgradeSurgeFor]; ok {
-			continue // surge Workspace (runner-owned)
-		}
-		managed = append(managed, workspaces[i])
-		if _, ok := replacedOld[workspaces[i].Name]; !ok {
-			stable = append(stable, workspaces[i])
-		}
-	}
-	return
+	return workspace.GetInferenceContainerImage(ss) != desiredImage, nil
 }
 
-// stableTargetForReplicas returns the number of stable Workspaces the controller should
-// maintain given the desired replica count and the number of in-flight surges. Each surge
-// reserves one replica slot, so the controller only manages the leftover slots. Clamped to
-// be non-negative.
-func stableTargetForReplicas(desiredReplicas int32, numSurges int) int {
-	target := int(desiredReplicas) - numSurges
-	if target < 0 {
-		target = 0
+// selectWorkspacesToDelete chooses which Workspaces to remove when the InferenceSet is over
+// its desired replica count. It balances two goals:
+//
+//   - Zero-downtime auto-upgrade: prefer deleting Workspaces running an OLD base image so
+//     that freshly created new-image Workspaces survive the scale-down. A Ready old Workspace
+//     is only retired while enough Ready replicas remain (see below), which makes the
+//     controller wait for a new-image surge Workspace to become Ready before cutting over.
+//   - Availability: never delete a Ready Workspace if doing so would drop the number of Ready
+//     replicas below desiredReplicas.
+//
+// New-image Workspaces are deleted only as a last resort — when the surplus exceeds the
+// number of old Workspaces (e.g. the user genuinely scaled the InferenceSet down) — so a
+// normal upgrade surge never deletes the incoming replica.
+//
+// Workspaces already being deleted count toward the target without issuing a new delete.
+func (c *InferenceSetReconciler) selectWorkspacesToDelete(ctx context.Context, workspaces []kaitov1beta1.Workspace, desiredReplicas, numToDelete int) ([]*kaitov1beta1.Workspace, error) {
+	desiredImage := inference.GetBaseImageName()
+
+	// Classify each live Workspace once, recording whether it is Ready and whether it is
+	// running an old base image. Workspaces already terminating count toward the target.
+	type candidate struct {
+		ws    *kaitov1beta1.Workspace
+		ready bool
+		old   bool
 	}
-	return target
+	candidates := make([]candidate, 0, len(workspaces))
+	readyCount, oldCount := 0, 0
+	for i := range workspaces {
+		ws := &workspaces[i]
+		if !ws.DeletionTimestamp.IsZero() {
+			numToDelete--
+			klog.InfoS("Skipping workspace that is already being deleted...", "workspace", klog.KObj(ws))
+			continue
+		}
+		ready := controllers.DetermineWorkspacePhase(ws) == "succeeded"
+		old, err := c.isWorkspaceOnOldImage(ctx, ws, desiredImage)
+		if err != nil {
+			return nil, err
+		}
+		if ready {
+			readyCount++
+		}
+		if old {
+			oldCount++
+		}
+		candidates = append(candidates, candidate{ws: ws, ready: ready, old: old})
+	}
+	if numToDelete <= 0 {
+		return nil, nil
+	}
+
+	// Delete in priority order: old before new, and within each, not-ready before ready.
+	sort.SliceStable(candidates, func(i, j int) bool {
+		if candidates[i].old != candidates[j].old {
+			return candidates[i].old // old-image workspaces first
+		}
+		return !candidates[i].ready && candidates[j].ready // not-ready first
+	})
+
+	// Two budgets bound the selection:
+	//   - readyBudget: how many Ready workspaces may be deleted without dropping the Ready
+	//     count below desiredReplicas. This makes the controller wait for a new-image surge
+	//     workspace to become Ready before retiring the old one it replaces.
+	//   - newBudget: new-image workspaces are retired only when the surplus exceeds the number
+	//     of old workspaces (a genuine scale-down), so a normal upgrade never deletes the
+	//     incoming replica.
+	readyBudget := readyCount - desiredReplicas
+	newBudget := numToDelete - oldCount
+
+	toDelete := make([]*kaitov1beta1.Workspace, 0, numToDelete)
+	for _, cand := range candidates {
+		if len(toDelete) >= numToDelete {
+			break
+		}
+		if cand.ready && readyBudget <= 0 {
+			continue // would drop Ready below desiredReplicas
+		}
+		if !cand.old && newBudget <= 0 {
+			continue // keep new-image replicas unless genuinely over-provisioned
+		}
+		toDelete = append(toDelete, cand.ws)
+		if cand.ready {
+			readyBudget--
+		}
+		if !cand.old {
+			newBudget--
+		}
+	}
+
+	return toDelete, nil
 }
 
 func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iObj *kaitov1beta1.InferenceSet) (reconcile.Result, error) {
@@ -269,48 +320,16 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 		desiredReplicas = *iObj.Spec.Replicas
 	}
 
-	// Workspaces created by the surge-based auto-upgrade strategy carry the
-	// upgrade-surge-for label and are owned by the AutoUpgradeRunner for the
-	// duration of the rollout. Each surge (together with the old Workspace it is
-	// replacing) reserves one replica slot; the InferenceSet controller manages
-	// only the remaining "stable" Workspaces, reconciling them toward
-	// (desiredReplicas - numSurges). This keeps the controller from fighting the
-	// runner over the surge or its paired old Workspace, while still allowing
-	// scale up/down even while an upgrade is in progress or stuck.
-	managed, stable, numSurges := classifyWorkspaces(wsList.Items)
-	stableTarget := stableTargetForReplicas(desiredReplicas, numSurges)
 	klog.InfoS("Found workspaces for inference set", "name", iObj.Name,
-		"managed", len(managed), "stable", len(stable), "surges", numSurges,
-		"desired", desiredReplicas, "stableTarget", stableTarget)
+		"current", len(wsList.Items), "desired", desiredReplicas)
 
-	replicaNumToDelete := len(stable) - stableTarget
+	replicaNumToDelete := len(wsList.Items) - int(desiredReplicas)
 	if replicaNumToDelete > 0 {
-		klog.InfoS("Found extra workspaces, deleting...", "stable", len(stable), "stableTarget", stableTarget)
+		klog.InfoS("Found extra workspaces, deleting...", "current", len(wsList.Items), "desired", desiredReplicas)
 
-		// Partition workspaces into those already being deleted, those that are
-		// not ready, and those that are ready. Workspaces already being deleted
-		// count toward the target without issuing a new delete; among the rest,
-		// prefer deleting non-ready workspaces before ready ones.
-		var notReady, ready []*kaitov1beta1.Workspace
-		for i := range stable {
-			ws := &stable[i]
-			if !ws.DeletionTimestamp.IsZero() {
-				replicaNumToDelete--
-				klog.InfoS("Skipping workspace that is already being deleted...", "workspace", klog.KObj(ws))
-			} else if controllers.DetermineWorkspacePhase(ws) != "succeeded" {
-				notReady = append(notReady, ws)
-			} else {
-				ready = append(ready, ws)
-			}
-		}
-
-		var toDelete []*kaitov1beta1.Workspace
-		for _, ws := range append(notReady, ready...) {
-			if replicaNumToDelete <= 0 {
-				break
-			}
-			toDelete = append(toDelete, ws)
-			replicaNumToDelete--
+		toDelete, err := c.selectWorkspacesToDelete(ctx, wsList.Items, int(desiredReplicas), replicaNumToDelete)
+		if err != nil {
+			return ctrl.Result{}, err
 		}
 
 		if len(toDelete) > 0 {
@@ -341,13 +360,11 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 		if wsList, err = inferenceset.ListWorkspaces(ctx, iObj, c.Client); err != nil {
 			return ctrl.Result{}, err
 		}
-		managed, stable, numSurges = classifyWorkspaces(wsList.Items)
-		stableTarget = stableTargetForReplicas(desiredReplicas, numSurges)
 	}
 
-	replicaNumToCreate := stableTarget - len(stable)
+	replicaNumToCreate := int(desiredReplicas) - len(wsList.Items)
 	if replicaNumToCreate > 0 {
-		klog.InfoS("Need to create more workspaces...", "stable", len(stable), "stableTarget", stableTarget)
+		klog.InfoS("Need to create more workspaces...", "current", len(wsList.Items), "desired", desiredReplicas)
 		// Set creation expectations before issuing any create so that a stale
 		// cache read in a subsequent reconcile does not create duplicate
 		// workspaces. The expectation is lowered when the create event is
@@ -409,7 +426,7 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 	}
 
 	// check whether all the workspaces are ready
-	totalTPM, readyReplicas, benchmarkedReplicas, hasBenchmarkTPMResult := aggregateBenchmarkResults(managed)
+	totalTPM, readyReplicas, benchmarkedReplicas, hasBenchmarkTPMResult := aggregateBenchmarkResults(wsList.Items)
 
 	// update the replicas in the status
 	if err = inferenceset.UpdateInferenceSetStatus(ctx, c.Client, &client.ObjectKey{Name: iObj.Name, Namespace: iObj.Namespace}, func(status *kaitov1beta1.InferenceSetStatus) error {

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -193,7 +193,7 @@ func aggregateBenchmarkResults(workspaces []kaitov1beta1.Workspace) (totalTPM fl
 
 // partitionManagedWorkspaces splits the given workspaces into those managed by
 // the InferenceSet's normal replica accounting (returned in managed) and detects
-// whether a blue-green auto-upgrade is in progress.
+// whether a surge-based auto-upgrade is in progress.
 //
 // Workspaces carrying the upgrade-surge-for label are surge replacements owned by
 // the AutoUpgradeRunner; they are excluded from managed and their presence sets
@@ -231,7 +231,7 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 		desiredReplicas = *iObj.Spec.Replicas
 	}
 
-	// Workspaces created by the blue-green auto-upgrade strategy carry the
+	// Workspaces created by the surge-based auto-upgrade strategy carry the
 	// upgrade-surge-for label and are owned by the AutoUpgradeRunner for the
 	// duration of the rollout. Exclude them from replica accounting so the
 	// InferenceSet controller does not fight the runner (e.g. delete the surge

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -16,7 +16,6 @@ package inferenceset
 import (
 	"context"
 	"fmt"
-	"maps"
 	"sort"
 	"strconv"
 	"time"
@@ -192,6 +191,25 @@ func aggregateBenchmarkResults(workspaces []kaitov1beta1.Workspace) (totalTPM fl
 	return
 }
 
+// partitionManagedWorkspaces splits the given workspaces into those managed by
+// the InferenceSet's normal replica accounting (returned in managed) and detects
+// whether a blue-green auto-upgrade is in progress.
+//
+// Workspaces carrying the upgrade-surge-for label are surge replacements owned by
+// the AutoUpgradeRunner; they are excluded from managed and their presence sets
+// upgradeInProgress to true so the InferenceSet controller pauses scaling for the
+// duration of the rollout.
+func partitionManagedWorkspaces(workspaces []kaitov1beta1.Workspace) (managed []kaitov1beta1.Workspace, upgradeInProgress bool) {
+	for i := range workspaces {
+		if _, ok := workspaces[i].Labels[kaitov1alpha1.LabelUpgradeSurgeFor]; ok {
+			upgradeInProgress = true
+			continue
+		}
+		managed = append(managed, workspaces[i])
+	}
+	return
+}
+
 func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iObj *kaitov1beta1.InferenceSet) (reconcile.Result, error) {
 	if iObj == nil {
 		return reconcile.Result{}, nil
@@ -212,19 +230,28 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 	if iObj.Spec.Replicas != nil {
 		desiredReplicas = *iObj.Spec.Replicas
 	}
-	klog.InfoS("Found workspaces for inference set", "name", iObj.Name, "current", len(wsList.Items), "desired", desiredReplicas)
 
-	replicaNumToDelete := len(wsList.Items) - int(desiredReplicas)
-	if replicaNumToDelete > 0 {
-		klog.InfoS("Found extra workspaces, deleting...", "current", len(wsList.Items), "desired", desiredReplicas)
+	// Workspaces created by the blue-green auto-upgrade strategy carry the
+	// upgrade-surge-for label and are owned by the AutoUpgradeRunner for the
+	// duration of the rollout. Exclude them from replica accounting so the
+	// InferenceSet controller does not fight the runner (e.g. delete the surge
+	// or create extra replicas). While an upgrade is in progress, the runner
+	// owns the workspace pool entirely; the InferenceSet controller pauses
+	// scaling until the rollout completes (surge label removed).
+	managed, upgradeInProgress := partitionManagedWorkspaces(wsList.Items)
+	klog.InfoS("Found workspaces for inference set", "name", iObj.Name, "current", len(managed), "desired", desiredReplicas, "upgradeInProgress", upgradeInProgress)
+
+	replicaNumToDelete := len(managed) - int(desiredReplicas)
+	if !upgradeInProgress && replicaNumToDelete > 0 {
+		klog.InfoS("Found extra workspaces, deleting...", "current", len(managed), "desired", desiredReplicas)
 
 		// Partition workspaces into those already being deleted, those that are
 		// not ready, and those that are ready. Workspaces already being deleted
 		// count toward the target without issuing a new delete; among the rest,
 		// prefer deleting non-ready workspaces before ready ones.
 		var notReady, ready []*kaitov1beta1.Workspace
-		for i := range wsList.Items {
-			ws := &wsList.Items[i]
+		for i := range managed {
+			ws := &managed[i]
 			if !ws.DeletionTimestamp.IsZero() {
 				replicaNumToDelete--
 				klog.InfoS("Skipping workspace that is already being deleted...", "workspace", klog.KObj(ws))
@@ -272,11 +299,12 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 		if wsList, err = inferenceset.ListWorkspaces(ctx, iObj, c.Client); err != nil {
 			return ctrl.Result{}, err
 		}
+		managed, upgradeInProgress = partitionManagedWorkspaces(wsList.Items)
 	}
 
-	replicaNumToCreate := int(desiredReplicas) - len(wsList.Items)
-	if replicaNumToCreate > 0 {
-		klog.InfoS("Need to create more workspaces...", "current", len(wsList.Items), "desired", desiredReplicas)
+	replicaNumToCreate := int(desiredReplicas) - len(managed)
+	if !upgradeInProgress && replicaNumToCreate > 0 {
+		klog.InfoS("Need to create more workspaces...", "current", len(managed), "desired", desiredReplicas)
 		// Set creation expectations before issuing any create so that a stale
 		// cache read in a subsequent reconcile does not create duplicate
 		// workspaces. The expectation is lowered when the create event is
@@ -286,51 +314,7 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 			return reconcile.Result{}, err
 		}
 		for i := range replicaNumToCreate {
-			workspaceObj := &kaitov1beta1.Workspace{}
-			workspaceObj.GenerateName = iObj.Name + "-"
-			workspaceObj.Namespace = iObj.Namespace
-
-			// Start with labels from the template metadata, then add controller labels.
-			workspaceLabels := maps.Clone(iObj.Spec.Template.Labels)
-			if workspaceLabels == nil {
-				workspaceLabels = make(map[string]string)
-			}
-			// Also propagate select labels from the InferenceSet's own metadata,
-			// in case template.metadata.labels was pruned by the API server.
-			if role, ok := iObj.Labels[kaitov1beta1.LabelInferenceRole]; ok {
-				workspaceLabels[kaitov1beta1.LabelInferenceRole] = role
-			}
-			if mriParent, ok := iObj.Labels[kaitov1alpha1.LabelMultiRoleInferenceParent]; ok {
-				workspaceLabels[kaitov1alpha1.LabelMultiRoleInferenceParent] = mriParent
-			}
-			workspaceLabels[consts.WorkspaceCreatedByInferenceSetLabel] = iObj.Name
-			workspaceObj.Labels = workspaceLabels
-
-			// Start with annotations from the template metadata.
-			workspaceAnnotations := maps.Clone(iObj.Spec.Template.Annotations)
-			// Propagate the disable-benchmark opt-out so each child workspace inherits it.
-			// Benchmark is on by default; only propagate when explicitly disabled.
-			if !kaitov1beta1.IsInferenceSetBenchmarkEnabled(iObj) {
-				if workspaceAnnotations == nil {
-					workspaceAnnotations = make(map[string]string)
-				}
-				workspaceAnnotations[kaitov1beta1.AnnotationDisableBenchmark] = "true"
-			}
-			workspaceObj.Annotations = workspaceAnnotations
-			workspaceObj.OwnerReferences = []metav1.OwnerReference{
-				*metav1.NewControllerRef(iObj, kaitov1beta1.GroupVersion.WithKind("InferenceSet")),
-			}
-			workspaceObj.Resource = kaitov1beta1.ResourceSpec{
-				LabelSelector: iObj.Spec.Selector,
-				Partition:     iObj.Spec.Template.Resource.Partition,
-			}
-			// Only set InstanceType when node auto-provisioning is enabled.
-			// In BYO mode, the Workspace webhook rejects instanceType.
-			if consts.ActiveNodeProvisioner != consts.NodeProvisionerBYO {
-				workspaceObj.Resource.InstanceType = iObj.Spec.Template.Resource.InstanceType
-			}
-			workspaceObj.Inference = &iObj.Spec.Template.Inference
-
+			workspaceObj := inferenceset.NewWorkspaceForInferenceSet(iObj)
 			klog.InfoS("creating workspace", "workspace", workspaceObj.Name, "index", i)
 			if err := c.Client.Create(ctx, workspaceObj); err != nil {
 				// The create failed, so no create event will be observed for it;
@@ -382,7 +366,7 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 	}
 
 	// check whether all the workspaces are ready
-	totalTPM, readyReplicas, benchmarkedReplicas, hasBenchmarkTPMResult := aggregateBenchmarkResults(wsList.Items)
+	totalTPM, readyReplicas, benchmarkedReplicas, hasBenchmarkTPMResult := aggregateBenchmarkResults(managed)
 
 	// update the replicas in the status
 	if err = inferenceset.UpdateInferenceSetStatus(ctx, c.Client, &client.ObjectKey{Name: iObj.Name, Namespace: iObj.Namespace}, func(status *kaitov1beta1.InferenceSetStatus) error {

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -508,7 +508,7 @@ func TestInferenceSetBenchmarkAggregation(t *testing.T) {
 	}
 }
 
-func TestPartitionManagedWorkspaces(t *testing.T) {
+func TestClassifyWorkspaces(t *testing.T) {
 	ws := func(name string, labels map[string]string) v1beta1.Workspace {
 		return v1beta1.Workspace{
 			ObjectMeta: v1.ObjectMeta{Name: name, Labels: labels},
@@ -516,45 +516,85 @@ func TestPartitionManagedWorkspaces(t *testing.T) {
 	}
 
 	tests := []struct {
-		name           string
-		input          []v1beta1.Workspace
-		wantManaged    []string
-		wantInProgress bool
+		name         string
+		input        []v1beta1.Workspace
+		wantManaged  []string
+		wantStable   []string
+		wantNumSurge int
 	}{
 		{
-			name:           "no surge - all managed",
-			input:          []v1beta1.Workspace{ws("a", nil), ws("b", nil)},
-			wantManaged:    []string{"a", "b"},
-			wantInProgress: false,
+			name:         "no surge - all managed and stable",
+			input:        []v1beta1.Workspace{ws("a", nil), ws("b", nil)},
+			wantManaged:  []string{"a", "b"},
+			wantStable:   []string{"a", "b"},
+			wantNumSurge: 0,
 		},
 		{
-			name: "one surge excluded - upgrade in progress",
+			name: "one surge - old workspace managed but not stable",
 			input: []v1beta1.Workspace{
-				ws("blue", nil),
-				ws("green", map[string]string{kaitov1alpha1.LabelUpgradeSurgeFor: "blue"}),
+				ws("old", nil),
+				ws("surge", map[string]string{kaitov1alpha1.LabelUpgradeSurgeFor: "old"}),
 			},
-			wantManaged:    []string{"blue"},
-			wantInProgress: true,
+			// old is still serving (managed) but reserved by the runner (not stable).
+			wantManaged:  []string{"old"},
+			wantStable:   nil,
+			wantNumSurge: 1,
 		},
 		{
-			name: "only surge",
+			name: "surge plus an unrelated stable replica",
 			input: []v1beta1.Workspace{
-				ws("green", map[string]string{kaitov1alpha1.LabelUpgradeSurgeFor: "blue"}),
+				ws("old", nil),
+				ws("surge", map[string]string{kaitov1alpha1.LabelUpgradeSurgeFor: "old"}),
+				ws("other", nil),
 			},
-			wantManaged:    nil,
-			wantInProgress: true,
+			// "other" is freely scalable; "old" is reserved; "surge" is runner-owned.
+			wantManaged:  []string{"old", "other"},
+			wantStable:   []string{"other"},
+			wantNumSurge: 1,
+		},
+		{
+			name: "surge whose old workspace is already deleted",
+			input: []v1beta1.Workspace{
+				ws("surge", map[string]string{kaitov1alpha1.LabelUpgradeSurgeFor: "old"}),
+			},
+			wantManaged:  nil,
+			wantStable:   nil,
+			wantNumSurge: 1,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			managed, inProgress := partitionManagedWorkspaces(tt.input)
-			assert.Equal(t, tt.wantInProgress, inProgress)
-			var names []string
-			for _, m := range managed {
-				names = append(names, m.Name)
+			managed, stable, numSurges := classifyWorkspaces(tt.input)
+			assert.Equal(t, tt.wantNumSurge, numSurges)
+			names := func(wss []v1beta1.Workspace) []string {
+				var out []string
+				for _, w := range wss {
+					out = append(out, w.Name)
+				}
+				return out
 			}
-			assert.Equal(t, tt.wantManaged, names)
+			assert.Equal(t, tt.wantManaged, names(managed))
+			assert.Equal(t, tt.wantStable, names(stable))
+		})
+	}
+}
+
+func TestStableTargetForReplicas(t *testing.T) {
+	tests := []struct {
+		name      string
+		desired   int32
+		numSurges int
+		want      int
+	}{
+		{name: "no surge", desired: 3, numSurges: 0, want: 3},
+		{name: "one surge reserves a slot", desired: 3, numSurges: 1, want: 2},
+		{name: "clamped to zero", desired: 1, numSurges: 2, want: 0},
+		{name: "zero desired", desired: 0, numSurges: 0, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, stableTargetForReplicas(tt.desired, tt.numSurges))
 		})
 	}
 }

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -32,14 +32,15 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/model"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/test"
 	"github.com/kaito-project/kaito/pkg/workspace/controllers"
+	"github.com/kaito-project/kaito/pkg/workspace/inference"
 	"github.com/kaito-project/kaito/pkg/workspace/manifests"
 )
 
@@ -508,93 +509,196 @@ func TestInferenceSetBenchmarkAggregation(t *testing.T) {
 	}
 }
 
-func TestClassifyWorkspaces(t *testing.T) {
-	ws := func(name string, labels map[string]string) v1beta1.Workspace {
-		return v1beta1.Workspace{
-			ObjectMeta: v1.ObjectMeta{Name: name, Labels: labels},
-		}
+func TestSelectWorkspacesToDelete(t *testing.T) {
+	ctx := context.Background()
+	const ns = "default"
+	desiredImage := inference.GetBaseImageName()
+	oldImage := desiredImage + "-old"
+
+	type wsSpec struct {
+		name        string
+		ready       bool
+		old         bool
+		terminating bool
 	}
 
-	tests := []struct {
-		name         string
-		input        []v1beta1.Workspace
-		wantManaged  []string
-		wantStable   []string
-		wantNumSurge int
-	}{
-		{
-			name:         "no surge - all managed and stable",
-			input:        []v1beta1.Workspace{ws("a", nil), ws("b", nil)},
-			wantManaged:  []string{"a", "b"},
-			wantStable:   []string{"a", "b"},
-			wantNumSurge: 0,
-		},
-		{
-			name: "one surge - old workspace managed but not stable",
-			input: []v1beta1.Workspace{
-				ws("old", nil),
-				ws("surge", map[string]string{kaitov1alpha1.LabelUpgradeSurgeFor: "old"}),
-			},
-			// old is still serving (managed) but reserved by the runner (not stable).
-			wantManaged:  []string{"old"},
-			wantStable:   nil,
-			wantNumSurge: 1,
-		},
-		{
-			name: "surge plus an unrelated stable replica",
-			input: []v1beta1.Workspace{
-				ws("old", nil),
-				ws("surge", map[string]string{kaitov1alpha1.LabelUpgradeSurgeFor: "old"}),
-				ws("other", nil),
-			},
-			// "other" is freely scalable; "old" is reserved; "surge" is runner-owned.
-			wantManaged:  []string{"old", "other"},
-			wantStable:   []string{"other"},
-			wantNumSurge: 1,
-		},
-		{
-			name: "surge whose old workspace is already deleted",
-			input: []v1beta1.Workspace{
-				ws("surge", map[string]string{kaitov1alpha1.LabelUpgradeSurgeFor: "old"}),
-			},
-			wantManaged:  nil,
-			wantStable:   nil,
-			wantNumSurge: 1,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			managed, stable, numSurges := classifyWorkspaces(tt.input)
-			assert.Equal(t, tt.wantNumSurge, numSurges)
-			names := func(wss []v1beta1.Workspace) []string {
-				var out []string
-				for _, w := range wss {
-					out = append(out, w.Name)
-				}
-				return out
+	build := func(specs []wsSpec) ([]v1beta1.Workspace, []client.Object) {
+		var wss []v1beta1.Workspace
+		var objs []client.Object
+		for _, s := range specs {
+			ws := v1beta1.Workspace{ObjectMeta: v1.ObjectMeta{Name: s.name, Namespace: ns}}
+			if s.terminating {
+				now := v1.Now()
+				ws.DeletionTimestamp = &now
+				ws.Finalizers = []string{"kaito.sh/test"}
 			}
-			assert.Equal(t, tt.wantManaged, names(managed))
-			assert.Equal(t, tt.wantStable, names(stable))
-		})
-	}
-}
+			if s.ready {
+				ws.Status.Conditions = []v1.Condition{{
+					Type:               string(v1beta1.WorkspaceConditionTypeSucceeded),
+					Status:             v1.ConditionTrue,
+					Reason:             "ready",
+					LastTransitionTime: v1.Now(),
+				}}
+			}
+			wss = append(wss, ws)
 
-func TestStableTargetForReplicas(t *testing.T) {
-	tests := []struct {
-		name      string
-		desired   int32
-		numSurges int
-		want      int
-	}{
-		{name: "no surge", desired: 3, numSurges: 0, want: 3},
-		{name: "one surge reserves a slot", desired: 3, numSurges: 1, want: 2},
-		{name: "clamped to zero", desired: 1, numSurges: 2, want: 0},
-		{name: "zero desired", desired: 0, numSurges: 0, want: 0},
+			img := desiredImage
+			if s.old {
+				img = oldImage
+			}
+			objs = append(objs, &appsv1.StatefulSet{
+				ObjectMeta: v1.ObjectMeta{Name: s.name, Namespace: ns},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: s.name, Image: img}}},
+					},
+				},
+			})
+		}
+		return wss, objs
 	}
+
+	oldByName := func(specs []wsSpec) map[string]bool {
+		m := make(map[string]bool)
+		for _, s := range specs {
+			m[s.name] = s.old
+		}
+		return m
+	}
+
+	tests := []struct {
+		name            string
+		specs           []wsSpec
+		desiredReplicas int
+		numToDelete     int
+		wantDeleted     int
+		wantOldDeleted  int
+		wantNewDeleted  int
+	}{
+		{
+			// Surge in flight: 3 old Ready + 1 new not-Ready. The controller must wait
+			// for the new replica to become Ready before retiring an old one.
+			name: "waits for new-image replica to become Ready",
+			specs: []wsSpec{
+				{name: "old-1", ready: true, old: true},
+				{name: "old-2", ready: true, old: true},
+				{name: "old-3", ready: true, old: true},
+				{name: "new-1", ready: false, old: false},
+			},
+			desiredReplicas: 3,
+			numToDelete:     1,
+			wantDeleted:     0,
+		},
+		{
+			// New replica is now Ready: retire exactly one old-image workspace.
+			name: "retires an old-image replica once the new one is Ready",
+			specs: []wsSpec{
+				{name: "old-1", ready: true, old: true},
+				{name: "old-2", ready: true, old: true},
+				{name: "old-3", ready: true, old: true},
+				{name: "new-1", ready: true, old: false},
+			},
+			desiredReplicas: 3,
+			numToDelete:     1,
+			wantDeleted:     1,
+			wantOldDeleted:  1,
+		},
+		{
+			// User scale-down during an upgrade: prefer removing old-image workspaces.
+			name: "scale down prefers old-image workspaces",
+			specs: []wsSpec{
+				{name: "old-1", ready: true, old: true},
+				{name: "old-2", ready: true, old: true},
+				{name: "new-1", ready: true, old: false},
+				{name: "new-2", ready: true, old: false},
+			},
+			desiredReplicas: 2,
+			numToDelete:     2,
+			wantDeleted:     2,
+			wantOldDeleted:  2,
+		},
+		{
+			// Hard scale-down: not enough old workspaces, so new ones must go too.
+			name: "deletes new-image workspaces when surplus exceeds old count",
+			specs: []wsSpec{
+				{name: "old-1", ready: true, old: true},
+				{name: "new-1", ready: true, old: false},
+				{name: "new-2", ready: true, old: false},
+				{name: "new-3", ready: true, old: false},
+			},
+			desiredReplicas: 1,
+			numToDelete:     3,
+			wantDeleted:     3,
+			wantOldDeleted:  1,
+			wantNewDeleted:  2,
+		},
+		{
+			// A workspace already terminating counts toward the target without a new delete.
+			name: "terminating workspace counts toward the target",
+			specs: []wsSpec{
+				{name: "old-1", terminating: true, old: true},
+				{name: "old-2", ready: true, old: true},
+				{name: "old-3", ready: true, old: true},
+			},
+			desiredReplicas: 2,
+			numToDelete:     1,
+			wantDeleted:     0,
+		},
+		{
+			// A not-ready old workspace is retired first (free: does not reduce Ready count).
+			name: "deletes not-ready old workspace first",
+			specs: []wsSpec{
+				{name: "old-1", ready: false, old: true},
+				{name: "new-1", ready: true, old: false},
+				{name: "new-2", ready: true, old: false},
+			},
+			desiredReplicas: 2,
+			numToDelete:     1,
+			wantDeleted:     1,
+			wantOldDeleted:  1,
+		},
+		{
+			// Scale-to-zero: no Ready floor to preserve, so every workspace is retired
+			// (old-image ones first), even Ready ones.
+			name: "scale to zero deletes all workspaces",
+			specs: []wsSpec{
+				{name: "old-1", ready: true, old: true},
+				{name: "new-1", ready: true, old: false},
+			},
+			desiredReplicas: 0,
+			numToDelete:     2,
+			wantDeleted:     2,
+			wantOldDeleted:  1,
+			wantNewDeleted:  1,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = appsv1.AddToScheme(scheme)
+	_ = corev1.AddToScheme(scheme)
+	_ = v1beta1.AddToScheme(scheme)
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, stableTargetForReplicas(tt.desired, tt.numSurges))
+			wss, objs := build(tt.specs)
+			cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+			c := &InferenceSetReconciler{Client: cl}
+
+			toDelete, err := c.selectWorkspacesToDelete(ctx, wss, tt.desiredReplicas, tt.numToDelete)
+			assert.NoError(t, err)
+			assert.Len(t, toDelete, tt.wantDeleted)
+
+			isOld := oldByName(tt.specs)
+			oldDeleted, newDeleted := 0, 0
+			for _, ws := range toDelete {
+				if isOld[ws.Name] {
+					oldDeleted++
+				} else {
+					newDeleted++
+				}
+			}
+			assert.Equal(t, tt.wantOldDeleted, oldDeleted, "old workspaces deleted")
+			assert.Equal(t, tt.wantNewDeleted, newDeleted, "new workspaces deleted")
 		})
 	}
 }

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -33,6 +33,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	"github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/featuregates"
 	"github.com/kaito-project/kaito/pkg/model"
@@ -503,6 +504,57 @@ func TestInferenceSetBenchmarkAggregation(t *testing.T) {
 			}
 			assert.Equal(t, tc.expectBenchmarkMsg,
 				fmt.Sprintf("%d/%d replicas benchmarked", benchmarkedReplicas, *tc.inferenceset.Spec.Replicas))
+		})
+	}
+}
+
+func TestPartitionManagedWorkspaces(t *testing.T) {
+	ws := func(name string, labels map[string]string) v1beta1.Workspace {
+		return v1beta1.Workspace{
+			ObjectMeta: v1.ObjectMeta{Name: name, Labels: labels},
+		}
+	}
+
+	tests := []struct {
+		name           string
+		input          []v1beta1.Workspace
+		wantManaged    []string
+		wantInProgress bool
+	}{
+		{
+			name:           "no surge - all managed",
+			input:          []v1beta1.Workspace{ws("a", nil), ws("b", nil)},
+			wantManaged:    []string{"a", "b"},
+			wantInProgress: false,
+		},
+		{
+			name: "one surge excluded - upgrade in progress",
+			input: []v1beta1.Workspace{
+				ws("blue", nil),
+				ws("green", map[string]string{kaitov1alpha1.LabelUpgradeSurgeFor: "blue"}),
+			},
+			wantManaged:    []string{"blue"},
+			wantInProgress: true,
+		},
+		{
+			name: "only surge",
+			input: []v1beta1.Workspace{
+				ws("green", map[string]string{kaitov1alpha1.LabelUpgradeSurgeFor: "blue"}),
+			},
+			wantManaged:    nil,
+			wantInProgress: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			managed, inProgress := partitionManagedWorkspaces(tt.input)
+			assert.Equal(t, tt.wantInProgress, inProgress)
+			var names []string
+			for _, m := range managed {
+				names = append(names, m.Name)
+			}
+			assert.Equal(t, tt.wantManaged, names)
 		})
 	}
 }

--- a/pkg/utils/inferenceset/inferenceset.go
+++ b/pkg/utils/inferenceset/inferenceset.go
@@ -127,7 +127,7 @@ func ListWorkspaces(ctx context.Context, iObj *kaitov1beta1.InferenceSet, kubeCl
 // GenerateName so the API server assigns a unique name on creation.
 //
 // It is shared by the InferenceSet controller (replica scale-up) and the
-// AutoUpgradeRunner (blue-green surge) so both construct identical Workspaces.
+// AutoUpgradeRunner (surge-based upgrade) so both construct identical Workspaces.
 func NewWorkspaceForInferenceSet(iObj *kaitov1beta1.InferenceSet) *kaitov1beta1.Workspace {
 	workspaceObj := &kaitov1beta1.Workspace{}
 	workspaceObj.GenerateName = iObj.Name + "-"

--- a/pkg/utils/inferenceset/inferenceset.go
+++ b/pkg/utils/inferenceset/inferenceset.go
@@ -19,6 +19,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -28,6 +29,7 @@ import (
 	"k8s.io/klog/v2"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	kaitov1alpha1 "github.com/kaito-project/kaito/api/v1alpha1"
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
@@ -117,6 +119,62 @@ func ListWorkspaces(ctx context.Context, iObj *kaitov1beta1.InferenceSet, kubeCl
 		)
 	})
 	return workspaceList, err
+}
+
+// NewWorkspaceForInferenceSet builds a child Workspace object owned by the given
+// InferenceSet, applying the InferenceSet's template labels/annotations, owner
+// reference, resource spec, and inference spec. The returned Workspace uses
+// GenerateName so the API server assigns a unique name on creation.
+//
+// It is shared by the InferenceSet controller (replica scale-up) and the
+// AutoUpgradeRunner (blue-green surge) so both construct identical Workspaces.
+func NewWorkspaceForInferenceSet(iObj *kaitov1beta1.InferenceSet) *kaitov1beta1.Workspace {
+	workspaceObj := &kaitov1beta1.Workspace{}
+	workspaceObj.GenerateName = iObj.Name + "-"
+	workspaceObj.Namespace = iObj.Namespace
+
+	// Start with labels from the template metadata, then add controller labels.
+	workspaceLabels := maps.Clone(iObj.Spec.Template.Labels)
+	if workspaceLabels == nil {
+		workspaceLabels = make(map[string]string)
+	}
+	// Also propagate select labels from the InferenceSet's own metadata,
+	// in case template.metadata.labels was pruned by the API server.
+	if role, ok := iObj.Labels[kaitov1beta1.LabelInferenceRole]; ok {
+		workspaceLabels[kaitov1beta1.LabelInferenceRole] = role
+	}
+	if mriParent, ok := iObj.Labels[kaitov1alpha1.LabelMultiRoleInferenceParent]; ok {
+		workspaceLabels[kaitov1alpha1.LabelMultiRoleInferenceParent] = mriParent
+	}
+	workspaceLabels[consts.WorkspaceCreatedByInferenceSetLabel] = iObj.Name
+	workspaceObj.Labels = workspaceLabels
+
+	// Start with annotations from the template metadata.
+	workspaceAnnotations := maps.Clone(iObj.Spec.Template.Annotations)
+	// Propagate the disable-benchmark opt-out so each child workspace inherits it.
+	// Benchmark is on by default; only propagate when explicitly disabled.
+	if !kaitov1beta1.IsInferenceSetBenchmarkEnabled(iObj) {
+		if workspaceAnnotations == nil {
+			workspaceAnnotations = make(map[string]string)
+		}
+		workspaceAnnotations[kaitov1beta1.AnnotationDisableBenchmark] = "true"
+	}
+	workspaceObj.Annotations = workspaceAnnotations
+	workspaceObj.OwnerReferences = []metav1.OwnerReference{
+		*metav1.NewControllerRef(iObj, kaitov1beta1.GroupVersion.WithKind("InferenceSet")),
+	}
+	workspaceObj.Resource = kaitov1beta1.ResourceSpec{
+		LabelSelector: iObj.Spec.Selector,
+		Partition:     iObj.Spec.Template.Resource.Partition,
+	}
+	// Only set InstanceType when node auto-provisioning is enabled.
+	// In BYO mode, the Workspace webhook rejects instanceType.
+	if consts.ActiveNodeProvisioner != consts.NodeProvisionerBYO {
+		workspaceObj.Resource.InstanceType = iObj.Spec.Template.Resource.InstanceType
+	}
+	workspaceObj.Inference = &iObj.Spec.Template.Inference
+
+	return workspaceObj
 }
 
 func ComputeInferenceSetHash(iObj *kaitov1beta1.InferenceSet) string {

--- a/website/docs/inference.md
+++ b/website/docs/inference.md
@@ -216,12 +216,12 @@ Auto-upgrade supports two strategies, selected via `spec.autoUpgrade.strategy`. 
 | Strategy | How it works | Downtime | Extra capacity |
 | --- | --- | --- | --- |
 | `InPlace` (default) | Updates the existing replica's `StatefulSet` image in place. The pod is recreated on the new image and the model is reloaded before it becomes ready again. | Brief per-replica downtime while the pod restarts and reloads weights. | None. |
-| `BlueGreen` | Creates a **new** replica ("green") on the new base image, waits for it to become inference-ready, then deletes the **old** replica ("blue"). | None — the old replica keeps serving until the new one is ready. | Temporarily runs one extra replica during each cutover, requiring additional GPU capacity. |
+| `Surge` | Creates a **new** (surge) replica on the new base image, waits for it to become inference-ready, then deletes the **old** replica. | None — the old replica keeps serving until the new one is ready. | Temporarily runs one extra replica during each cutover, requiring additional GPU capacity. |
 
-Choose `BlueGreen` for latency-sensitive or large models where a reload-induced gap is unacceptable and you have spare GPU capacity for the surge replica. Choose `InPlace` (the default) when minimizing capacity/cost matters more than avoiding a brief per-replica interruption.
+Choose `Surge` for latency-sensitive or large models where a reload-induced gap is unacceptable and you have spare GPU capacity for the surge replica. Choose `InPlace` (the default) when minimizing capacity/cost matters more than avoiding a brief per-replica interruption.
 
 :::note
-With `BlueGreen`, the surge replica downloads the model weights into its own storage before it can become ready, so a cutover for a large model can take a while — but this happens off the serving path, so the old replica continues serving with no downtime. When node auto-provisioning is enabled this may provision an additional GPU node for the surge replica; in bring-your-own-nodes setups, ensure there is spare labeled node capacity or the surge replica will stay `Pending`.
+With `Surge`, the surge replica downloads the model weights into its own storage before it can become ready, so a cutover for a large model can take a while — but this happens off the serving path, so the old replica continues serving with no downtime. When node auto-provisioning is enabled this may provision an additional GPU node for the surge replica; in bring-your-own-nodes setups, ensure there is spare labeled node capacity or the surge replica will stay `Pending`.
 :::
 
 ### Enabling auto-upgrade
@@ -256,7 +256,7 @@ Auto-upgrade requires two things:
            name: "google/gemma-4-31B-it"
      autoUpgrade:
        enabled: true
-       # strategy: InPlace   # default; use BlueGreen for zero-downtime upgrades
+       # strategy: InPlace   # default; use Surge for zero-downtime upgrades
    ```
 
 ### Restricting upgrades to a maintenance window

--- a/website/docs/inference.md
+++ b/website/docs/inference.md
@@ -209,6 +209,21 @@ KAITO ships the inference server (vLLM) as a base image embedded in the controll
 ### When to use
 Enable auto-upgrade when you want long-running `InferenceSet` workloads to automatically pick up newer base images (e.g. vLLM bug fixes, performance improvements, or security patches) shipped with KAITO controller upgrades, without manually recreating replicas — while keeping the service available throughout the rollout. If you instead prefer to pin replicas to a fixed base image and control exactly when they change, leave auto-upgrade disabled.
 
+### Upgrade strategies
+
+Auto-upgrade supports two strategies, selected via `spec.autoUpgrade.strategy`. Both upgrade one replica at a time; they differ in how each replica is replaced.
+
+| Strategy | How it works | Downtime | Extra capacity |
+| --- | --- | --- | --- |
+| `InPlace` (default) | Updates the existing replica's `StatefulSet` image in place. The pod is recreated on the new image and the model is reloaded before it becomes ready again. | Brief per-replica downtime while the pod restarts and reloads weights. | None. |
+| `BlueGreen` | Creates a **new** replica ("green") on the new base image, waits for it to become inference-ready, then deletes the **old** replica ("blue"). | None — the old replica keeps serving until the new one is ready. | Temporarily runs one extra replica during each cutover, requiring additional GPU capacity. |
+
+Choose `BlueGreen` for latency-sensitive or large models where a reload-induced gap is unacceptable and you have spare GPU capacity for the surge replica. Choose `InPlace` (the default) when minimizing capacity/cost matters more than avoiding a brief per-replica interruption.
+
+:::note
+With `BlueGreen`, the surge replica downloads the model weights into its own storage before it can become ready, so a cutover for a large model can take a while — but this happens off the serving path, so the old replica continues serving with no downtime. When node auto-provisioning is enabled this may provision an additional GPU node for the surge replica; in bring-your-own-nodes setups, ensure there is spare labeled node capacity or the surge replica will stay `Pending`.
+:::
+
 ### Enabling auto-upgrade
 
 Auto-upgrade requires two things:
@@ -241,6 +256,7 @@ Auto-upgrade requires two things:
            name: "google/gemma-4-31B-it"
      autoUpgrade:
        enabled: true
+       # strategy: InPlace   # default; use BlueGreen for zero-downtime upgrades
    ```
 
 ### Restricting upgrades to a maintenance window


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
InferenceSet base-image auto-upgrade previously only supported the InPlace strategy, which rolls each Workspace's StatefulSet in place and incurs a serving gap while the pod restarts and reloads model weights. For latency-sensitive or large models this downtime is unacceptable.

This PR adds a second strategy, Surge, that upgrades with no downtime: a new Workspace on the new base image is brought up alongside the old one, and traffic only cuts over once the new replica is Ready.

The design keeps the two controllers cleanly separated:

* **AutoUpgradeRunner** only adds capacity. When an InferenceSet is at its desired replica count and at least one Workspace is drifted (running an old base image), it creates exactly one new-image Workspace. It self-throttles on the replica count (one surge in flight at a time) and honors the maintenance window.
* **InferenceSet controller** performs the cutover during scale-down. selectWorkspacesToDelete classifies each Workspace once (Ready? old-image?), then deletes in priority order (old before new, not-ready before ready) bounded by two budgets: a Ready-surplus budget that never lets Ready replicas drop below [desiredReplicas](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (so it waits for the new replica to become Ready before retiring the old one), and a new-image budget so a normal upgrade never deletes the incoming replica.

**CRD**: adds [spec.autoUpgrade.strategy](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) (+kubebuilder:validation:Enum=InPlace;Surge, default InPlace) to both v1alpha1 and [v1beta1](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), with regenerated CRD manifests.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).
Added a `surge-based-auto-upgrade-test` e2e test job to base-image-auto-upgrade-test.yaml. 
- [x] manually tested surge-based auto upgrade for a two-replica inferenceset on AKS:

Baseline on `0.4.4`:
| Time | Event |
|---|---|
| 18:03:35 | InferenceSet created (`strategy: Surge`, autoUpgrade enabled); workspaces `67k65`, `s4s65` |
| 18:08:08 | `numDriftedWorkspaces => 0` |
| 18:08:55 | `67k65` StatefulSet up on `0.4.4` (resourceReady, loading) |
| 18:08:56 | `s4s65` StatefulSet up on `0.4.4` (resourceReady, loading) |
| 18:19:42 | `readyReplicas => 2/2` |
| 18:19:43–44 | both `67k65` and `s4s65` `InferenceReady` on `0.4.4` — **count stayed 2, drift 0, no spurious surge** ✅ |

Upgrade to `0.4.5`:
| Time | Event | Cycle Δ |
|---|---|---|
| 18:22:42 | Controller redeployed; desired base → `0.4.5` | |
| 18:27:43 | Runner detects `drift 0→2`, creates **surge `q8gwz`** (18:27:45) | +5.0m after bump |
| 18:33:23 | `q8gwz` StatefulSet up on `0.4.5` (3rd H100 provisioned), loading | |
| 18:44:14 | `q8gwz` `InferenceReady` → old `s4s65` **deleted same second** (**cutover #1**) | ≈16.5m |
| 18:47:49 | Runner recomputes `drift→1`, creates **surge `p6w5j`** (18:47:51) | |
| 18:52:28 | `p6w5j` StatefulSet up on `0.4.5`, loading | |
| 19:03:04 | `p6w5j` `InferenceReady` → old `67k65` **deleted same second** (**cutover #2**) | ≈15.2m |
| 19:07:42 | `lastSuccessfulUpgradeTime` recorded | |
| 19:08:01 | **Settled: 2 replicas on `0.4.5`, `drift=0`** | rollout ≈45m |

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: