### PR TITLE
feat: expose kaito_vllm_inflight_{queuing,running}_seconds metrics

### DIFF
--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -32,6 +32,8 @@ import vllm.entrypoints.openai.api_server as api_server
 import yaml
 from huggingface_hub import HfFileSystem, scan_cache_dir
 from prometheus_client import CONTENT_TYPE_LATEST, Gauge, generate_latest
+from prometheus_client.core import GaugeMetricFamily
+from prometheus_client.registry import Collector
 from vllm.entrypoints.openai.models.protocol import LoRAModulePath
 from vllm.utils.argparse_utils import FlexibleArgumentParser
 from vllm.v1.metrics.prometheus import get_prometheus_registry
@@ -59,6 +61,58 @@ kaito_model_download_remaining_seconds = Gauge(
     "Estimated remaining time for model download in seconds; -1 when unknown",
     registry=_registry,
 )
+
+
+class _InflightRequestTimesCollector(Collector):
+    """Per-scrape aggregate of queuing/running time for in-flight requests.
+
+    Fills the gap left by `vllm:request_queue_time_seconds` and
+    `vllm:request_inference_time_seconds`, which are only recorded on
+    request completion.
+
+    WARNING: reads internal vLLM state (`AsyncLLM.output_processor
+    .request_states[*].stats.{arrival_time,scheduled_ts}`). May break on
+    vLLM upgrade; consider upstreaming to vllm-project/vllm.
+    """
+
+    def __init__(self, engine_client: Any) -> None:
+        self._engine_client = engine_client
+
+    def collect(self):
+        # arrival_time is wall-clock; scheduled_ts is monotonic. We can't
+        # use queued_ts for waiting: it's only set once an EngineCoreOutput
+        # arrives, which never happens while the request is still WAITING.
+        wall_now, mono_now = time.time(), time.monotonic()
+        queuing: list[float] = []
+        running: list[float] = []
+        op = getattr(self._engine_client, "output_processor", None)
+        for st in getattr(op, "request_states", {}).values():
+            s = getattr(st, "stats", None)
+            if s is None:
+                continue
+            if s.scheduled_ts:
+                running.append(mono_now - s.scheduled_ts)
+            elif s.arrival_time:
+                queuing.append(wall_now - s.arrival_time)
+
+        yield from self._emit("queuing", "WAITING", queuing)
+        yield from self._emit("running", "RUNNING", running)
+
+    @staticmethod
+    def _emit(kind: str, phase: str, samples: list[float]):
+        prefix = f"kaito_vllm_inflight_{kind}_seconds"
+        yield GaugeMetricFamily(
+            f"{prefix}_max", f"Max {kind} time (s), in-flight requests.",
+            value=max(samples) if samples else 0.0,
+        )
+        yield GaugeMetricFamily(
+            f"{prefix}_sum", f"Sum of {kind} time (s), in-flight requests.",
+            value=sum(samples),
+        )
+        yield GaugeMetricFamily(
+            f"{prefix}_count", f"Number of in-flight ({phase}) requests.",
+            value=len(samples),
+        )
 
 
 class KAITOArgumentParser(argparse.ArgumentParser):
@@ -631,6 +685,10 @@ if __name__ == "__main__":
             )
 
         _wrap_build_and_serve(_stop_pre_download_metrics)
+
+    _wrap_build_and_serve(
+        lambda ec: _registry.register(_InflightRequestTimesCollector(ec))
+    )
 
     # Install the queue-depth rate limit guard via vLLM's built-in --middleware
     # extension point. vLLM imports the dotted path and registers it on its

--- a/presets/workspace/inference/vllm/inference_api.py
+++ b/presets/workspace/inference/vllm/inference_api.py
@@ -102,15 +102,18 @@ class _InflightRequestTimesCollector(Collector):
     def _emit(kind: str, phase: str, samples: list[float]):
         prefix = f"kaito_vllm_inflight_{kind}_seconds"
         yield GaugeMetricFamily(
-            f"{prefix}_max", f"Max {kind} time (s), in-flight requests.",
+            f"{prefix}_max",
+            f"Max {kind} time (s), in-flight requests.",
             value=max(samples) if samples else 0.0,
         )
         yield GaugeMetricFamily(
-            f"{prefix}_sum", f"Sum of {kind} time (s), in-flight requests.",
+            f"{prefix}_sum",
+            f"Sum of {kind} time (s), in-flight requests.",
             value=sum(samples),
         )
         yield GaugeMetricFamily(
-            f"{prefix}_count", f"Number of in-flight ({phase}) requests.",
+            f"{prefix}_count",
+            f"Number of in-flight ({phase}) requests.",
             value=len(samples),
         )
 

--- a/presets/workspace/inference/vllm/tests/test_inflight_request_times.py
+++ b/presets/workspace/inference/vllm/tests/test_inflight_request_times.py
@@ -98,9 +98,7 @@ class TestCollect:
         values = _collect(_engine_client({}), monkeypatch)
         for kind in ("queuing", "running"):
             for suffix in ("max", "sum", "count"):
-                assert (
-                    values[f"kaito_vllm_inflight_{kind}_seconds_{suffix}"] == 0.0
-                )
+                assert values[f"kaito_vllm_inflight_{kind}_seconds_{suffix}"] == 0.0
 
     def test_running_only(self, monkeypatch):
         engine = _engine_client(
@@ -186,9 +184,7 @@ class TestEmittedMetadata:
     def test_metric_family_names(self, monkeypatch):
         monkeypatch.setattr(inference_api.time, "time", lambda: WALL_NOW)
         monkeypatch.setattr(inference_api.time, "monotonic", lambda: MONO_NOW)
-        families = list(
-            _InflightRequestTimesCollector(_engine_client({})).collect()
-        )
+        families = list(_InflightRequestTimesCollector(_engine_client({})).collect())
         names = [f.name for f in families]
         assert names == [
             "kaito_vllm_inflight_queuing_seconds_max",

--- a/presets/workspace/inference/vllm/tests/test_inflight_request_times.py
+++ b/presets/workspace/inference/vllm/tests/test_inflight_request_times.py
@@ -1,0 +1,203 @@
+# Copyright (c) KAITO authors.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for _InflightRequestTimesCollector in inference_api.py."""
+
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# Stub dependencies not available in the CI test environment. Mirrors the
+# pattern in test_download_monitor.py; setdefault preserves real modules when
+# they are already loaded (e.g., in a full vLLM install).
+class _StubBaseHTTPMiddleware:
+    def __init__(self, app=None):
+        self.app = app
+
+
+class _StubJSONResponse:
+    def __init__(self, status_code, content):
+        self.status_code = status_code
+        self.content = content
+
+
+_starlette_base = ModuleType("starlette.middleware.base")
+_starlette_base.BaseHTTPMiddleware = _StubBaseHTTPMiddleware
+_starlette_responses = ModuleType("starlette.responses")
+_starlette_responses.JSONResponse = _StubJSONResponse
+
+for _name, _mod in {
+    "vllm": MagicMock(),
+    "vllm.entrypoints": MagicMock(),
+    "vllm.entrypoints.openai": MagicMock(),
+    "vllm.entrypoints.openai.api_server": MagicMock(),
+    "vllm.entrypoints.openai.models": MagicMock(),
+    "vllm.entrypoints.openai.models.protocol": MagicMock(),
+    "vllm.utils": MagicMock(),
+    "vllm.utils.argparse_utils": MagicMock(),
+    "vllm.v1": MagicMock(),
+    "vllm.v1.metrics": MagicMock(),
+    "vllm.v1.metrics.prometheus": MagicMock(),
+    "torch": MagicMock(),
+    "uvloop": MagicMock(),
+    "psutil": MagicMock(),
+    "yaml": MagicMock(),
+    "huggingface_hub": MagicMock(),
+    "starlette": ModuleType("starlette"),
+    "starlette.middleware": ModuleType("starlette.middleware"),
+    "starlette.middleware.base": _starlette_base,
+    "starlette.responses": _starlette_responses,
+}.items():
+    sys.modules.setdefault(_name, _mod)
+
+_PARENT = str(Path(__file__).resolve().parent.parent)
+if _PARENT not in sys.path:
+    sys.path.insert(0, _PARENT)
+
+import inference_api  # noqa: E402
+from inference_api import _InflightRequestTimesCollector  # noqa: E402
+
+WALL_NOW = 1_000_000.0
+MONO_NOW = 5_000.0
+
+
+def _stats(*, arrival_time=0.0, scheduled_ts=0.0):
+    return SimpleNamespace(arrival_time=arrival_time, scheduled_ts=scheduled_ts)
+
+
+def _engine_client(states):
+    """Build a stub engine_client with `output_processor.request_states`."""
+    request_states = {rid: SimpleNamespace(stats=s) for rid, s in states.items()}
+    output_processor = SimpleNamespace(request_states=request_states)
+    return SimpleNamespace(output_processor=output_processor)
+
+
+def _collect(engine_client, monkeypatch):
+    monkeypatch.setattr(inference_api.time, "time", lambda: WALL_NOW)
+    monkeypatch.setattr(inference_api.time, "monotonic", lambda: MONO_NOW)
+    families = list(_InflightRequestTimesCollector(engine_client).collect())
+    return {f.name: f.samples[0].value for f in families}
+
+
+class TestCollect:
+    def test_empty_when_no_requests(self, monkeypatch):
+        values = _collect(_engine_client({}), monkeypatch)
+        for kind in ("queuing", "running"):
+            for suffix in ("max", "sum", "count"):
+                assert (
+                    values[f"kaito_vllm_inflight_{kind}_seconds_{suffix}"] == 0.0
+                )
+
+    def test_running_only(self, monkeypatch):
+        engine = _engine_client(
+            {
+                "r1": _stats(arrival_time=WALL_NOW - 100, scheduled_ts=MONO_NOW - 30),
+                "r2": _stats(arrival_time=WALL_NOW - 50, scheduled_ts=MONO_NOW - 10),
+            }
+        )
+        v = _collect(engine, monkeypatch)
+        assert v["kaito_vllm_inflight_running_seconds_count"] == 2
+        assert v["kaito_vllm_inflight_running_seconds_max"] == 30.0
+        assert v["kaito_vllm_inflight_running_seconds_sum"] == 40.0
+        assert v["kaito_vllm_inflight_queuing_seconds_count"] == 0
+        assert v["kaito_vllm_inflight_queuing_seconds_max"] == 0.0
+
+    def test_queuing_only(self, monkeypatch):
+        engine = _engine_client(
+            {
+                "w1": _stats(arrival_time=WALL_NOW - 12.5),
+                "w2": _stats(arrival_time=WALL_NOW - 2.5),
+            }
+        )
+        v = _collect(engine, monkeypatch)
+        assert v["kaito_vllm_inflight_queuing_seconds_count"] == 2
+        assert v["kaito_vllm_inflight_queuing_seconds_max"] == 12.5
+        assert v["kaito_vllm_inflight_queuing_seconds_sum"] == 15.0
+        assert v["kaito_vllm_inflight_running_seconds_count"] == 0
+
+    def test_mixed(self, monkeypatch):
+        engine = _engine_client(
+            {
+                "w1": _stats(arrival_time=WALL_NOW - 5),
+                "r1": _stats(arrival_time=WALL_NOW - 100, scheduled_ts=MONO_NOW - 20),
+            }
+        )
+        v = _collect(engine, monkeypatch)
+        assert v["kaito_vllm_inflight_queuing_seconds_count"] == 1
+        assert v["kaito_vllm_inflight_queuing_seconds_max"] == 5.0
+        assert v["kaito_vllm_inflight_running_seconds_count"] == 1
+        assert v["kaito_vllm_inflight_running_seconds_max"] == 20.0
+
+    def test_scheduled_wins_over_arrival(self, monkeypatch):
+        # A scheduled request must never be double-counted as queuing.
+        engine = _engine_client(
+            {"r1": _stats(arrival_time=WALL_NOW - 999, scheduled_ts=MONO_NOW - 1)}
+        )
+        v = _collect(engine, monkeypatch)
+        assert v["kaito_vllm_inflight_running_seconds_count"] == 1
+        assert v["kaito_vllm_inflight_queuing_seconds_count"] == 0
+
+    def test_skips_when_stats_none(self, monkeypatch):
+        # log_stats=False on vLLM produces RequestState.stats = None.
+        request_states = {"r1": SimpleNamespace(stats=None)}
+        engine = SimpleNamespace(
+            output_processor=SimpleNamespace(request_states=request_states)
+        )
+        v = _collect(engine, monkeypatch)
+        assert v["kaito_vllm_inflight_queuing_seconds_count"] == 0
+        assert v["kaito_vllm_inflight_running_seconds_count"] == 0
+
+    def test_skips_when_arrival_time_zero(self, monkeypatch):
+        # Freshly-added request before frontend admission recorded time.
+        engine = _engine_client({"r1": _stats(arrival_time=0.0, scheduled_ts=0.0)})
+        v = _collect(engine, monkeypatch)
+        assert v["kaito_vllm_inflight_queuing_seconds_count"] == 0
+        assert v["kaito_vllm_inflight_running_seconds_count"] == 0
+
+    @pytest.mark.parametrize(
+        "engine",
+        [
+            SimpleNamespace(),  # no output_processor
+            SimpleNamespace(output_processor=None),  # output_processor is None
+            SimpleNamespace(output_processor=SimpleNamespace()),  # no request_states
+        ],
+    )
+    def test_missing_internal_attrs_degrades_to_zero(self, engine, monkeypatch):
+        v = _collect(engine, monkeypatch)
+        for kind in ("queuing", "running"):
+            assert v[f"kaito_vllm_inflight_{kind}_seconds_count"] == 0
+
+
+class TestEmittedMetadata:
+    def test_metric_family_names(self, monkeypatch):
+        monkeypatch.setattr(inference_api.time, "time", lambda: WALL_NOW)
+        monkeypatch.setattr(inference_api.time, "monotonic", lambda: MONO_NOW)
+        families = list(
+            _InflightRequestTimesCollector(_engine_client({})).collect()
+        )
+        names = [f.name for f in families]
+        assert names == [
+            "kaito_vllm_inflight_queuing_seconds_max",
+            "kaito_vllm_inflight_queuing_seconds_sum",
+            "kaito_vllm_inflight_queuing_seconds_count",
+            "kaito_vllm_inflight_running_seconds_max",
+            "kaito_vllm_inflight_running_seconds_sum",
+            "kaito_vllm_inflight_running_seconds_count",
+        ]
+        for f in families:
+            assert f.type == "gauge"
+            assert f.documentation


### PR DESCRIPTION

**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

vLLM only records per-request queuing/inference time histograms on request completion. Add a Prometheus collector that scrapes AsyncLLM.output_processor.request_states at scrape time to emit aggregate max/sum/count gauges for currently in-flight requests in both WAITING and RUNNING phases, enabling scaling and stall detection on active work.

Notes for Reviewers:

Validated end-to-end with guidellm at 512 concurrency against a local vLLM server; the new gauges track vLLM's own Running/Waiting counters in lock-step.

  guidellm benchmark \
      --target http://localhost:5000 \
      --rate-type concurrent \
      --rate 512 \
      --max-requests 512 \
      --processor google/gemma-4-e4b-it \
      --data '{"prompt_tokens": 512, "output_tokens": 1024}'

vLLM engine log (saturated):

  Engine 000: Avg prompt throughput: 0.0 tokens/s,
  Avg generation throughput: 7573.2 tokens/s,
  Running: 256 reqs, Waiting: 251 reqs,
  GPU KV cache usage: 20.5%, Prefix cache hit rate: 0.0%

/metrics scrape at saturation (Running=256, Waiting=251):

  kaito_vllm_inflight_queuing_seconds_max   32.58631348609924
  kaito_vllm_inflight_queuing_seconds_sum   8130.47839307785
  kaito_vllm_inflight_queuing_seconds_count 251.0
  kaito_vllm_inflight_running_seconds_max   32.866286710021086
  kaito_vllm_inflight_running_seconds_sum   7581.434429870424
  kaito_vllm_inflight_running_seconds_count 256.0

Later scrape after some requests completed (queue draining):

  kaito_vllm_inflight_queuing_seconds_max   40.98731875419617
  kaito_vllm_inflight_queuing_seconds_sum   9107.045262813568
  kaito_vllm_inflight_queuing_seconds_count 228.0
  kaito_vllm_inflight_running_seconds_max   40.473577149998164
  kaito_vllm_inflight_running_seconds_sum   8168.135399727937
  kaito_vllm_inflight_running_seconds_count 245.0

The _count gauges match vLLM's Running/Waiting counters, and _max / _sum grow monotonically as expected while requests age in each phase.


**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: