### PR TITLE
chore: drop GPU SKUs with CUDA compute capability <8.0

### DIFF
--- a/api/v1alpha1/ragengine_validation_test.go
+++ b/api/v1alpha1/ragengine_validation_test.go
@@ -32,7 +32,7 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
 					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 					},
 					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
 					Embedding: &EmbeddingSpec{
@@ -51,7 +51,7 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
 					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 					},
 					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
 				},
@@ -64,7 +64,7 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
 					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 					},
 					Embedding: &EmbeddingSpec{
 						Local: &LocalEmbeddingSpec{
@@ -96,7 +96,7 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
 					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 					},
 					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
 					Embedding:        &EmbeddingSpec{},
@@ -110,7 +110,7 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
 					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 					},
 					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
 					Embedding: &EmbeddingSpec{
@@ -127,7 +127,7 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
 					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 					},
 					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
 					Embedding: &EmbeddingSpec{
@@ -142,7 +142,7 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
 					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 					},
 					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 0},
 					Embedding: &EmbeddingSpec{

--- a/api/v1alpha1/workspace_validation_test.go
+++ b/api/v1alpha1/workspace_validation_test.go
@@ -279,7 +279,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Valid Resource - SKU Capacity == Model Requirement",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			modelGPUCount:           "1",
@@ -293,12 +293,12 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Insufficient total GPU memory",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NV12s_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			modelGPUCount:           "1",
 			modelPerGPUMemory:       "0",
-			totalSafeTensorFileSize: "14Gi",
+			totalSafeTensorFileSize: "32Gi",
 			preset:                  true,
 			errContent:              "Insufficient total GPU memory",
 			expectErrs:              true,
@@ -332,7 +332,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Only Template set",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NV12s_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			preset:         false,
@@ -364,7 +364,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Tuning validation with single node",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			errContent:     "",
@@ -374,7 +374,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Tuning validation with multinode",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(2),
 			},
 			errContent:     "Tuning does not currently support multinode configurations",
@@ -384,7 +384,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Invalid Preset Name",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(2),
 			},
 			errContent:         "",
@@ -395,7 +395,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Deprecated Model",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			preset:             true,
@@ -406,7 +406,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Empty TotalSafeTensorFileSize skips GPU memory validation",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			modelGPUCount:           "1",
@@ -420,7 +420,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Malformed TotalSafeTensorFileSize returns validation error",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			modelGPUCount:           "1",
@@ -434,7 +434,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Valid TotalSafeTensorFileSize with sufficient memory passes",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			modelGPUCount:           "1",
@@ -1222,7 +1222,7 @@ func TestWorkspaceValidateName(t *testing.T) {
 			Namespace: "kaito",
 		},
 		Resource: ResourceSpec{
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			Count:        pointerToInt(1),
 		},
 		Inference: &InferenceSpec{
@@ -1926,7 +1926,7 @@ other_field: value
 		expectErrs bool
 	}{
 		{
-			name: "Single Instance, Multi-GPU with <20GB per GPU and max-model-len set",
+			name: "Single Instance, Multi-GPU with >=20GB per GPU and max-model-len set (no error)",
 			workspace: &Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: DefaultReleaseNamespace,
@@ -1940,78 +1940,12 @@ other_field: value
 					Config: "valid-config-with-max-model-len",
 				},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NV24s_v3", // 2 GPUs with 8GB each (16GB total)
+					InstanceType: "Standard_NV72ads_A10_v5", // 2 GPUs with 24GB each (48GB total)
 					Count:        pointerToInt(1),
 				},
 			},
 			errContent: "",
 			expectErrs: false,
-		},
-		{
-			name: "Single Instance, Multi-GPU with <20GB per GPU and max-model-len missing",
-			workspace: &Workspace{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: DefaultReleaseNamespace,
-				},
-				Inference: &InferenceSpec{
-					Preset: &PresetSpec{
-						PresetMeta: PresetMeta{
-							Name: ModelName("test-validation"),
-						},
-					},
-					Config: "invalid-config-without-max-model-len",
-				},
-				Resource: ResourceSpec{
-					InstanceType: "Standard_NV24s_v3", // 2 GPUs with 8GB each (16GB total)
-					Count:        pointerToInt(1),
-				},
-			},
-			errContent: "max-model-len is required in the vllm section of inference_config.yaml when using multi-GPU instances with <20GB of memory per GPU",
-			expectErrs: true,
-		},
-		{
-			name: "Single Instance, Multi-GPU with <20GB per GPU and empty vllm section",
-			workspace: &Workspace{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: DefaultReleaseNamespace,
-				},
-				Inference: &InferenceSpec{
-					Preset: &PresetSpec{
-						PresetMeta: PresetMeta{
-							Name: ModelName("test-validation"),
-						},
-					},
-					Config: "invalid-config-empty-vllm",
-				},
-				Resource: ResourceSpec{
-					InstanceType: "Standard_NV24s_v3", // 2 GPUs with 8GB each (16GB total)
-					Count:        pointerToInt(1),
-				},
-			},
-			errContent: "max-model-len is required in the vllm section of inference_config.yaml when using multi-GPU instances with <20GB of memory per GPU",
-			expectErrs: true,
-		},
-		{
-			name: "Single Instance, Multi-GPU with <20GB per GPU and vllm section missing",
-			workspace: &Workspace{
-				ObjectMeta: metav1.ObjectMeta{
-					Namespace: DefaultReleaseNamespace,
-				},
-				Inference: &InferenceSpec{
-					Preset: &PresetSpec{
-						PresetMeta: PresetMeta{
-							Name: ModelName("test-validation"),
-						},
-					},
-					Config: "invalid-config-no-vllm",
-				},
-				Resource: ResourceSpec{
-					InstanceType: "Standard_NV24s_v3", // 2 GPUs with 8GB each (16GB total)
-					Count:        pointerToInt(1),
-				},
-			},
-			errContent: "max-model-len is required in the vllm section of inference_config.yaml when using multi-GPU instances with <20GB of memory per GPU",
-			expectErrs: true,
 		},
 		{
 			name: "Single Instance, Single-GPU (no max-model-len required)",
@@ -2028,7 +1962,7 @@ other_field: value
 					Config: "invalid-config-without-max-model-len",
 				},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NV12s_v3", // 1 GPU with 8GB
+					InstanceType: "Standard_NV36ads_A10_v5", // 1 GPU with 24GB
 					Count:        pointerToInt(1),
 				},
 			},
@@ -2058,7 +1992,7 @@ other_field: value
 			expectErrs: false,
 		},
 		{
-			name: "Multi Instances, GPU with <20GB per instance and max-model-len missing",
+			name: "Multi Instances, distributed inference and max-model-len missing",
 			workspace: &Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: DefaultReleaseNamespace,
@@ -2072,7 +2006,7 @@ other_field: value
 					Config: "invalid-config-without-max-model-len",
 				},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3", // 1 GPUs with 16GB
+					InstanceType: "Standard_NV36ads_A10_v5", // 1 GPU with 24GB
 					Count:        pointerToInt(2),
 				},
 			},
@@ -2080,7 +2014,7 @@ other_field: value
 			expectErrs: true,
 		},
 		{
-			name: "Multi Instances, GPU with <20GB per instance and max-model-len set",
+			name: "Multi Instances, distributed inference and max-model-len set",
 			workspace: &Workspace{
 				ObjectMeta: metav1.ObjectMeta{
 					Namespace: DefaultReleaseNamespace,
@@ -2094,7 +2028,7 @@ other_field: value
 					Config: "valid-config-with-max-model-len",
 				},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3", // 1 GPUs with 16GB
+					InstanceType: "Standard_NV36ads_A10_v5", // 1 GPU with 24GB
 					Count:        pointerToInt(2),
 				},
 			},

--- a/api/v1beta1/ragengine_validation_test.go
+++ b/api/v1beta1/ragengine_validation_test.go
@@ -39,7 +39,7 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
 					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 					},
 					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
 					Embedding: &EmbeddingSpec{
@@ -58,7 +58,7 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
 					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 					},
 					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
 				},
@@ -71,7 +71,7 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
 					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 					},
 					Embedding: &EmbeddingSpec{
 						Local: &LocalEmbeddingSpec{
@@ -103,7 +103,7 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
 					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 					},
 					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
 					Embedding:        &EmbeddingSpec{},
@@ -117,7 +117,7 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
 					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 					},
 					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
 					Embedding: &EmbeddingSpec{
@@ -134,7 +134,7 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
 					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 					},
 					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 512},
 					Embedding: &EmbeddingSpec{
@@ -149,7 +149,7 @@ func TestRAGEngineValidateCreate(t *testing.T) {
 			ragEngine: &RAGEngine{
 				Spec: &RAGEngineSpec{
 					Compute: &ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 					},
 					InferenceService: &InferenceServiceSpec{URL: "http://example.com", ContextWindowSize: 0},
 					Embedding: &EmbeddingSpec{

--- a/api/v1beta1/workspace_validation_test.go
+++ b/api/v1beta1/workspace_validation_test.go
@@ -336,7 +336,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Valid Resource - SKU Capacity == Model Requirement",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			modelGPUCount:           "1",
@@ -362,7 +362,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Only Template set",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NV12s_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			preset:         false,
@@ -397,7 +397,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Tuning validation with single node",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			runtime:        model.RuntimeNameVLLM,
@@ -408,7 +408,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Tuning validation with multinode",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(2),
 			},
 			runtime:        model.RuntimeNameVLLM,
@@ -419,7 +419,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Invalid Preset Name",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(2),
 			},
 			errContent:         "",
@@ -431,7 +431,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "vLLM + Distributed Inference",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(4),
 			},
 			preset:             true,
@@ -777,7 +777,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Deprecated Model",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			preset:             true,
@@ -789,7 +789,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Empty TotalSafeTensorFileSize skips GPU memory validation",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			modelGPUCount:           "1",
@@ -804,7 +804,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Malformed TotalSafeTensorFileSize returns validation error",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			modelGPUCount:           "1",
@@ -819,7 +819,7 @@ func TestResourceSpecValidateCreate(t *testing.T) {
 		{
 			name: "Valid TotalSafeTensorFileSize with sufficient memory passes",
 			resourceSpec: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			modelGPUCount:           "1",
@@ -964,7 +964,7 @@ func TestResourceSpecValidateUpdate(t *testing.T) {
 				Count:        pointerToInt(1),
 			},
 			oldResource: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				Count:        pointerToInt(1),
 			},
 			disableNAP: false, // NAP enabled
@@ -974,7 +974,7 @@ func TestResourceSpecValidateUpdate(t *testing.T) {
 		{
 			name: "NAP enabled - set instanceType initially (valid)",
 			newResource: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3", // Setting for first time
+				InstanceType: "Standard_NV36ads_A10_v5", // Setting for first time
 				Count:        pointerToInt(1),
 			},
 			oldResource: &ResourceSpec{
@@ -1010,7 +1010,7 @@ func TestResourceSpecValidateUpdate(t *testing.T) {
 				},
 			},
 			oldResource: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3", // Had instanceType from v0.7
+				InstanceType: "Standard_NV36ads_A10_v5", // Had instanceType from v0.7
 				Count:        pointerToInt(1),
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{"gpu": "v100"}, // Same labelSelector
@@ -1023,11 +1023,11 @@ func TestResourceSpecValidateUpdate(t *testing.T) {
 		{
 			name: "NAP disabled - keep instanceType set (backward compatibility)",
 			newResource: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3", // Still has instanceType
+				InstanceType: "Standard_NV36ads_A10_v5", // Still has instanceType
 				Count:        pointerToInt(1),
 			},
 			oldResource: &ResourceSpec{
-				InstanceType: "Standard_NC4as_T4_v3", // Had instanceType from v0.7
+				InstanceType: "Standard_NV36ads_A10_v5", // Had instanceType from v0.7
 				Count:        pointerToInt(1),
 			},
 			disableNAP: true, // NAP disabled (BYO mode)
@@ -1701,7 +1701,7 @@ func TestWorkspaceValidateCreate(t *testing.T) {
 			name: "Neither Inference nor Tuning specified",
 			workspace: &Workspace{
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 					Count:        pointerToInt(1),
 				},
 			},
@@ -1714,7 +1714,7 @@ func TestWorkspaceValidateCreate(t *testing.T) {
 				Inference: &InferenceSpec{},
 				Tuning:    &TuningSpec{},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 					Count:        pointerToInt(1),
 				},
 			},
@@ -1726,7 +1726,7 @@ func TestWorkspaceValidateCreate(t *testing.T) {
 			workspace: &Workspace{
 				Inference: &InferenceSpec{},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 					Count:        pointerToInt(1),
 				},
 			},
@@ -1738,7 +1738,7 @@ func TestWorkspaceValidateCreate(t *testing.T) {
 			workspace: &Workspace{
 				Tuning: &TuningSpec{Input: &DataSource{}},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 					Count:        pointerToInt(1),
 				},
 			},
@@ -1755,7 +1755,7 @@ func TestWorkspaceValidateCreate(t *testing.T) {
 				},
 				Inference: &InferenceSpec{},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 					Count:        pointerToInt(1),
 				},
 			},
@@ -1798,7 +1798,7 @@ func TestWorkspaceValidateName(t *testing.T) {
 			Namespace: "kaito",
 		},
 		Resource: ResourceSpec{
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			Count:        pointerToInt(1),
 		},
 		Inference: &InferenceSpec{
@@ -1869,7 +1869,7 @@ func TestWorkspaceValidatePerformanceModeAnnotation(t *testing.T) {
 			Namespace: "kaito",
 		},
 		Resource: ResourceSpec{
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			Count:        pointerToInt(1),
 		},
 		Inference: &InferenceSpec{
@@ -1978,7 +1978,7 @@ func TestWorkspaceValidateNAPFeatureGate(t *testing.T) {
 					Namespace: "kaito",
 				},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3", // Valid instanceType when NAP enabled
+					InstanceType: "Standard_NV36ads_A10_v5", // Valid instanceType when NAP enabled
 					Count:        pointerToInt(1),
 				},
 				Inference: &InferenceSpec{
@@ -2001,7 +2001,7 @@ func TestWorkspaceValidateNAPFeatureGate(t *testing.T) {
 					Namespace: "kaito",
 				},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3", // Invalid: instanceType provided when NAP disabled
+					InstanceType: "Standard_NV36ads_A10_v5", // Invalid: instanceType provided when NAP disabled
 					Count:        pointerToInt(1),
 					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -2171,7 +2171,7 @@ func TestWorkspaceValidateUpdate(t *testing.T) {
 				},
 				Tuning: &TuningSpec{Input: &DataSource{}, Output: &DataDestination{Image: "test-image:latest", ImagePushSecret: "secret"}},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 					Count:        pointerToInt(1),
 				},
 			},
@@ -2182,7 +2182,7 @@ func TestWorkspaceValidateUpdate(t *testing.T) {
 				},
 				Tuning: &TuningSpec{Input: &DataSource{}, Output: &DataDestination{Image: "test-image:latest", ImagePushSecret: "secret"}},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 					Count:        pointerToInt(1),
 				},
 			},
@@ -2196,7 +2196,7 @@ func TestWorkspaceValidateUpdate(t *testing.T) {
 					Namespace: "kaito",
 				},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3", // Created in v0.7 with instanceType
+					InstanceType: "Standard_NV36ads_A10_v5", // Created in v0.7 with instanceType
 					Count:        pointerToInt(1),
 					LabelSelector: &metav1.LabelSelector{
 						MatchLabels: map[string]string{
@@ -2838,7 +2838,7 @@ vllm:
 					Config: "valid-config-with-max-model-len",
 				},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NV24s_v3", // 2 GPUs with 8GB each (16GB total)
+					InstanceType: "Standard_NV72ads_A10_v5", // 2 GPUs with 24GB each (48GB total)
 					Count:        pointerToInt(1),
 				},
 			},
@@ -2860,7 +2860,7 @@ vllm:
 					Config: "invalid-config-exceeds-token-limit",
 				},
 				Resource: ResourceSpec{
-					InstanceType: "Standard_NV24s_v3", // 2 GPUs with 8GB each (16GB total)
+					InstanceType: "Standard_NV72ads_A10_v5", // 2 GPUs with 24GB each (48GB total)
 					Count:        pointerToInt(1),
 				},
 			},

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -59,7 +59,7 @@ func TestInferenceSetSyncControllerRevision(t *testing.T) {
 						*dep = appsv1.ControllerRevision{
 							ObjectMeta: v1.ObjectMeta{
 								Annotations: map[string]string{
-									InferenceSetHashAnnotation: "05e6d3ba23ae871ac11ab7a93452f7e70fe02fb5a88827c6ff7a77f91e5d45bc",
+									InferenceSetHashAnnotation: "8b215f13847260f94d2debfebec7ee9540a7b2c08c0d5cabdfdded1ca133f6cc",
 								},
 							},
 							Revision: 1,

--- a/pkg/ragengine/controllers/preset_rag_test.go
+++ b/pkg/ragengine/controllers/preset_rag_test.go
@@ -180,8 +180,8 @@ func TestGPUConfigLogic(t *testing.T) {
 				c.On("Create", mock.IsType(context.TODO()), mock.IsType(&appsv1.Deployment{}), mock.Anything).Return(nil)
 			},
 			ragEngine:        test.MockRAGEngineWithPreset,
-			expectedGPUReq:   int64(1), // Standard_NC4as_T4_v3 has 1 GPU
-			expectedLimitReq: int64(1), // Standard_NC4as_T4_v3 has 1 GPU
+			expectedGPUReq:   int64(1), // Standard_NV36ads_A10_v5 has 1 GPU
+			expectedLimitReq: int64(1), // Standard_NV36ads_A10_v5 has 1 GPU
 		},
 		"test-rag-preferred-nodes": {
 			callMocks: func(c *test.MockClient) {

--- a/pkg/ragengine/controllers/ragengine_controller_test.go
+++ b/pkg/ragengine/controllers/ragengine_controller_test.go
@@ -245,7 +245,7 @@ func TestGetAllQualifiedNodesforRAGEngine(t *testing.T) {
 					ObjectMeta: v1.ObjectMeta{
 						Name: "node4",
 						Labels: map[string]string{
-							corev1.LabelInstanceTypeStable: "Standard_NC4as_T4_v3",
+							corev1.LabelInstanceTypeStable: "Standard_NV36ads_A10_v5",
 						},
 						DeletionTimestamp: &v1.Time{Time: time.Now()},
 					},
@@ -392,7 +392,7 @@ func TestUpdateControllerRevision1(t *testing.T) {
 						*dep = appsv1.ControllerRevision{
 							ObjectMeta: v1.ObjectMeta{
 								Annotations: map[string]string{
-									RAGEngineHashAnnotation: "01d86e3f2e4fe40da099e879d9af1881169b9468d4c44e2512d616b9a4e07641",
+									RAGEngineHashAnnotation: "f9e0ee8d79842f43edf3d9edfe7a6130cda56d0dff37d614ded22d9e2675dda5",
 								},
 							},
 						}
@@ -1319,7 +1319,7 @@ func TestComputeHash(t *testing.T) {
 			ragengine1: &v1beta1.RAGEngine{
 				Spec: &v1beta1.RAGEngineSpec{
 					Compute: &v1beta1.ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 						Count:        &[]int{1}[0],
 					},
 				},
@@ -1327,7 +1327,7 @@ func TestComputeHash(t *testing.T) {
 			ragengine2: &v1beta1.RAGEngine{
 				Spec: &v1beta1.RAGEngineSpec{
 					Compute: &v1beta1.ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 						Count:        &[]int{1}[0],
 					},
 				},
@@ -1338,7 +1338,7 @@ func TestComputeHash(t *testing.T) {
 			ragengine1: &v1beta1.RAGEngine{
 				Spec: &v1beta1.RAGEngineSpec{
 					Compute: &v1beta1.ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 						Count:        &[]int{1}[0],
 					},
 				},
@@ -1346,7 +1346,7 @@ func TestComputeHash(t *testing.T) {
 			ragengine2: &v1beta1.RAGEngine{
 				Spec: &v1beta1.RAGEngineSpec{
 					Compute: &v1beta1.ResourceSpec{
-						InstanceType: "Standard_NC64as_T4_v3",
+						InstanceType: "Standard_NC96ads_A100_v4",
 						Count:        &[]int{1}[0],
 					},
 				},
@@ -1357,7 +1357,7 @@ func TestComputeHash(t *testing.T) {
 			ragengine1: &v1beta1.RAGEngine{
 				Spec: &v1beta1.RAGEngineSpec{
 					Compute: &v1beta1.ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 						Count:        &[]int{1}[0],
 					},
 				},
@@ -1365,7 +1365,7 @@ func TestComputeHash(t *testing.T) {
 			ragengine2: &v1beta1.RAGEngine{
 				Spec: &v1beta1.RAGEngineSpec{
 					Compute: &v1beta1.ResourceSpec{
-						InstanceType: "Standard_NC4as_T4_v3",
+						InstanceType: "Standard_NV36ads_A10_v5",
 						Count:        &[]int{2}[0],
 					},
 				},

--- a/pkg/sku/arc_sku_handker.go
+++ b/pkg/sku/arc_sku_handker.go
@@ -17,9 +17,9 @@ import "k8s.io/apimachinery/pkg/api/resource"
 
 func NewArcSKUHandler() CloudSKUHandler {
 	// The SKU including Azure Local official sku: https://learn.microsoft.com/en-us/azure/aks/aksarc/scale-requirements
+	// KAITO only supports GPUs with CUDA compute capability >= 8.0 (Ampere and newer).
+	// Older architectures (Turing T4) have been removed.
 	supportedSKUs := []GPUConfig{
-		{SKU: "Standard_NK6", GPUCount: 1, GPUMem: resource.MustParse("8Gi"), GPUModel: "NVIDIA T4", CUDAComputeCapability: 7.5},
-		{SKU: "Standard_NK12", GPUCount: 2, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA T4", CUDAComputeCapability: 7.5},
 		{SKU: "Standard_NC4_A2", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA A2", CUDAComputeCapability: 8.6},
 		{SKU: "Standard_NC8_A2", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA A2", CUDAComputeCapability: 8.6},
 		{SKU: "Standard_NC16_A2", GPUCount: 2, GPUMem: resource.MustParse("32Gi"), GPUModel: "NVIDIA A2", CUDAComputeCapability: 8.6},

--- a/pkg/sku/aws_sku_handler.go
+++ b/pkg/sku/aws_sku_handler.go
@@ -17,14 +17,9 @@ import "k8s.io/apimachinery/pkg/api/resource"
 
 func NewAwsSKUHandler() CloudSKUHandler {
 	// Reference: https://aws.amazon.com/ec2/instance-types/
+	// KAITO only supports GPUs with CUDA compute capability >= 8.0 (Ampere and newer).
+	// Older architectures (K80, V100, T4, M60, etc.) have been removed.
 	supportedSKUs := []GPUConfig{
-		{SKU: "p2.xlarge", GPUCount: 1, GPUMem: resource.MustParse("12Gi"), GPUModel: "NVIDIA K80", CUDAComputeCapability: 3.7},
-		{SKU: "p2.8xlarge", GPUCount: 8, GPUMem: resource.MustParse("96Gi"), GPUModel: "NVIDIA K80", CUDAComputeCapability: 3.7},
-		{SKU: "p2.16xlarge", GPUCount: 16, GPUMem: resource.MustParse("192Gi"), GPUModel: "NVIDIA K80", CUDAComputeCapability: 3.7},
-		{SKU: "p3.2xlarge", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA V100", CUDAComputeCapability: 7.0},
-		{SKU: "p3.8xlarge", GPUCount: 4, GPUMem: resource.MustParse("64Gi"), GPUModel: "NVIDIA V100", CUDAComputeCapability: 7.0},
-		{SKU: "p3.16xlarge", GPUCount: 8, GPUMem: resource.MustParse("128Gi"), GPUModel: "NVIDIA V100", CUDAComputeCapability: 7.0},
-		{SKU: "p3dn.24xlarge", GPUCount: 8, GPUMem: resource.MustParse("256Gi"), GPUModel: "NVIDIA V100", CUDAComputeCapability: 7.0},
 		{SKU: "p4d.24xlarge", GPUCount: 8, GPUMem: resource.MustParse("320Gi"), GPUModel: "NVIDIA A100", NVMeDiskEnabled: true, CUDAComputeCapability: 8.0},
 		{SKU: "p4de.24xlarge", GPUCount: 8, GPUMem: resource.MustParse("640Gi"), GPUModel: "NVIDIA A100", NVMeDiskEnabled: true, CUDAComputeCapability: 8.0},
 		{SKU: "p5.48xlarge", GPUCount: 8, GPUMem: resource.MustParse("640Gi"), GPUModel: "NVIDIA H100", NVMeDiskEnabled: true, CUDAComputeCapability: 9.0},
@@ -40,12 +35,6 @@ func NewAwsSKUHandler() CloudSKUHandler {
 		{SKU: "g6.12xlarge", GPUCount: 4, GPUMem: resource.MustParse("96Gi"), GPUModel: "NVIDIA L4", NVMeDiskEnabled: true, CUDAComputeCapability: 8.9},
 		{SKU: "g6.24xlarge", GPUCount: 4, GPUMem: resource.MustParse("96Gi"), GPUModel: "NVIDIA L4", NVMeDiskEnabled: true, CUDAComputeCapability: 8.9},
 		{SKU: "g6.48xlarge", GPUCount: 8, GPUMem: resource.MustParse("192Gi"), GPUModel: "NVIDIA L4", NVMeDiskEnabled: true, CUDAComputeCapability: 8.9},
-		{SKU: "g5g.xlarge", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA T4", CUDAComputeCapability: 7.5},
-		{SKU: "g5g.2xlarge", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA T4", CUDAComputeCapability: 7.5},
-		{SKU: "g5g.4xlarge", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA T4", CUDAComputeCapability: 7.5},
-		{SKU: "g5g.8xlarge", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA T4", CUDAComputeCapability: 7.5},
-		{SKU: "g5g.16xlarge", GPUCount: 2, GPUMem: resource.MustParse("32Gi"), GPUModel: "NVIDIA T4", CUDAComputeCapability: 7.5},
-		{SKU: "g5g.metal", GPUCount: 2, GPUMem: resource.MustParse("32Gi"), GPUModel: "NVIDIA T4", CUDAComputeCapability: 7.5},
 		{SKU: "g5.xlarge", GPUCount: 1, GPUMem: resource.MustParse("24Gi"), GPUModel: "NVIDIA A10G", NVMeDiskEnabled: true, CUDAComputeCapability: 8.6},
 		{SKU: "g5.2xlarge", GPUCount: 1, GPUMem: resource.MustParse("24Gi"), GPUModel: "NVIDIA A10G", NVMeDiskEnabled: true, CUDAComputeCapability: 8.6},
 		{SKU: "g5.4xlarge", GPUCount: 1, GPUMem: resource.MustParse("24Gi"), GPUModel: "NVIDIA A10G", NVMeDiskEnabled: true, CUDAComputeCapability: 8.6},
@@ -54,22 +43,11 @@ func NewAwsSKUHandler() CloudSKUHandler {
 		{SKU: "g5.16xlarge", GPUCount: 1, GPUMem: resource.MustParse("24Gi"), GPUModel: "NVIDIA A10G", NVMeDiskEnabled: true, CUDAComputeCapability: 8.6},
 		{SKU: "g5.24xlarge", GPUCount: 4, GPUMem: resource.MustParse("96Gi"), GPUModel: "NVIDIA A10G", NVMeDiskEnabled: true, CUDAComputeCapability: 8.6},
 		{SKU: "g5.48xlarge", GPUCount: 8, GPUMem: resource.MustParse("192Gi"), GPUModel: "NVIDIA A10G", NVMeDiskEnabled: true, CUDAComputeCapability: 8.6},
-		{SKU: "g4dn.xlarge", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA T4", NVMeDiskEnabled: true, CUDAComputeCapability: 7.5},
-		{SKU: "g4dn.2xlarge", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA T4", NVMeDiskEnabled: true, CUDAComputeCapability: 7.5},
-		{SKU: "g4dn.4xlarge", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA T4", NVMeDiskEnabled: true, CUDAComputeCapability: 7.5},
-		{SKU: "g4dn.8xlarge", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA T4", NVMeDiskEnabled: true, CUDAComputeCapability: 7.5},
-		{SKU: "g4dn.16xlarge", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA T4", NVMeDiskEnabled: true, CUDAComputeCapability: 7.5},
-		{SKU: "g4dn.12xlarge", GPUCount: 4, GPUMem: resource.MustParse("64Gi"), GPUModel: "NVIDIA T4", NVMeDiskEnabled: true, CUDAComputeCapability: 7.5},
-		{SKU: "g4dn.metal", GPUCount: 8, GPUMem: resource.MustParse("128Gi"), GPUModel: "NVIDIA T4", NVMeDiskEnabled: true, CUDAComputeCapability: 7.5},
 		{SKU: "g4ad.xlarge", GPUCount: 1, GPUMem: resource.MustParse("8Gi"), GPUModel: "AMD Radeon Pro V520", NVMeDiskEnabled: true},
 		{SKU: "g4ad.2xlarge", GPUCount: 1, GPUMem: resource.MustParse("8Gi"), GPUModel: "AMD Radeon Pro V520", NVMeDiskEnabled: true},
 		{SKU: "g4ad.4xlarge", GPUCount: 1, GPUMem: resource.MustParse("8Gi"), GPUModel: "AMD Radeon Pro V520", NVMeDiskEnabled: true},
 		{SKU: "g4ad.8xlarge", GPUCount: 2, GPUMem: resource.MustParse("16Gi"), GPUModel: "AMD Radeon Pro V520", NVMeDiskEnabled: true},
 		{SKU: "g4ad.16xlarge", GPUCount: 4, GPUMem: resource.MustParse("32Gi"), GPUModel: "AMD Radeon Pro V520", NVMeDiskEnabled: true},
-		{SKU: "g3s.xlarge", GPUCount: 1, GPUMem: resource.MustParse("8Gi"), GPUModel: "NVIDIA M60", CUDAComputeCapability: 5.2},
-		{SKU: "g3s.4xlarge", GPUCount: 1, GPUMem: resource.MustParse("8Gi"), GPUModel: "NVIDIA M60", CUDAComputeCapability: 5.2},
-		{SKU: "g3s.8xlarge", GPUCount: 2, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA M60", CUDAComputeCapability: 5.2},
-		{SKU: "g3s.16xlarge", GPUCount: 4, GPUMem: resource.MustParse("32Gi"), GPUModel: "NVIDIA M60", CUDAComputeCapability: 5.2},
 		//accelerator optimized
 		{SKU: "trn1.2xlarge", GPUCount: 1, GPUMem: resource.MustParse("32Gi"), GPUModel: "AWS Trainium accelerators", NVMeDiskEnabled: true},
 		{SKU: "trn1.32xlarge", GPUCount: 16, GPUMem: resource.MustParse("512Gi"), GPUModel: "AWS Trainium accelerators", NVMeDiskEnabled: true},

--- a/pkg/sku/azure_sku_handler.go
+++ b/pkg/sku/azure_sku_handler.go
@@ -16,11 +16,9 @@ package sku
 import "k8s.io/apimachinery/pkg/api/resource"
 
 func NewAzureSKUHandler() CloudSKUHandler {
+	// KAITO only supports GPUs with CUDA compute capability >= 8.0 (Ampere and newer).
+	// Older architectures (Turing T4, Maxwell M60, etc.) have been removed.
 	supportedSKUs := []GPUConfig{
-		{SKU: "Standard_NC4as_T4_v3", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA T4", CUDAComputeCapability: 7.5},
-		{SKU: "Standard_NC8as_T4_v3", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA T4", CUDAComputeCapability: 7.5},
-		{SKU: "Standard_NC16as_T4_v3", GPUCount: 1, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA T4", CUDAComputeCapability: 7.5},
-		{SKU: "Standard_NC64as_T4_v3", GPUCount: 4, GPUMem: resource.MustParse("64Gi"), GPUModel: "NVIDIA T4", CUDAComputeCapability: 7.5},
 		{SKU: "Standard_NV36ads_A10_v5", GPUCount: 1, GPUMem: resource.MustParse("24Gi"), GPUModel: "NVIDIA A10", CUDAComputeCapability: 8.6},
 		{SKU: "Standard_NV72ads_A10_v5", GPUCount: 2, GPUMem: resource.MustParse("48Gi"), GPUModel: "NVIDIA A10", CUDAComputeCapability: 8.6},
 		{SKU: "Standard_NC24ads_A100_v4", GPUCount: 1, GPUMem: resource.MustParse("80Gi"), GPUModel: "NVIDIA A100", NVMeDiskEnabled: true, CUDAComputeCapability: 8.0},
@@ -39,9 +37,6 @@ func NewAzureSKUHandler() CloudSKUHandler {
 		{SKU: "Standard_ND96isr_H200_v5", GPUCount: 8, GPUMem: resource.MustParse("1128Gi"), GPUModel: "NVIDIA H200", NVMeDiskEnabled: true, CUDAComputeCapability: 9.0},
 		{SKU: "Standard_NG32ads_V620_v1", GPUCount: 1, GPUMem: resource.MustParse("32Gi"), GPUModel: "AMD Radeon PRO V620"},
 		{SKU: "Standard_NG32adms_V620_v1", GPUCount: 1, GPUMem: resource.MustParse("32Gi"), GPUModel: "AMD Radeon PRO V620"},
-		{SKU: "Standard_NV12s_v3", GPUCount: 1, GPUMem: resource.MustParse("8Gi"), GPUModel: "NVIDIA M60", CUDAComputeCapability: 5.2},
-		{SKU: "Standard_NV24s_v3", GPUCount: 2, GPUMem: resource.MustParse("16Gi"), GPUModel: "NVIDIA M60", CUDAComputeCapability: 5.2},
-		{SKU: "Standard_NV48s_v3", GPUCount: 4, GPUMem: resource.MustParse("32Gi"), GPUModel: "NVIDIA M60", CUDAComputeCapability: 5.2},
 
 		// Not supporting partial gpu skus for now
 		// {SKU: "Standard_NG8ads_V620_v1", GPUCount: 1.0 / 4.0, GPUMem: 8, GPUModel: "AMD Radeon PRO V620"},

--- a/pkg/sku/cloud_sku_handler_test.go
+++ b/pkg/sku/cloud_sku_handler_test.go
@@ -29,7 +29,7 @@ func TestAzureSKUHandler(t *testing.T) {
 	}
 
 	// Test GetGPUConfigs with a SKU that is supported
-	sku := "Standard_NC4as_T4_v3"
+	sku := "Standard_NV36ads_A10_v5"
 	gpuConfig1 := handler.GetGPUConfigBySKU(sku)
 	if gpuConfig1 == nil {
 		t.Fatalf("Supported SKU missing from GPUConfigs")
@@ -49,8 +49,8 @@ func TestAzureSKUHandler(t *testing.T) {
 func TestGetGPUConfigBySKUCaseInsensitive(t *testing.T) {
 	handler := NewAzureSKUHandler()
 
-	canonical := "Standard_NC4as_T4_v3"
-	cases := []string{canonical, "standard_nc4as_t4_v3", "STANDARD_NC4AS_T4_V3"}
+	canonical := "Standard_NV36ads_A10_v5"
+	cases := []string{canonical, "standard_nv36ads_a10_v5", "STANDARD_NV36ADS_A10_V5"}
 	for _, input := range cases {
 		config := handler.GetGPUConfigBySKU(input)
 		if config == nil {
@@ -69,15 +69,15 @@ func TestHasSKUNamePrefix(t *testing.T) {
 		prefixes []string
 		expected bool
 	}{
-		{"exact case match", "Standard_NC4as_T4_v3", []string{"Standard_N"}, true},
-		{"lowercase sku", "standard_nc4as_t4_v3", []string{"Standard_N"}, true},
-		{"uppercase sku", "STANDARD_NC4AS_T4_V3", []string{"Standard_N"}, true},
+		{"exact case match", "Standard_NV36ads_A10_v5", []string{"Standard_N"}, true},
+		{"lowercase sku", "standard_nv36ads_a10_v5", []string{"Standard_N"}, true},
+		{"uppercase sku", "STANDARD_NV36ADS_A10_V5", []string{"Standard_N"}, true},
 		{"d-series match", "standard_d2s_v6", []string{"Standard_D"}, true},
-		{"multiple prefixes first match", "Standard_NC4as_T4_v3", []string{"Standard_N", "Standard_D"}, true},
+		{"multiple prefixes first match", "Standard_NV36ads_A10_v5", []string{"Standard_N", "Standard_D"}, true},
 		{"multiple prefixes second match", "Standard_D2s_v6", []string{"Standard_N", "Standard_D"}, true},
 		{"no match", "Standard_E4s_v3", []string{"Standard_N", "Standard_D"}, false},
 		{"empty sku", "", []string{"Standard_N"}, false},
-		{"empty prefixes", "Standard_NC4as_T4_v3", []string{}, false},
+		{"empty prefixes", "Standard_NV36ads_A10_v5", []string{}, false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestAwsSKUHandler(t *testing.T) {
 	}
 
 	// Test GetGPUConfigs with a SKU that is supported
-	sku := "p2.xlarge"
+	sku := "p4d.24xlarge"
 	gpuConfig1 := handler.GetGPUConfigBySKU(sku)
 	if gpuConfig1 == nil {
 		t.Fatalf("Supported SKU missing from GPUConfigs")
@@ -124,10 +124,10 @@ func TestGPUConfigMemoryIsQuantity(t *testing.T) {
 		expectedMemGiB string
 	}{
 		{
-			name:           "Azure Standard_NC4as_T4_v3",
+			name:           "Azure Standard_NV36ads_A10_v5",
 			handler:        NewAzureSKUHandler(),
-			sku:            "Standard_NC4as_T4_v3",
-			expectedMemGiB: "16Gi",
+			sku:            "Standard_NV36ads_A10_v5",
+			expectedMemGiB: "24Gi",
 		},
 		{
 			name:           "Azure Standard_NC24ads_A100_v4",
@@ -136,10 +136,10 @@ func TestGPUConfigMemoryIsQuantity(t *testing.T) {
 			expectedMemGiB: "80Gi",
 		},
 		{
-			name:           "AWS p2.xlarge",
+			name:           "AWS p4d.24xlarge",
 			handler:        NewAwsSKUHandler(),
-			sku:            "p2.xlarge",
-			expectedMemGiB: "12Gi",
+			sku:            "p4d.24xlarge",
+			expectedMemGiB: "320Gi",
 		},
 		{
 			name:           "AWS p5.48xlarge",
@@ -148,10 +148,10 @@ func TestGPUConfigMemoryIsQuantity(t *testing.T) {
 			expectedMemGiB: "640Gi",
 		},
 		{
-			name:           "Arc Standard_NK6",
+			name:           "Arc Standard_NC4_A2",
 			handler:        NewArcSKUHandler(),
-			sku:            "Standard_NK6",
-			expectedMemGiB: "8Gi",
+			sku:            "Standard_NC4_A2",
+			expectedMemGiB: "16Gi",
 		},
 	}
 

--- a/pkg/utils/test/test_utils.go
+++ b/pkg/utils/test/test_utils.go
@@ -43,7 +43,7 @@ var (
 		},
 		Resource: v1beta1.ResourceSpec{
 			Count:        &gpuNodeCount,
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"apps": "test",
@@ -65,7 +65,7 @@ var (
 		},
 		Resource: v1beta1.ResourceSpec{
 			Count:        lo.ToPtr(2), // 2 nodes = distributed model
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"apps": "test",
@@ -87,7 +87,7 @@ var (
 		},
 		Resource: v1beta1.ResourceSpec{
 			Count:        &gpuNodeCount,
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"apps": "test",
@@ -110,7 +110,7 @@ var (
 		},
 		Resource: v1beta1.ResourceSpec{
 			Count:        &gpuNodeCount,
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"apps": "test",
@@ -141,10 +141,10 @@ var (
 		Spec: &v1beta1.RAGEngineSpec{
 			Compute: &v1beta1.ResourceSpec{
 				Count:        &gpuNodeCount,
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						corev1.LabelInstanceTypeStable: "Standard_NC4as_T4_v3",
+						corev1.LabelInstanceTypeStable: "Standard_NV36ads_A10_v5",
 					},
 				},
 				PreferredNodes: []string{"node1"},
@@ -164,7 +164,7 @@ var (
 		Spec: &v1beta1.RAGEngineSpec{
 			Compute: &v1beta1.ResourceSpec{
 				Count:        &gpuNodeCount,
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"ragengine.kaito.io/name": "testRAGEngine",
@@ -188,7 +188,7 @@ var (
 		Spec: &v1beta1.RAGEngineSpec{
 			Compute: &v1beta1.ResourceSpec{
 				Count:        &gpuNodeCount,
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"apps": "test",
@@ -299,7 +299,7 @@ var (
 		},
 		Resource: v1beta1.ResourceSpec{
 			Count:        &gpuNodeCount,
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"apps": "test",
@@ -338,28 +338,6 @@ var (
 				},
 				PresetOptions: v1beta1.PresetOptions{
 					ModelAccessSecret: "test-secret",
-				},
-			},
-		},
-	}
-	MockWorkspaceWithPresetVLLMFloat16 = &v1beta1.Workspace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "testWorkspace",
-			Namespace: "kaito",
-		},
-		Resource: v1beta1.ResourceSpec{
-			Count:        &gpuNodeCount,
-			InstanceType: "Standard_NC4as_T4_v3",
-			LabelSelector: &metav1.LabelSelector{
-				MatchLabels: map[string]string{
-					"apps": "test",
-				},
-			},
-		},
-		Inference: &v1beta1.InferenceSpec{
-			Preset: &v1beta1.PresetSpec{
-				PresetMeta: v1beta1.PresetMeta{
-					Name: "test-model",
 				},
 			},
 		},
@@ -406,7 +384,7 @@ var (
 		Spec: &v1beta1.RAGEngineSpec{
 			Compute: &v1beta1.ResourceSpec{
 				Count:        &gpuNodeCount,
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"ragengine.kaito.io/name": "testRAGEngine",
@@ -461,7 +439,7 @@ var (
 		Spec: &v1beta1.RAGEngineSpec{
 			Compute: &v1beta1.ResourceSpec{
 				Count:        &gpuNodeCount,
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"ragengine.kaito.io/name": "testRAGEngine",
@@ -488,7 +466,7 @@ var (
 		Spec: &v1beta1.RAGEngineSpec{
 			Compute: &v1beta1.ResourceSpec{
 				Count:        &gpuNodeCount,
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"ragengine.kaito.io/name": "testRAGEngine",
@@ -517,10 +495,10 @@ var (
 		Spec: &v1beta1.RAGEngineSpec{
 			Compute: &v1beta1.ResourceSpec{
 				Count:        &gpuNodeCount,
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
-						corev1.LabelInstanceTypeStable: "Standard_NC4as_T4_v3",
+						corev1.LabelInstanceTypeStable: "Standard_NV36ads_A10_v5",
 					},
 				},
 				PreferredNodes: []string{"node1"},
@@ -584,7 +562,7 @@ var (
 		},
 		Resource: v1beta1.ResourceSpec{
 			Count:        &gpuNodeCount,
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"workspace.kaito.io/name": "testWorkspace",
@@ -612,7 +590,7 @@ var (
 		Spec: v1beta1.InferenceSetSpec{
 			Template: v1beta1.InferenceSetTemplate{
 				Resource: v1beta1.InferenceSetResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 				},
 				Inference: v1beta1.InferenceSpec{
 					Preset: &v1beta1.PresetSpec{
@@ -639,7 +617,7 @@ var (
 		Spec: &v1beta1.RAGEngineSpec{
 			Compute: &v1beta1.ResourceSpec{
 				Count:        &gpuNodeCount,
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"ragengine.kaito.io/name": "testRAGEngine",
@@ -666,7 +644,7 @@ var (
 		},
 		Resource: v1beta1.ResourceSpec{
 			Count:        &gpuNodeCount,
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"workspace.kaito.io/name": "testWorkspace",
@@ -693,7 +671,7 @@ var (
 		Spec: v1beta1.InferenceSetSpec{
 			Template: v1beta1.InferenceSetTemplate{
 				Resource: v1beta1.InferenceSetResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 				},
 				Inference: v1beta1.InferenceSpec{
 					Preset: &v1beta1.PresetSpec{
@@ -719,7 +697,7 @@ var (
 		Spec: &v1beta1.RAGEngineSpec{
 			Compute: &v1beta1.ResourceSpec{
 				Count:        &gpuNodeCount,
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"ragengine.kaito.io/name": "testRAGEngine",
@@ -740,7 +718,7 @@ var (
 		},
 		Resource: v1beta1.ResourceSpec{
 			Count:        &gpuNodeCount,
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"workspace.kaito.io/name": "testWorkspace",
@@ -767,7 +745,7 @@ var (
 		Spec: v1beta1.InferenceSetSpec{
 			Template: v1beta1.InferenceSetTemplate{
 				Resource: v1beta1.InferenceSetResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 				},
 				Inference: v1beta1.InferenceSpec{
 					Preset: &v1beta1.PresetSpec{
@@ -793,7 +771,7 @@ var (
 		Spec: &v1beta1.RAGEngineSpec{
 			Compute: &v1beta1.ResourceSpec{
 				Count:        &gpuNodeCount,
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"ragengine.kaito.io/name": "testRAGEngine",
@@ -815,7 +793,7 @@ var (
 		},
 		Resource: v1beta1.ResourceSpec{
 			Count:        &gpuNodeCount,
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"workspace.kaito.io/name": "testWorkspace",
@@ -843,7 +821,7 @@ var (
 		Spec: v1beta1.InferenceSetSpec{
 			Template: v1beta1.InferenceSetTemplate{
 				Resource: v1beta1.InferenceSetResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 				},
 				Inference: v1beta1.InferenceSpec{
 					Preset: &v1beta1.PresetSpec{
@@ -870,7 +848,7 @@ var (
 		Spec: &v1beta1.RAGEngineSpec{
 			Compute: &v1beta1.ResourceSpec{
 				Count:        &gpuNodeCount,
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"ragengine.kaito.io/name": "testRAGEngine",
@@ -892,7 +870,7 @@ var (
 		},
 		Resource: v1beta1.ResourceSpec{
 			Count:        &gpuNodeCount,
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"workspace.kaito.io/name": "testWorkspace",
@@ -920,7 +898,7 @@ var (
 		Spec: v1beta1.InferenceSetSpec{
 			Template: v1beta1.InferenceSetTemplate{
 				Resource: v1beta1.InferenceSetResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 				},
 				Inference: v1beta1.InferenceSpec{
 					Preset: &v1beta1.PresetSpec{
@@ -946,7 +924,7 @@ var (
 		},
 		Resource: v1beta1.ResourceSpec{
 			Count:        &gpuNodeCount,
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"workspace.kaito.io/name": "testWorkspace",
@@ -983,7 +961,7 @@ var (
 		Spec: v1beta1.InferenceSetSpec{
 			Template: v1beta1.InferenceSetTemplate{
 				Resource: v1beta1.InferenceSetResourceSpec{
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 				},
 				Inference: v1beta1.InferenceSpec{
 					Preset: &v1beta1.PresetSpec{
@@ -1019,7 +997,7 @@ var (
 		Spec: &v1beta1.RAGEngineSpec{
 			Compute: &v1beta1.ResourceSpec{
 				Count:        &gpuNodeCount,
-				InstanceType: "Standard_NC4as_T4_v3",
+				InstanceType: "Standard_NV36ads_A10_v5",
 				LabelSelector: &metav1.LabelSelector{
 					MatchLabels: map[string]string{
 						"ragengine.kaito.io/name": "testRAGEngine",
@@ -1238,7 +1216,7 @@ var (
 		},
 		Resource: v1beta1.ResourceSpec{
 			Count:        &gpuNodeCount,
-			InstanceType: "Standard_NC4as_T4_v3",
+			InstanceType: "Standard_NV36ads_A10_v5",
 			LabelSelector: &metav1.LabelSelector{
 				MatchLabels: map[string]string{
 					"apps": "test",
@@ -1266,7 +1244,7 @@ var (
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "node1",
 				Labels: map[string]string{
-					corev1.LabelInstanceTypeStable: "Standard_NC4as_T4_v3",
+					corev1.LabelInstanceTypeStable: "Standard_NV36ads_A10_v5",
 					LabelKeyNvidia:                 LabelValueNvidia,
 				},
 			},

--- a/pkg/workspace/controllers/workspace_controller_test.go
+++ b/pkg/workspace/controllers/workspace_controller_test.go
@@ -628,7 +628,7 @@ func TestSyncControllerRevision(t *testing.T) {
 						*dep = appsv1.ControllerRevision{
 							ObjectMeta: v1.ObjectMeta{
 								Annotations: map[string]string{
-									WorkspaceHashAnnotation: "7ecd8e1b6ebc187b70fc18389f367e6d782e3b7e917e39bfadfc99cfb5ecb872",
+									WorkspaceHashAnnotation: "79676e4782172441933f628c7f541c81accd0fe88af9588101e2344589f6dbae",
 								},
 							},
 							Revision: 1,

--- a/pkg/workspace/estimator/interfaces.go
+++ b/pkg/workspace/estimator/interfaces.go
@@ -39,7 +39,7 @@ type ModelProfile struct {
 
 // ResourceProfile describes the compute resources available for the workload.
 type ResourceProfile struct {
-	// InstanceType is the GPU SKU identifier (e.g. "Standard_NC4as_T4_v3").
+	// InstanceType is the GPU SKU identifier (e.g. "Standard_NV36ads_A10_v5").
 	InstanceType string
 	// RequestedNodeCount is the caller-preferred node count; 0 means unspecified.
 	RequestedNodeCount int

--- a/pkg/workspace/estimator/nodesestimator/estimator_test.go
+++ b/pkg/workspace/estimator/nodesestimator/estimator_test.go
@@ -66,7 +66,7 @@ func TestNodeEstimator_EstimateNodeCount(t *testing.T) {
 				},
 				Resource: kaitov1beta1.ResourceSpec{
 					Count:        ptr.To(3),
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 				},
 				Inference: nil,
 			},
@@ -82,7 +82,7 @@ func TestNodeEstimator_EstimateNodeCount(t *testing.T) {
 				},
 				Resource: kaitov1beta1.ResourceSpec{
 					Count:        nil,
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 				},
 				Inference: nil,
 			},
@@ -98,7 +98,7 @@ func TestNodeEstimator_EstimateNodeCount(t *testing.T) {
 				},
 				Resource: kaitov1beta1.ResourceSpec{
 					Count:        ptr.To(2),
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 				},
 				Inference: &kaitov1beta1.InferenceSpec{
 					Preset: nil,
@@ -116,7 +116,7 @@ func TestNodeEstimator_EstimateNodeCount(t *testing.T) {
 				},
 				Resource: kaitov1beta1.ResourceSpec{
 					Count:        ptr.To(4),
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 				},
 				Inference: &kaitov1beta1.InferenceSpec{
 					Preset: &kaitov1beta1.PresetSpec{
@@ -182,8 +182,8 @@ func TestNodeEstimator_EstimateNodeCount(t *testing.T) {
 					Namespace: "default",
 				},
 				Resource: kaitov1beta1.ResourceSpec{
-					Count:        ptr.To(1),              // User requests 1 node
-					InstanceType: "Standard_NC4as_T4_v3", // Smaller GPU memory
+					Count:        ptr.To(1),                 // User requests 1 node
+					InstanceType: "Standard_NV36ads_A10_v5", // Smaller GPU memory
 				},
 				Inference: &kaitov1beta1.InferenceSpec{
 					Preset: &kaitov1beta1.PresetSpec{
@@ -205,7 +205,7 @@ func TestNodeEstimator_EstimateNodeCount(t *testing.T) {
 				},
 				Resource: kaitov1beta1.ResourceSpec{
 					Count:        nil, // No count specified
-					InstanceType: "Standard_NC4as_T4_v3",
+					InstanceType: "Standard_NV36ads_A10_v5",
 				},
 				Inference: &kaitov1beta1.InferenceSpec{
 					Preset: &kaitov1beta1.PresetSpec{

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -123,21 +123,6 @@ func TestGeneratePresetInference(t *testing.T) {
 			expectedEnvVars: []corev1.EnvVar{flashInferSamplerEnvVar},
 		},
 
-		"test-model/vllm-float16": {
-			workspace: test.MockWorkspaceWithPresetVLLMFloat16,
-			nodeCount: 1,
-			modelName: "test-model",
-			callMocks: func(c *test.MockClient) {
-				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
-				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
-			},
-			expectedModelImage: "test-registry/kaito-test-model:1.0.0",
-			// T4 GPU does not support bfloat16, so dtype=float16 is added
-			expectedCmd:     "/bin/sh -c python3 /workspace/vllm/inference_api.py --dtype=float16 --gpu-memory-utilization=0.84 --max-model-len=auto --tensor-parallel-size=1 --served-model-name=mymodel",
-			hasAdapters:     false,
-			expectedEnvVars: []corev1.EnvVar{flashInferSamplerEnvVar},
-		},
-
 		"test-model-no-parallel/vllm": {
 			workspace: test.MockWorkspaceWithPresetVLLM,
 			nodeCount: 1,
@@ -253,7 +238,7 @@ func TestGeneratePresetInference(t *testing.T) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.Service{}), mock.Anything).Return(nil)
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
 			},
-			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=7 --ray_port=6379; python3 /workspace/vllm/inference_api.py --distributed-executor-backend=ray --model=test-repo/test-model --code-revision=test-revision --download-dir=/workspace/weights --dtype=float16 --gpu-memory-utilization=0.84 --max-model-len=auto --kaito-kv-cache-cpu-memory-utilization=0 --pipeline-parallel-size=7 --tensor-parallel-size=1; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
+			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=4 --ray_port=6379; python3 /workspace/vllm/inference_api.py --distributed-executor-backend=ray --model=test-repo/test-model --code-revision=test-revision --download-dir=/workspace/weights --gpu-memory-utilization=0.84 --max-model-len=auto --kaito-kv-cache-cpu-memory-utilization=0 --pipeline-parallel-size=4 --tensor-parallel-size=1; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
 
 			expectedEnvVars: []corev1.EnvVar{flashInferSamplerEnvVar, {
 				Name: "HF_TOKEN",
@@ -277,10 +262,10 @@ func TestGeneratePresetInference(t *testing.T) {
 		},
 
 		"test-model-download-distributed/vllm (more nodes than required)": {
-			// Using Standard_NC4as_T4_v3, which has 16GB GPU memory per node.
-			// The preset requires 64GB GPU memory for the model; estimator computes 7 nodes needed.
+			// Using Standard_NV36ads_A10_v5, which has 24GB GPU memory per node.
+			// The preset requires 64GB GPU memory for the model; estimator computes 4 nodes needed.
 			workspace: test.MockWorkspaceWithPresetDownloadVLLM,
-			nodeCount: 8, // 8 nodes requested; model requires 7, so 7 pipeline stages are used
+			nodeCount: 8, // 8 nodes requested; model requires 4, so 4 pipeline stages are used
 			modelName: "test-model-download",
 			callMocks: func(c *test.MockClient) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
@@ -290,7 +275,7 @@ func TestGeneratePresetInference(t *testing.T) {
 				// Mock node list for BYO node discovery
 				c.On("List", mock.Anything, mock.IsType(&corev1.NodeList{}), mock.Anything).Return(nil)
 			},
-			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=7 --ray_port=6379; python3 /workspace/vllm/inference_api.py --distributed-executor-backend=ray --model=test-repo/test-model --code-revision=test-revision --download-dir=/workspace/weights --dtype=float16 --gpu-memory-utilization=0.84 --max-model-len=auto --kaito-kv-cache-cpu-memory-utilization=0 --pipeline-parallel-size=7 --tensor-parallel-size=1; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
+			expectedCmd: `/bin/sh -c if [ "${POD_INDEX}" = "0" ]; then  --ray_cluster_size=4 --ray_port=6379; python3 /workspace/vllm/inference_api.py --distributed-executor-backend=ray --model=test-repo/test-model --code-revision=test-revision --download-dir=/workspace/weights --gpu-memory-utilization=0.84 --max-model-len=auto --kaito-kv-cache-cpu-memory-utilization=0 --pipeline-parallel-size=4 --tensor-parallel-size=1; else  --ray_address=testWorkspace-0.testWorkspace-headless.kaito.svc.cluster.local --ray_port=6379; fi`,
 
 			expectedEnvVars: []corev1.EnvVar{flashInferSamplerEnvVar, {
 				Name: "HF_TOKEN",

--- a/pkg/workspace/resource/node_test.go
+++ b/pkg/workspace/resource/node_test.go
@@ -57,7 +57,7 @@ func TestSetNodePluginsReadyCondition_SetsToTrue(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3", // GPU instance type
+					InstanceType:  "Standard_NV36ads_A10_v5", // GPU instance type
 					LabelSelector: &metav1.LabelSelector{},
 				},
 				Status: kaitov1beta1.WorkspaceStatus{
@@ -81,7 +81,7 @@ func TestSetNodePluginsReadyCondition_SetsToTrue(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-node",
 						Labels: map[string]string{
-							corev1.LabelInstanceTypeStable: "Standard_NC4as_T4_v3",
+							corev1.LabelInstanceTypeStable: "Standard_NV36ads_A10_v5",
 							nodeutil.LabelKeyNvidia:        nodeutil.LabelValueNvidia,
 						},
 					},
@@ -144,7 +144,7 @@ func TestSetNodePluginsReadyCondition_SetsToTrue(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3", // GPU instance type
+					InstanceType:  "Standard_NV36ads_A10_v5", // GPU instance type
 					LabelSelector: &metav1.LabelSelector{},
 				},
 				Status: kaitov1beta1.WorkspaceStatus{
@@ -184,7 +184,7 @@ func TestSetNodePluginsReadyCondition_SetsToTrue(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3", // GPU instance type
+					InstanceType:  "Standard_NV36ads_A10_v5", // GPU instance type
 					LabelSelector: &metav1.LabelSelector{},
 				},
 				Status: kaitov1beta1.WorkspaceStatus{
@@ -208,7 +208,7 @@ func TestSetNodePluginsReadyCondition_SetsToTrue(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-node",
 						Labels: map[string]string{
-							corev1.LabelInstanceTypeStable: "Standard_NC4as_T4_v3",
+							corev1.LabelInstanceTypeStable: "Standard_NV36ads_A10_v5",
 							nodeutil.LabelKeyNvidia:        nodeutil.LabelValueNvidia,
 						},
 					},
@@ -307,7 +307,7 @@ func TestSetNodePluginsReadyCondition_AdditionalCases(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3", // GPU instance type
+					InstanceType:  "Standard_NV36ads_A10_v5", // GPU instance type
 					LabelSelector: &metav1.LabelSelector{},
 				},
 				Status: kaitov1beta1.WorkspaceStatus{
@@ -331,7 +331,7 @@ func TestSetNodePluginsReadyCondition_AdditionalCases(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-node",
 						Labels: map[string]string{
-							corev1.LabelInstanceTypeStable: "Standard_NC4as_T4_v3",
+							corev1.LabelInstanceTypeStable: "Standard_NV36ads_A10_v5",
 							nodeutil.LabelKeyNvidia:        nodeutil.LabelValueNvidia,
 						},
 					},
@@ -364,7 +364,7 @@ func TestSetNodePluginsReadyCondition_AdditionalCases(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3", // GPU instance type
+					InstanceType:  "Standard_NV36ads_A10_v5", // GPU instance type
 					LabelSelector: &metav1.LabelSelector{},
 				},
 			},
@@ -424,7 +424,7 @@ func TestCheckNodePlugin(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3",
+					InstanceType:  "Standard_NV36ads_A10_v5",
 					LabelSelector: &metav1.LabelSelector{},
 				},
 			},
@@ -451,7 +451,7 @@ func TestCheckNodePlugin(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3",
+					InstanceType:  "Standard_NV36ads_A10_v5",
 					LabelSelector: &metav1.LabelSelector{},
 				},
 			},
@@ -469,7 +469,7 @@ func TestCheckNodePlugin(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-node",
 						Labels: map[string]string{
-							corev1.LabelInstanceTypeStable: "Standard_NC4as_T4_v3",
+							corev1.LabelInstanceTypeStable: "Standard_NV36ads_A10_v5",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -498,7 +498,7 @@ func TestCheckNodePlugin(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3",
+					InstanceType:  "Standard_NV36ads_A10_v5",
 					LabelSelector: &metav1.LabelSelector{},
 				},
 			},
@@ -516,7 +516,7 @@ func TestCheckNodePlugin(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-node",
 						Labels: map[string]string{
-							corev1.LabelInstanceTypeStable: "Standard_NC4as_T4_v3",
+							corev1.LabelInstanceTypeStable: "Standard_NV36ads_A10_v5",
 							nodeutil.LabelKeyNvidia:        nodeutil.LabelValueNvidia,
 						},
 					},
@@ -552,7 +552,7 @@ func TestCheckNodePlugin(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3",
+					InstanceType:  "Standard_NV36ads_A10_v5",
 					LabelSelector: &metav1.LabelSelector{},
 				},
 			},
@@ -597,7 +597,7 @@ func TestCheckNodePlugin(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3",
+					InstanceType:  "Standard_NV36ads_A10_v5",
 					LabelSelector: &metav1.LabelSelector{},
 				},
 			},
@@ -615,7 +615,7 @@ func TestCheckNodePlugin(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-node",
 						Labels: map[string]string{
-							corev1.LabelInstanceTypeStable: "Standard_NC4as_T4_v3",
+							corev1.LabelInstanceTypeStable: "Standard_NV36ads_A10_v5",
 							nodeutil.LabelKeyNvidia:        nodeutil.LabelValueNvidia,
 						},
 					},
@@ -642,7 +642,7 @@ func TestCheckNodePlugin(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3",
+					InstanceType:  "Standard_NV36ads_A10_v5",
 					LabelSelector: &metav1.LabelSelector{},
 				},
 			},
@@ -660,7 +660,7 @@ func TestCheckNodePlugin(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-node",
 						Labels: map[string]string{
-							corev1.LabelInstanceTypeStable: "Standard_NC4as_T4_v3",
+							corev1.LabelInstanceTypeStable: "Standard_NV36ads_A10_v5",
 						},
 					},
 					Status: corev1.NodeStatus{
@@ -723,7 +723,7 @@ func TestGetReadyNodesFromNodeClaims(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3",
+					InstanceType:  "Standard_NV36ads_A10_v5",
 					LabelSelector: &metav1.LabelSelector{},
 				},
 			},
@@ -746,7 +746,7 @@ func TestGetReadyNodesFromNodeClaims(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3",
+					InstanceType:  "Standard_NV36ads_A10_v5",
 					LabelSelector: &metav1.LabelSelector{},
 				},
 			},
@@ -770,7 +770,7 @@ func TestGetReadyNodesFromNodeClaims(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3",
+					InstanceType:  "Standard_NV36ads_A10_v5",
 					LabelSelector: &metav1.LabelSelector{},
 				},
 			},
@@ -808,7 +808,7 @@ func TestGetReadyNodesFromNodeClaims(t *testing.T) {
 			workspace: &kaitov1beta1.Workspace{
 				ObjectMeta: metav1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Resource: kaitov1beta1.ResourceSpec{
-					InstanceType:  "Standard_NC4as_T4_v3",
+					InstanceType:  "Standard_NV36ads_A10_v5",
 					LabelSelector: &metav1.LabelSelector{},
 				},
 			},
@@ -826,7 +826,7 @@ func TestGetReadyNodesFromNodeClaims(t *testing.T) {
 					ObjectMeta: metav1.ObjectMeta{
 						Name: "test-node",
 						Labels: map[string]string{
-							corev1.LabelInstanceTypeStable: "Standard_NC4as_T4_v3",
+							corev1.LabelInstanceTypeStable: "Standard_NV36ads_A10_v5",
 						},
 					},
 					Status: corev1.NodeStatus{

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -1353,7 +1353,7 @@ var _ = Describe("Karpenter Bootstrap", func() {
 		numOfNode := 1
 		uniqueID := fmt.Sprint("nodeclass-override-", rand.Intn(1000))
 		workspaceObj := utils.GenerateInferenceWorkspaceManifest(uniqueID, namespaceName, "",
-			numOfNode, "Standard_NC4as_T4_v3", &metav1.LabelSelector{
+			numOfNode, "Standard_NV36ads_A10_v5", &metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": uniqueID},
 			}, nil, PresetPhi3Mini128kModel, nil, nil, nil, "", "")
 

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -155,7 +155,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		// Need 2 Standard_NC6s_v3 nodes to run Llama 3.1-8B Instruct model.
 		// Each node has 1 V100 GPU, so total 2 GPUs are used
 		numOfNode := 2
-		workspaceObj := createLlama3_1_8BInstructWorkspaceWithPresetPublicModeAndVLLM(numOfNode, "Standard_NC16as_T4_v3")
+		workspaceObj := createLlama3_1_8BInstructWorkspaceWithPresetPublicModeAndVLLM(numOfNode, "Standard_NV36ads_A10_v5")
 
 		defer cleanupResources(workspaceObj)
 		time.Sleep(30 * time.Second)

--- a/website/docs/rag.md
+++ b/website/docs/rag.md
@@ -96,7 +96,7 @@ metadata:
   name: ragengine-start
 spec:
   compute:
-    instanceType: "Standard_NC4as_T4_v3"
+    instanceType: "Standard_NV36ads_A10_v5"
     labelSelector:
       matchLabels:
         apps: ragengine-example
@@ -211,7 +211,7 @@ metadata:
   name: ragengine-with-pvc
 spec:
   compute:
-    instanceType: "Standard_NC4as_T4_v3"
+    instanceType: "Standard_NV36ads_A10_v5"
     labelSelector:
       matchLabels:
         apps: ragengine-example


### PR DESCRIPTION


**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Remove all cloud SKUs (Azure/AWS/Arc) backed by GPUs older than Ampere: K80 (3.7), M60 (5.2), V100 (7.0), and T4 (7.5). These architectures lack bfloat16 and modern vLLM features KAITO depends on. Migrate all tests and the RAG doc sample to supported SKUs (A10/A100/H100), recompute spec hashes for Workspace/InferenceSet/RAGEngine mocks, and drop the redundant <20GB-per-GPU single-instance inference-config tests (unreachable via the supported SKU set; still covered via distributed inference).

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: