### PR TITLE
fix: surface underlying node provisioning error in workspace status

### DIFF
--- a/pkg/nodeprovision/gpu-provisioner/gpu_provisioner.go
+++ b/pkg/nodeprovision/gpu-provisioner/gpu_provisioner.go
@@ -216,6 +216,12 @@ func (g *AzureGPUProvisioner) CollectNodeStatusInfo(ctx context.Context, ws *kai
 		nodeClaimCond.Status = metav1.ConditionTrue
 		nodeClaimCond.Reason = "NodeClaimsReady"
 		nodeClaimCond.Message = "Enough NodeClaims are ready"
+	} else if reason, message, ok := nodeclaim.FirstProvisioningError(existingNodeClaims); ok {
+		// Surface the underlying cloud-provider provisioning error (e.g. quota
+		// exceeded, unauthorized) so users can see the root cause in the
+		// workspace/inferenceset status instead of a generic message.
+		nodeClaimCond.Reason = reason
+		nodeClaimCond.Message = message
 	}
 
 	// Node readiness.

--- a/pkg/nodeprovision/karpenter/provisioner.go
+++ b/pkg/nodeprovision/karpenter/provisioner.go
@@ -389,6 +389,9 @@ type nodeReadinessSnapshot struct {
 	// readyNodeClaims is the subset of karpenter-managed NodeClaims that are Ready and not deleting.
 	// Used for GPU plugin readiness checks.
 	readyNodeClaims []*karpenterv1.NodeClaim
+	// allNodeClaims is every karpenter-managed NodeClaim for the workspace (ready or not).
+	// Used to surface the underlying cloud-provider provisioning error in status.
+	allNodeClaims []*karpenterv1.NodeClaim
 }
 
 // buildNodeReadinessSnapshot lists karpenter NodeClaims and all workspace nodes,
@@ -411,6 +414,11 @@ func (p *KarpenterProvisioner) buildNodeReadinessSnapshot(ctx context.Context, w
 		}
 	}
 
+	allNodeClaims := make([]*karpenterv1.NodeClaim, 0, len(nodeClaimList.Items))
+	for i := range nodeClaimList.Items {
+		allNodeClaims = append(allNodeClaims, &nodeClaimList.Items[i])
+	}
+
 	// Count all ready nodes matching workspace labels (BYO + legacy + karpenter).
 	coveredByNonKarpenterCount, readyWithInstanceTypeCount, err := countCoveredNodes(ctx, p.client, ws)
 	if err != nil {
@@ -424,6 +432,7 @@ func (p *KarpenterProvisioner) buildNodeReadinessSnapshot(ctx context.Context, w
 		coveredByNonKarpenterCount: coveredByNonKarpenterCount,
 		targetNodeClaimCount:       targetNodeClaimCount,
 		readyNodeClaims:            readyNodeClaims,
+		allNodeClaims:              allNodeClaims,
 	}, nil
 }
 
@@ -548,6 +557,12 @@ func (p *KarpenterProvisioner) CollectNodeStatusInfo(ctx context.Context, ws *ka
 		nodeClaimCond.Status = metav1.ConditionTrue
 		nodeClaimCond.Reason = "NodeClaimsReady"
 		nodeClaimCond.Message = "Enough NodeClaims are ready"
+	} else if reason, message, ok := nodeclaim.FirstProvisioningError(snap.allNodeClaims); ok {
+		// Surface the underlying cloud-provider provisioning error (e.g. quota
+		// exceeded, unauthorized) so users can see the root cause in the
+		// workspace/inferenceset status instead of a generic message.
+		nodeClaimCond.Reason = reason
+		nodeClaimCond.Message = message
 	}
 
 	// Node condition: are enough nodes ready with GPU resources?

--- a/pkg/nodeprovision/karpenter/provisioner_test.go
+++ b/pkg/nodeprovision/karpenter/provisioner_test.go
@@ -833,3 +833,39 @@ func TestCollectNodeStatusInfo_ConditionTypes(t *testing.T) {
 	assert.True(t, typeSet[string(kaitov1beta1.ConditionTypeNodeClaimStatus)])
 	assert.True(t, typeSet[string(kaitov1beta1.ConditionTypeResourceStatus)])
 }
+
+func TestCollectNodeStatusInfo_SurfacesProvisioningError(t *testing.T) {
+	// A NodeClaim that failed to launch (e.g. quota exceeded) must surface its
+	// underlying reason/message on the NodeClaim and Resource conditions.
+	failedNC := makeKarpenterNodeClaim("nc-1", NodePoolName("default", "ws1"), false)
+	failedNC.Status.Conditions = []status.Condition{
+		{
+			Type:    karpenterv1.ConditionTypeLaunched,
+			Status:  metav1.ConditionUnknown,
+			Reason:  "SubscriptionQuotaReached",
+			Message: "Family Cores quota exceeded",
+		},
+	}
+	c := newFakeClient(failedNC) // No ready nodes.
+
+	p := NewKarpenterProvisioner(c, testConfig)
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, nil)
+
+	conditions, err := p.CollectNodeStatusInfo(context.Background(), ws)
+	require.NoError(t, err)
+
+	byType := map[string]metav1.Condition{}
+	for _, cond := range conditions {
+		byType[cond.Type] = cond
+	}
+
+	ncCond := byType[string(kaitov1beta1.ConditionTypeNodeClaimStatus)]
+	assert.Equal(t, metav1.ConditionFalse, ncCond.Status)
+	assert.Equal(t, "SubscriptionQuotaReached", ncCond.Reason)
+	assert.Equal(t, "Family Cores quota exceeded", ncCond.Message)
+
+	// The resource condition mirrors the NodeClaim failure cause.
+	resCond := byType[string(kaitov1beta1.ConditionTypeResourceStatus)]
+	assert.Equal(t, "SubscriptionQuotaReached", resCond.Reason)
+	assert.Equal(t, "Family Cores quota exceeded", resCond.Message)
+}

--- a/pkg/utils/nodeclaim/nodeclaim.go
+++ b/pkg/utils/nodeclaim/nodeclaim.go
@@ -402,3 +402,61 @@ func IsNodeClaimReadyNotDeleting(nodeClaim *karpenterv1.NodeClaim) bool {
 
 	return nodeClaim.Status.NodeName != ""
 }
+
+// maxProvisioningErrorMessageLen caps the length of the message surfaced by
+// FirstProvisioningError so it stays readable in the workspace status.
+const maxProvisioningErrorMessageLen = 256
+
+// awaitingReconciliationReason is the reason the operatorpkg status library
+// (used by Karpenter core) stamps on freshly-initialized Unknown conditions
+// before any reconciliation has run. It marks a benign "not started / in
+// progress" state — not a provisioning failure — so it must be ignored when
+// looking for real errors.
+const awaitingReconciliationReason = "AwaitingReconciliation"
+
+// FirstProvisioningError scans NodeClaims for a provisioning failure that
+// Karpenter core surfaced on the standard lifecycle conditions
+// (Launched -> Registered -> Initialized) and returns the Reason and Message of
+// the earliest (root-cause) blocking condition.
+//
+// It is provider-agnostic: it reads only the Karpenter core condition types and
+// the generic Reason/Message fields (populated by the cloud provider via
+// cloudprovider.CreateError), so it works for any Karpenter provider (Azure,
+// AWS, gpu-provisioner, ...) and survives provider-specific reason changes.
+//
+// A blocking condition is one whose status is not True, that carries an
+// explanatory message, and whose reason is not the benign
+// "AwaitingReconciliation" initializer. A freshly created NodeClaim whose
+// conditions are still Unknown/AwaitingReconciliation (launch not yet attempted
+// or still in progress) is not an error and is skipped, as are NodeClaims that
+// are being deleted.
+func FirstProvisioningError(nodeClaims []*karpenterv1.NodeClaim) (reason, message string, found bool) {
+	// Earlier lifecycle stages are the root cause, so check them first.
+	for _, stage := range []string{
+		karpenterv1.ConditionTypeLaunched,
+		karpenterv1.ConditionTypeRegistered,
+		karpenterv1.ConditionTypeInitialized,
+	} {
+		for _, nc := range nodeClaims {
+			if nc == nil || !nc.DeletionTimestamp.IsZero() {
+				continue
+			}
+			for _, c := range nc.Status.Conditions {
+				if c.Type == stage &&
+					c.Status != metav1.ConditionTrue &&
+					c.Reason != awaitingReconciliationReason &&
+					c.Message != "" {
+					return c.Reason, truncateProvisioningMessage(c.Message), true
+				}
+			}
+		}
+	}
+	return "", "", false
+}
+
+func truncateProvisioningMessage(msg string) string {
+	if len(msg) <= maxProvisioningErrorMessageLen {
+		return msg
+	}
+	return msg[:maxProvisioningErrorMessageLen] + "..."
+}

--- a/pkg/utils/nodeclaim/nodeclaim_test.go
+++ b/pkg/utils/nodeclaim/nodeclaim_test.go
@@ -16,6 +16,7 @@ package nodeclaim
 import (
 	"context"
 	"errors"
+	"strings"
 	"testing"
 
 	azurev1beta1 "github.com/Azure/karpenter-provider-azure/pkg/apis/v1beta1"
@@ -299,4 +300,104 @@ func TestGenerateNodeClaimManifest(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFirstProvisioningError(t *testing.T) {
+	nc := func(conds ...status.Condition) *karpenterv1.NodeClaim {
+		return &karpenterv1.NodeClaim{Status: karpenterv1.NodeClaimStatus{Conditions: conds}}
+	}
+	deleting := func(conds ...status.Condition) *karpenterv1.NodeClaim {
+		n := nc(conds...)
+		now := metav1.Now()
+		n.DeletionTimestamp = &now
+		n.Finalizers = []string{"karpenter.sh/termination"}
+		return n
+	}
+
+	testcases := map[string]struct {
+		nodeClaims      []*karpenterv1.NodeClaim
+		expectedFound   bool
+		expectedReason  string
+		expectedMessage string
+	}{
+		"no node claims": {
+			nodeClaims:    nil,
+			expectedFound: false,
+		},
+		"pending launched with no message is skipped": {
+			nodeClaims: []*karpenterv1.NodeClaim{
+				nc(status.Condition{Type: karpenterv1.ConditionTypeLaunched, Status: metav1.ConditionUnknown}),
+			},
+			expectedFound: false,
+		},
+		"initial AwaitingReconciliation state is not an error": {
+			// Freshly created NodeClaim: operatorpkg initializes conditions to
+			// Unknown/AwaitingReconciliation before launch is attempted.
+			nodeClaims: []*karpenterv1.NodeClaim{
+				nc(
+					status.Condition{Type: karpenterv1.ConditionTypeLaunched, Status: metav1.ConditionUnknown, Reason: "AwaitingReconciliation", Message: "object is awaiting reconciliation"},
+					status.Condition{Type: karpenterv1.ConditionTypeRegistered, Status: metav1.ConditionUnknown, Reason: "AwaitingReconciliation", Message: "object is awaiting reconciliation"},
+					status.Condition{Type: karpenterv1.ConditionTypeInitialized, Status: metav1.ConditionUnknown, Reason: "AwaitingReconciliation", Message: "object is awaiting reconciliation"},
+				),
+			},
+			expectedFound: false,
+		},
+		"ready node claim has no error": {
+			nodeClaims: []*karpenterv1.NodeClaim{
+				nc(status.Condition{Type: karpenterv1.ConditionTypeLaunched, Status: metav1.ConditionTrue}),
+			},
+			expectedFound: false,
+		},
+		"launched failure surfaced": {
+			nodeClaims: []*karpenterv1.NodeClaim{
+				nc(status.Condition{
+					Type:    karpenterv1.ConditionTypeLaunched,
+					Status:  metav1.ConditionUnknown,
+					Reason:  "SubscriptionQuotaReached",
+					Message: "Family Cores quota exceeded",
+				}),
+			},
+			expectedFound:   true,
+			expectedReason:  "SubscriptionQuotaReached",
+			expectedMessage: "Family Cores quota exceeded",
+		},
+		"launched takes priority over registered": {
+			nodeClaims: []*karpenterv1.NodeClaim{
+				nc(
+					status.Condition{Type: karpenterv1.ConditionTypeRegistered, Status: metav1.ConditionUnknown, Reason: "NotRegistered", Message: "node not registered"},
+					status.Condition{Type: karpenterv1.ConditionTypeLaunched, Status: metav1.ConditionUnknown, Reason: "Unauthorized", Message: "unauthorized to create VM"},
+				),
+			},
+			expectedFound:   true,
+			expectedReason:  "Unauthorized",
+			expectedMessage: "unauthorized to create VM",
+		},
+		"deleting node claim is skipped": {
+			nodeClaims: []*karpenterv1.NodeClaim{
+				deleting(status.Condition{Type: karpenterv1.ConditionTypeLaunched, Status: metav1.ConditionFalse, Reason: "Gone", Message: "gone"}),
+			},
+			expectedFound: false,
+		},
+	}
+
+	for name, tc := range testcases {
+		t.Run(name, func(t *testing.T) {
+			reason, message, found := FirstProvisioningError(tc.nodeClaims)
+			assert.Equal(t, found, tc.expectedFound)
+			assert.Equal(t, reason, tc.expectedReason)
+			assert.Equal(t, message, tc.expectedMessage)
+		})
+	}
+}
+
+func TestFirstProvisioningErrorTruncatesMessage(t *testing.T) {
+	long := strings.Repeat("a", maxProvisioningErrorMessageLen+50)
+	nodeClaims := []*karpenterv1.NodeClaim{
+		{Status: karpenterv1.NodeClaimStatus{Conditions: []status.Condition{
+			{Type: karpenterv1.ConditionTypeLaunched, Status: metav1.ConditionUnknown, Reason: "LaunchFailed", Message: long},
+		}}},
+	}
+	_, message, found := FirstProvisioningError(nodeClaims)
+	assert.Check(t, found)
+	assert.Equal(t, len(message), maxProvisioningErrorMessageLen+len("..."))
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

When Karpenter fails to create a node (e.g. quota exceeded, unauthorized), the workspace/inferenceset status only showed a generic "NodeClaims not enough" message, hiding the real cause.

- Add nodeclaim.FirstProvisioningError, which reads the underlying reason and message from the Karpenter core NodeClaim lifecycle conditions (Launched -> Registered -> Initialized). It is provider-agnostic: it reads only core condition types and generic Reason/Message, so it works for any Karpenter provider and does not couple to Azure/AWS specifics.
- Skip the benign operatorpkg "AwaitingReconciliation" initializer so a freshly created, still-provisioning NodeClaim is not reported as an error.
- Surface the extracted reason/message on the NodeClaim and Resource conditions in both the Karpenter and Azure gpu-provisioner CollectNodeStatusInfo implementations.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: