### PR TITLE
feat: workload-identity-authed storage class streaming

### DIFF
--- a/api/v1alpha1/modelmirror_types.go
+++ b/api/v1alpha1/modelmirror_types.go
@@ -55,10 +55,8 @@ type ModelMirrorSpec struct {
 	// omit entirely for static mirrors.
 	// +optional
 	JobNamespace string `json:"jobNamespace,omitempty"`
-	// ServiceAccountName is the ServiceAccount the download Job pod runs as. When set, the
-	// pod also gets the azure.workload.identity/use="true" label so a Workload-Identity-authed
-	// blob StorageClass can mount without a storage account key. Empty (the default) runs the
-	// Job under the namespace default ServiceAccount.
+	// ServiceAccountName is the ServiceAccount used by the workload identity that the download
+	// Job pod runs as. Empty (the default) runs the Job under the namespace default ServiceAccount.
 	// +optional
 	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }

--- a/api/v1alpha1/modelmirror_types.go
+++ b/api/v1alpha1/modelmirror_types.go
@@ -55,6 +55,12 @@ type ModelMirrorSpec struct {
 	// omit entirely for static mirrors.
 	// +optional
 	JobNamespace string `json:"jobNamespace,omitempty"`
+	// ServiceAccountName is the ServiceAccount the download Job pod runs as. When set, the
+	// pod also gets the azure.workload.identity/use="true" label so a Workload-Identity-authed
+	// blob StorageClass can mount without a storage account key. Empty (the default) runs the
+	// Job under the namespace default ServiceAccount.
+	// +optional
+	ServiceAccountName string `json:"serviceAccountName,omitempty"`
 }
 
 // ModelMirrorMode describes how a ModelMirror provisions the model weights.

--- a/charts/kaito/workspace/templates/kaito.sh_modelmirrors.yaml
+++ b/charts/kaito/workspace/templates/kaito.sh_modelmirrors.yaml
@@ -68,10 +68,8 @@ spec:
                 type: string
               serviceAccountName:
                 description: |-
-                  ServiceAccountName is the ServiceAccount the download Job pod runs as. When set, the
-                  pod also gets the azure.workload.identity/use="true" label so a Workload-Identity-authed
-                  blob StorageClass can mount without a storage account key. Empty (the default) runs the
-                  Job under the namespace default ServiceAccount.
+                  ServiceAccountName is the ServiceAccount used by the workload identity that the download
+                  Job pod runs as. Empty (the default) runs the Job under the namespace default ServiceAccount.
                 type: string
               source:
                 description: |-

--- a/charts/kaito/workspace/templates/kaito.sh_modelmirrors.yaml
+++ b/charts/kaito/workspace/templates/kaito.sh_modelmirrors.yaml
@@ -51,8 +51,8 @@ spec:
             properties:
               jobNamespace:
                 description: |-
-                  JobNamespace is the namespace where the PVC and download Job will be created.
-                  Empty for static mirrors that create no PVC or Job.
+                  JobNamespace is the namespace where the PVC and download Job will be created;
+                  omit entirely for static mirrors.
                 type: string
               mode:
                 default: Managed
@@ -66,11 +66,17 @@ spec:
                 - Managed
                 - Static
                 type: string
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the ServiceAccount the download Job pod runs as. When set, the
+                  pod also gets the azure.workload.identity/use="true" label so a Workload-Identity-authed
+                  blob StorageClass can mount without a storage account key. Empty (the default) runs the
+                  Job under the namespace default ServiceAccount.
+                type: string
               source:
                 description: |-
                   Source describes where to download the model weights from. Required for a Managed
-                  mirror; omit entirely for a Static mirror (the weights already exist in BYO storage,
-                  so there is nothing to download).
+                  mirror; omit entirely for a Static mirror.
                 properties:
                   accessSecret:
                     description: AccessSecret references a secret containing authentication
@@ -132,17 +138,14 @@ spec:
               storage:
                 description: |-
                   Storage describes the PVC to download the model weights into. Required for a Managed
-                  mirror; omit entirely for a Static mirror (no PVC is created).
+                  mirror; omit entirely for a Static mirror.
                 properties:
                   size:
-                    description: |-
-                      Size is the requested model storage: the PVC size for managed mirrors, or
-                      informational for static mirrors that create no PVC.
+                    description: Size is the PVC size for managed mirrors.
                     type: string
                   storageClassName:
-                    description: |-
-                      StorageClassName is the StorageClass to use for the PVC. Nil for static
-                      mirrors that create no PVC.
+                    description: StorageClassName is the StorageClass to use for the
+                      PVC.
                     type: string
                 required:
                 - size

--- a/cmd/workspace/main.go
+++ b/cmd/workspace/main.go
@@ -133,7 +133,7 @@ func main() {
 	flag.StringVar(&karpenterNodeClassVersion, "karpenter-node-class-version", "v1beta1", "Karpenter NodeClass API version. Only used when node-provisioner=karpenter.")
 	flag.StringVar(&karpenterNodeClassResourceName, "karpenter-node-class-resource-name", "aksnodeclasses", "Plural resource name for the NodeClass CRD (e.g. aksnodeclasses). Combined with --karpenter-node-class-group to form the full CRD name. Only used when node-provisioner=karpenter.")
 	flag.BoolVar(&printVersionAndExit, "version", false, "Print version and exit.")
-	flag.StringVar(&defaultModelMirrorStorageClass, "default-model-mirror-storage-class", "", "StorageClass for ModelMirror PVCs (required when ModelStreaming=true).")
+	flag.StringVar(&defaultModelMirrorStorageClass, "default-model-mirror-storage-class", "", "StorageClass for ModelMirror PVCs.")
 	flag.StringVar(&defaultStreamingServiceAccount, "default-streaming-service-account", "", "Default ServiceAccount for streaming inference pods.")
 	flag.StringVar(&modelMirrorDownloadCPU, "model-mirror-download-cpu", "", "CPU request==limit for the ModelMirror download Job container. Empty uses the built-in default (3).")
 	flag.StringVar(&modelMirrorDownloadMemory, "model-mirror-download-memory", "", "Memory request==limit for the ModelMirror download Job container. Empty uses the built-in default (8Gi).")

--- a/config/crd/bases/kaito.sh_modelmirrors.yaml
+++ b/config/crd/bases/kaito.sh_modelmirrors.yaml
@@ -68,10 +68,8 @@ spec:
                 type: string
               serviceAccountName:
                 description: |-
-                  ServiceAccountName is the ServiceAccount the download Job pod runs as. When set, the
-                  pod also gets the azure.workload.identity/use="true" label so a Workload-Identity-authed
-                  blob StorageClass can mount without a storage account key. Empty (the default) runs the
-                  Job under the namespace default ServiceAccount.
+                  ServiceAccountName is the ServiceAccount used by the workload identity that the download
+                  Job pod runs as. Empty (the default) runs the Job under the namespace default ServiceAccount.
                 type: string
               source:
                 description: |-

--- a/config/crd/bases/kaito.sh_modelmirrors.yaml
+++ b/config/crd/bases/kaito.sh_modelmirrors.yaml
@@ -51,8 +51,8 @@ spec:
             properties:
               jobNamespace:
                 description: |-
-                  JobNamespace is the namespace where the PVC and download Job will be created.
-                  Empty for static mirrors that create no PVC or Job.
+                  JobNamespace is the namespace where the PVC and download Job will be created;
+                  omit entirely for static mirrors.
                 type: string
               mode:
                 default: Managed
@@ -66,11 +66,17 @@ spec:
                 - Managed
                 - Static
                 type: string
+              serviceAccountName:
+                description: |-
+                  ServiceAccountName is the ServiceAccount the download Job pod runs as. When set, the
+                  pod also gets the azure.workload.identity/use="true" label so a Workload-Identity-authed
+                  blob StorageClass can mount without a storage account key. Empty (the default) runs the
+                  Job under the namespace default ServiceAccount.
+                type: string
               source:
                 description: |-
                   Source describes where to download the model weights from. Required for a Managed
-                  mirror; omit entirely for a Static mirror (the weights already exist in BYO storage,
-                  so there is nothing to download).
+                  mirror; omit entirely for a Static mirror.
                 properties:
                   accessSecret:
                     description: AccessSecret references a secret containing authentication
@@ -132,17 +138,14 @@ spec:
               storage:
                 description: |-
                   Storage describes the PVC to download the model weights into. Required for a Managed
-                  mirror; omit entirely for a Static mirror (no PVC is created).
+                  mirror; omit entirely for a Static mirror.
                 properties:
                   size:
-                    description: |-
-                      Size is the requested model storage: the PVC size for managed mirrors, or
-                      informational for static mirrors that create no PVC.
+                    description: Size is the PVC size for managed mirrors.
                     type: string
                   storageClassName:
-                    description: |-
-                      StorageClassName is the StorageClass to use for the PVC. Nil for static
-                      mirrors that create no PVC.
+                    description: StorageClassName is the StorageClass to use for the
+                      PVC.
                     type: string
                 required:
                 - size

--- a/pkg/modelmirror/controllers/modelmirror_controller.go
+++ b/pkg/modelmirror/controllers/modelmirror_controller.go
@@ -16,6 +16,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -229,7 +230,7 @@ func (r *ModelMirrorReconciler) ensureDownloadJob(ctx context.Context, cr *kaito
 		return nil
 	}
 
-	job := download.BuildDownloadJob(cr, r.DownloadResources)
+	job := download.BuildDownloadJob(cr, r.DownloadResources, download.WorkloadIdentityPodLabels(os.Getenv("CLOUD_PROVIDER")))
 	log.Info("Creating download Job", "namespace", cr.Spec.JobNamespace)
 	return r.Create(ctx, job)
 }

--- a/pkg/modelmirror/download/azure/podidentity.go
+++ b/pkg/modelmirror/download/azure/podidentity.go
@@ -1,0 +1,23 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azure
+
+// WorkloadIdentityPodLabels returns the pod labels that opt the download Job into Azure
+// Workload Identity, so a workload-identity-authenticated blob StorageClass can mount the
+// download PVC.
+func WorkloadIdentityPodLabels() map[string]string {
+	return map[string]string{
+		"azure.workload.identity/use": "true",
+	}
+}

--- a/pkg/modelmirror/download/job.go
+++ b/pkg/modelmirror/download/job.go
@@ -129,8 +129,8 @@ find "/models/${MODEL_ID}/" -mindepth 1 -type d -exec rm -rf {} + 2>/dev/null ||
 		},
 	}
 
-	// When a ServiceAccount is set, run the Job under it and add the Azure Workload Identity
-	// pod label so a WI-authed blob StorageClass mounts without a storage account key.
+	// When a ServiceAccount is set, run the Job under it and add the cloud workload-identity
+	// pod label. Empty leaves the pod on the namespace default ServiceAccount.
 	if cr.Spec.ServiceAccountName != "" {
 		job.Spec.Template.Spec.ServiceAccountName = cr.Spec.ServiceAccountName
 		if job.Spec.Template.Labels == nil {

--- a/pkg/modelmirror/download/job.go
+++ b/pkg/modelmirror/download/job.go
@@ -28,7 +28,9 @@ import (
 
 // BuildDownloadJob constructs the Job that downloads model files to the PVC.
 // resources sets the CPU/memory request==limit on the downloader container.
-func BuildDownloadJob(cr *kaitov1alpha1.ModelMirror, resources mmconsts.DownloadJobResources) *batchv1.Job {
+// podLabels are applied to the Job pod template when a ServiceAccount is set (e.g. the
+// cloud workload-identity label); pass nil to add none.
+func BuildDownloadJob(cr *kaitov1alpha1.ModelMirror, resources mmconsts.DownloadJobResources, podLabels map[string]string) *batchv1.Job {
 	modelID := cr.Spec.Source.ModelID
 
 	// Build --exclude flags from DownloadExcludePatterns
@@ -129,14 +131,17 @@ find "/models/${MODEL_ID}/" -mindepth 1 -type d -exec rm -rf {} + 2>/dev/null ||
 		},
 	}
 
-	// When a ServiceAccount is set, run the Job under it and add the cloud workload-identity
-	// pod label. Empty leaves the pod on the namespace default ServiceAccount.
+	// When a ServiceAccount is set, run the Job under it and apply the provider-supplied pod
+	// labels (e.g. the cloud workload-identity label). Empty leaves the pod on the namespace
+	// default ServiceAccount with no extra labels.
 	if cr.Spec.ServiceAccountName != "" {
 		job.Spec.Template.Spec.ServiceAccountName = cr.Spec.ServiceAccountName
-		if job.Spec.Template.Labels == nil {
-			job.Spec.Template.Labels = map[string]string{}
+		for k, v := range podLabels {
+			if job.Spec.Template.Labels == nil {
+				job.Spec.Template.Labels = map[string]string{}
+			}
+			job.Spec.Template.Labels[k] = v
 		}
-		job.Spec.Template.Labels["azure.workload.identity/use"] = "true"
 	}
 	return job
 }

--- a/pkg/modelmirror/download/job.go
+++ b/pkg/modelmirror/download/job.go
@@ -128,5 +128,15 @@ find "/models/${MODEL_ID}/" -mindepth 1 -type d -exec rm -rf {} + 2>/dev/null ||
 			},
 		},
 	}
+
+	// When a ServiceAccount is set, run the Job under it and add the Azure Workload Identity
+	// pod label so a WI-authed blob StorageClass mounts without a storage account key.
+	if cr.Spec.ServiceAccountName != "" {
+		job.Spec.Template.Spec.ServiceAccountName = cr.Spec.ServiceAccountName
+		if job.Spec.Template.Labels == nil {
+			job.Spec.Template.Labels = map[string]string{}
+		}
+		job.Spec.Template.Labels["azure.workload.identity/use"] = "true"
+	}
 	return job
 }

--- a/pkg/modelmirror/download/job_test.go
+++ b/pkg/modelmirror/download/job_test.go
@@ -92,7 +92,7 @@ func TestBuildDownloadJobServiceAccount(t *testing.T) {
 
 		assert.Empty(t, job.Spec.Template.Spec.ServiceAccountName, "no ServiceAccount should be set")
 		assert.NotContains(t, job.Spec.Template.Labels, "azure.workload.identity/use",
-			"WI label must be absent when no ServiceAccount is set (account-key mount path)")
+			"workload-identity label must be absent when no ServiceAccount is set (account-key mount path)")
 	})
 
 	t.Run("set stamps SA and WI label", func(t *testing.T) {
@@ -102,6 +102,6 @@ func TestBuildDownloadJobServiceAccount(t *testing.T) {
 
 		assert.Equal(t, "kaito-model-streamer", job.Spec.Template.Spec.ServiceAccountName)
 		assert.Equal(t, "true", job.Spec.Template.Labels["azure.workload.identity/use"],
-			"WI label must be set so a WI-authed blob StorageClass can mount")
+			"workload-identity label must be set so a workload-identity-authenticated StorageClass can mount")
 	})
 }

--- a/pkg/modelmirror/download/job_test.go
+++ b/pkg/modelmirror/download/job_test.go
@@ -84,3 +84,24 @@ func TestBuildDownloadJobResources(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildDownloadJobServiceAccount(t *testing.T) {
+	t.Run("empty leaves default SA and no WI label", func(t *testing.T) {
+		cr := newTestModelMirror() // ServiceAccountName unset
+		job := BuildDownloadJob(cr, mmconsts.DefaultDownloadJobResources())
+
+		assert.Empty(t, job.Spec.Template.Spec.ServiceAccountName, "no ServiceAccount should be set")
+		assert.NotContains(t, job.Spec.Template.Labels, "azure.workload.identity/use",
+			"WI label must be absent when no ServiceAccount is set (account-key mount path)")
+	})
+
+	t.Run("set stamps SA and WI label", func(t *testing.T) {
+		cr := newTestModelMirror()
+		cr.Spec.ServiceAccountName = "kaito-model-streamer"
+		job := BuildDownloadJob(cr, mmconsts.DefaultDownloadJobResources())
+
+		assert.Equal(t, "kaito-model-streamer", job.Spec.Template.Spec.ServiceAccountName)
+		assert.Equal(t, "true", job.Spec.Template.Labels["azure.workload.identity/use"],
+			"WI label must be set so a WI-authed blob StorageClass can mount")
+	})
+}

--- a/pkg/modelmirror/download/job_test.go
+++ b/pkg/modelmirror/download/job_test.go
@@ -67,7 +67,7 @@ func TestBuildDownloadJobResources(t *testing.T) {
 				resources.Memory = tc.memory
 			}
 
-			job := BuildDownloadJob(newTestModelMirror(), resources)
+			job := BuildDownloadJob(newTestModelMirror(), resources, nil)
 			containers := job.Spec.Template.Spec.Containers
 			assert.Len(t, containers, 1)
 			res := containers[0].Resources
@@ -86,22 +86,31 @@ func TestBuildDownloadJobResources(t *testing.T) {
 }
 
 func TestBuildDownloadJobServiceAccount(t *testing.T) {
-	t.Run("empty leaves default SA and no WI label", func(t *testing.T) {
+	t.Run("empty SA leaves default SA and applies no labels", func(t *testing.T) {
 		cr := newTestModelMirror() // ServiceAccountName unset
-		job := BuildDownloadJob(cr, mmconsts.DefaultDownloadJobResources())
+		job := BuildDownloadJob(cr, mmconsts.DefaultDownloadJobResources(), map[string]string{"azure.workload.identity/use": "true"})
 
 		assert.Empty(t, job.Spec.Template.Spec.ServiceAccountName, "no ServiceAccount should be set")
 		assert.NotContains(t, job.Spec.Template.Labels, "azure.workload.identity/use",
-			"workload-identity label must be absent when no ServiceAccount is set (account-key mount path)")
+			"pod labels must not be applied when no ServiceAccount is set (account-key mount path)")
 	})
 
-	t.Run("set stamps SA and WI label", func(t *testing.T) {
+	t.Run("set SA stamps SA and applies provider pod labels", func(t *testing.T) {
 		cr := newTestModelMirror()
 		cr.Spec.ServiceAccountName = "kaito-model-streamer"
-		job := BuildDownloadJob(cr, mmconsts.DefaultDownloadJobResources())
+		job := BuildDownloadJob(cr, mmconsts.DefaultDownloadJobResources(), map[string]string{"azure.workload.identity/use": "true"})
 
 		assert.Equal(t, "kaito-model-streamer", job.Spec.Template.Spec.ServiceAccountName)
 		assert.Equal(t, "true", job.Spec.Template.Labels["azure.workload.identity/use"],
-			"workload-identity label must be set so a workload-identity-authenticated StorageClass can mount")
+			"provider pod labels must be applied so a workload-identity-authenticated StorageClass can mount")
+	})
+
+	t.Run("set SA with nil labels stamps SA but adds no labels", func(t *testing.T) {
+		cr := newTestModelMirror()
+		cr.Spec.ServiceAccountName = "kaito-model-streamer"
+		job := BuildDownloadJob(cr, mmconsts.DefaultDownloadJobResources(), nil)
+
+		assert.Equal(t, "kaito-model-streamer", job.Spec.Template.Spec.ServiceAccountName)
+		assert.Empty(t, job.Spec.Template.Labels, "no pod labels expected when provider supplies none (non-Azure cloud)")
 	})
 }

--- a/pkg/modelmirror/download/provider.go
+++ b/pkg/modelmirror/download/provider.go
@@ -1,0 +1,30 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package download
+
+import (
+	"github.com/kaito-project/kaito/pkg/modelmirror/download/azure"
+	"github.com/kaito-project/kaito/pkg/utils/consts"
+)
+
+// WorkloadIdentityPodLabels returns the cloud-specific pod labels that let the download Job
+// mount a workload-identity-authenticated StorageClass.
+func WorkloadIdentityPodLabels(cloud string) map[string]string {
+	switch cloud {
+	case consts.AzureCloudName:
+		return azure.WorkloadIdentityPodLabels()
+	default:
+		return nil
+	}
+}

--- a/pkg/modelmirror/download/provider_test.go
+++ b/pkg/modelmirror/download/provider_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package download
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/kaito-project/kaito/pkg/utils/consts"
+)
+
+func TestWorkloadIdentityPodLabels(t *testing.T) {
+	t.Run("azure returns the WI label", func(t *testing.T) {
+		labels := WorkloadIdentityPodLabels(consts.AzureCloudName)
+		assert.Equal(t, "true", labels["azure.workload.identity/use"])
+	})
+
+	t.Run("non-azure returns nil", func(t *testing.T) {
+		assert.Nil(t, WorkloadIdentityPodLabels("aws"))
+		assert.Nil(t, WorkloadIdentityPodLabels(""))
+	})
+}

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -213,7 +213,10 @@ func (c *WorkspaceReconciler) ensureModelMirror(ctx context.Context, wObj *kaito
 	}
 
 	// Managed mirror: validate the StorageClass exists and uses the correct CSI provisioner.
-	storageClass := modelstreaming.ResolveStorageClass(wObj, modelstreaming.StreamingDefaults.StorageClass)
+	storageClass, err := modelstreaming.ResolveStorageClass(wObj, modelstreaming.StreamingDefaults.StorageClass)
+	if err != nil {
+		return err
+	}
 	sc := &storagev1.StorageClass{}
 	if err := c.Client.Get(ctx, client.ObjectKey{Name: storageClass}, sc); err != nil {
 		return fmt.Errorf("StorageClass %q not found: %w", storageClass, err)

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -233,6 +233,11 @@ func (c *WorkspaceReconciler) ensureModelMirror(ctx context.Context, wObj *kaito
 		return err
 	}
 
+	serviceAccount, err := modelstreaming.ResolveStreamingServiceAccount(wObj, modelstreaming.StreamingDefaults.ServiceAccount)
+	if err != nil {
+		return err
+	}
+
 	// Resolve model metadata for DiskStorageRequirement
 	presetName := string(wObj.Inference.Preset.Name)
 	model, err := models.GetModelByName(ctx, presetName, wObj.Inference.Preset.PresetOptions.ModelAccessSecret, wObj.Namespace, c.Client)
@@ -266,7 +271,8 @@ func (c *WorkspaceReconciler) ensureModelMirror(ctx context.Context, wObj *kaito
 				Size:             modelSize,
 				StorageClassName: ptr.To(storageClass),
 			},
-			JobNamespace: wObj.Namespace,
+			JobNamespace:       wObj.Namespace,
+			ServiceAccountName: serviceAccount,
 		},
 	}
 

--- a/pkg/workspace/controllers/workspace_controller_test.go
+++ b/pkg/workspace/controllers/workspace_controller_test.go
@@ -51,6 +51,7 @@ import (
 	"github.com/kaito-project/kaito/pkg/workspace/estimator/nodesestimator"
 	"github.com/kaito-project/kaito/pkg/workspace/inference"
 	"github.com/kaito-project/kaito/pkg/workspace/inference/modelstreaming"
+	"github.com/kaito-project/kaito/pkg/workspace/inference/modelstreaming/registry"
 )
 
 func TestSelectWorkspaceNodes(t *testing.T) {
@@ -1056,6 +1057,71 @@ func TestEnsureModelMirror_StaticWithoutSASFails(t *testing.T) {
 	err := reconciler.ensureModelMirror(context.Background(), ws)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), modelstreaming.AnnotationStaticModelMirror)
+}
+
+// TestEnsureModelMirror_ManagedStampsServiceAccount verifies the managed (download) path
+// resolves the streaming ServiceAccount and stamps it onto the created ModelMirror CR, so the
+// download Job can later mount a Workload-Identity-authed blob StorageClass.
+func TestEnsureModelMirror_ManagedStampsServiceAccount(t *testing.T) {
+	t.Setenv("CLOUD_PROVIDER", consts.AzureCloudName)
+
+	const saName = "kaito-model-streamer"
+	streamer, err := registry.GetModelStreamer(consts.AzureCloudName)
+	assert.NoError(t, err)
+	prevSA := modelstreaming.StreamingDefaults.ServiceAccount
+	prevSC := modelstreaming.StreamingDefaults.StorageClass
+	prevStreamer := modelstreaming.StreamingDefaults.ModelStreamer
+	modelstreaming.StreamingDefaults.ServiceAccount = saName
+	modelstreaming.StreamingDefaults.StorageClass = "blob-fuse"
+	modelstreaming.StreamingDefaults.ModelStreamer = streamer
+	t.Cleanup(func() {
+		modelstreaming.StreamingDefaults.ServiceAccount = prevSA
+		modelstreaming.StreamingDefaults.StorageClass = prevSC
+		modelstreaming.StreamingDefaults.ModelStreamer = prevStreamer
+	})
+
+	mockClient := test.NewClient()
+	// Seed the streaming ServiceAccount (exists + WI annotation) so ValidateAuth passes.
+	mockClient.CreateOrUpdateObjectInMap(&corev1.ServiceAccount{
+		ObjectMeta: v1.ObjectMeta{
+			Name:        saName,
+			Namespace:   "default",
+			Annotations: map[string]string{"azure.workload.identity/client-id": "00000000-0000-0000-0000-000000000000"},
+		},
+	})
+	// Seed the StorageClass with the Azure blob CSI provisioner so SC validation passes.
+	mockClient.CreateOrUpdateObjectInMap(&storagev1.StorageClass{
+		ObjectMeta:  v1.ObjectMeta{Name: "blob-fuse"},
+		Provisioner: consts.CSIDriverNameForCloud(consts.AzureCloudName),
+	})
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.IsType(&corev1.ServiceAccount{}), mock.Anything).Return(nil)
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
+	mockClient.On("Get", mock.Anything, mock.Anything, mock.IsType(&kaitov1alpha1.ModelMirror{}), mock.Anything).Return(test.NotFoundError())
+	mockClient.On("Create", mock.Anything, mock.IsType(&kaitov1alpha1.ModelMirror{}), mock.Anything).Return(nil)
+
+	ws := &v1beta1.Workspace{
+		ObjectMeta: v1.ObjectMeta{Name: "ws-managed-sa", Namespace: "default"},
+		Inference: &v1beta1.InferenceSpec{
+			Preset: &v1beta1.PresetSpec{PresetMeta: v1beta1.PresetMeta{Name: "phi-4"}},
+		},
+	}
+
+	reconciler := &WorkspaceReconciler{Client: mockClient}
+	err = reconciler.ensureModelMirror(context.Background(), ws)
+	assert.NoError(t, err)
+
+	// The created CR must carry the resolved ServiceAccount and be Managed.
+	crMap := mockClient.CreateMapWithType(&kaitov1alpha1.ModelMirror{})
+	var created *kaitov1alpha1.ModelMirror
+	for _, obj := range crMap {
+		if mm, ok := obj.(*kaitov1alpha1.ModelMirror); ok {
+			created = mm
+			break
+		}
+	}
+	assert.NotNil(t, created, "a ModelMirror CR should have been created")
+	assert.Equal(t, kaitov1alpha1.ModelMirrorModeManaged, created.Spec.Mode)
+	assert.Equal(t, saName, created.Spec.ServiceAccountName)
 }
 
 func TestSyncWorkspaceStatus(t *testing.T) {

--- a/pkg/workspace/controllers/workspace_controller_test.go
+++ b/pkg/workspace/controllers/workspace_controller_test.go
@@ -1061,7 +1061,7 @@ func TestEnsureModelMirror_StaticWithoutSASFails(t *testing.T) {
 
 // TestEnsureModelMirror_ManagedStampsServiceAccount verifies the managed (download) path
 // resolves the streaming ServiceAccount and stamps it onto the created ModelMirror CR, so the
-// download Job can later mount a Workload-Identity-authed blob StorageClass.
+// download Job can later mount a workload-identity-authenticated StorageClass.
 func TestEnsureModelMirror_ManagedStampsServiceAccount(t *testing.T) {
 	t.Setenv("CLOUD_PROVIDER", consts.AzureCloudName)
 

--- a/pkg/workspace/inference/modelstreaming/modelstreaming.go
+++ b/pkg/workspace/inference/modelstreaming/modelstreaming.go
@@ -110,13 +110,17 @@ func ResolveStreamingServiceAccount(ws *v1beta1.Workspace, defaultSA string) (st
 }
 
 // ResolveStorageClass resolves the StorageClass for the ModelMirror PVC.
-// Priority: workspace annotation > controller flag.
-func ResolveStorageClass(ws *v1beta1.Workspace, defaultSC string) string {
+func ResolveStorageClass(ws *v1beta1.Workspace, defaultSC string) (string, error) {
 	sc := ws.Annotations[mmconsts.AnnotationModelMirrorStorageClass]
 	if sc == "" {
 		sc = defaultSC
 	}
-	return sc
+	if sc == "" {
+		return "", fmt.Errorf("model streaming enabled but no storage class configured: "+
+			"set annotation %s on the workspace or --default-model-mirror-storage-class on the controller",
+			mmconsts.AnnotationModelMirrorStorageClass)
+	}
+	return sc, nil
 }
 
 // buildCommonStreamingEnvVars returns env vars common to all cloud providers:

--- a/pkg/workspace/inference/modelstreaming/modelstreaming_test.go
+++ b/pkg/workspace/inference/modelstreaming/modelstreaming_test.go
@@ -157,11 +157,12 @@ func TestResolveStorageClass(t *testing.T) {
 		annotation string
 		defaultSC  string
 		expected   string
+		wantErr    bool
 	}{
-		{"annotation set", "my-sc", "", "my-sc"},
-		{"default flag set", "", "default-sc", "default-sc"},
-		{"annotation overrides default", "my-sc", "default-sc", "my-sc"},
-		{"neither set", "", "", ""},
+		{"annotation set", "my-sc", "", "my-sc", false},
+		{"default flag set", "", "default-sc", "default-sc", false},
+		{"annotation overrides default", "my-sc", "default-sc", "my-sc", false},
+		{"neither set", "", "", "", true},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -169,7 +170,13 @@ func TestResolveStorageClass(t *testing.T) {
 			if tc.annotation != "" {
 				ws.Annotations[mmconsts.AnnotationModelMirrorStorageClass] = tc.annotation
 			}
-			assert.Equal(t, tc.expected, ResolveStorageClass(ws, tc.defaultSC))
+			got, err := ResolveStorageClass(ws, tc.defaultSC)
+			if tc.wantErr {
+				assert.Error(t, err)
+				return
+			}
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expected, got)
 		})
 	}
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
Make Kaito streaming support storage class that authenticates through workload identity. Writes the service account name to download job's ```Spec.Template.Spec.ServiceAccountName``` and add ```job.Spec.Template.Labels["azure.workload.identity/use"] = "true"``` label to it.

Also included a small improvement to fail fast on empty storage class when streaming feature gate is on.
**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Closes #2194 
**Notes for Reviewers**: