### PR TITLE
fix: skip inference config validation when no ConfigMap is specified

### DIFF
--- a/api/v1beta1/inference_config_validation.go
+++ b/api/v1beta1/inference_config_validation.go
@@ -22,13 +22,11 @@ import (
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/klog/v2"
 	"knative.dev/pkg/apis"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kaito-project/kaito/pkg/k8sclient"
 	"github.com/kaito-project/kaito/pkg/model"
-	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/plugin"
 	"github.com/kaito-project/kaito/presets/workspace/models"
 )
@@ -52,13 +50,7 @@ func (w *Workspace) validateInferenceConfig(ctx context.Context) (errs *apis.Fie
 		err    error
 	)
 	if cmName == "" {
-		klog.Infof("Inference config not specified. Using default: %q", DefaultInferenceConfigTemplate)
-		cmName = DefaultInferenceConfigTemplate
-		cmNS, err = utils.GetReleaseNamespace()
-		if err != nil {
-			errs = errs.Also(apis.ErrGeneric(fmt.Sprintf("Failed to determine release namespace: %v", err), "namespace"))
-			return errs
-		}
+		return nil
 	}
 
 	// Check if the ConfigMap exists

--- a/charts/kaito/workspace/templates/inference-params.yaml
+++ b/charts/kaito/workspace/templates/inference-params.yaml
@@ -16,4 +16,4 @@ data:
       # num-scheduler-steps: 1
       # enable-chunked-prefill: false
       # max-model-len: 2048
-      # see https://docs.vllm.ai/en/stable/serving/engine_args.html for more options.
+      # see https://docs.vllm.ai/en/stable/cli/serve/ for more options.

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -1538,11 +1538,12 @@ func validateCreateNode(workspaceObj *kaitov1beta1.Workspace, numOfNode int) {
 func validateInferenceConfig(workspaceObj *kaitov1beta1.Workspace) {
 	By("Checking the inference config exists", func() {
 		Eventually(func() bool {
-			configMap := &corev1.ConfigMap{}
-			configName := kaitov1beta1.DefaultInferenceConfigTemplate
-			if workspaceObj.Inference.Config != "" {
-				configName = workspaceObj.Inference.Config
+			if workspaceObj.Inference.Config == "" {
+				return true
 			}
+			configMap := &corev1.ConfigMap{}
+			configName := workspaceObj.Inference.Config
+
 			err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
 				Namespace: workspaceObj.Namespace,
 				Name:      configName,


### PR DESCRIPTION
## What this PR does

When no inference config ConfigMap is specified in the Workspace CR, the validation webhook previously fell back to a default ConfigMap name and attempted to resolve the release namespace. This could fail in environments where the namespace couldn't be determined, blocking workspace creation unnecessarily.

## Changes

- **api/v1beta1/inference_config_validation.go**: Return early (no error) when `cmName` is empty instead of falling back to the default template and resolving the release namespace. Removes unused imports (`klog`, `utils`).
- **charts/kaito/workspace/templates/inference-params.yaml**: Update vLLM documentation link from deprecated `engine_args` page to current `cli/serve/` page.
- **test/e2e/preset_test.go**: Update `validateInferenceConfig` to skip validation when no config is set, matching the new webhook behavior.

## Why

Users who don't specify an inference config should not be blocked by namespace resolution failures or missing default ConfigMaps. The inference service already handles defaults at runtime.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)