### PR TITLE
docs: add wiki for inferenceset and auto-upgrade

### DIFF
--- a/website/docs/azure.md
+++ b/website/docs/azure.md
@@ -29,7 +29,7 @@ Choose auto-provisioning when:
 - You prefer to specify exact Azure instance types in your workspaces
 
 :::note
-Alternative: If you already have GPU nodes or manage them separately, use the [preferred nodes approach](quick-start#option-1-using-preferred-nodes-existing-gpu-nodes) instead.
+Alternative: If you already have GPU nodes or manage them separately, use the [bring your own GPU nodes approach](./installation.md#option-2-bring-your-own-gpu-nodes) instead.
 :::
 
 ## Set Up Auto-Provisioning

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -17,11 +17,13 @@ Then the node should have the label: `apps=falcon-7b`. In addition, if the GPU n
 
 ### Will KAITO controller upgrade affect existing inference workload?
 
-No. KAITO controller does not update existing inference workload when controller is upgraded. 
+By default, no. Upgrading the KAITO controller does not change existing `Workspace` inference workloads — they keep running their current base image until recreated.
+
+The exception is `InferenceSet` with **automatic base image upgrades** enabled. When you upgrade the controller to a release that bundles a newer base image, an `InferenceSet` with `spec.autoUpgrade.enabled: true` (and the `enableBaseImageAutoUpgrade` feature gate turned on) detects the version drift and rolls its replicas onto the new image one at a time, keeping the service available throughout. See [Automatic base image upgrades](./inference.md#automatic-base-image-upgrades) for details.
 
 ### How to upgrade the existing workload to use the latest model configuration?
-
-You can delete the existing inference workload (`StatefulSet`) manually, and the workspace controller will create a new one with the latest preset configuration (e.g., the latest base image) defined in the latest release.
+- Option 1 (recommended): **Use an `InferenceSet` with auto-upgrade**. Enable `spec.autoUpgrade.enabled: true` so the controller automatically performs a rolling, one-replica-at-a-time upgrade onto the latest base image after a controller upgrade. See [Automatic base image upgrades](./inference.md#automatic-base-image-upgrades).
+- Option 2: **Delete and recreate**. You can delete the existing inference workload (`StatefulSet`) manually, and the workspace controller will create a new one with the latest preset configuration (e.g., the latest base image) defined in the latest release.
 
 
 ### How to update model/inference parameters to override the KAITO Preset Configuration?

--- a/website/docs/inference.md
+++ b/website/docs/inference.md
@@ -2,103 +2,97 @@
 title: Inference
 ---
 
-This document presents how to use the KAITO `workspace` Custom Resource Definition (CRD) for model serving and serving with LoRA adapters.
+`InferenceSet` is the recommended Custom Resource Definition (CRD) for serving models in production. It supports 
+- Serving a model with more than one replica for higher throughput and availability.
+- Autoscaling the number of replicas based on inference request load (e.g. with the [KEDA autoscaler](./keda-autoscaler-inference.md)).
+- Integrating with the [Gateway API Inference Extension](./gateway-api-inference-extension.md) for KV-cache-aware request routing.
 
-:::tip Multi-Node Inference
-For large models requiring multiple nodes, see the [Multi-Node Inference](./multi-node-inference.md) documentation.
+:::info
+The `InferenceSet` controller is available starting from KAITO v0.8.0 (alpha) and was promoted to **beta** in KAITO v0.11.0, where it is enabled by default. For older versions, enable it explicitly with `--set featureGates.enableInferenceSetController=true` during installation.
 :::
+
+## How it works
+
+An `InferenceSet` is a higher-level controller that creates and manages one inference replica per `spec.replicas`. Every replica is rendered from the same shared `spec.template`, so all replicas serve the same model with the same configuration. The controller continuously reconciles the actual number of replicas to match `spec.replicas`, creating or deleting them as needed. Each replica runs as an independent inference server pod exposing the same OpenAI-compatible API.
+
+```mermaid
+flowchart TD
+    IS[InferenceSet] -->|creates spec.replicas| WS1[Workspace 1]
+    IS -->|creates| WS2[Workspace 2]
+    IS -->|creates| WSN[Workspace N]
+    WS1 --> P1[Inference Pod]
+    WS2 --> P2[Inference Pod]
+    WSN --> PN[Inference Pod]
+```
 
 ## Usage
 
-The basic usage for inference is simple. Users just need to specify the GPU SKU used for inference in the `resource` spec and one of the KAITO supported model name in the `inference` spec in the `workspace` custom resource. For example,
+Deploying a Hugging Face model with `InferenceSet` is straightforward. You just need to specify a Hugging Face model card ID (or a KAITO preset name), the GPU SKU, the desired number of replicas, and a `labelSelector` that the controller applies to each replica. For example:
 
 ```yaml
 apiVersion: kaito.sh/v1beta1
-kind: Workspace
+kind: InferenceSet
 metadata:
-  name: workspace-falcon-7b
-resource:
-  instanceType: "Standard_NC24ads_A100_v4"
+  name: gemma-4-31b
+spec:
+  replicas: 2
   labelSelector:
     matchLabels:
-      apps: falcon-7b
-inference:
-  preset:
-    name: "falcon-7b"
+      apps: gemma-4-31b
+  template:
+    resource:
+      instanceType: "Standard_NC24ads_A100_v4"
+    inference:
+      preset:
+        name: "google/gemma-4-31B-it"
 ```
 
-:::info
+### InferenceSet spec fields
 
-Starting from KAITO v0.9.0, generic Hugging Face models are supported on a best-effort basis. By specifying a Hugging Face model card ID as `inference.preset.name` in the KAITO workspace, you can run any Hugging Face model with a model architecture supported by vLLM on KAITO. Below is an example illustrating how to create a Hugging Face inference workload using the model card ID `Qwen/Qwen3-0.6B` from https://huggingface.co/Qwen/Qwen3-0.6B:
+| Field | Required | Description |
+| --- | --- | --- |
+| `spec.replicas` | No (default `1`) | Desired number of replicas. Set to `0` to scale to zero. |
+| `spec.labelSelector` | Yes | Labels applied to each replica so the controller can identify and manage them. |
+| `spec.nodeCountLimit` | No | Maximum number of GPU nodes that may be created across all replicas. Unlimited if unset. |
+| `spec.template.resource.instanceType` | Yes | GPU node SKU used for every replica. |
+| `spec.template.inference.preset.name` | Yes | The model to serve — a Hugging Face model card ID or a KAITO preset name. |
+| `spec.template.inference.adapters` | No | One or more LoRA adapters to merge at serving time. |
+| `spec.template.inference.config` | No | Name of a ConfigMap holding custom vLLM runtime parameters. |
+| `spec.autoUpgrade` | No | Configures automatic base image upgrades of replicas after a controller upgrade. See [Automatic base image upgrades](#automatic-base-image-upgrades). |
 
-```yaml
-apiVersion: kaito.sh/v1beta1
-kind: Workspace
-metadata:
-  name: qwen3-06b
-resource:
-  instanceType: Standard_NC24ads_A100_v4
-  labelSelector:
-    matchLabels:
-      apps: qwen3-06b
-inference:
-  preset:
-    name: Qwen/Qwen3-0.6B
+### Checking status
+
+The `InferenceSet` status reports how many replicas exist and how many are ready:
+
+```bash
+$ kubectl get inferenceset gemma-4-31b
+NAME         REPLICAS   READYREPLICAS   AGE
+gemma-4-31b   2          2               5m
 ```
 
+You can also list the individual replicas created by the `InferenceSet`:
+
+```bash
+$ kubectl get workspace -l kaito.sh/inferenceset=gemma-4-31b
+```
+
+### Scaling
+
+To change the number of replicas, update `spec.replicas`:
+
+```bash
+kubectl scale inferenceset gemma-4-31b --replicas=3
+```
+
+The controller adds or removes replicas to match the new count. When scaling down, replicas that are not yet ready are removed first. The `InferenceSet` exposes the Kubernetes `scale` subresource, so it can be targeted directly by autoscalers such as HPA or a KEDA `ScaledObject`. For load-based and schedule-based autoscaling, see [Autoscaling Inference with KEDA](./keda-autoscaler-inference.md).
+
+:::note Updating the template
+The `InferenceSet` controller reconciles the replica **count** (scaling) and replica labels. It does not currently perform an in-place rolling update of existing replicas when you edit other `spec.template` fields (such as inference parameters or adapters) — the one exception is the base image, which can be rolled out automatically via [Automatic base image upgrades](#automatic-base-image-upgrades). To apply other template changes today, recreate the `InferenceSet` (or delete individual replicas so the controller recreates them from the updated template).
 :::
 
-If a user runs KAITO in an on-premise Kubernetes cluster where GPU SKUs are unavailable, the GPU nodes can be pre-configured. The user should ensure that the corresponding vendor-specific GPU plugin is installed successfully in every prepared node, i.e. the node status should report a non-zero GPU resource in the allocatable field. For example:
+## Serving with custom parameters
 
-```
-$ kubectl get node $NODE_NAME -o json | jq .status.allocatable
-{
-  "cpu": "XXXX",
-  "ephemeral-storage": "YYYY",
-  "hugepages-1Gi": "0",
-  "hugepages-2Mi": "0",
-  "memory": "ZZZZ",
-  "nvidia.com/gpu": "1",
-  "pods": "100"
-}
-```
-
-Next, the user needs to add the node names in the `preferredNodes` field in the `resource` spec. As a result, the KAITO controller will skip the steps for GPU node provisioning and use the prepared nodes to run the inference workload.
-
-:::warning
-The node objects of the preferred nodes need to contain the same matching labels as specified in the `resource` spec. Otherwise, the KAITO controller would not recognize them.
-:::
-
-### Inference runtime selection
-
-KAITO now supports both [vLLM](https://github.com/vllm-project/vllm) and [transformers](https://github.com/huggingface/transformers) runtime. `vLLM` provides better serving latency and throughput. `transformers` provides more compatibility with models in the Huggingface model hub.
-
-From KAITO v0.4.0, the default runtime is switched to `vLLM`. If you want to use `transformers` runtime, you can specify the runtime in the `inference` spec using an annotation. For example,
-
-```yaml
-apiVersion: kaito.sh/v1beta1
-kind: Workspace
-metadata:
-  name: workspace-falcon-7b
-  annotations:
-    kaito.sh/runtime: "transformers"
-resource:
-  instanceType: "Standard_NC24ads_A100_v4"
-  labelSelector:
-    matchLabels:
-      apps: falcon-7b
-inference:
-  preset:
-    name: "falcon-7b"
-```
-
-:::note Multi-Node Support
-Multi-node distributed inference is currently supported only with the vLLM runtime. For details on configuring multi-node deployments, see [Multi-Node Inference](./multi-node-inference.md).
-:::
-
-### Inference with custom parameters
-
-Users can customize vLLM runtime parameters by creating a ConfigMap containing an `inference_config.yaml` file and referencing it in the workspace spec. For example:
+You can customize vLLM runtime parameters by creating a ConfigMap containing an `inference_config.yaml` file and referencing it from `spec.template.inference.config`. Every replica created by the `InferenceSet` uses the same parameters. For example:
 
 ```yaml
 apiVersion: v1
@@ -111,25 +105,27 @@ data:
     max_probe_steps: 6
     vllm:
       gpu-memory-utilization: 0.95  # Controls GPU memory usage (0.0-1.0)
-      tensor-parallel-size: 2        # Number of GPUs for tensor parallelism
+      tensor-parallel-size: 2       # Number of GPUs for tensor parallelism
       max-model-len: 131072         # Maximum sequence length
-      swap-space: 4                 # CPU swap space in GB
       cpu-offload-gb: 0             # Amount of GPU memory to offload to CPU
 ---
 apiVersion: kaito.sh/v1beta1
-kind: Workspace
+kind: InferenceSet
 metadata:
   namespace: myns
-  name: workspace-example
-resource:
-  instanceType: "Standard_NC24ads_A100_v4"
+  name: example
+spec:
+  replicas: 2
   labelSelector:
     matchLabels:
       apps: example
-inference:
-  preset:
-    name: "example-model"
-  config: "my-inference-params"  # Reference to ConfigMap name
+  template:
+    resource:
+      instanceType: "Standard_NC24ads_A100_v4"
+    inference:
+      preset:
+        name: "example-model"
+      config: "my-inference-params"  # Reference to ConfigMap name
 ```
 
 Key vLLM parameters include:
@@ -139,78 +135,43 @@ Key vLLM parameters include:
 
 For the complete list of vLLM parameters, refer to the [vLLM documentation](https://docs.vllm.ai/en/latest/serving/engine_args.html).
 
-### Inference benchmark
+## Serving with LoRA adapters
 
-When using the vLLM runtime, KAITO automatically runs a post-load throughput benchmark (via [guidellm](https://github.com/neuralmagic/guidellm)) after the model loads and before marking the workspace as ready. The benchmark result is stored in `status.performance.metrics` and the `BenchmarkCompleted` condition is set on the workspace.
-
-To disable the benchmark, set the `kaito.sh/disable-benchmark` annotation to `"true"` on a Workspace or InferenceSet:
+KAITO supports serving inference with LoRA adapters produced by [model fine-tuning jobs](./tuning.md). Specify one or more adapters in the `adapters` field of `spec.template.inference`. Each replica created by the `InferenceSet` loads the adapters alongside the raw model weights. For example:
 
 ```yaml
 apiVersion: kaito.sh/v1beta1
-kind: Workspace
+kind: InferenceSet
 metadata:
-  name: workspace-phi-4-mini
-  annotations:
-    kaito.sh/disable-benchmark: "true"
-resource:
-  instanceType: "Standard_NC24ads_A100_v4"
+  name: phi4-mini
+spec:
+  replicas: 2
   labelSelector:
     matchLabels:
-      apps: phi-4-mini
-inference:
-  preset:
-    name: "phi-4-mini"
+      apps: phi4-mini
+  template:
+    resource:
+      instanceType: "Standard_NC24ads_A100_v4"
+    inference:
+      preset:
+        name: "microsoft/Phi-4-mini-instruct"
+      adapters:
+        - source:
+            name: "phi4-mini-adapter"
+            image: "<YOUR_IMAGE>"
 ```
 
-When set on an InferenceSet, the annotation is propagated to all child Workspaces it creates.
-
-:::note
-The benchmark only runs with the vLLM runtime. It is not supported with the `transformers` runtime.
-:::
-
-### Inference with LoRA adapters
-
-KAITO also supports running the inference workload with LoRA adapters produced by [model fine-tuning jobs](./tuning.md). Users can specify one or more adapters in the `adapters` field of the `inference` spec. For example,
-
-```yaml
-apiVersion: kaito.sh/v1beta1
-kind: Workspace
-metadata:
-  name: workspace-falcon-7b
-resource:
-  instanceType: "Standard_NC24ads_A100_v4"
-  labelSelector:
-    matchLabels:
-      apps: falcon-7b
-inference:
-  preset:
-    name: "falcon-7b"
-  adapters:
-    - source:
-        name: "falcon-7b-adapter"
-        image:  "<YOUR_IMAGE>"
-      strength: "0.2"
-```
-Currently, only images are supported as adapter sources. The `strength` field specifies the multiplier applied to the adapter weights relative to the raw model weights.
+Currently, only images are supported as adapter sources.
 
 **Note:** When building a container image for an existing adapter, ensure all adapter files are copied to the **/data** directory inside the container.
 
-For detailed `InferenceSpec` API definitions, refer to the [documentation](https://github.com/kaito-project/kaito/blob/2ccc93daf9d5385649f3f219ff131ee7c9c47f3e/api/v1alpha1/workspace_types.go#L75).
+## Inference API
 
-### Inference API
-
-The OpenAPI specification for the inference API is available at [vLLM API](../../presets/workspace/inference/vllm/api_spec.json), [transformers API](../../presets/workspace/inference/text-generation/api_spec.json).
-
-#### vLLM inference API
-
-vLLM supports OpenAI-compatible inference APIs. Check [here](https://docs.vllm.ai/en/stable/serving/openai_compatible_server.html) for more details.
-
-#### Transformers inference API
-
-The transformers runtime now uses an OpenAI-compatible API powered by the HuggingFace `transformers serve` engine.
+Every replica runs the vLLM runtime and exposes an OpenAI-compatible HTTP API on port 80, reachable through the Kubernetes `Service` of each replica. To distribute requests across all replicas behind a single endpoint, front the `InferenceSet` with the [Gateway API Inference Extension](./gateway-api-inference-extension.md).
 
 **Chat Completions**
-```
+
+```bash
 curl -X POST "http://<SERVICE>:80/v1/chat/completions" \
     -H "Content-Type: application/json" \
     -d '{
@@ -221,43 +182,96 @@ curl -X POST "http://<SERVICE>:80/v1/chat/completions" \
     }'
 ```
 
-**Responses API**
-```
-curl -X POST "http://<SERVICE>:80/v1/responses" \
+**Completions**
+
+```bash
+curl -X POST "http://<SERVICE>:80/v1/completions" \
     -H "Content-Type: application/json" \
     -d '{
         "model": "MODEL_NAME",
-        "input": "YOUR_PROMPT_HERE",
-        "max_output_tokens": 200
+        "prompt": "YOUR_PROMPT_HERE",
+        "max_tokens": 200
     }'
 ```
 
 **List Models**
-```
+
+```bash
 curl -X GET "http://<SERVICE>:80/v1/models"
 ```
 
-For the full list of supported parameters, refer to the [OpenAI API reference](https://platform.openai.com/docs/api-reference/chat/create) and the [HuggingFace transformers serve documentation](https://huggingface.co/docs/transformers/en/serve-cli/serving).
+vLLM supports the full set of OpenAI-compatible inference APIs. See the [vLLM OpenAI-compatible server documentation](https://docs.vllm.ai/en/stable/serving/openai_compatible_server.html) for the complete list of endpoints and parameters.
 
-# Inference workload
+## Automatic base image upgrades
 
-Depending on whether the specified model supports distributed inference or not, the KAITO controller will choose to use either Kubernetes **apps.deployment** workload (by default) or Kubernetes **apps.statefulset** workload (if the model supports distributed inference) to manage the inference service, which is exposed using a Cluster-IP type of Kubernetes `service`.
+KAITO ships the inference server (vLLM) as a base image embedded in the controller. When you upgrade the KAITO controller to a release that bundles a newer base image, existing replicas keep running their old image until they are recreated. With automatic base image upgrades enabled, the controller detects this version drift and rolls the replicas onto the new image one at a time, waiting for each replica to become ready before moving to the next. This is the rolling-update mechanism KAITO provides for `InferenceSet`.
 
-For multi-node distributed inference, KAITO uses StatefulSets to ensure stable pod identity and coordination between leader and worker pods. See [Multi-Node Inference](./multi-node-inference.md) for detailed architecture information.
+### When to use
+Enable auto-upgrade when you want long-running `InferenceSet` workloads to automatically pick up newer base images (e.g. vLLM bug fixes, performance improvements, or security patches) shipped with KAITO controller upgrades, without manually recreating replicas — while keeping the service available throughout the rollout. If you instead prefer to pin replicas to a fixed base image and control exactly when they change, leave auto-upgrade disabled.
 
-When adapters are specified in the `inference` spec, the KAITO controller adds an initcontainer for each adapter in addition to the main container. The pod structure is shown in Figure 1.
+### Enabling auto-upgrade
 
-![KAITO inference service pod structure](/img/kaito-inference-adapter.png)
+Auto-upgrade requires two things:
 
-If an image is specified as the adapter source, the corresponding initcontainer uses that image as its container image. These initcontainers ensure all adapter data is available locally before the inference service starts. The main container uses a supported model image, launching the [inference_api.py](../../presets/workspace/inference/text-generation/inference_api.py) script.
+1. The `enableBaseImageAutoUpgrade` feature gate must be enabled on the KAITO controller (it is **off by default**). Enable it at install/upgrade time:
 
-All containers share local volumes by mounting the same `EmptyDir` volumes, avoiding file copies between containers.
+   ```bash
+   helm upgrade --install kaito-workspace ./charts/kaito/workspace \
+     --set featureGates.enableBaseImageAutoUpgrade=true \
+     # ... other values
+   ```
 
-## Workload update
+2. The `InferenceSet` must opt in via `spec.autoUpgrade.enabled: true`:
 
-To update the `adapters` field in the `inference` spec, users can modify the `workspace` custom resource. The KAITO controller will apply the changes, triggering a workload deployment update. This will recreate the inference service pod, resulting in a brief service downtime. Once the new adapters are merged with the raw model weights and loaded into GPU memory, the service will resume.
+   ```yaml
+   apiVersion: kaito.sh/v1beta1
+   kind: InferenceSet
+   metadata:
+     name: gemma-4-31b
+   spec:
+     replicas: 3
+     labelSelector:
+       matchLabels:
+         apps: gemma-4-31b
+     template:
+       resource:
+         instanceType: "Standard_NC24ads_A100_v4"
+       inference:
+         preset:
+           name: "google/gemma-4-31B-it"
+     autoUpgrade:
+       enabled: true
+   ```
 
+### Restricting upgrades to a maintenance window
 
-# Troubleshooting
+By default, upgrades may start at any time. To limit when rollouts begin, set a `maintenanceWindow` with a 5-field cron `schedule` (UTC) and an optional `duration` (defaults to `4h`). The controller only starts
+upgrading replicas while the current time is inside the window; an upgrade already in progress is allowed to finish even if the window closes, and the next replica waits for the following window.
 
-TBD
+```yaml
+spec:
+  autoUpgrade:
+    enabled: true
+    maintenanceWindow:
+      schedule: "0 2 * * 6"   # every Saturday at 02:00 UTC
+      duration: "4h"           # window stays open for 4 hours
+```
+
+### Observing upgrade progress
+
+The upgrade state is reported under `status.autoUpgrade`:
+
+- `numDriftedWorkspaces` — number of replicas still running an old base image (`0` when fully up-to-date).
+- `lastSuccessfulUpgradeTime` — timestamp of the most recently completed replica upgrade.
+
+```bash
+kubectl get inferenceset gemma-4-31b -o jsonpath='{.status.autoUpgrade}'
+```
+
+## Related documentation
+
+- [Workspace](./workspace.md) - The underlying single-replica CRD and how it works internally.
+- [Autoscaling Inference with KEDA](./keda-autoscaler-inference.md) - Load- and schedule-based autoscaling of an `InferenceSet`.
+- [Gateway API Inference Extension](./gateway-api-inference-extension.md) - KV-cache-aware routing across `InferenceSet` replicas.
+- [Multi-Node Inference](./multi-node-inference.md) - Distributed inference for large models across multiple nodes.
+

--- a/website/docs/multi-node-inference.md
+++ b/website/docs/multi-node-inference.md
@@ -2,244 +2,147 @@
 title: Multi-Node Inference
 ---
 
-This document explains how to configure and use multi-node distributed inference in KAITO for large models that require more GPU resources than a single node can provide.
+Multi-node inference is used for models that are too large to fit on a single GPU node. KAITO automatically combines **tensor parallelism** within each node and **pipeline parallelism** across nodes so a single model can be served by a coordinated group of pods.
 
-## Overview
-
-Multi-node inference allows you to deploy large AI models across multiple nodes (servers) when the model is too large to fit on a single node. KAITO supports different parallelism strategies depending on your model's requirements:
-
-| Strategy | Use Case | Supported |
-|----------|----------|-----------|
-| **Single GPU** | Small models that fit on one GPU | ✅ |
-| **Single-Node Multi-GPU** | Models that need multiple GPUs but fit on one node | ✅ |
-| **Multi-Node Multi-GPU** | Very large models (400B+ parameters) requiring multiple nodes | ✅ |
-
-## When to Use Multi-Node Inference
-
-Consider multi-node inference when:
-
-- Your model has 400B+ parameters and cannot fit on a single node
-- You need to serve models like very large language models that exceed single-node memory capacity
-- You have specific performance requirements that benefit from distributed processing
-
-:::note
-Multi-node inference introduces additional complexity and network overhead. Only use it when your model truly requires more resources than a single node can provide.
+:::note Runtime
+Multi-node distributed inference is supported **only with the vLLM runtime**. The `transformers` runtime is single-node only.
 :::
 
-## Supported Models
+## When KAITO uses multi-node inference
 
-The following preset models support multi-node distributed inference:
+Multi-node inference is not something you switch on with a flag — the controller decides automatically. Distributed inference is used when **all three** of these hold (`shouldUseDistributedInference`):
 
-- **Llama3**: `llama-3.3-70b-instruct`
-- **DeepSeek**: `deepseek-r1-0528`, `deepseek-v3-0324` 
+1. **The model supports it** — `Model.SupportDistributedInference()` returns `true`. All vLLM-served models qualify, whether a KAITO preset or a Hugging Face model card ID.
+2. **The runtime is vLLM.**
+3. **More than one node is required** — `Workspace.Status.TargetNodeCount > 1`.
 
-Check the [presets documentation](./presets.md) for the complete list and their specific requirements.
+### How the node count is decided
 
-## Configuration
+The number of nodes is computed by KAITO's **node estimator** (`NodeEstimator.EstimateNodeCount`), not taken directly from the spec. The estimator sizes the deployment from:
 
-### Basic Multi-Node Setup
+- the model's total weight size (expanded ~2% for the vLLM in-memory representation),
+- the GPU memory and GPU count of the requested `instanceType`,
+- the KV-cache requirement for the configured context length, plus a fixed memory overhead and a utilization factor (default `0.84`).
 
-To deploy a model across multiple nodes, specify the node count in your Workspace configuration:
-
-```yaml
-apiVersion: kaito.sh/v1beta1
-kind: Workspace
-metadata:
-  name: workspace-large-model
-resource:
-  count: 2                    # Number of nodes to use
-  instanceType: "Standard_NC80adis_H100_v5"
-  labelSelector:
-    matchLabels:
-      apps: large-model
-inference:
-  preset:
-    name: "llama-3.3-70b-instruct"
-```
-
-### Pre-Provisioned Nodes
-
-If you're using pre-provisioned GPU nodes, specify them explicitly:
-
-```yaml
-apiVersion: kaito.sh/v1beta1
-kind: Workspace
-metadata:
-  name: workspace-large-model
-resource:
-  count: 2
-  preferredNodes:
-    - gpu-node-1
-    - gpu-node-2
-  labelSelector:
-    matchLabels:
-      apps: large-model
-inference:
-  preset:
-    name: "llama-3.3-70b-instruct"
-```
-
-:::warning
-Pre-provisioned nodes must have the same matching labels as specified in the `resource` spec, and each node must report available GPU resources.
-:::
-
-### Custom vLLM Parameters for Multi-Node
-
-You can customize vLLM runtime parameters for distributed inference using a ConfigMap:
-
-```yaml
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: distributed-inference-config
-data:
-  inference_config.yaml: |
-    vllm:
-      gpu-memory-utilization: 0.95
-      max-model-len: 131072
----
-apiVersion: kaito.sh/v1beta1
-kind: Workspace
-metadata:
-  name: workspace-large-model
-resource:
-  count: 2
-  instanceType: "Standard_NC80adis_H100_v5"
-  labelSelector:
-    matchLabels:
-      apps: large-model
-inference:
-  preset:
-    name: "llama-3.3-70b-instruct"
-  config: "distributed-inference-config"
-```
-
-Key parameters for multi-node inference:
-- `tensor-parallel-size`: Automatically set by KAITO based on the number of GPUs per node
-- `pipeline-parallel-size`: Automatically set by KAITO based on the number of nodes
-- `gpu-memory-utilization`: Fraction of GPU memory to use (0.0-1.0) - user configurable
-- `max-model-len`: Maximum sequence length - user configurable
-
-:::note
-The `tensor-parallel-size` and `pipeline-parallel-size` parameters are automatically managed by KAITO based on your cluster configuration and do not need to be specified in the ConfigMap.
-:::
-
-## Architecture
-
-### Single-Node Multi-GPU
-
-When using multiple GPUs on a single node, KAITO uses **tensor parallelism** to split the model across GPUs within that node:
-
-```
-┌─────────────────────────────────────┐
-│             Node 1                  │
-│  ┌─────┐ ┌─────┐ ┌─────┐ ┌─────┐    │
-│  │GPU 1│ │GPU 2│ │GPU 3│ │GPU 4│    │
-│  └─────┘ └─────┘ └─────┘ └─────┘    │
-│           Model Split               │
-└─────────────────────────────────────┘
-```
-
-### Multi-Node Multi-GPU
-
-For multi-node deployments, KAITO combines **pipeline parallelism** between nodes and **tensor parallelism** within each node:
-
-```
-┌─────────────────────┐    ┌─────────────────────┐
-│       Node 1        │    │       Node 2        │
-│  ┌─────┐┌─────┐     │    │  ┌─────┐ ┌─────┐    │
-│  │GPU 1││GPU 2│     │◄──►│  │GPU 3│ │GPU 4│    │
-│  └─────┘└─────┘     │    │  └─────┘ └─────┘    │
-│   Layers 1-N/2      │    │   Layers N/2+1-N    │
-└─────────────────────┘    └─────────────────────┘
-```
-
-## Resource Validation
-
-KAITO automatically validates that your configuration provides sufficient resources:
-
-- **GPU Count**: `(GPUs per instance) × (workspace.resource.count) ≥ (Required GPUs for model)`
-- **Memory**: `(GPU memory) × (Total GPUs) ≥ (Required model memory)`
-
-If validation fails, you'll receive an error message when creating or updating the workspace.
-
-:::tip Resource Optimization
-KAITO may use fewer nodes than specified in `workspace.resource.count` if the model can fit efficiently on fewer nodes. This optimizes GPU utilization and reduces network overhead, but be mindful of the costs when provisioning many nodes.
-:::
-
-## Service Architecture
-
-Multi-node inference uses Kubernetes StatefulSets to ensure stable pod identity and coordination:
-
-- **Leader Pod** (index 0): Coordinates the distributed inference and serves the API
-- **Worker Pods** (index 1+): Join the Ray cluster and participate in model serving
-
-The service endpoint points to the leader pod, which handles all incoming requests and coordinates with worker pods.
-
-:::note Future Enhancement
-KAITO will support [LeaderWorkerSet](https://lws.sigs.k8s.io/docs/overview/) in the future to provide better management of leader-worker topologies and improved fault tolerance for multi-node deployments.
-:::
-
-## Health Monitoring
-
-Multi-node deployments use specialized health checks:
-
-- **Liveness Probes**: Monitor Ray cluster health and detect dead actors
-- **Readiness Probes**: Check service availability via the leader pod's `/health` endpoint
-
-If worker pods fail, the leader will restart to reinitialize the entire cluster, ensuring all pods are synchronized.
-
-## Best Practices
-
-1. **Resource Planning**: Carefully plan your GPU and memory requirements before deployment
-2. **Network Bandwidth**: Ensure sufficient network bandwidth between nodes for optimal performance
-3. **Monitoring**: Monitor both individual node health and overall cluster performance
-4. **Cost Management**: Be aware that multi-node deployments can be expensive; only use when necessary
-
-## Troubleshooting
-
-### Service Unavailable After Deployment
-
-If the service becomes unavailable:
-
-1. Check if all pods are running: `kubectl get pods -l app=<your-app-label>`
-2. Verify Ray cluster health in leader pod logs
-3. Ensure network connectivity between nodes
-4. Check resource allocation and GPU availability
-
-### Worker Pod Failures
-
-Worker pod failures will trigger leader pod restart to reinitialize the cluster:
-
-1. Monitor pod restart events
-2. Check for resource constraints (memory, GPU)
-3. Verify node-to-node network connectivity
-4. Review pod logs for Ray cluster connection issues
-
-### Performance Issues
-
-If you experience poor performance:
-
-1. Monitor network latency between nodes
-2. Check GPU utilization across all nodes
-3. Review memory usage and potential bottlenecks
-4. Consider adjusting parallelism parameters
-
-## API Usage
-
-Multi-node inference services expose the same API as single-node deployments. The vLLM runtime provides OpenAI-compatible endpoints:
+It then picks the smallest node count whose aggregate GPU memory can hold the model plus overhead, and records the result in `status.targetNodeCount`. If that value is greater than `1`, the workspace is served as a multi-node deployment.
 
 ```bash
-# Get the cluster IP of your service
-kubectl get services
+$ kubectl get workspace workspace-large-model
+NAME                    INSTANCE                    TARGETNODECOUNT   ...
+workspace-large-model   Standard_NC80adis_H100_v5   2                 ...
+```
 
-# Check service health
-kubectl run -it --rm --restart=Never curl --image=curlimages/curl -- \
-  curl http://<CLUSTER-IP>:80/health
+:::info `resource.count` is deprecated
+The legacy `resource.count` and `resource.preferredNodes` fields are deprecated in `v1beta1`. You no longer need to specify how many nodes a model needs — KAITO derives it from the model and the GPU SKU. A minimal spec is enough:
 
-# Generate text using chat completions API
-kubectl run -it --rm --restart=Never curl --image=curlimages/curl -- \
-  curl -X POST http://<CLUSTER-IP>:80/v1/chat/completions \
+```yaml
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  name: workspace-large-model
+resource:
+  instanceType: "Standard_NC80adis_H100_v5"
+  labelSelector:
+    matchLabels:
+      apps: large-model
+inference:
+  preset:
+    name: "llama-3.3-70b-instruct"
+```
+:::
+
+## Parallelism strategy
+
+Based on the model size, the GPU SKU, and the estimated node count, KAITO selects a parallelism layout and injects the corresponding vLLM flags automatically (`configureParallelism`). Users do **not** set these.
+
+| Scenario | vLLM configuration |
+| --- | --- |
+| Model fits on one GPU | `data-parallel-size = GPUs per node`, `tensor-parallel-size = 1` |
+| Model fits on one node (multi-GPU) | `tensor-parallel-size = GPUs per node` |
+| Model spans multiple nodes | `tensor-parallel-size = GPUs per node`, `pipeline-parallel-size = number of nodes`, `distributed-executor-backend = ray` |
+
+In the multi-node case, each node holds a slice of the model's layers (a pipeline stage), and within a node those layers are sharded across that node's GPUs (tensor parallel).
+
+```mermaid
+flowchart LR
+    subgraph N1["Node 0 — Pod-0 (leader)"]
+        direction TB
+        G1[GPU 0] --- G2[GPU 1]
+        L1["Pipeline stage 0<br/>layers 1…N/2"]
+    end
+    subgraph N2["Node 1 — Pod-1 (worker)"]
+        direction TB
+        G3[GPU 2] --- G4[GPU 3]
+        L2["Pipeline stage 1<br/>layers N/2+1…N"]
+    end
+    N1 <-->|Ray| N2
+```
+
+## Workload topology: StatefulSet + Ray
+
+For distributed inference KAITO manages the pods with a **StatefulSet** sized to `targetNodeCount` replicas (`GenerateStatefulSetManifest`). A StatefulSet is used because the pods need **stable, ordinal identities** to form a deterministic leader/worker topology:
+
+- **Pod-0 (leader)** starts the Ray cluster head and the vLLM OpenAI API server.
+- **Pod-1 … Pod-N (workers)** start Ray and join the leader's cluster; they contribute GPUs to the pipeline but do not serve the API directly.
+
+Each pod learns its role from a `POD_INDEX` environment variable, projected from the Kubernetes pod-ordinal label `apps.kubernetes.io/pod-index`. The model launch command branches on it:
+
+```sh
+if [ "${POD_INDEX}" = "0" ]; then
+  /workspace/vllm/multi-node-serving.sh leader ...   # Ray head + vLLM API
+else
+  /workspace/vllm/multi-node-serving.sh worker ...   # Ray worker joins leader
+fi
+```
+
+Workers find the leader through a **headless Service** that gives every pod a stable DNS name. The leader address is constructed as (`GetRayLeaderHost`):
+
+```
+<workspace-name>-0.<workspace-name>-headless.<namespace>.svc.cluster.local
+```
+
+Ray cluster communication uses port **6379** (`PortRayCluster`), and the leader is told the expected `ray_cluster_size` so it waits for all workers to join before initialization completes.
+
+## Services and ports
+
+KAITO creates two Services for a distributed workspace:
+
+| Service | Type | Selector | Purpose |
+| --- | --- | --- | --- |
+| `<name>-headless` | Headless (`clusterIP: None`) | all pods | Per-pod DNS so workers can reach the leader. Uses `publishNotReadyAddresses: true` so names resolve before pods are ready. |
+| `<name>` | ClusterIP | **pod-0 only** (`statefulset.kubernetes.io/pod-name=<name>-0`) | Client-facing API endpoint. |
+
+Port mapping on the main Service:
+
+- `80 → 5000` — the vLLM OpenAI-compatible HTTP API (served by the leader).
+- `6379` — Ray cluster port.
+- `8265` — Ray dashboard.
+
+Because the client Service selects only pod-0, all inference requests land on the leader, which coordinates the pipeline across the worker pods.
+
+## Health probes and fault tolerance
+
+Distributed pods use specialized probes wired up by `SetDistributedInferenceProbe`, all backed by `multi-node-health-check.py`:
+
+- **Startup & readiness probes** call the script in `readiness` mode, which issues an HTTP `GET` to the leader's `http://<leader>:5000/health`. The startup probe tolerates a long window (≈30 minutes by default, ≈60 minutes for models larger than 300 GiB) to allow weights to download and the full cluster to initialize.
+- **Liveness probe** (on the leader) calls the script in `liveness` mode, which queries the **Ray GCS** for dead actors. If any worker has died, the probe fails immediately (`failureThreshold: 1`).
+
+When a worker pod fails, the leader's liveness probe detects the dead Ray actor and the leader pod is restarted. Because pipeline parallelism requires a synchronized cluster, restarting the leader forces the whole group to reinitialize: the StatefulSet brings pods back in ordinal order, the leader rebuilds the Ray head, and all workers rejoin. A short `terminationGracePeriodSeconds` keeps this recovery fast.
+
+:::note Future enhancement
+KAITO plans to adopt [LeaderWorkerSet](https://lws.sigs.k8s.io/docs/overview/) to provide finer-grained management of leader-worker topologies and improved fault tolerance for multi-node deployments.
+:::
+
+## Inference API
+
+A multi-node workspace exposes exactly the same OpenAI-compatible API as a single-node workspace — clients are unaware of the distributed topology. Requests go to the main ClusterIP Service (port 80), which routes to the leader:
+
+```bash
+# Health
+curl http://<CLUSTER-IP>:80/health
+
+# Chat completions
+curl -X POST http://<CLUSTER-IP>:80/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
     "model": "llama-3.3-70b-instruct",
@@ -248,17 +151,8 @@ kubectl run -it --rm --restart=Never curl --image=curlimages/curl -- \
   }'
 ```
 
-For detailed API specifications, see the [inference documentation](./inference.md#inference-api).
+## Related documentation
 
-## Limitations
-
-- **Custom Models**: Multi-node inference is currently only supported for preset models
-- **Fault Tolerance**: The system requires leader restart when worker pods fail
-- **Network Dependency**: Performance heavily depends on inter-node network quality
-- **Complexity**: Debugging and monitoring are more complex than single-node deployments
-
-## Related Documentation
-
-- [Inference](./inference.md) - General inference documentation
-- [Presets](./presets.md) - Supported models and their requirements
-- [Custom Model](./custom-model.md) - Using custom models (single-node only)
+- [Workspace](./workspace.md) - The single-replica CRD and how it works internally.
+- [Inference](./inference.md) - Serving models with `InferenceSet`.
+- [Presets](./presets.md) - Supported models and their requirements.

--- a/website/docs/workspace.md
+++ b/website/docs/workspace.md
@@ -1,0 +1,123 @@
+---
+title: Workspace
+---
+
+The `Workspace` Custom Resource Definition (CRD) is KAITO's low-level building block for model serving. A single `Workspace` provisions GPU capacity and runs **one** inference replica of a model. This document focuses on how a `Workspace` works internally — the reconcile lifecycle, how model weights reach the pod, what workload is created, and the status conditions it reports.
+
+:::tip Recommended entry point
+[`InferenceSet`](./inference.md) is the **recommended way to serve models** in KAITO. It builds on top of `Workspace`, managing multiple replicas behind a single specification and enabling autoscaling, rolling base-image upgrades, and gateway-based routing. Reach for `Workspace` directly only when you want a single replica or need to understand the underlying mechanics.
+:::
+
+## How a Workspace works
+
+When you create a `Workspace`, the KAITO controller drives it through a reconcile lifecycle from raw spec to a ready inference service:
+
+```mermaid
+flowchart TD
+    A[Workspace created] --> B[Provision / select GPU nodes]
+    B --> C[Make model weights available]
+    C --> D[Create inference workload + Service]
+    D --> E[Wait for pods ready]
+    E --> F[Optional: run throughput benchmark]
+    F --> G[Workspace State = Ready]
+```
+
+Each step is reflected in the `Workspace` status conditions (see [Status conditions](#status-conditions)). The following sections explain what happens internally at each step.
+
+### Node provisioning and selection
+
+The controller first ensures enough GPU nodes exist to satisfy the `resource` spec. Based on the requested `instanceType`, KAITO provisions GPU nodes (for example, by creating `NodeClaim` objects through the GPU provisioner) and waits until the nodes are `Ready` with their vendor GPU device plugins reporting allocatable GPUs. The matching `labelSelector` labels are applied so the inference pods land on those nodes.
+
+For on-premise clusters where GPU SKUs cannot be provisioned dynamically, nodes can be pre-configured and supplied directly. The user must ensure the vendor-specific GPU plugin is installed on every prepared node — i.e. the node's `status.allocatable` reports a non-zero GPU resource:
+
+```
+$ kubectl get node $NODE_NAME -o json | jq .status.allocatable
+{
+  "cpu": "XXXX",
+  "ephemeral-storage": "YYYY",
+  "hugepages-1Gi": "0",
+  "hugepages-2Mi": "0",
+  "memory": "ZZZZ",
+  "nvidia.com/gpu": "1",
+  "pods": "100"
+}
+```
+
+When node names are listed in the `preferredNodes` field of the `resource` spec, the controller skips GPU node provisioning and schedules the workload onto those prepared nodes.
+
+:::warning
+The node objects of the preferred nodes need to contain the same matching labels as specified in the `resource` spec. Otherwise, the KAITO controller would not recognize them.
+:::
+
+A minimal `Workspace` only needs the GPU SKU in the `resource` spec and a model name in the `inference` spec:
+
+```yaml
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  name: workspace-gemma4-31b
+resource:
+  instanceType: "Standard_NC24ads_A100_v4"
+  labelSelector:
+    matchLabels:
+      apps: gemma4-31b
+inference:
+  preset:
+    name: "google/gemma-4-31B-it"
+```
+
+Starting from KAITO v0.9.0, generic Hugging Face models are supported on a best-effort basis: specifying a Hugging Face model card ID (for example `Qwen/Qwen3-0.6B`) as `inference.preset.name` runs any model whose architecture is supported by vLLM.
+
+### Downloading model weights into the pod
+
+Depending on the model and configuration, the controller makes weights available to the inference container in one of two ways:
+
+- **Runtime download** — the controller injects an init container that downloads the weights (e.g. from Hugging Face, using the secret referenced by `inference.preset.presetOptions.modelAccessSecret`) into a shared `EmptyDir` volume before the inference server starts.
+Weights will be downloaded to local NVMe disks when available.
+- **Model streaming** — when streaming is enabled, weights are served from cloud storage and streamed into the pod instead of being fully downloaded first. See [Model Mirror & Streaming](./model-mirror-streaming.md).
+
+When adapters are specified, an additional init container is added per adapter to fetch the adapter data into the same shared volume (see [Serving with LoRA adapters](./inference.md#serving-with-lora-adapters)).
+
+### Inference workload and Service
+
+From v0.8.0 onwards, KAITO manages the inference service with a Kubernetes **StatefulSet** (older `Deployment`-based workloads are automatically migrated). The StatefulSet gives pods stable identities, which is required for multi-node distributed inference where leader and worker pods must coordinate. For single-node models the StatefulSet simply runs one replica.
+
+The inference server is exposed through a `ClusterIP` Kubernetes `Service` (port 80 by default). For multi-node distributed inference, a headless Service is additionally created for pod-to-pod discovery. See [Multi-Node Inference](./multi-node-inference.md) for the distributed architecture.
+
+### Inference benchmark
+
+When using the vLLM runtime, KAITO automatically runs a post-load throughput benchmark (via [guidellm](https://github.com/neuralmagic/guidellm)) after the model loads and before marking the workspace as ready. The benchmark result is stored in `status.performance.metrics` and the `BenchmarkCompleted` condition is set on the workspace.
+
+To disable the benchmark, set the `kaito.sh/disable-benchmark` annotation to `"true"` on a Workspace or InferenceSet:
+
+```yaml
+apiVersion: kaito.sh/v1beta1
+kind: Workspace
+metadata:
+  name: workspace-phi-4-mini
+  annotations:
+    kaito.sh/disable-benchmark: "true"
+resource:
+  instanceType: "Standard_NC24ads_A100_v4"
+  labelSelector:
+    matchLabels:
+      apps: phi-4-mini
+inference:
+  preset:
+    name: "microsoft/Phi-4-mini-instruct"
+```
+
+When set on an InferenceSet, the annotation is propagated to all child Workspaces it creates.
+
+### Status conditions
+
+The controller reports progress through `status.conditions`. The most relevant ones are:
+
+| Condition | Meaning |
+| --- | --- |
+| `ResourceReady` | The required GPU nodes are provisioned and ready. |
+| `InferenceReady` | The inference StatefulSet has its desired replicas ready. |
+| `BenchmarkCompleted` | The optional post-load throughput benchmark finished (vLLM only). |
+| `WorkspaceSucceeded` | Summary condition: resources and inference are ready. |
+
+When inference is ready (and the benchmark, if enabled, has completed), `status.state` becomes `Ready`.

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -41,7 +41,6 @@ const sidebars = {
             collapsed: false,
             items: [
                 'inference',
-                'multi-node-inference',
                 'model-mirror-streaming',
                 'memory-estimator',
                 'keda-autoscaler-inference',
@@ -95,6 +94,8 @@ const sidebars = {
                 'contributing',
                 'preset-onboarding',
                 'proposals',
+                'workspace',
+                'multi-node-inference',
             ],
         },
     ],


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
- Repurposed `inference.md` to illustrate serving models with InferenceSet (including how to enable base image auto-upgrade)
- Added `workspace.md` to illustrate how `Workspace` CRD works internally.
- Refreshed contents in `multi-node-inference.md`.
- Moved `workspace.md` and `multi-node-inference.md` under `Contributing` since they now mostly contain internal details.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: