### PR TITLE
feat: Add ordered multi-choice stream buffer

### DIFF
--- a/presets/ragengine/streaming/ordered_guardrail_buffer.py
+++ b/presets/ragengine/streaming/ordered_guardrail_buffer.py
@@ -1,0 +1,287 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Ordered multi-choice streaming buffer for guardrail scanning.
+
+This module deliberately stays below OutputGuardrails, HTTP/SSE framing,
+llm-guard, and block-response policy. It coordinates choice-local
+StreamingBufferWindow instances and releases the original input events only
+after all content offsets referenced by earlier queued events have been
+scanner-confirmed.
+"""
+
+from collections import deque
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from ragengine.streaming.buffer_window import (
+    StreamingBufferWindow,
+    WindowEmitResult,
+    WindowScanner,
+)
+from ragengine.streaming.openai import ParsedOpenAIChoice
+
+WindowScannerFactory = Callable[[int], WindowScanner]
+DEFAULT_MAX_PENDING_EVENTS = 1024
+DEFAULT_MAX_PENDING_BYTES = 1024 * 1024
+
+
+class OrderedGuardrailBufferOverflowError(RuntimeError):
+    """Raised when the pending event queue reaches its configured limit."""
+
+
+@dataclass(frozen=True)
+class OrderedGuardrailBufferResult:
+    ready_events: tuple[str, ...] = ()
+    blocked: bool = False
+
+
+@dataclass
+class _ChoiceState:
+    """Scanning progress for one OpenAI choice."""
+
+    window: StreamingBufferWindow
+    received_offset: int = 0  # Total characters received.
+    released_offset: int = 0  # Characters confirmed safe by the window.
+    finished: bool = False  # Whether the window has been flushed.
+
+
+@dataclass(frozen=True)
+class _PendingEvent:
+    """A raw event waiting for its referenced content to become safe."""
+
+    raw: str
+    # choice_index -> released_offset required before release.
+    required_offsets: dict[int, int]
+    size: int  # UTF-8 size used for queue limits.
+
+
+class OrderedGuardrailBuffer:
+    def __init__(
+        self,
+        scanner_factory: WindowScannerFactory,
+        *,
+        holdback_len: int,
+        max_pending_events: int = DEFAULT_MAX_PENDING_EVENTS,
+        max_pending_bytes: int = DEFAULT_MAX_PENDING_BYTES,
+    ) -> None:
+        """Initialize per-choice scanning and pending raw-event queue limits."""
+        if holdback_len < 0:
+            raise ValueError("holdback_len must be non-negative.")
+        if max_pending_events <= 0:
+            raise ValueError("max_pending_events must be positive.")
+        if max_pending_bytes <= 0:
+            raise ValueError("max_pending_bytes must be positive.")
+
+        self._scanner_factory = scanner_factory
+        self._holdback_len = holdback_len
+        self._max_pending_events = max_pending_events
+        self._max_pending_bytes = max_pending_bytes
+        self._choices: dict[int, _ChoiceState] = {}
+        self._pending_events: deque[_PendingEvent] = deque()
+        self._pending_bytes = 0
+        self._blocked = False
+        self._stream_finished = False
+
+    def feed(
+        self,
+        raw: str,
+        choices: tuple[ParsedOpenAIChoice, ...],
+    ) -> OrderedGuardrailBufferResult:
+        """Public entry point for one parsed OpenAI event.
+
+        Scans choice content, records this raw event's release requirements, and
+        returns all queued raw events that are now safe to pass through.
+        """
+        if self._blocked:
+            return OrderedGuardrailBufferResult(blocked=True)
+        if self._stream_finished:
+            raise RuntimeError("cannot feed events after the stream is finished.")
+
+        raw_size = self._ensure_queue_capacity(raw)
+        required_offsets: dict[int, int] = {}
+
+        for choice in choices:
+            if choice.content is not None and self._scan_content(
+                choice.choice_index,
+                choice.content,
+                required_offsets,
+            ):
+                return OrderedGuardrailBufferResult(blocked=True)
+
+            if choice.finish_reason is not None:
+                state = self._get_choice_state(choice.choice_index)
+                required_offsets[choice.choice_index] = state.received_offset
+
+        # Enqueue the raw event before flushing finished choices so the finish
+        # event is released together with all earlier content in its original order.
+        self._enqueue(raw, required_offsets, raw_size)
+
+        for choice in choices:
+            if choice.finish_reason is None:
+                continue
+            if self._finish_choice(choice.choice_index):
+                return OrderedGuardrailBufferResult(blocked=True)
+
+        return self._release_ready_events()
+
+    def finish_stream(self, raw: str | None = None) -> OrderedGuardrailBufferResult:
+        """Public entry point for stream completion.
+
+        Optionally queues a final raw event, flushes every choice window, and
+        releases all safe raw events before marking the stream finished.
+        """
+        if self._blocked:
+            return OrderedGuardrailBufferResult(blocked=True)
+        if self._stream_finished:
+            raise RuntimeError("stream is already finished.")
+
+        if raw is not None:
+            raw_size = self._ensure_queue_capacity(raw)
+            required_offsets = {
+                choice_index: state.received_offset
+                for choice_index, state in self._choices.items()
+            }
+            self._enqueue(raw, required_offsets, raw_size)
+
+        for choice_index in tuple(self._choices):
+            if self._finish_choice(choice_index):
+                return OrderedGuardrailBufferResult(blocked=True)
+        self._stream_finished = True
+
+        return self._release_ready_events()
+
+    def _scan_content(
+        self,
+        choice_index: int,
+        content: str,
+        required_offsets: dict[int, int],
+    ) -> bool:
+        """Update one choice's scan state for content in the current raw event."""
+        state = self._get_choice_state(choice_index)
+        if state.finished:
+            raise RuntimeError(f"choice {choice_index} is already finished.")
+
+        state.received_offset += len(content)
+        required_offsets[choice_index] = state.received_offset
+
+        if not content:
+            return False
+
+        emit_result = state.window.feed(content)
+        return self._record_window_result(state, emit_result)
+
+    def _finish_choice(self, choice_index: int) -> bool:
+        """Flush one choice window so its final raw event can be released."""
+        state = self._get_choice_state(choice_index)
+        if state.finished:
+            return False
+
+        emit_result = state.window.flush()
+        if self._record_window_result(state, emit_result):
+            return True
+
+        if state.released_offset != state.received_offset:
+            raise RuntimeError("choice offsets do not match after flush.")
+
+        state.finished = True
+        return False
+
+    def _record_window_result(
+        self,
+        state: _ChoiceState,
+        emit_result: WindowEmitResult,
+    ) -> bool:
+        """Record a window result into choice offsets and block state."""
+        if emit_result.blocked:
+            self._blocked = True
+            self._pending_events.clear()
+            self._pending_bytes = 0
+            return True
+
+        state.released_offset += sum(len(chunk) for chunk in emit_result.chunks)
+        if state.released_offset > state.received_offset:
+            raise RuntimeError("released offset exceeded received offset.")
+
+        return False
+
+    def _ensure_queue_capacity(self, raw: str) -> int:
+        """Protect the pending raw-event queue before accepting another event."""
+        raw_size = len(raw.encode("utf-8"))
+        if len(self._pending_events) >= self._max_pending_events:
+            raise OrderedGuardrailBufferOverflowError(
+                "pending event queue reached max_pending_events."
+            )
+        if self._pending_bytes + raw_size > self._max_pending_bytes:
+            raise OrderedGuardrailBufferOverflowError(
+                "pending event queue reached max_pending_bytes."
+            )
+        return raw_size
+
+    def _enqueue(
+        self,
+        raw: str,
+        required_offsets: dict[int, int],
+        raw_size: int,
+    ) -> None:
+        """Store a raw event until all of its choice offsets are safe."""
+        self._pending_events.append(
+            _PendingEvent(
+                raw=raw,
+                required_offsets=required_offsets,
+                size=raw_size,
+            )
+        )
+        self._pending_bytes += raw_size
+
+    def _release_ready_events(self) -> OrderedGuardrailBufferResult:
+        """Release queued raw events from the head while they are safe."""
+        ready_events: list[str] = []
+        while self._pending_events and self._event_is_ready(self._pending_events[0]):
+            event = self._pending_events.popleft()
+            self._pending_bytes -= event.size
+            ready_events.append(event.raw)
+
+        return OrderedGuardrailBufferResult(ready_events=tuple(ready_events))
+
+    def _event_is_ready(self, event: _PendingEvent) -> bool:
+        """Check whether one pending raw event has met every choice requirement."""
+        for choice_index, required_offset in event.required_offsets.items():
+            state = self._choices.get(choice_index)
+            if state is None or state.released_offset < required_offset:
+                return False
+        return True
+
+    def _get_choice_state(self, choice_index: int) -> _ChoiceState:
+        """Return the scanning state and window dedicated to one choice."""
+        self._validate_choice_index(choice_index)
+        state = self._choices.get(choice_index)
+        if state is None:
+            state = _ChoiceState(
+                window=StreamingBufferWindow(
+                    self._scanner_factory(choice_index),
+                    holdback_len=self._holdback_len,
+                )
+            )
+            self._choices[choice_index] = state
+        return state
+
+    @staticmethod
+    def _validate_choice_index(choice_index: int) -> None:
+        """Validate OpenAI choice indexes before they create buffer state."""
+        if (
+            isinstance(choice_index, bool)
+            or not isinstance(choice_index, int)
+            or choice_index < 0
+        ):
+            raise ValueError("choice_index must be a non-negative integer.")

--- a/presets/ragengine/tests/streaming/test_ordered_guardrail_buffer.py
+++ b/presets/ragengine/tests/streaming/test_ordered_guardrail_buffer.py
@@ -1,0 +1,504 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../..")))
+
+from ragengine.streaming import ordered_guardrail_buffer as buffer_module  # noqa: E402
+from ragengine.streaming.buffer_window import (  # noqa: E402
+    WindowEmitResult,
+    WindowScanResult,
+)
+from ragengine.streaming.openai import ParsedOpenAIChoice  # noqa: E402
+from ragengine.streaming.ordered_guardrail_buffer import (  # noqa: E402
+    OrderedGuardrailBuffer,
+    OrderedGuardrailBufferOverflowError,
+)
+
+
+class FakeScanner:
+    def __init__(self, *, blocked_substring: str | None = None) -> None:
+        self.blocked_substring = blocked_substring
+        self.scanned_texts: list[str] = []
+
+    def scan(self, text: str) -> WindowScanResult:
+        self.scanned_texts.append(text)
+        return WindowScanResult(
+            blocked=self.blocked_substring is not None
+            and self.blocked_substring in text
+        )
+
+
+class FakeScannerFactory:
+    def __init__(self, *, blocked_substring: str | None = None) -> None:
+        self.blocked_substring = blocked_substring
+        self.scanners: dict[int, FakeScanner] = {}
+
+    def __call__(self, choice_index: int) -> FakeScanner:
+        scanner = FakeScanner(blocked_substring=self.blocked_substring)
+        self.scanners[choice_index] = scanner
+        return scanner
+
+
+class OverReleasingWindow:
+    def __init__(self, scanner: FakeScanner, *, holdback_len: int) -> None:
+        self.scanner = scanner
+        self.holdback_len = holdback_len
+
+    def feed(self, text: str) -> WindowEmitResult:
+        return WindowEmitResult(chunks=(text + "extra",))
+
+    def flush(self) -> WindowEmitResult:
+        return WindowEmitResult(chunks=())
+
+
+class UnderReleasingFlushWindow:
+    def __init__(self, scanner: FakeScanner, *, holdback_len: int) -> None:
+        self.scanner = scanner
+        self.holdback_len = holdback_len
+
+    def feed(self, text: str) -> WindowEmitResult:
+        return WindowEmitResult(chunks=())
+
+    def flush(self) -> WindowEmitResult:
+        return WindowEmitResult(chunks=())
+
+
+def _choice(
+    choice_index: int,
+    *,
+    content: str | None = None,
+    finish_reason: str | None = None,
+) -> ParsedOpenAIChoice:
+    return ParsedOpenAIChoice(
+        choice_index=choice_index,
+        content=content,
+        finish_reason=finish_reason,
+    )
+
+
+def test_releases_original_events_in_order_when_choice_offsets_are_safe():
+    factory = FakeScannerFactory()
+    buffer = OrderedGuardrailBuffer(
+        factory,
+        holdback_len=2,
+        max_pending_events=10,
+    )
+
+    assert buffer.feed("choice-0-a", (_choice(0, content="abc"),)).ready_events == ()
+    assert buffer.feed("choice-1-a", (_choice(1, content="XYZ"),)).ready_events == ()
+
+    result = buffer.feed("choice-0-b", (_choice(0, content="de"),))
+
+    assert result.ready_events == ("choice-0-a",)
+
+    finish_result = buffer.feed("finish-1", (_choice(1, finish_reason="stop"),))
+
+    assert finish_result.ready_events == ("choice-1-a",)
+
+    assert buffer.feed(
+        "finish-0", (_choice(0, finish_reason="stop"),)
+    ).ready_events == (
+        "choice-0-b",
+        "finish-1",
+        "finish-0",
+    )
+
+
+def test_scans_text_crossing_chunk_boundaries_per_choice():
+    factory = FakeScannerFactory(blocked_substring="bad")
+    buffer = OrderedGuardrailBuffer(
+        factory,
+        holdback_len=2,
+        max_pending_events=10,
+    )
+
+    assert buffer.feed("first", (_choice(0, content="ba"),)).blocked is False
+
+    result = buffer.feed("second", (_choice(0, content="d payload"),))
+
+    assert result.blocked is True
+    assert result.ready_events == ()
+    assert factory.scanners[0].scanned_texts == ["bad payload"]
+
+
+def test_does_not_scan_across_choice_boundaries():
+    factory = FakeScannerFactory(blocked_substring="bad")
+    buffer = OrderedGuardrailBuffer(
+        factory,
+        holdback_len=2,
+        max_pending_events=10,
+    )
+
+    assert buffer.feed("choice-0", (_choice(0, content="ba"),)).blocked is False
+    assert buffer.feed("choice-1", (_choice(1, content="d"),)).blocked is False
+
+    result = buffer.finish_stream("done")
+
+    assert result.ready_events == ("choice-0", "choice-1", "done")
+    assert factory.scanners[0].scanned_texts == ["ba"]
+    assert factory.scanners[1].scanned_texts == ["d"]
+
+
+def test_multi_choice_event_waits_for_all_choice_offsets():
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(),
+        holdback_len=2,
+        max_pending_events=10,
+    )
+
+    assert (
+        buffer.feed(
+            "both",
+            (_choice(0, content="abc"), _choice(1, content="x")),
+        ).ready_events
+        == ()
+    )
+    assert (
+        buffer.feed("finish-0", (_choice(0, finish_reason="stop"),)).ready_events == ()
+    )
+
+    assert buffer.feed(
+        "finish-1", (_choice(1, finish_reason="stop"),)
+    ).ready_events == (
+        "both",
+        "finish-0",
+        "finish-1",
+    )
+
+
+def test_dangerous_holdback_blocks_on_finish_choice():
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(blocked_substring="bad"),
+        holdback_len=3,
+        max_pending_events=10,
+    )
+
+    assert buffer.feed("pending", (_choice(0, content="bad"),)).blocked is False
+
+    result = buffer.feed("finish", (_choice(0, finish_reason="stop"),))
+
+    assert result.blocked is True
+    assert result.ready_events == ()
+
+
+def test_dangerous_holdback_blocks_on_finish_stream():
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(blocked_substring="bad"),
+        holdback_len=3,
+        max_pending_events=10,
+    )
+
+    assert buffer.feed("pending", (_choice(0, content="bad"),)).blocked is False
+
+    result = buffer.finish_stream("done")
+
+    assert result.blocked is True
+    assert result.ready_events == ()
+
+
+def test_blocked_buffer_remains_blocked():
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(blocked_substring="bad"),
+        holdback_len=3,
+        max_pending_events=10,
+    )
+
+    assert buffer.feed("pending", (_choice(0, content="ok"),)).ready_events == ()
+
+    blocked_result = buffer.feed("blocking", (_choice(0, content="bad"),))
+
+    assert blocked_result.blocked is True
+    assert blocked_result.ready_events == ()
+
+    feed_result = buffer.feed("after-block", (_choice(0, content="safe"),))
+    finish_result = buffer.finish_stream("done")
+
+    assert feed_result.blocked is True
+    assert feed_result.ready_events == ()
+    assert finish_result.blocked is True
+    assert finish_result.ready_events == ()
+
+
+def test_metadata_event_waits_behind_unreleased_content_event():
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(),
+        holdback_len=5,
+        max_pending_events=10,
+    )
+
+    assert buffer.feed("content", (_choice(0, content="abc"),)).ready_events == ()
+    assert buffer.feed("metadata-only", ()).ready_events == ()
+
+    assert buffer.feed("finish", (_choice(0, finish_reason="stop"),)).ready_events == (
+        "content",
+        "metadata-only",
+        "finish",
+    )
+
+
+def test_feed_can_finish_choice_and_release_the_original_finish_event():
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(),
+        holdback_len=5,
+        max_pending_events=10,
+    )
+
+    assert buffer.feed("content", (_choice(0, content="tail"),)).ready_events == ()
+
+    result = buffer.feed("finish-choice", (_choice(0, finish_reason="stop"),))
+
+    assert result.ready_events == ("content", "finish-choice")
+
+
+def test_finish_stream_flushes_all_choices_before_releasing_stream_event():
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(),
+        holdback_len=5,
+        max_pending_events=10,
+    )
+
+    assert buffer.feed("choice-0", (_choice(0, content="abc"),)).ready_events == ()
+    assert buffer.feed("choice-1", (_choice(1, content="xyz"),)).ready_events == ()
+
+    result = buffer.finish_stream("done")
+
+    assert result.ready_events == ("choice-0", "choice-1", "done")
+
+
+def test_finish_stream_without_raw_flushes_pending_events_on_upstream_eof():
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(),
+        holdback_len=5,
+        max_pending_events=10,
+    )
+
+    assert buffer.feed("choice-0", (_choice(0, content="abc"),)).ready_events == ()
+    assert buffer.feed("metadata-only", ()).ready_events == ()
+
+    result = buffer.finish_stream()
+
+    assert result.ready_events == ("choice-0", "metadata-only")
+
+
+def test_finish_choice_is_idempotent(monkeypatch: pytest.MonkeyPatch):
+    windows = []
+
+    class CountingFlushWindow:
+        def __init__(self, scanner: FakeScanner, *, holdback_len: int) -> None:
+            self.scanner = scanner
+            self.holdback_len = holdback_len
+            self.flush_count = 0
+            windows.append(self)
+
+        def feed(self, text: str) -> WindowEmitResult:
+            return WindowEmitResult(chunks=(text,))
+
+        def flush(self) -> WindowEmitResult:
+            self.flush_count += 1
+            return WindowEmitResult(chunks=())
+
+    monkeypatch.setattr(buffer_module, "StreamingBufferWindow", CountingFlushWindow)
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(),
+        holdback_len=0,
+        max_pending_events=10,
+    )
+
+    assert buffer.feed(
+        "finish-once",
+        (_choice(0, content="done", finish_reason="stop"),),
+    ).ready_events == ("finish-once",)
+    assert len(windows) == 1
+    assert windows[0].flush_count == 1
+
+    assert buffer.feed(
+        "finish-again", (_choice(0, finish_reason="stop"),)
+    ).ready_events == ("finish-again",)
+    assert windows[0].flush_count == 1
+
+
+def test_queue_limit_rejects_more_pending_events():
+    factory = FakeScannerFactory()
+    buffer = OrderedGuardrailBuffer(
+        factory,
+        holdback_len=5,
+        max_pending_events=1,
+    )
+
+    assert buffer.feed("first", (_choice(0, content="abc"),)).ready_events == ()
+
+    with pytest.raises(OrderedGuardrailBufferOverflowError, match="max_pending"):
+        buffer.feed("second", (_choice(0, content="def"),))
+
+    assert factory.scanners[0].scanned_texts == []
+
+
+def test_queue_limit_rejects_more_pending_bytes():
+    factory = FakeScannerFactory()
+    buffer = OrderedGuardrailBuffer(
+        factory,
+        holdback_len=5,
+        max_pending_events=10,
+        max_pending_bytes=len(b"first"),
+    )
+
+    assert buffer.feed("first", (_choice(0, content="abc"),)).ready_events == ()
+
+    with pytest.raises(OrderedGuardrailBufferOverflowError, match="max_pending"):
+        buffer.feed("second", (_choice(0, content="def"),))
+
+    assert factory.scanners[0].scanned_texts == []
+
+
+def test_byte_limit_allows_more_events_after_pending_events_release():
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(),
+        holdback_len=0,
+        max_pending_events=10,
+        max_pending_bytes=len(b"content"),
+    )
+
+    assert buffer.feed("content", (_choice(0, content="abc"),)).ready_events == (
+        "content",
+    )
+
+    assert buffer.feed("next", ()).ready_events == ("next",)
+
+
+def test_constructor_rejects_invalid_queue_limit():
+    with pytest.raises(ValueError, match="holdback_len"):
+        OrderedGuardrailBuffer(
+            FakeScannerFactory(),
+            holdback_len=-1,
+        )
+
+    with pytest.raises(ValueError, match="max_pending_events"):
+        OrderedGuardrailBuffer(
+            FakeScannerFactory(),
+            holdback_len=0,
+            max_pending_events=0,
+        )
+
+    with pytest.raises(ValueError, match="max_pending_bytes"):
+        OrderedGuardrailBuffer(
+            FakeScannerFactory(),
+            holdback_len=0,
+            max_pending_bytes=0,
+        )
+
+
+@pytest.mark.parametrize("choice_index", [True, -1, "0"])
+def test_content_choice_rejects_invalid_choice_index(choice_index: object):
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(),
+        holdback_len=0,
+        max_pending_events=10,
+    )
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        buffer.feed(
+            "content",
+            (ParsedOpenAIChoice(choice_index=choice_index, content="content"),),
+        )
+
+
+@pytest.mark.parametrize("choice_index", [True, -1, "0"])
+def test_finished_choice_rejects_invalid_choice_index(choice_index: object):
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(),
+        holdback_len=0,
+        max_pending_events=10,
+    )
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        buffer.feed(
+            "finish",
+            (ParsedOpenAIChoice(choice_index=choice_index, finish_reason="stop"),),
+        )
+
+
+def test_feed_after_choice_finish_raises():
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(),
+        holdback_len=0,
+        max_pending_events=10,
+    )
+
+    assert buffer.feed(
+        "finish",
+        (_choice(0, content="done", finish_reason="stop"),),
+    ).ready_events
+
+    with pytest.raises(RuntimeError, match="already finished"):
+        buffer.feed("after-finish", (_choice(0, content="again"),))
+
+
+def test_released_offset_cannot_exceed_received_offset(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setattr(buffer_module, "StreamingBufferWindow", OverReleasingWindow)
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(),
+        holdback_len=0,
+        max_pending_events=10,
+    )
+
+    with pytest.raises(RuntimeError, match="released offset exceeded received offset"):
+        buffer.feed("content", (_choice(0, content="abc"),))
+
+
+def test_finish_choice_requires_all_received_offsets_released(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(
+        buffer_module, "StreamingBufferWindow", UnderReleasingFlushWindow
+    )
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(),
+        holdback_len=0,
+        max_pending_events=10,
+    )
+
+    assert buffer.feed("content", (_choice(0, content="abc"),)).ready_events == ()
+
+    with pytest.raises(RuntimeError, match="choice offsets do not match after flush"):
+        buffer.feed("finish", (_choice(0, finish_reason="stop"),))
+
+
+def test_feed_after_stream_finish_raises():
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(),
+        holdback_len=0,
+        max_pending_events=10,
+    )
+
+    assert buffer.finish_stream("done").ready_events == ("done",)
+
+    with pytest.raises(RuntimeError, match="stream is finished"):
+        buffer.feed("after-stream", (_choice(0, content="again"),))
+
+
+def test_finish_stream_after_stream_finish_raises():
+    buffer = OrderedGuardrailBuffer(
+        FakeScannerFactory(),
+        holdback_len=0,
+        max_pending_events=10,
+    )
+
+    assert buffer.finish_stream().ready_events == ()
+
+    with pytest.raises(RuntimeError, match="stream is already finished"):
+        buffer.finish_stream()


### PR DESCRIPTION
## Summary

Add a standalone ordered buffer for multi-choice streaming guardrail checks.

The buffer keeps one `StreamingBufferWindow` per choice, tracks received/released offsets, and releases original raw events in order once their required offsets are safe.

## Scope

Included:
- Per-choice streaming windows
- Cross-chunk scanning
- Pending event queue
- Received/released offsets
- Ordered raw event release
- Choice finish and stream finish
- Queue limit
- Fake scanner unit tests

Not included:
- OutputGuardrails integration
- HTTP/SSE integration
- llm-guard integration
- Block response behavior

## Tests

- `./.venv/bin/python -m pytest presets/ragengine/tests/streaming/test_ordered_guardrail_buffer.py`
- `./.venv/bin/python -m pytest presets/ragengine/tests/streaming/test_buffer_window.py presets/ragengine/tests/streaming/test_ordered_guardrail_buffer.py`
- `./.venv/bin/python -m ruff check presets/ragengine/streaming/ordered_guardrail_buffer.py presets/ragengine/tests/streaming/test_ordered_guardrail_buffer.py`