### PR TITLE
fix: make InferenceSet instanceType optional for BYO node provisioner

### DIFF
--- a/api/v1alpha1/inferenceset_types.go
+++ b/api/v1alpha1/inferenceset_types.go
@@ -22,8 +22,10 @@ import (
 
 type InferenceSetResourceSpec struct {
 	// InstanceType specifies the GPU node SKU.
-	// +required
-	InstanceType string `json:"instanceType"`
+	// This field is required when node auto-provisioning is enabled.
+	// This field must be empty when node auto-provisioning is disabled (BYO scenario).
+	// +optional
+	InstanceType string `json:"instanceType,omitempty"`
 }
 
 // InferenceSetTemplate defines the template for creating InferenceSet instances.

--- a/api/v1alpha1/inferenceset_validation.go
+++ b/api/v1alpha1/inferenceset_validation.go
@@ -23,6 +23,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 	"knative.dev/pkg/apis"
+
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func (is *InferenceSet) SupportedVerbs() []admissionregistrationv1.OperationType {
@@ -56,6 +58,7 @@ func (is *InferenceSet) validateCreate() (errs *apis.FieldError) {
 	if is.Spec.Replicas != nil && *is.Spec.Replicas < 0 {
 		errs = errs.Also(apis.ErrInvalidValue(*is.Spec.Replicas, "replicas", "must be non-negative"))
 	}
+	errs = errs.Also(is.validateInstanceType().ViaField("template"))
 	errs = errs.Also(validateMaintenanceWindow(is.Spec.AutoUpgrade))
 	return errs
 }
@@ -81,6 +84,23 @@ func validateMaintenanceWindow(autoUpgrade *AutoUpgradePolicy) (errs *apis.Field
 	if window.Duration != nil && window.Duration.Duration <= 0 {
 		errs = errs.Also(apis.ErrInvalidValue(window.Duration.Duration.String(), "autoUpgrade.maintenanceWindow.duration",
 			"must be a positive duration"))
+	}
+	return errs
+}
+
+// validateInstanceType ensures instanceType is set when node auto-provisioning
+// is enabled, and is empty when using BYO (Bring Your Own) nodes.
+func (is *InferenceSet) validateInstanceType() (errs *apis.FieldError) {
+	instanceType := is.Spec.Template.Resource.InstanceType
+	if consts.ActiveNodeProvisioner == consts.NodeProvisionerBYO {
+		if instanceType != "" {
+			errs = errs.Also(apis.ErrInvalidValue(instanceType, "resource.instanceType",
+				"instanceType must be empty when nodeProvisioner is byo"))
+		}
+	} else {
+		if instanceType == "" {
+			errs = errs.Also(apis.ErrMissingField("resource.instanceType"))
+		}
 	}
 	return errs
 }

--- a/api/v1alpha1/inferenceset_validation.go
+++ b/api/v1alpha1/inferenceset_validation.go
@@ -64,6 +64,7 @@ func (is *InferenceSet) validateCreate() (errs *apis.FieldError) {
 }
 
 func (is *InferenceSet) validateUpdate(_ *InferenceSet) (errs *apis.FieldError) {
+	errs = errs.Also(is.validateInstanceType().ViaField("template"))
 	errs = errs.Also(validateMaintenanceWindow(is.Spec.AutoUpgrade))
 	return errs
 }

--- a/api/v1alpha1/inferenceset_validation.go
+++ b/api/v1alpha1/inferenceset_validation.go
@@ -18,13 +18,13 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kaito-project/kaito/pkg/utils/consts"
-
 	"github.com/robfig/cron/v3"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 	"knative.dev/pkg/apis"
+
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func (is *InferenceSet) SupportedVerbs() []admissionregistrationv1.OperationType {

--- a/api/v1alpha1/inferenceset_validation.go
+++ b/api/v1alpha1/inferenceset_validation.go
@@ -18,13 +18,13 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kaito-project/kaito/pkg/utils/consts"
+
 	"github.com/robfig/cron/v3"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 	"knative.dev/pkg/apis"
-
-	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func (is *InferenceSet) SupportedVerbs() []admissionregistrationv1.OperationType {

--- a/api/v1alpha1/inferenceset_validation.go
+++ b/api/v1alpha1/inferenceset_validation.go
@@ -92,15 +92,20 @@ func validateMaintenanceWindow(autoUpgrade *AutoUpgradePolicy) (errs *apis.Field
 // is enabled, and is empty when using BYO (Bring Your Own) nodes.
 func (is *InferenceSet) validateInstanceType() (errs *apis.FieldError) {
 	instanceType := is.Spec.Template.Resource.InstanceType
-	if consts.ActiveNodeProvisioner == consts.NodeProvisionerBYO {
+	switch consts.ActiveNodeProvisioner {
+	case consts.NodeProvisionerBYO:
+		// BYO mode: instanceType must be empty.
 		if instanceType != "" {
 			errs = errs.Also(apis.ErrInvalidValue(instanceType, "resource.instanceType",
 				"instanceType must be empty when nodeProvisioner is byo"))
 		}
-	} else {
+	case consts.NodeProvisionerKarpenter, consts.NodeProvisionerAzureGPU:
+		// Auto-provisioning modes: instanceType is required.
 		if instanceType == "" {
 			errs = errs.Also(apis.ErrMissingField("resource.instanceType"))
 		}
+	default:
+		// Unknown or unset provisioner: no validation (backward compat).
 	}
 	return errs
 }

--- a/api/v1alpha1/inferenceset_validation_test.go
+++ b/api/v1alpha1/inferenceset_validation_test.go
@@ -21,6 +21,8 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func TestInferenceSet_SupportedVerbs(t *testing.T) {
@@ -397,6 +399,96 @@ func TestValidateMaintenanceWindow(t *testing.T) {
 				assert.NotNil(t, err)
 				if tt.errMsg != "" {
 					assert.Contains(t, err.Error(), tt.errMsg)
+				}
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
+}
+
+func TestInferenceSet_validateInstanceType(t *testing.T) {
+	tests := []struct {
+		name             string
+		nodeProvisioner  string
+		instanceType     string
+		wantErr          bool
+		errField         string
+	}{
+		{
+			name:            "BYO mode with empty instanceType - valid",
+			nodeProvisioner: consts.NodeProvisionerBYO,
+			instanceType:    "",
+			wantErr:         false,
+		},
+		{
+			name:            "BYO mode with instanceType set - invalid",
+			nodeProvisioner: consts.NodeProvisionerBYO,
+			instanceType:    "Standard_NC6s_v3",
+			wantErr:         true,
+			errField:        "resource.instanceType",
+		},
+		{
+			name:            "Karpenter mode with instanceType set - valid",
+			nodeProvisioner: consts.NodeProvisionerKarpenter,
+			instanceType:    "Standard_NC6s_v3",
+			wantErr:         false,
+		},
+		{
+			name:            "Karpenter mode with empty instanceType - invalid",
+			nodeProvisioner: consts.NodeProvisionerKarpenter,
+			instanceType:    "",
+			wantErr:         true,
+			errField:        "resource.instanceType",
+		},
+		{
+			name:            "AzureGPU mode with instanceType set - valid",
+			nodeProvisioner: consts.NodeProvisionerAzureGPU,
+			instanceType:    "Standard_NC6s_v3",
+			wantErr:         false,
+		},
+		{
+			name:            "AzureGPU mode with empty instanceType - invalid",
+			nodeProvisioner: consts.NodeProvisionerAzureGPU,
+			instanceType:    "",
+			wantErr:         true,
+			errField:        "resource.instanceType",
+		},
+		{
+			name:            "Unknown provisioner with instanceType - no error",
+			nodeProvisioner: "",
+			instanceType:    "Standard_NC6s_v3",
+			wantErr:         false,
+		},
+		{
+			name:            "Unknown provisioner without instanceType - no error",
+			nodeProvisioner: "",
+			instanceType:    "",
+			wantErr:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save and restore global state
+			orig := consts.ActiveNodeProvisioner
+			consts.ActiveNodeProvisioner = tt.nodeProvisioner
+			defer func() { consts.ActiveNodeProvisioner = orig }()
+
+			is := &InferenceSet{
+				Spec: InferenceSetSpec{
+					Template: InferenceSetTemplate{
+						Resource: InferenceSetResourceSpec{
+							InstanceType: tt.instanceType,
+						},
+					},
+				},
+			}
+			err := is.validateInstanceType()
+			if tt.wantErr {
+				assert.NotNil(t, err)
+				if tt.errField != "" {
+					assert.Contains(t, err.Error(), tt.errField)
 				}
 			} else {
 				assert.Nil(t, err)

--- a/api/v1alpha1/inferenceset_validation_test.go
+++ b/api/v1alpha1/inferenceset_validation_test.go
@@ -409,11 +409,11 @@ func TestValidateMaintenanceWindow(t *testing.T) {
 
 func TestInferenceSet_validateInstanceType(t *testing.T) {
 	tests := []struct {
-		name             string
-		nodeProvisioner  string
-		instanceType     string
-		wantErr          bool
-		errField         string
+		name            string
+		nodeProvisioner string
+		instanceType    string
+		wantErr         bool
+		errField        string
 	}{
 		{
 			name:            "BYO mode with empty instanceType - valid",

--- a/api/v1alpha1/inferenceset_validation_test.go
+++ b/api/v1alpha1/inferenceset_validation_test.go
@@ -17,12 +17,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/kaito-project/kaito/pkg/utils/consts"
+
 	"github.com/stretchr/testify/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
-
-	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func TestInferenceSet_SupportedVerbs(t *testing.T) {

--- a/api/v1alpha1/inferenceset_validation_test.go
+++ b/api/v1alpha1/inferenceset_validation_test.go
@@ -17,12 +17,12 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kaito-project/kaito/pkg/utils/consts"
-
 	"github.com/stretchr/testify/assert"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func TestInferenceSet_SupportedVerbs(t *testing.T) {

--- a/api/v1alpha1/multiroleinference_types.go
+++ b/api/v1alpha1/multiroleinference_types.go
@@ -59,8 +59,10 @@ type MultiRoleInferenceRoleSpec struct {
 
 	// InstanceType specifies the GPU node SKU for this role.
 	// Different roles may use different instance types (e.g., larger GPU for prefill).
-	// +required
-	InstanceType string `json:"instanceType"`
+	// This field is required when node auto-provisioning is enabled.
+	// This field must be empty when node auto-provisioning is disabled (BYO scenario).
+	// +optional
+	InstanceType string `json:"instanceType,omitempty"`
 
 	// RuntimeConfig references a ConfigMap with role-specific vLLM runtime arguments.
 	// These override or extend the default inference parameters for this role.

--- a/api/v1alpha1/multiroleinference_validation.go
+++ b/api/v1alpha1/multiroleinference_validation.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 	"knative.dev/pkg/apis"
+
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func (m *MultiRoleInference) SupportedVerbs() []admissionregistrationv1.OperationType {
@@ -118,9 +120,19 @@ func (m *MultiRoleInference) validateRoles() (errs *apis.FieldError) {
 			))
 		}
 
-		// Validate instanceType is not empty.
-		if role.InstanceType == "" {
-			errs = errs.Also(apis.ErrMissingField(field + ".instanceType"))
+		// Validate instanceType based on active node provisioner.
+		switch consts.ActiveNodeProvisioner {
+		case consts.NodeProvisionerBYO:
+			if role.InstanceType != "" {
+				errs = errs.Also(apis.ErrInvalidValue(role.InstanceType, field+".instanceType",
+					"instanceType must be empty when nodeProvisioner is byo"))
+			}
+		case consts.NodeProvisionerKarpenter, consts.NodeProvisionerAzureGPU:
+			if role.InstanceType == "" {
+				errs = errs.Also(apis.ErrMissingField(field + ".instanceType"))
+			}
+		default:
+			// Unknown or unset provisioner: no validation (backward compat).
 		}
 
 		// Validate replicas >= 1 when specified (nil means autoscaling).

--- a/api/v1alpha1/multiroleinference_validation_test.go
+++ b/api/v1alpha1/multiroleinference_validation_test.go
@@ -21,6 +21,8 @@ import (
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
+
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func int32Ptr(v int32) *int32 { return &v }
@@ -79,6 +81,11 @@ func TestMultiRoleInference_SetDefaults(t *testing.T) {
 }
 
 func TestMultiRoleInference_Validate(t *testing.T) {
+	// Existing tests assume the default (required) behavior for instanceType,
+	// which corresponds to auto-provisioning (Karpenter/AzureGPU).
+	orig := consts.ActiveNodeProvisioner
+	consts.ActiveNodeProvisioner = consts.NodeProvisionerKarpenter
+	defer func() { consts.ActiveNodeProvisioner = orig }()
 	validMRI := func() *MultiRoleInference {
 		return &MultiRoleInference{
 			ObjectMeta: metav1.ObjectMeta{
@@ -195,6 +202,11 @@ func TestMultiRoleInference_Validate(t *testing.T) {
 }
 
 func TestMultiRoleInference_validateUpdate(t *testing.T) {
+	// Existing tests assume the default (required) behavior for instanceType,
+	// which corresponds to auto-provisioning (Karpenter/AzureGPU).
+	orig := consts.ActiveNodeProvisioner
+	consts.ActiveNodeProvisioner = consts.NodeProvisionerKarpenter
+	defer func() { consts.ActiveNodeProvisioner = orig }()
 	validMRI := func() *MultiRoleInference {
 		return &MultiRoleInference{
 			ObjectMeta: metav1.ObjectMeta{

--- a/api/v1beta1/inferenceset_validation.go
+++ b/api/v1beta1/inferenceset_validation.go
@@ -24,6 +24,8 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 	"knative.dev/pkg/apis"
+
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func (is *InferenceSet) SupportedVerbs() []admissionregistrationv1.OperationType {
@@ -56,11 +58,13 @@ func (is *InferenceSet) validateCreate() (errs *apis.FieldError) {
 	if is.Spec.Replicas != nil && *is.Spec.Replicas < 0 {
 		errs = errs.Also(apis.ErrInvalidValue(*is.Spec.Replicas, "replicas", "must be non-negative"))
 	}
+	errs = errs.Also(is.validateInstanceType().ViaField("template"))
 	errs = errs.Also(validateInferenceSetMaintenanceWindow(is.Spec.AutoUpgrade))
 	return errs
 }
 
 func (is *InferenceSet) validateUpdate(old *InferenceSet) (errs *apis.FieldError) {
+	errs = errs.Also(is.validateInstanceType().ViaField("template"))
 	errs = errs.Also(validateInferenceSetMaintenanceWindow(is.Spec.AutoUpgrade))
 	// Partition config is immutable once set.
 	if !apiequality.Semantic.DeepEqual(is.Spec.Template.Resource.Partition, old.Spec.Template.Resource.Partition) {
@@ -85,6 +89,28 @@ func validateInferenceSetMaintenanceWindow(autoUpgrade *AutoUpgradePolicy) (errs
 	if window.Duration != nil && window.Duration.Duration <= 0 {
 		errs = errs.Also(apis.ErrInvalidValue(window.Duration.Duration.String(), "autoUpgrade.maintenanceWindow.duration",
 			"must be a positive duration"))
+	}
+	return errs
+}
+
+// validateInstanceType ensures instanceType is set when node auto-provisioning
+// is enabled, and is empty when using BYO (Bring Your Own) nodes.
+func (is *InferenceSet) validateInstanceType() (errs *apis.FieldError) {
+	instanceType := is.Spec.Template.Resource.InstanceType
+	switch consts.ActiveNodeProvisioner {
+	case consts.NodeProvisionerBYO:
+		// BYO mode: instanceType must be empty.
+		if instanceType != "" {
+			errs = errs.Also(apis.ErrInvalidValue(instanceType, "resource.instanceType",
+				"instanceType must be empty when nodeProvisioner is byo"))
+		}
+	case consts.NodeProvisionerKarpenter, consts.NodeProvisionerAzureGPU:
+		// Auto-provisioning modes: instanceType is required.
+		if instanceType == "" {
+			errs = errs.Also(apis.ErrMissingField("resource.instanceType"))
+		}
+	default:
+		// Unknown or unset provisioner: no validation (backward compat).
 	}
 	return errs
 }

--- a/api/v1beta1/inferenceset_validation.go
+++ b/api/v1beta1/inferenceset_validation.go
@@ -18,14 +18,14 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kaito-project/kaito/pkg/utils/consts"
-
 	"github.com/robfig/cron/v3"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 	"knative.dev/pkg/apis"
+
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func (is *InferenceSet) SupportedVerbs() []admissionregistrationv1.OperationType {

--- a/api/v1beta1/inferenceset_validation.go
+++ b/api/v1beta1/inferenceset_validation.go
@@ -18,14 +18,14 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kaito-project/kaito/pkg/utils/consts"
+
 	"github.com/robfig/cron/v3"
 	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/util/validation"
 	"k8s.io/klog/v2"
 	"knative.dev/pkg/apis"
-
-	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func (is *InferenceSet) SupportedVerbs() []admissionregistrationv1.OperationType {

--- a/api/v1beta1/inferenceset_validation_test.go
+++ b/api/v1beta1/inferenceset_validation_test.go
@@ -19,6 +19,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func TestInferenceSetValidate(t *testing.T) {
@@ -98,4 +100,93 @@ func TestInferenceSetMIGImmutable(t *testing.T) {
 	errs = makeIS("1g.10gb").validateUpdate(makeIS(""))
 	assert.NotNil(t, errs)
 	assert.Contains(t, errs.Error(), "field is immutable")
+}
+
+func TestInferenceSet_validateInstanceType(t *testing.T) {
+	tests := []struct {
+		name            string
+		nodeProvisioner string
+		instanceType    string
+		wantErr         bool
+		errField        string
+	}{
+		{
+			name:            "BYO mode with empty instanceType - valid",
+			nodeProvisioner: consts.NodeProvisionerBYO,
+			instanceType:    "",
+			wantErr:         false,
+		},
+		{
+			name:            "BYO mode with instanceType set - invalid",
+			nodeProvisioner: consts.NodeProvisionerBYO,
+			instanceType:    "Standard_NC6s_v3",
+			wantErr:         true,
+			errField:        "resource.instanceType",
+		},
+		{
+			name:            "Karpenter mode with instanceType set - valid",
+			nodeProvisioner: consts.NodeProvisionerKarpenter,
+			instanceType:    "Standard_NC6s_v3",
+			wantErr:         false,
+		},
+		{
+			name:            "Karpenter mode with empty instanceType - invalid",
+			nodeProvisioner: consts.NodeProvisionerKarpenter,
+			instanceType:    "",
+			wantErr:         true,
+			errField:        "resource.instanceType",
+		},
+		{
+			name:            "AzureGPU mode with instanceType set - valid",
+			nodeProvisioner: consts.NodeProvisionerAzureGPU,
+			instanceType:    "Standard_NC6s_v3",
+			wantErr:         false,
+		},
+		{
+			name:            "AzureGPU mode with empty instanceType - invalid",
+			nodeProvisioner: consts.NodeProvisionerAzureGPU,
+			instanceType:    "",
+			wantErr:         true,
+			errField:        "resource.instanceType",
+		},
+		{
+			name:            "Unknown provisioner with instanceType - no error",
+			nodeProvisioner: "",
+			instanceType:    "Standard_NC6s_v3",
+			wantErr:         false,
+		},
+		{
+			name:            "Unknown provisioner without instanceType - no error",
+			nodeProvisioner: "",
+			instanceType:    "",
+			wantErr:         false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := consts.ActiveNodeProvisioner
+			consts.ActiveNodeProvisioner = tt.nodeProvisioner
+			defer func() { consts.ActiveNodeProvisioner = orig }()
+
+			is := &InferenceSet{
+				Spec: InferenceSetSpec{
+					Template: InferenceSetTemplate{
+						Resource: InferenceSetResourceSpec{
+							InstanceType: tt.instanceType,
+						},
+					},
+				},
+			}
+			err := is.validateInstanceType()
+			if tt.wantErr {
+				assert.NotNil(t, err)
+				if tt.errField != "" {
+					assert.Contains(t, err.Error(), tt.errField)
+				}
+			} else {
+				assert.Nil(t, err)
+			}
+		})
+	}
 }

--- a/api/v1beta1/inferenceset_validation_test.go
+++ b/api/v1beta1/inferenceset_validation_test.go
@@ -17,10 +17,10 @@ import (
 	"context"
 	"testing"
 
-	"github.com/kaito-project/kaito/pkg/utils/consts"
-
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func TestInferenceSetValidate(t *testing.T) {

--- a/api/v1beta1/inferenceset_validation_test.go
+++ b/api/v1beta1/inferenceset_validation_test.go
@@ -17,10 +17,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/kaito-project/kaito/pkg/utils/consts"
+
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
 func TestInferenceSetValidate(t *testing.T) {

--- a/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
+++ b/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
@@ -263,10 +263,11 @@ spec:
                   resource:
                     properties:
                       instanceType:
-                        description: InstanceType specifies the GPU node SKU.
+                        description: |-
+                          InstanceType specifies the GPU node SKU.
+                          This field is required when node auto-provisioning is enabled.
+                          This field must be empty when node auto-provisioning is disabled (BYO scenario).
                         type: string
-                    required:
-                    - instanceType
                     type: object
                 required:
                 - inference

--- a/charts/kaito/workspace/templates/kaito.sh_multiroleinferences.yaml
+++ b/charts/kaito/workspace/templates/kaito.sh_multiroleinferences.yaml
@@ -146,6 +146,8 @@ spec:
                       description: |-
                         InstanceType specifies the GPU node SKU for this role.
                         Different roles may use different instance types (e.g., larger GPU for prefill).
+                        This field is required when node auto-provisioning is enabled.
+                        This field must be empty when node auto-provisioning is disabled (BYO scenario).
                       type: string
                     replicas:
                       default: 1
@@ -168,7 +170,6 @@ spec:
                       - decode
                       type: string
                   required:
-                  - instanceType
                   - type
                   type: object
                 maxItems: 2

--- a/config/crd/bases/kaito.sh_inferencesets.yaml
+++ b/config/crd/bases/kaito.sh_inferencesets.yaml
@@ -263,10 +263,11 @@ spec:
                   resource:
                     properties:
                       instanceType:
-                        description: InstanceType specifies the GPU node SKU.
+                        description: |-
+                          InstanceType specifies the GPU node SKU.
+                          This field is required when node auto-provisioning is enabled.
+                          This field must be empty when node auto-provisioning is disabled (BYO scenario).
                         type: string
-                    required:
-                    - instanceType
                     type: object
                 required:
                 - inference

--- a/config/crd/bases/kaito.sh_multiroleinferences.yaml
+++ b/config/crd/bases/kaito.sh_multiroleinferences.yaml
@@ -147,6 +147,8 @@ spec:
                       description: |-
                         InstanceType specifies the GPU node SKU for this role.
                         Different roles may use different instance types (e.g., larger GPU for prefill).
+                        This field is required when node auto-provisioning is enabled.
+                        This field must be empty when node auto-provisioning is disabled (BYO scenario).
                       type: string
                     replicas:
                       description: |-
@@ -170,7 +172,6 @@ spec:
                       - decode
                       type: string
                   required:
-                  - instanceType
                   - type
                   type: object
                 maxItems: 2

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -321,9 +321,13 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 				*metav1.NewControllerRef(iObj, kaitov1beta1.GroupVersion.WithKind("InferenceSet")),
 			}
 			workspaceObj.Resource = kaitov1beta1.ResourceSpec{
-				InstanceType:  iObj.Spec.Template.Resource.InstanceType,
 				LabelSelector: iObj.Spec.Selector,
 				Partition:     iObj.Spec.Template.Resource.Partition,
+			}
+			// Only set InstanceType when node auto-provisioning is enabled.
+			// In BYO mode, the Workspace webhook rejects instanceType.
+			if consts.ActiveNodeProvisioner != consts.NodeProvisionerBYO {
+				workspaceObj.Resource.InstanceType = iObj.Spec.Template.Resource.InstanceType
 			}
 			workspaceObj.Inference = &iObj.Spec.Template.Inference
 


### PR DESCRIPTION
## Problem

When using `nodeProvisioner: byo` (Bring Your Own nodes), users hit an impossible contradiction:
- The InferenceSet CRD schema **requires** `spec.template.resource.instanceType`
- The Workspace admission webhook **rejects** workspaces with `instanceType` set in BYO mode

This means BYO users cannot create InferenceSets at all.

## Fix

1. **CRD (api/v1alpha1/inferenceset_types.go):** Changed `instanceType` from `+required` to `+optional` with `omitempty`, matching the Workspace CRD pattern.

2. **Webhook validation (api/v1alpha1/inferenceset_validation.go):** Added `validateInstanceType()` that:
   - Rejects `instanceType` when `nodeProvisioner=byo` (consistent with Workspace webhook)
   - Requires `instanceType` when auto-provisioning is enabled (preserves existing behavior)

3. **Controller (pkg/inferenceset/inferenceset_controller.go):** Only sets `InstanceType` on the generated Workspace when `nodeProvisioner != byo`, preventing the Workspace webhook rejection.

## Related

- Fixes #2181
- Related to #1974 (added --node-provisioner parameter)
- Related to #2176 (refactoring to drop disableNodeAutoProvisioning gate)

## Testing

- BYO mode: InferenceSet can be created without `instanceType`, and generated Workspace omits it
- Auto-provisioning mode: `instanceType` is still required (no behavior change)