### PR TITLE
fix: scope workspace node listing to owning workspace

### DIFF
--- a/pkg/nodeprovision/byo-provisioner/byo_provisioner.go
+++ b/pkg/nodeprovision/byo-provisioner/byo_provisioner.go
@@ -66,9 +66,7 @@ func (n *BYOProvisioner) DisableDriftRemediation(ctx context.Context, workspaceN
 // Workspace. In BYO mode there are no provisioning resources, so needRequeue
 // is always true when nodes are not ready.
 func (n *BYOProvisioner) EnsureNodesReady(ctx context.Context, ws *kaitov1beta1.Workspace) (bool, bool, error) {
-	matchLabels := client.MatchingLabels(kaitov1beta1.SanitizedMatchLabels(ws.Resource.LabelSelector))
-
-	nodeList, err := nodes.ListNodes(ctx, n.client, matchLabels)
+	nodeList, err := nodeprovision.ListWorkspaceNodes(ctx, n.client, n, ws)
 	if err != nil {
 		return false, true, err
 	}
@@ -103,8 +101,7 @@ func (n *BYOProvisioner) CollectNodeStatusInfo(ctx context.Context, ws *kaitov1b
 		Reason: "workspaceResourceStatusNotReady", Message: "node status condition not ready",
 	}
 
-	matchLabels := client.MatchingLabels(kaitov1beta1.SanitizedMatchLabels(ws.Resource.LabelSelector))
-	nodeList, err := nodes.ListNodes(ctx, n.client, matchLabels)
+	nodeList, err := nodeprovision.ListWorkspaceNodes(ctx, n.client, n, ws)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/nodeprovision/gpu-provisioner/gpu_provisioner.go
+++ b/pkg/nodeprovision/gpu-provisioner/gpu_provisioner.go
@@ -108,7 +108,9 @@ func (g *AzureGPUProvisioner) DisableDriftRemediation(ctx context.Context, works
 func (g *AzureGPUProvisioner) EnsureNodesReady(ctx context.Context, ws *kaitov1beta1.Workspace) (bool, bool, error) {
 	// List nodes once and derive both readyNodes (for NodeClaim check) and
 	// readyCount with correct instance type (for node readiness check).
-	nodeList, err := nodes.ListNodes(ctx, g.nodeClaimManager.Client, kaitov1beta1.SanitizedMatchLabels(ws.Resource.LabelSelector))
+	// Scope to nodes owned by this workspace so sibling workspaces sharing the
+	// same label selector (e.g. InferenceSet replicas) are not counted.
+	nodeList, err := nodeprovision.ListWorkspaceNodes(ctx, g.nodeClaimManager.Client, g, ws)
 	if err != nil {
 		return false, false, fmt.Errorf("failed to list nodes: %w", err)
 	}
@@ -180,7 +182,7 @@ func (g *AzureGPUProvisioner) CollectNodeStatusInfo(ctx context.Context, ws *kai
 		Reason: "workspaceResourceStatusNotReady", Message: "node claim or node status condition not ready",
 	}
 
-	nodeList, err := nodes.ListNodes(ctx, g.nodeClaimManager.Client, kaitov1beta1.SanitizedMatchLabels(ws.Resource.LabelSelector))
+	nodeList, err := nodeprovision.ListWorkspaceNodes(ctx, g.nodeClaimManager.Client, g, ws)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list nodes: %w", err)
 	}

--- a/pkg/nodeprovision/karpenter/provisioner.go
+++ b/pkg/nodeprovision/karpenter/provisioner.go
@@ -237,13 +237,18 @@ func (p *KarpenterProvisioner) waitForNodeClassReady(ctx context.Context, name s
 //     because karpenter will either self-heal them or delete them after a timeout,
 //     at which point a reconcile is triggered via the NodeClaim watch)
 //   - readyWithInstanceType: total ready nodes (BYO + legacy + karpenter) with correct instance type.
-func countCoveredNodes(ctx context.Context, c client.Client, ws *kaitov1beta1.Workspace) (coveredByNonKarpenter int, readyWithInstanceType int, err error) {
+//
+// Nodes provisioned for a different Workspace that happens to share this
+// Workspace's user-supplied label selector (e.g. a sibling replica of the same
+// InferenceSet) are excluded by comparing the ownership labels, so they do not
+// inflate either count. BYO nodes (which carry no ownership label) remain in scope.
+func (p *KarpenterProvisioner) countCoveredNodes(ctx context.Context, ws *kaitov1beta1.Workspace) (coveredByNonKarpenter int, readyWithInstanceType int, err error) {
 	if ws.Resource.LabelSelector == nil {
 		return 0, 0, nil
 	}
 
 	// Count ready nodes (all types).
-	nodeList, err := nodes.ListNodes(ctx, c, kaitov1beta1.SanitizedMatchLabels(ws.Resource.LabelSelector))
+	nodeList, err := nodes.ListNodes(ctx, p.client, kaitov1beta1.SanitizedMatchLabels(ws.Resource.LabelSelector))
 	if err != nil {
 		return 0, 0, fmt.Errorf("listing nodes: %w", err)
 	}
@@ -254,6 +259,15 @@ func countCoveredNodes(ctx context.Context, c client.Client, ws *kaitov1beta1.Wo
 			continue
 		}
 		if node.Labels[corev1.LabelInstanceTypeStable] != ws.Resource.InstanceType {
+			continue
+		}
+		// Skip nodes provisioned for a different workspace that shares this
+		// workspace's label selector (e.g. an InferenceSet sibling replica).
+		// BYO nodes carry neither ownership label and remain in scope.
+		if name, ok := node.Labels[consts.KarpenterWorkspaceNameKey]; ok && name != ws.Name {
+			continue
+		}
+		if name, ok := node.Labels[kaitov1beta1.LabelWorkspaceName]; ok && name != ws.Name {
 			continue
 		}
 		readyWithInstanceType++
@@ -269,7 +283,7 @@ func countCoveredNodes(ctx context.Context, c client.Client, ws *kaitov1beta1.Wo
 	// These are covered because karpenter engine will self-heal the node or
 	// delete the NodeClaim after a timeout (triggering a reconcile).
 	legacyNodeClaimList := &karpenterv1.NodeClaimList{}
-	if err := c.List(ctx, legacyNodeClaimList,
+	if err := p.client.List(ctx, legacyNodeClaimList,
 		client.MatchingLabels{
 			kaitov1beta1.LabelWorkspaceName:      ws.Name,
 			kaitov1beta1.LabelWorkspaceNamespace: ws.Namespace,
@@ -301,7 +315,7 @@ func (p *KarpenterProvisioner) ProvisionNodes(ctx context.Context, ws *kaitov1be
 	}
 
 	// Count non-karpenter ready nodes to compute delta.
-	coveredCount, _, err := countCoveredNodes(ctx, p.client, ws)
+	coveredCount, _, err := p.countCoveredNodes(ctx, ws)
 	if err != nil {
 		return fmt.Errorf("counting non-karpenter nodes: %w", err)
 	}
@@ -412,7 +426,7 @@ func (p *KarpenterProvisioner) buildNodeReadinessSnapshot(ctx context.Context, w
 	}
 
 	// Count all ready nodes matching workspace labels (BYO + legacy + karpenter).
-	coveredByNonKarpenterCount, readyWithInstanceTypeCount, err := countCoveredNodes(ctx, p.client, ws)
+	coveredByNonKarpenterCount, readyWithInstanceTypeCount, err := p.countCoveredNodes(ctx, ws)
 	if err != nil {
 		return nil, fmt.Errorf("counting ready nodes: %w", err)
 	}

--- a/pkg/nodeprovision/karpenter/provisioner_test.go
+++ b/pkg/nodeprovision/karpenter/provisioner_test.go
@@ -629,10 +629,11 @@ func TestEnsureNodesReady_DeletingNodeNotCounted(t *testing.T) {
 
 func TestCountCoveredNodes_NilLabelSelector(t *testing.T) {
 	c := newFakeClient()
+	p := NewKarpenterProvisioner(c, testConfig)
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 	ws.Resource.LabelSelector = nil
 
-	covered, ready, err := countCoveredNodes(context.Background(), c, ws)
+	covered, ready, err := p.countCoveredNodes(context.Background(), ws)
 	require.NoError(t, err)
 	assert.Equal(t, 0, covered)
 	assert.Equal(t, 0, ready)
@@ -643,10 +644,11 @@ func TestCountCoveredNodes_LegacyNCCountedDespiteNodeNotReady(t *testing.T) {
 	// when its node is not ready (or doesn't exist at all).
 	legacyNC := makeLegacyNodeClaim("legacy-nc-1", "ws1", "default")
 	c := newFakeClient(legacyNC) // No ready nodes.
+	p := NewKarpenterProvisioner(c, testConfig)
 
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
-	covered, readyCount, err := countCoveredNodes(context.Background(), c, ws)
+	covered, readyCount, err := p.countCoveredNodes(context.Background(), ws)
 	require.NoError(t, err)
 	assert.Equal(t, 1, covered, "legacy NC should count as covered")
 	assert.Equal(t, 0, readyCount, "no ready nodes exist")
@@ -658,10 +660,11 @@ func TestCountCoveredNodes_DeletingLegacyNCExcluded(t *testing.T) {
 	legacyNC.DeletionTimestamp = &now
 	legacyNC.Finalizers = []string{"karpenter.sh/termination"}
 	c := newFakeClient(legacyNC)
+	p := NewKarpenterProvisioner(c, testConfig)
 
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
-	covered, _, err := countCoveredNodes(context.Background(), c, ws)
+	covered, _, err := p.countCoveredNodes(context.Background(), ws)
 	require.NoError(t, err)
 	assert.Equal(t, 0, covered, "deleting legacy NC should not count as covered")
 }
@@ -673,10 +676,11 @@ func TestCountCoveredNodes_LegacyNodeExcludedFromBYO(t *testing.T) {
 	})
 	legacyNC := makeLegacyNodeClaim("legacy-nc-1", "ws1", "default")
 	c := newFakeClient(legacyNode, legacyNC)
+	p := NewKarpenterProvisioner(c, testConfig)
 
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 2, nil, nil)
 
-	covered, readyCount, err := countCoveredNodes(context.Background(), c, ws)
+	covered, readyCount, err := p.countCoveredNodes(context.Background(), ws)
 	require.NoError(t, err)
 	// coveredByNonKarpenter = 0 BYO + 1 legacy NC = 1
 	assert.Equal(t, 1, covered)
@@ -689,10 +693,11 @@ func TestCountCoveredNodes_BYOAndLegacyCombinedDelta(t *testing.T) {
 	byoNode := makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)
 	legacyNC := makeLegacyNodeClaim("legacy-nc-1", "ws1", "default")
 	c := newFakeClient(byoNode, legacyNC)
+	p := NewKarpenterProvisioner(c, testConfig)
 
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 3, nil, nil)
 
-	covered, readyCount, err := countCoveredNodes(context.Background(), c, ws)
+	covered, readyCount, err := p.countCoveredNodes(context.Background(), ws)
 	require.NoError(t, err)
 	assert.Equal(t, 2, covered, "1 BYO + 1 legacy NC")
 	assert.Equal(t, 1, readyCount, "only the BYO node is ready")
@@ -702,10 +707,11 @@ func TestCountCoveredNodes_LegacyNCsForDifferentWorkspaceNotCounted(t *testing.T
 	// A legacy NodeClaim for a different workspace should not be counted.
 	otherNC := makeLegacyNodeClaim("other-nc", "other-ws", "default")
 	c := newFakeClient(otherNC)
+	p := NewKarpenterProvisioner(c, testConfig)
 
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
-	covered, _, err := countCoveredNodes(context.Background(), c, ws)
+	covered, _, err := p.countCoveredNodes(context.Background(), ws)
 	require.NoError(t, err)
 	assert.Equal(t, 0, covered, "NC for different workspace should not count")
 }
@@ -716,13 +722,36 @@ func TestCountCoveredNodes_KarpenterNodeNotCountedAsBYO(t *testing.T) {
 		consts.KarpenterWorkspaceNameKey: "ws1",
 	})
 	c := newFakeClient(karpNode)
+	p := NewKarpenterProvisioner(c, testConfig)
 
 	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
 
-	covered, readyCount, err := countCoveredNodes(context.Background(), c, ws)
+	covered, readyCount, err := p.countCoveredNodes(context.Background(), ws)
 	require.NoError(t, err)
 	assert.Equal(t, 0, covered, "karpenter node should not count as non-karpenter coverage")
 	assert.Equal(t, 1, readyCount, "karpenter node still counted in total ready")
+}
+
+func TestCountCoveredNodes_SiblingKarpenterNodeExcluded(t *testing.T) {
+	// A karpenter node provisioned for a sibling workspace (same InferenceSet,
+	// shared label selector) must NOT be counted for this workspace.
+	ownNode := makeReadyNode("ws1-node", "Standard_NC24ads_A100_v4", map[string]string{
+		consts.KarpenterWorkspaceNameKey:      "ws1",
+		consts.KarpenterWorkspaceNamespaceKey: "default",
+	})
+	siblingNode := makeReadyNode("ws2-node", "Standard_NC24ads_A100_v4", map[string]string{
+		consts.KarpenterWorkspaceNameKey:      "ws2",
+		consts.KarpenterWorkspaceNamespaceKey: "default",
+	})
+	c := newFakeClient(ownNode, siblingNode)
+	p := NewKarpenterProvisioner(c, testConfig)
+
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
+
+	covered, readyCount, err := p.countCoveredNodes(context.Background(), ws)
+	require.NoError(t, err)
+	assert.Equal(t, 0, covered, "no BYO/legacy coverage")
+	assert.Equal(t, 1, readyCount, "only this workspace's own karpenter node is counted, not the sibling's")
 }
 
 // --- ProvisionNodes delta with legacy NodeClaims ---

--- a/pkg/nodeprovision/nodes.go
+++ b/pkg/nodeprovision/nodes.go
@@ -24,13 +24,19 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils/nodes"
 )
 
-// GetReadyNodes returns all ready nodes that match the workspace's label
-// selector AND the provisioner's BuildNodeSelector output. Pinning the listing
-// to provisioner-managed nodes mirrors what pods see at scheduling time, so
-// callers do not count nodes pods cannot actually land on.
+// WorkspaceNodeSelector returns the label selector that identifies nodes
+// belonging to the given Workspace: the user-supplied match labels merged with
+// the provisioner's per-workspace ownership requirements from BuildNodeSelector.
 //
-// A nil provisioner is treated as "no extra requirements" (BYO-style).
-func GetReadyNodes(ctx context.Context, c client.Client, p NodeProvisioner, ws *kaitov1beta1.Workspace) ([]*corev1.Node, error) {
+// This is the canonical way to scope a node listing to a single Workspace.
+// It matters when several Workspaces share the same user-supplied selector
+// (e.g. replicas created by an InferenceSet): the user selector alone cannot
+// tell sibling Workspaces apart, but BuildNodeSelector contributes a
+// per-workspace ownership label (e.g. kaito.sh/workspace) that disambiguates.
+//
+// A nil provisioner is treated as "no extra requirements" (BYO-style), in which
+// case the returned selector is just the sanitized user match labels.
+func WorkspaceNodeSelector(ctx context.Context, p NodeProvisioner, ws *kaitov1beta1.Workspace) client.MatchingLabels {
 	matchLabels := kaitov1beta1.SanitizedMatchLabels(ws.Resource.LabelSelector)
 	if p != nil {
 		for _, r := range p.BuildNodeSelector(ctx, ws) {
@@ -45,8 +51,25 @@ func GetReadyNodes(ctx context.Context, c client.Client, p NodeProvisioner, ws *
 			matchLabels[r.Key] = r.Values[0]
 		}
 	}
+	return client.MatchingLabels(matchLabels)
+}
 
-	nodeList, err := nodes.ListNodes(ctx, c, client.MatchingLabels(matchLabels))
+// ListWorkspaceNodes lists the nodes that belong to the given Workspace using
+// WorkspaceNodeSelector. Callers should prefer this over listing by the raw
+// user selector, which can leak nodes owned by sibling Workspaces that share
+// the same selector.
+func ListWorkspaceNodes(ctx context.Context, c client.Client, p NodeProvisioner, ws *kaitov1beta1.Workspace) (*corev1.NodeList, error) {
+	return nodes.ListNodes(ctx, c, WorkspaceNodeSelector(ctx, p, ws))
+}
+
+// GetReadyNodes returns all ready nodes that match the workspace's label
+// selector AND the provisioner's BuildNodeSelector output. Pinning the listing
+// to provisioner-managed nodes mirrors what pods see at scheduling time, so
+// callers do not count nodes pods cannot actually land on.
+//
+// A nil provisioner is treated as "no extra requirements" (BYO-style).
+func GetReadyNodes(ctx context.Context, c client.Client, p NodeProvisioner, ws *kaitov1beta1.Workspace) ([]*corev1.Node, error) {
+	nodeList, err := ListWorkspaceNodes(ctx, c, p, ws)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -57,7 +57,6 @@ import (
 	"github.com/kaito-project/kaito/pkg/utils"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 	"github.com/kaito-project/kaito/pkg/utils/nodeclaim"
-	"github.com/kaito-project/kaito/pkg/utils/nodes"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/utils/workspace"
 	"github.com/kaito-project/kaito/pkg/workspace/estimator"
@@ -593,7 +592,7 @@ func (c *WorkspaceReconciler) applyInference(ctx context.Context, wObj *kaitov1b
 
 	if wObj.Inference.Template != nil {
 		// TODO: handle update
-		_, err := inference.CreateTemplateInference(ctx, wObj, c.Client)
+		_, err := inference.CreateTemplateInference(ctx, wObj, c.Client, c.nodeProvisioner)
 		return err
 	}
 
@@ -825,9 +824,10 @@ func (c *WorkspaceReconciler) collectNodeStatusSnapshot(ctx context.Context, wOb
 		workerNodeNames: []string{},
 	}
 
-	// Collect worker node names for status.
-	matchLabels := client.MatchingLabels(kaitov1beta1.SanitizedMatchLabels(wObj.Resource.LabelSelector))
-	nodeList, err := nodes.ListNodes(ctx, c.Client, matchLabels)
+	// Collect worker node names for status. Scope to nodes owned by this
+	// workspace so sibling workspaces sharing the same label selector
+	// (e.g. InferenceSet replicas) are not reported as this workspace's nodes.
+	nodeList, err := nodeprovision.ListWorkspaceNodes(ctx, c.Client, c.nodeProvisioner, wObj)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -856,10 +856,21 @@ func SetDefaultModelWeightsVolume(ctx *generator.WorkspaceGeneratorContext, spec
 // created for this workspace. No-op when the provisioner returns no
 // requirements (BYO mode).
 func SetProvisionerNodeSelector(ctx *generator.WorkspaceGeneratorContext, spec *corev1.PodSpec) error {
-	if ctx.NodeProvisioner == nil {
+	return ApplyProvisionerNodeSelector(ctx.Ctx, ctx.NodeProvisioner, ctx.Workspace, spec)
+}
+
+// ApplyProvisionerNodeSelector appends the provisioner's per-workspace node
+// selector requirements to spec's required node affinity, isolating pods to the
+// nodes provisioned for this workspace. This matters when several workspaces
+// share the same user-supplied label selector (e.g. InferenceSet replicas):
+// without these requirements a pod could schedule onto a sibling workspace's
+// node. It is a no-op when provisioner is nil or returns no requirements
+// (BYO mode, where nodes are matched purely via the user label selector).
+func ApplyProvisionerNodeSelector(ctx context.Context, provisioner nodeprovision.NodeProvisioner, ws *v1beta1.Workspace, spec *corev1.PodSpec) error {
+	if provisioner == nil {
 		return nil
 	}
-	extra := ctx.NodeProvisioner.BuildNodeSelector(ctx.Ctx, ctx.Workspace)
+	extra := provisioner.BuildNodeSelector(ctx, ws)
 	if len(extra) == 0 {
 		return nil
 	}

--- a/pkg/workspace/inference/template_inference.go
+++ b/pkg/workspace/inference/template_inference.go
@@ -19,15 +19,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
+	"github.com/kaito-project/kaito/pkg/nodeprovision"
 	"github.com/kaito-project/kaito/pkg/utils/resources"
 	"github.com/kaito-project/kaito/pkg/workspace/manifests"
 )
 
-func CreateTemplateInference(ctx context.Context, workspaceObj *kaitov1beta1.Workspace, kubeClient client.Client) (client.Object, error) {
-	depObj := manifests.GenerateManifestWithPodTemplate(workspaceObj, defaultTolerations(workspaceObj))
-	err := resources.CreateResource(ctx, client.Object(depObj), kubeClient)
+func CreateTemplateInference(ctx context.Context, workspaceObj *kaitov1beta1.Workspace, kubeClient client.Client, provisioner nodeprovision.NodeProvisioner) (client.Object, error) {
+	ssObj := manifests.GenerateManifestWithPodTemplate(workspaceObj, defaultTolerations(workspaceObj))
+	// Pin the pod to nodes provisioned for this workspace. Without this, a
+	// custom-template pod could schedule onto a sibling workspace's node when
+	// they share the same user label selector (e.g. InferenceSet replicas).
+	if err := ApplyProvisionerNodeSelector(ctx, provisioner, workspaceObj, &ssObj.Spec.Template.Spec); err != nil {
+		return nil, err
+	}
+	err := resources.CreateResource(ctx, client.Object(ssObj), kubeClient)
 	if client.IgnoreAlreadyExists(err) != nil {
 		return nil, err
 	}
-	return depObj, nil
+	return ssObj, nil
 }

--- a/pkg/workspace/inference/template_inference_test.go
+++ b/pkg/workspace/inference/template_inference_test.go
@@ -55,7 +55,7 @@ func TestCreateTemplateInference(t *testing.T) {
 			mockClient := test.NewClient()
 			tc.callMocks(mockClient)
 
-			obj, err := CreateTemplateInference(context.Background(), test.MockWorkspaceWithInferenceTemplate, mockClient)
+			obj, err := CreateTemplateInference(context.Background(), test.MockWorkspaceWithInferenceTemplate, mockClient, nil)
 			if tc.expectedError == nil {
 				assert.Check(t, err == nil, "Not expected to return error")
 				assert.Check(t, obj != nil, "Return object should not be nil")


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

Multiple workspaces created by an InferenceSet share the same Resource.LabelSelector, so listing nodes by that selector alone could count nodes owned by sibling workspaces, inflating readiness/status counts and letting custom-template pods schedule onto a sibling's node.

- Add WorkspaceNodeSelector/ListWorkspaceNodes helpers that merge the user selector with the provisioner's BuildNodeSelector ownership labels, and route GetReadyNodes, gpu/byo provisioners and the workspace controller node-status snapshot through them.
- countCoveredNodes now excludes nodes owned by a different workspace while keeping BYO/legacy nodes in scope.
- Extract ApplyProvisionerNodeSelector and apply it to the custom template inference path so those pods are pinned to workspace nodes.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: