### PR TITLE
feat: expose runtime metadata (engine, engineVersion, quantization) in status

### DIFF
--- a/charts/kaito/workspace/templates/supported-models-configmap.yaml
+++ b/charts/kaito/workspace/templates/supported-models-configmap.yaml
@@ -12,6 +12,9 @@ data:
         type: text-generation
         runtime: tfs
         tag: 0.4.2
+        runtimeVersion:
+          vllm: 0.22.1
+          transformers: 5.6.0
       - name: llama-3.1-8b-instruct
         type: text-generation
         version: https://huggingface.co/meta-llama/Llama-3.1-8B-Instruct/commit/0e9e39f249a16976918f6564b8830bc894c89659

--- a/hack/compare_model_configs.sh
+++ b/hack/compare_model_configs.sh
@@ -96,7 +96,7 @@ extract_configmap_models() {
         found=1; 
         next 
     } 
-    found && /^[[:space:]]*[a-zA-Z]/ && !/^[[:space:]]*models:/ && !/^[[:space:]]*-/ && !/^[[:space:]]*name:/ && !/^[[:space:]]*type:/ && !/^[[:space:]]*version:/ && !/^[[:space:]]*runtime:/ && !/^[[:space:]]*downloadAtRuntime:/ && !/^[[:space:]]*downloadAuthRequired:/ && !/^[[:space:]]*deprecated:/ && !/^[[:space:]]*tag:/ && !/^[[:space:]]*resources:/ && !/^[[:space:]]*instanceType:/ && !/^[[:space:]]*labelSelector:/ && !/^[[:space:]]*preferredInstance:/ { 
+    found && /^[[:space:]]*[a-zA-Z]/ && !/^[[:space:]]*models:/ && !/^[[:space:]]*-/ && !/^[[:space:]]*name:/ && !/^[[:space:]]*type:/ && !/^[[:space:]]*version:/ && !/^[[:space:]]*runtime:/ && !/^[[:space:]]*runtimeVersion:/ && !/^[[:space:]]*vllm:/ && !/^[[:space:]]*transformers:/ && !/^[[:space:]]*downloadAtRuntime:/ && !/^[[:space:]]*downloadAuthRequired:/ && !/^[[:space:]]*deprecated:/ && !/^[[:space:]]*tag:/ && !/^[[:space:]]*resources:/ && !/^[[:space:]]*instanceType:/ && !/^[[:space:]]*labelSelector:/ && !/^[[:space:]]*preferredInstance:/ { 
         found=0 
     } 
     found { 

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -370,6 +370,12 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 		status.ReadyReplicas = readyReplicas
 		// set selector for HPA/VPA
 		status.Selector = fmt.Sprintf("%s=%s", consts.WorkspaceCreatedByInferenceSetLabel, iObj.Name)
+		runtimeName := kaitov1beta1.GetInferenceSetRuntimeName(iObj)
+		var presetName string
+		if iObj.Spec.Template.Inference.Preset != nil {
+			presetName = string(iObj.Spec.Template.Inference.Preset.Name)
+		}
+
 		if kaitov1beta1.ShouldRunInferenceSetBenchmark(iObj) {
 			if hasBenchmarkTPMResult {
 				if status.Performance == nil {
@@ -382,6 +388,7 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 					Description: controllers.BenchmarkDesc,
 					Value:       strconv.FormatFloat(totalTPM, 'f', 2, 64),
 					Unit:        controllers.BenchmarkMetricUnit,
+					Config:      controllers.RuntimeMetadataConfig(runtimeName, presetName),
 				}
 			} else {
 				// No ready replica has a TPM result — clear the TPM key so the profile
@@ -404,6 +411,7 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 				}
 			}
 		}
+
 		return nil
 	}); err != nil {
 		klog.ErrorS(err, "failed to update inferenceset replicas", "inferenceset", klog.KObj(iObj))

--- a/pkg/inferenceset/runtime_metadata_test.go
+++ b/pkg/inferenceset/runtime_metadata_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inferenceset
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/workspace/controllers"
+	"github.com/kaito-project/kaito/pkg/workspace/inference"
+)
+
+// TestInferenceSetRuntimeMetadata verifies that the runtime metadata written into
+// the aggregated benchmark metric's Config resolves the same way the InferenceSet
+// controller populates it, using the InferenceSet's own runtime name.
+func TestInferenceSetRuntimeMetadata(t *testing.T) {
+	iObj := &kaitov1beta1.InferenceSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-inferenceset"},
+		Spec: kaitov1beta1.InferenceSetSpec{
+			Template: kaitov1beta1.InferenceSetTemplate{
+				Inference: kaitov1beta1.InferenceSpec{
+					Preset: &kaitov1beta1.PresetSpec{
+						PresetMeta: kaitov1beta1.PresetMeta{Name: kaitov1beta1.ModelName("base")},
+					},
+				},
+			},
+		},
+	}
+
+	// Mirror the controller: resolve runtime name and preset name, then populate
+	// the aggregated metric's Config.
+	runtimeName := kaitov1beta1.GetInferenceSetRuntimeName(iObj)
+	presetName := string(iObj.Spec.Template.Inference.Preset.Name)
+
+	metric := kaitov1beta1.Metric{
+		Value:  "42",
+		Config: controllers.RuntimeMetadataConfig(runtimeName, presetName),
+	}
+
+	require.NotNil(t, metric.Config)
+	assert.Equal(t, string(runtimeName), metric.Config[controllers.ConfigKeyEngine])
+	assert.Equal(t, inference.GetBaseRuntimeVersion(runtimeName), metric.Config[controllers.ConfigKeyEngineVersion])
+	assert.NotEmpty(t, metric.Config[controllers.ConfigKeyEngineVersion])
+	// base is not quantized.
+	assert.Empty(t, metric.Config[controllers.ConfigKeyQuantization])
+}

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -170,6 +170,23 @@ type Metadata struct {
 	// model's HuggingFace config.json.
 	// +optional
 	QuantBits int `yaml:"quantBits,omitempty"`
+
+	// RuntimeVersion records the inference engine versions baked into the image.
+	// It is primarily meaningful on the "base" model entry and is used to surface
+	// the serving engine version in the workspace/inferenceset status.
+	// +optional
+	RuntimeVersion RuntimeVersion `yaml:"runtimeVersion,omitempty"`
+}
+
+// RuntimeVersion holds the versions of the inference engines shipped in the base image.
+type RuntimeVersion struct {
+	// VLLM is the vLLM engine version (e.g. "0.22.1").
+	// +optional
+	VLLM string `yaml:"vllm,omitempty"`
+
+	// Transformers is the Hugging Face Transformers version (e.g. "5.6.0").
+	// +optional
+	Transformers string `yaml:"transformers,omitempty"`
 }
 
 // Validate checks if the Metadata is valid.

--- a/pkg/workspace/controllers/benchmark.go
+++ b/pkg/workspace/controllers/benchmark.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"maps"
 	"strconv"
 	"strings"
 
@@ -56,6 +57,18 @@ const (
 
 	// BenchmarkMetricUnit is the unit for TPM metrics.
 	BenchmarkMetricUnit = "tokens/min"
+
+	// ConfigKeyEngine is the Metric.Config key for the serving engine name
+	// (e.g. "vllm" or "transformers").
+	ConfigKeyEngine = "engine"
+
+	// ConfigKeyEngineVersion is the Metric.Config key for the serving engine version
+	// (e.g. "0.22.1").
+	ConfigKeyEngineVersion = "engineVersion"
+
+	// ConfigKeyQuantization is the Metric.Config key for the model weight
+	// quantization method (e.g. "awq", "gptq"; empty when not quantized).
+	ConfigKeyQuantization = "quantization"
 )
 
 // benchmarkResultPayload mirrors the JSON emitted by benchmark_entrypoint.py.
@@ -98,7 +111,7 @@ const maxLogReadBytes = 32 << 20 // 32 MiB
 // (exit 0 stops further probe ticks).
 //
 // r is read incrementally; the caller is responsible for closing it.
-func parseBenchmarkResult(r io.Reader) (*kaitov1beta1.Performance, error) {
+func parseBenchmarkResult(r io.Reader, runtimeConfig map[string]string) (*kaitov1beta1.Performance, error) {
 	var lastResultPayload string
 	var lastConfigPayload string
 
@@ -134,21 +147,27 @@ func parseBenchmarkResult(r io.Reader) (*kaitov1beta1.Performance, error) {
 		Metrics: map[string]kaitov1beta1.Metric{},
 	}
 
+	config := map[string]string{}
+	if lastConfigPayload != "" {
+		var cfgPayload benchmarkConfigPayload
+		if err := json.Unmarshal([]byte(lastConfigPayload), &cfgPayload); err == nil {
+			config["durationSec"] = strconv.Itoa(int(cfgPayload.DurationSec))
+			config["inputTokens"] = strconv.Itoa(int(cfgPayload.InputTokens))
+			config["outputTokens"] = strconv.Itoa(int(cfgPayload.OutputTokens))
+			config["maxConcurrency"] = strconv.Itoa(int(cfgPayload.MaxConcurrency))
+		}
+	}
+	// Runtime metadata (engine, engine version, quantization) is recorded as part
+	// of the benchmark metric so external systems can read it.
+	maps.Copy(config, runtimeConfig)
+
 	metric := kaitov1beta1.Metric{
 		Description: BenchmarkDesc,
 		Value:       strconv.FormatFloat(payload.VLLMTotalTPM, 'f', -1, 64),
 		Unit:        BenchmarkMetricUnit,
 	}
-	if lastConfigPayload != "" {
-		var cfgPayload benchmarkConfigPayload
-		if err := json.Unmarshal([]byte(lastConfigPayload), &cfgPayload); err == nil {
-			metric.Config = map[string]string{
-				"durationSec":    strconv.Itoa(int(cfgPayload.DurationSec)),
-				"inputTokens":    strconv.Itoa(int(cfgPayload.InputTokens)),
-				"outputTokens":   strconv.Itoa(int(cfgPayload.OutputTokens)),
-				"maxConcurrency": strconv.Itoa(int(cfgPayload.MaxConcurrency)),
-			}
-		}
+	if len(config) > 0 {
+		metric.Config = config
 	}
 	result.Metrics[BenchmarkMetricPeakTPM] = metric
 	return result, nil
@@ -186,7 +205,13 @@ func reconcileBenchmarkResult(ctx context.Context, wObj *kaitov1beta1.Workspace)
 	}
 	defer stream.Close()
 
-	result, err := parseBenchmarkResult(io.LimitReader(stream, maxLogReadBytes))
+	var presetName string
+	if wObj.Inference != nil && wObj.Inference.Preset != nil {
+		presetName = string(wObj.Inference.Preset.Name)
+	}
+	runtimeConfig := RuntimeMetadataConfig(kaitov1beta1.GetWorkspaceRuntimeName(wObj), presetName)
+
+	result, err := parseBenchmarkResult(io.LimitReader(stream, maxLogReadBytes), runtimeConfig)
 	if err != nil {
 		return nil, fmt.Errorf("pod %s/%s: %w", wObj.Namespace, podName, err)
 	}

--- a/pkg/workspace/controllers/benchmark_test.go
+++ b/pkg/workspace/controllers/benchmark_test.go
@@ -86,7 +86,7 @@ func TestParseBenchmarkResult(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			result, err := parseBenchmarkResult(strings.NewReader(tc.logs))
+			result, err := parseBenchmarkResult(strings.NewReader(tc.logs), nil)
 			if tc.expectErr {
 				assert.Error(t, err)
 				assert.Nil(t, result)
@@ -103,4 +103,43 @@ func TestParseBenchmarkResult(t *testing.T) {
 			assert.Equal(t, tc.expectConfig, m.Config)
 		})
 	}
+}
+
+// TestParseBenchmarkResultMergesRuntimeConfig verifies that the runtime metadata
+// config is recorded in the peak metric alongside any benchmark parameters.
+func TestParseBenchmarkResultMergesRuntimeConfig(t *testing.T) {
+	logs := "KAITO_BENCHMARK_CONFIG 2026-01-01T00:00:00Z {\"duration_sec\":60,\"input_tokens\":2048,\"output_tokens\":256,\"max_concurrency\":523}\n" +
+		"KAITO_BENCHMARK_RESULT 2026-01-01T00:00:02Z {\"vllm_total_tpm\":12345.67,\"ttft_avg_ms\":100,\"tpot_avg_ms\":50}\n"
+	runtimeConfig := map[string]string{
+		ConfigKeyEngine:        "vllm",
+		ConfigKeyEngineVersion: "0.22.1",
+		ConfigKeyQuantization:  "",
+	}
+
+	result, err := parseBenchmarkResult(strings.NewReader(logs), runtimeConfig)
+	require.NoError(t, err)
+
+	m := result.Metrics[BenchmarkMetricPeakTPM]
+	// Benchmark parameters preserved.
+	assert.Equal(t, "60", m.Config["durationSec"])
+	assert.Equal(t, "523", m.Config["maxConcurrency"])
+	// Runtime metadata merged in.
+	assert.Equal(t, "vllm", m.Config[ConfigKeyEngine])
+	assert.Equal(t, "0.22.1", m.Config[ConfigKeyEngineVersion])
+	assert.Equal(t, "", m.Config[ConfigKeyQuantization])
+}
+
+// TestParseBenchmarkResultRuntimeConfigOnly verifies the runtime metadata is
+// recorded even when no KAITO_BENCHMARK_CONFIG line is present.
+func TestParseBenchmarkResultRuntimeConfigOnly(t *testing.T) {
+	logs := "KAITO_BENCHMARK_RESULT 2026-01-01T00:00:00Z {\"vllm_total_tpm\":500,\"ttft_avg_ms\":0,\"tpot_avg_ms\":0}\n"
+	runtimeConfig := map[string]string{ConfigKeyEngine: "transformers", ConfigKeyEngineVersion: "5.6.0"}
+
+	result, err := parseBenchmarkResult(strings.NewReader(logs), runtimeConfig)
+	require.NoError(t, err)
+
+	m := result.Metrics[BenchmarkMetricPeakTPM]
+	assert.Equal(t, "transformers", m.Config[ConfigKeyEngine])
+	assert.Equal(t, "5.6.0", m.Config[ConfigKeyEngineVersion])
+	assert.NotContains(t, m.Config, "durationSec")
 }

--- a/pkg/workspace/controllers/runtime_metadata_test.go
+++ b/pkg/workspace/controllers/runtime_metadata_test.go
@@ -1,0 +1,48 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	pkgmodel "github.com/kaito-project/kaito/pkg/model"
+	"github.com/kaito-project/kaito/pkg/workspace/inference"
+)
+
+func TestRuntimeMetadataConfig(t *testing.T) {
+	t.Run("vllm engine", func(t *testing.T) {
+		cfg := RuntimeMetadataConfig(pkgmodel.RuntimeNameVLLM, "base")
+		require.NotNil(t, cfg)
+		assert.Equal(t, string(pkgmodel.RuntimeNameVLLM), cfg[ConfigKeyEngine])
+		assert.Equal(t, inference.GetBaseRuntimeVersion(pkgmodel.RuntimeNameVLLM), cfg[ConfigKeyEngineVersion])
+		assert.NotEmpty(t, cfg[ConfigKeyEngineVersion])
+		// base is not quantized.
+		assert.Empty(t, cfg[ConfigKeyQuantization])
+	})
+
+	t.Run("transformers engine", func(t *testing.T) {
+		cfg := RuntimeMetadataConfig(pkgmodel.RuntimeNameHuggingfaceTransformers, "base")
+		assert.Equal(t, string(pkgmodel.RuntimeNameHuggingfaceTransformers), cfg[ConfigKeyEngine])
+		assert.Equal(t, inference.GetBaseRuntimeVersion(pkgmodel.RuntimeNameHuggingfaceTransformers), cfg[ConfigKeyEngineVersion])
+		assert.NotEmpty(t, cfg[ConfigKeyEngineVersion])
+	})
+
+	t.Run("unknown preset yields empty quantization", func(t *testing.T) {
+		cfg := RuntimeMetadataConfig(pkgmodel.RuntimeNameVLLM, "does-not-exist")
+		assert.Empty(t, cfg[ConfigKeyQuantization])
+	})
+}

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -631,7 +631,20 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1b
 	existingObj.SetAnnotations(annotations)
 
 	// Update it with the latest one generated above.
-	return c.Update(ctx, existingObj)
+	if err := c.Update(ctx, existingObj); err != nil {
+		return err
+	}
+
+	// After a base image auto-upgrade, clear the recorded benchmark result and reset
+	// the BenchmarkCompleted condition so the post-load benchmark re-runs against the
+	// new image on the next reconcile, re-recording all metrics (including the runtime
+	// metadata such as engineVersion) with fresh values.
+	if baseImageUpgrade {
+		if err := c.resetBenchmarkOnUpgrade(ctx, wObj); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // shouldUpgradeBaseImage checks if an auto-upgrade has been requested via the upgrade label
@@ -995,6 +1008,29 @@ func applyBenchmarkStatus(ctx context.Context, status *kaitov1beta1.WorkspaceSta
 		kaitov1beta1.WorkspaceConditionTypeBenchmarkCompleted, metav1.ConditionTrue,
 		"BenchmarkCompleted", "benchmark result has been recorded")
 	return nil
+}
+
+// resetBenchmarkOnUpgrade clears the recorded benchmark result and removes the
+// BenchmarkCompleted condition, so the post-load benchmark re-runs against the new
+// image on the next reconcile.
+func (c *WorkspaceReconciler) resetBenchmarkOnUpgrade(ctx context.Context, wObj *kaitov1beta1.Workspace) error {
+	return workspace.UpdateWorkspaceStatus(ctx, c.Client, &client.ObjectKey{Name: wObj.Name, Namespace: wObj.Namespace},
+		func(status *kaitov1beta1.WorkspaceStatus) error {
+			status.Performance = nil
+			meta.RemoveStatusCondition(&status.Conditions, string(kaitov1beta1.WorkspaceConditionTypeBenchmarkCompleted))
+			return nil
+		})
+}
+
+// RuntimeMetadataConfig returns the serving runtime metadata (engine, engine
+// version, quantization) as a Metric.Config map, so external systems (e.g. a
+// portal) can read it. Shared by the Workspace and InferenceSet controllers.
+func RuntimeMetadataConfig(runtimeName pkgmodel.RuntimeName, presetName string) map[string]string {
+	return map[string]string{
+		ConfigKeyEngine:        string(runtimeName),
+		ConfigKeyEngineVersion: inference.GetBaseRuntimeVersion(runtimeName),
+		ConfigKeyQuantization:  inference.GetPresetQuantization(presetName),
+	}
 }
 
 func (c *WorkspaceReconciler) updateWorkspaceStatusIfChanged(ctx context.Context, key types.NamespacedName, modifyFn func(*kaitov1beta1.WorkspaceStatus) error) error {

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -442,6 +442,35 @@ func GetBaseImageTag() string {
 	return presetObj.Tag
 }
 
+// GetBaseRuntimeVersion returns the inference engine version baked into the base
+// image for the given runtime, sourced from the base model metadata. It returns
+// an empty string when the runtime is unrecognized or the version is not set.
+func GetBaseRuntimeVersion(runtimeName pkgmodel.RuntimeName) string {
+	rv := metadata.MustGet("base").RuntimeVersion
+	switch runtimeName {
+	case pkgmodel.RuntimeNameVLLM:
+		return rv.VLLM
+	case pkgmodel.RuntimeNameHuggingfaceTransformers:
+		return rv.Transformers
+	default:
+		return ""
+	}
+}
+
+// GetPresetQuantization returns the weight quantization method for a preset model
+// (e.g. "awq", "gptq"). It returns an empty string when the preset name is empty,
+// the model is not in the supported catalog, or the model is not quantized.
+func GetPresetQuantization(presetName string) string {
+	if presetName == "" {
+		return ""
+	}
+	m, ok := metadata.Get(presetName)
+	if !ok {
+		return ""
+	}
+	return m.QuantMethod
+}
+
 func GenerateInferencePodSpec(gpuConfig *sku.GPUConfig, numNodes int, streamingModelPath, streamingLoadFormat string) func(*generator.WorkspaceGeneratorContext, *corev1.PodSpec) error {
 	return func(ctx *generator.WorkspaceGeneratorContext, spec *corev1.PodSpec) error {
 		// additional volume

--- a/pkg/workspace/inference/preset_runtime_metadata_test.go
+++ b/pkg/workspace/inference/preset_runtime_metadata_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package inference
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	pkgmodel "github.com/kaito-project/kaito/pkg/model"
+	metadata "github.com/kaito-project/kaito/presets/workspace/models"
+)
+
+func TestGetBaseRuntimeVersion(t *testing.T) {
+	base := metadata.MustGet("base")
+
+	// The base entry must define both engine versions so the status can surface them.
+	assert.NotEmpty(t, base.RuntimeVersion.VLLM, "base vllm runtime version should be set")
+	assert.NotEmpty(t, base.RuntimeVersion.Transformers, "base transformers runtime version should be set")
+
+	assert.Equal(t, base.RuntimeVersion.VLLM, GetBaseRuntimeVersion(pkgmodel.RuntimeNameVLLM))
+	assert.Equal(t, base.RuntimeVersion.Transformers, GetBaseRuntimeVersion(pkgmodel.RuntimeNameHuggingfaceTransformers))
+	assert.Empty(t, GetBaseRuntimeVersion(pkgmodel.RuntimeName("unknown")))
+}
+
+func TestGetPresetQuantization(t *testing.T) {
+	assert.Empty(t, GetPresetQuantization(""), "empty preset name yields empty quantization")
+	assert.Empty(t, GetPresetQuantization("does-not-exist"), "unknown preset yields empty quantization")
+	// The base model is not quantized.
+	assert.Empty(t, GetPresetQuantization("base"))
+}

--- a/presets/workspace/models/metadata.go
+++ b/presets/workspace/models/metadata.go
@@ -67,3 +67,14 @@ func MustGet(name string) model.Metadata {
 
 	return *(m.(*model.Metadata))
 }
+
+// Get retrieves the model metadata for the given model name. The second return
+// value reports whether the model exists in the supported models catalog.
+func Get(name string) (model.Metadata, bool) {
+	m, ok := supportedModels.Load(name)
+	if !ok {
+		return model.Metadata{}, false
+	}
+
+	return *(m.(*model.Metadata)), true
+}

--- a/presets/workspace/models/supported_models.yaml
+++ b/presets/workspace/models/supported_models.yaml
@@ -4,6 +4,9 @@ models:
     type: text-generation
     runtime: tfs
     tag: 0.4.2
+    runtimeVersion:
+      vllm: 0.22.1
+      transformers: 5.6.0
     # Tag history:
     # 0.4.2 - add runai-model-streamer for model streaming from cloud blob storage, add KAITO_PROCESSOR benchmark support
     # 0.4.1 - pass trust_remote_code=true to GuideLLM benchmark


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Surface serving runtime metadata on Workspace and InferenceSet status so
external systems (e.g. a portal) can read it. The values are recorded in the
Config map of the peak-TPM benchmark metric rather than as new metric keys or
schema fields:

  performance.metrics.peakTokensPerMinute.config:
    engine:        vllm | transformers
    engineVersion: e.g. 0.22.1 (vLLM) / 5.6.0 (transformers)
    quantization:  e.g. awq / gptq (empty when not quantized)

Details:
- Add a runtimeVersion (vllm/transformers) block to the base model entry and a
  RuntimeVersion type/field on model.Metadata; mirror it in the Helm
  supported-models ConfigMap and teach hack/compare_model_configs.sh the new keys.
- Add inference.GetBaseRuntimeVersion and inference.GetPresetQuantization helpers
  plus a non-panic metadata.Get accessor, wrapped by controllers.RuntimeMetadataConfig.
- Workspace: the runtime metadata is built as part of the benchmark metric in
  parseBenchmarkResult. On a base image auto-upgrade the recorded result and the
  BenchmarkCompleted condition are cleared, so the benchmark re-runs against the
  new image and re-records the metric with a refreshed engineVersion.
- InferenceSet: the aggregated peak metric is created with the same runtime
  metadata Config via controllers.RuntimeMetadataConfig.


**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: