### PR TITLE
feat: expand streaming output guardrails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -164,12 +164,12 @@ tuning-metrics-server-test: ## Run Tuning Metrics Server tests with pytest.
 
 .PHONY: inference-api-e2e
 inference-api-e2e: ## Run inference API e2e tests with pytest.
-	pip install -r ./presets/workspace/dependencies/requirements-test.txt --upgrade
+	pip install --no-cache-dir -r ./presets/workspace/dependencies/requirements-test.txt --upgrade
 	pip install pytest-cov
 	pytest --cov -o log_cli=true -o log_cli_level=INFO presets/workspace/inference/vllm
 	pytest --cov -o log_cli=true -o log_cli_level=INFO presets/workspace/inference/text-generation
 
-	pip install -r ./presets/workspace/generator/requirements.txt --upgrade
+	pip install --no-cache-dir -r ./presets/workspace/generator/requirements.txt --upgrade
 	pytest --cov -o log_cli=true -o log_cli_level=INFO presets/workspace/generator/
 
 # Ginkgo configurations

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,8 @@ tuning-metrics-server-test: ## Run Tuning Metrics Server tests with pytest.
 .PHONY: inference-api-e2e
 inference-api-e2e: ## Run inference API e2e tests with pytest.
 	pip install --no-cache-dir -r ./presets/workspace/dependencies/requirements-test.txt --upgrade
+	pip install --no-cache-dir --force-reinstall --no-deps huggingface-hub==1.11.0
+	python -c "import importlib.metadata; assert importlib.metadata.version('huggingface-hub') == '1.11.0'"
 	pip install pytest-cov
 	pytest --cov -o log_cli=true -o log_cli_level=INFO presets/workspace/inference/vllm
 	pytest --cov -o log_cli=true -o log_cli_level=INFO presets/workspace/inference/text-generation

--- a/presets/ragengine/streaming/README.md
+++ b/presets/ragengine/streaming/README.md
@@ -1,0 +1,176 @@
+# RAG Engine Streaming Guardrails
+
+This package implements Server-Sent Events (SSE) handling and incremental output guardrail scanning for OpenAI-compatible chat completion streams.
+
+## Scope
+
+The current implementation intentionally supports a narrow, reviewable contract:
+
+- OpenAI-compatible chat completion SSE responses
+- one choice (`n=1`, choice index `0`)
+- `action: block` only
+- these output scanners:
+  - `ban_substrings`
+  - `invisible_text`
+  - `secrets`
+  - `sensitive`
+
+The implementation does not support streaming redaction. Once bytes have been sent to a client, they cannot be withdrawn or replaced safely. Blocking is possible because the implementation retains an un-emitted tail and scans it before release.
+
+## Data Flow
+
+```text
+upstream byte chunks
+        |
+        v
+  SSEFramer / iter_sse_events        streaming/sse.py
+        |
+        v
+  parse_openai_chat_sse_event        streaming/openai.py
+        |
+        v
+  StreamingBufferWindow             streaming/buffer_window.py
+        |
+        v
+  llm_guard output scanners         streaming/guardrails.py
+        |
+        +-- safe: emit OpenAI SSE delta chunks
+        |
+        +-- blocked: emit refusal + content_filter + [DONE]
+```
+
+`apply_streaming_guardrails()` owns the complete pipeline. It closes the upstream async iterator when the stream completes or terminates early.
+
+## Files
+
+### `sse.py`
+
+Frames arbitrary text chunks into complete SSE events. Network chunk boundaries do not need to align with SSE event boundaries. Both `\n\n` and `\r\n\r\n` event separators are accepted.
+
+`SSEEvent` preserves the raw event text and exposes combined `data:` lines for protocol-specific parsing.
+
+### `openai.py`
+
+Parses and validates OpenAI chat completion SSE events. It recognizes normal JSON events and the terminal `data: [DONE]` event, and extracts choice content and finish reasons.
+
+The module also builds normalized OpenAI-compatible SSE chunks for:
+
+- content deltas
+- finish reasons
+- `[DONE]`
+
+Malformed or unsupported event shapes are rejected rather than passed through without scanning.
+
+### `buffer_window.py`
+
+Provides the protocol-independent sliding window used for incremental scanning.
+
+The window retains the newest `holdback_len` characters. Older text is emitted only after the complete pending buffer has passed every configured scanner. On stream completion, `flush()` scans the final retained tail before emitting it.
+
+The default holdback in `guardrails.py` is 256 characters. This lets scanners detect values that cross upstream chunk boundaries before any part of the value is released.
+
+The window keeps only a sliding tail, not the full response. It is therefore appropriate for local pattern detection, but not for scanners that require the entire completed document.
+
+### `guardrails.py`
+
+Integrates SSE parsing, the sliding window, scanner execution, and OpenAI-compatible response generation.
+
+Before streaming starts, `validate_streaming_guardrails()` rejects:
+
+- any action other than `block`
+- any scanner outside the streaming allowlist
+
+Each candidate window is scanned with the configured `llm_guard` scanners. When all scanners accept it, safe content is emitted. When any scanner rejects it, the stream emits:
+
+1. the configured block message
+2. `finish_reason: "content_filter"`
+3. `data: [DONE]`
+
+A malformed upstream SSE event follows the same fail-closed refusal path.
+
+## Supported Scanners
+
+| Scanner | Detects | Streaming suitability |
+| --- | --- | --- |
+| `ban_substrings` | Configured prohibited words or strings | Local text matching |
+| `invisible_text` | Invisible or non-printable Unicode content | Local character detection |
+| `secrets` | Common secret and credential formats | Local pattern detection |
+| `sensitive` | Email, phone, credit card, and IPv4 patterns | Local pattern detection |
+
+All four scanners must use `action: block` in streaming mode. Their non-streaming redaction capabilities do not change this streaming restriction.
+
+The following registered output scanners are deliberately not in the streaming allowlist:
+
+- `json`: validity can only be decided from the complete document
+- `reading_time`: requires cumulative output length
+- `token_limit`: requires a cumulative token count
+- `regex`: not part of the current n=1 delivery scope
+
+## Current Limitations
+
+### One choice only
+
+The implementation uses one global `StreamingBufferWindow` and emits rebuilt chunks with choice index `0`. The API rejects requests with `n > 1`. The guardrails pipeline also fails closed if an upstream event contains multiple parsed choices or a choice index other than `0`, preventing independent choices from being mixed in one scanner window.
+
+This is an intentional product scope decision rather than a parser limitation. Multi-choice streaming would require an independent scanner window for each choice and a defined policy for partial failures: if one choice is blocked, the service must decide whether to terminate only that choice or the entire response. It would also multiply inference and scanning cost for a workflow that normally consumes one answer. The OpenAI parser remains capable of recognizing multiple choices so this can be revisited without replacing the protocol layer, but implementation should wait for a concrete `n > 1` use case and an agreed blocking contract.
+
+### Normalized output events
+
+Content events are rebuilt instead of forwarding the raw upstream event. Metadata carried only on the original content event is not preserved. Finish-reason events are forwarded after the final buffered content is scanned.
+
+### Fixed character holdback
+
+The 256-character holdback is a safety boundary for local patterns, not an unlimited guarantee. A configured prohibited value or credential format longer than the holdback could be split across released and retained text. Changes to scanner behavior must be evaluated against this boundary.
+
+### Fail-closed parsing
+
+Malformed OpenAI SSE events produce the configured refusal. This prevents unparsed content from bypassing guardrails, but means protocol extensions must be added to `openai.py` before they can pass through this pipeline.
+
+## Policy Example
+
+```yaml
+action: block
+blockMessage: "The model output was blocked by policy."
+scanners:
+  - type: invisible_text
+    action: block
+  - type: secrets
+    action: block
+  - type: sensitive
+    action: block
+    detectors:
+      - email
+      - phone
+      - credit_card
+      - ip_address
+  - type: ban_substrings
+    action: block
+    substrings:
+      - prohibited phrase
+    match_type: str
+```
+
+The exact enclosing policy structure is owned by the RAG Engine output guardrails configuration. The important streaming constraints are that every scanner uses `block` and every scanner type appears in the streaming allowlist.
+
+## Tests
+
+Streaming-specific tests are under `presets/ragengine/tests/streaming/`.
+
+Run the focused suite from the repository root:
+
+```bash
+.venv/bin/python -m pytest presets/ragengine/tests/streaming -v
+```
+
+Run lint and formatting checks for this package and its tests:
+
+```bash
+.venv/bin/ruff check --output-format=github \
+  presets/ragengine/streaming \
+  presets/ragengine/tests/streaming
+.venv/bin/ruff format --check \
+  presets/ragengine/streaming \
+  presets/ragengine/tests/streaming
+```
+
+SSE test fixtures must include an integer `index` in every OpenAI choice object. Omitting it exercises the malformed-event refusal path instead of the intended scanner path.

--- a/presets/ragengine/streaming/README.md
+++ b/presets/ragengine/streaming/README.md
@@ -1,130 +1,71 @@
 # RAG Engine Streaming Guardrails
 
-This package implements Server-Sent Events (SSE) handling and incremental output guardrail scanning for OpenAI-compatible chat completion streams.
+Incremental output scanning for OpenAI-compatible chat completion SSE streams.
 
 ## Scope
 
-The current implementation intentionally supports a narrow, reviewable contract:
-
-- OpenAI-compatible chat completion SSE responses
-- one choice (`n=1`, choice index `0`)
+- single choice only (`n=1`, choice index `0`)
 - `action: block` only
-- these output scanners:
-  - `ban_substrings`
-  - `invisible_text`
-  - `secrets`
-  - `sensitive`
+- supported scanners: `ban_substrings`, `invisible_text`, `secrets`, `sensitive`
 
-The implementation does not support streaming redaction. Once bytes have been sent to a client, they cannot be withdrawn or replaced safely. Blocking is possible because the implementation retains an un-emitted tail and scans it before release.
+The API rejects `n > 1`. The pipeline also fails closed on multiple choices, a nonzero choice index, or malformed SSE.
 
-## Data Flow
+Streaming redaction is not supported because emitted bytes cannot be withdrawn. Text is held and scanned before release so a scanner hit can safely block the response.
+
+## Flow
 
 ```text
-upstream byte chunks
-        |
-        v
-  SSEFramer / iter_sse_events        streaming/sse.py
-        |
-        v
-  parse_openai_chat_sse_event        streaming/openai.py
-        |
-        v
-  StreamingBufferWindow             streaming/buffer_window.py
-        |
-        v
-  llm_guard output scanners         streaming/guardrails.py
-        |
-        +-- safe: emit OpenAI SSE delta chunks
-        |
-        +-- blocked: emit refusal + content_filter + [DONE]
+upstream chunks
+  -> SSE framing
+  -> OpenAI event parsing
+  -> holdback window
+  -> output scanners
+  -> safe deltas OR block message + content_filter + [DONE]
 ```
-
-`apply_streaming_guardrails()` owns the complete pipeline. It closes the upstream async iterator when the stream completes or terminates early.
 
 ## Files
 
-### `sse.py`
+| File | Responsibility |
+| --- | --- |
+| `sse.py` | Frame network chunks into complete SSE events |
+| `openai.py` | Parse and build OpenAI-compatible SSE events |
+| `buffer_window.py` | Retain and scan an un-emitted text tail |
+| `guardrails.py` | Validate policy, run scanners, and emit or block |
 
-Frames arbitrary text chunks into complete SSE events. Network chunk boundaries do not need to align with SSE event boundaries. Both `\n\n` and `\r\n\r\n` event separators are accepted.
+The default holdback is 256 characters. The window keeps only the pending tail, so it supports local pattern detection but not scanners that need the complete response.
 
-`SSEEvent` preserves the raw event text and exposes combined `data:` lines for protocol-specific parsing.
+## Scanner Support
 
-### `openai.py`
+| Scanner | Detects |
+| --- | --- |
+| `ban_substrings` | Configured prohibited strings |
+| `invisible_text` | Invisible or non-printable Unicode characters |
+| `secrets` | Common credentials and secret formats |
+| `sensitive` | Email, phone, credit card, and IPv4 patterns |
 
-Parses and validates OpenAI chat completion SSE events. It recognizes normal JSON events and the terminal `data: [DONE]` event, and extracts choice content and finish reasons.
+Not supported in streaming:
 
-The module also builds normalized OpenAI-compatible SSE chunks for:
+- `json`: requires the complete document
+- `reading_time`: requires cumulative output
+- `token_limit`: requires cumulative token count
+- `regex`: outside the current delivery scope
 
-- content deltas
-- finish reasons
-- `[DONE]`
+## Limitations
 
-Malformed or unsupported event shapes are rejected rather than passed through without scanning.
+- Content events are rebuilt with choice index `0`; original content-event metadata is not preserved.
+- Patterns longer than the 256-character holdback may cross the release boundary.
+- Multi-choice requires per-choice windows and defined partial-block semantics.
 
-### `buffer_window.py`
+## Future Redaction
 
-Provides the protocol-independent sliding window used for incremental scanning.
+Implement separately in this order:
 
-The window retains the newest `holdback_len` characters. Older text is emitted only after the complete pending buffer has passed every configured scanner. On stream completion, `flush()` scans the final retained tail before emitting it.
+1. `invisible_text`
+2. `sensitive`
+3. `secrets`
+4. `ban_substrings`
 
-The default holdback in `guardrails.py` is 256 characters. This lets scanners detect values that cross upstream chunk boundaries before any part of the value is released.
-
-The window keeps only a sliding tail, not the full response. It is therefore appropriate for local pattern detection, but not for scanners that require the entire completed document.
-
-### `guardrails.py`
-
-Integrates SSE parsing, the sliding window, scanner execution, and OpenAI-compatible response generation.
-
-Before streaming starts, `validate_streaming_guardrails()` rejects:
-
-- any action other than `block`
-- any scanner outside the streaming allowlist
-
-Each candidate window is scanned with the configured `llm_guard` scanners. When all scanners accept it, safe content is emitted. When any scanner rejects it, the stream emits:
-
-1. the configured block message
-2. `finish_reason: "content_filter"`
-3. `data: [DONE]`
-
-A malformed upstream SSE event follows the same fail-closed refusal path.
-
-## Supported Scanners
-
-| Scanner | Detects | Streaming suitability |
-| --- | --- | --- |
-| `ban_substrings` | Configured prohibited words or strings | Local text matching |
-| `invisible_text` | Invisible or non-printable Unicode content | Local character detection |
-| `secrets` | Common secret and credential formats | Local pattern detection |
-| `sensitive` | Email, phone, credit card, and IPv4 patterns | Local pattern detection |
-
-All four scanners must use `action: block` in streaming mode. Their non-streaming redaction capabilities do not change this streaming restriction.
-
-The following registered output scanners are deliberately not in the streaming allowlist:
-
-- `json`: validity can only be decided from the complete document
-- `reading_time`: requires cumulative output length
-- `token_limit`: requires a cumulative token count
-- `regex`: not part of the current n=1 delivery scope
-
-## Current Limitations
-
-### One choice only
-
-The implementation uses one global `StreamingBufferWindow` and emits rebuilt chunks with choice index `0`. The API rejects requests with `n > 1`. The guardrails pipeline also fails closed if an upstream event contains multiple parsed choices or a choice index other than `0`, preventing independent choices from being mixed in one scanner window.
-
-This is an intentional product scope decision rather than a parser limitation. Multi-choice streaming would require an independent scanner window for each choice and a defined policy for partial failures: if one choice is blocked, the service must decide whether to terminate only that choice or the entire response. It would also multiply inference and scanning cost for a workflow that normally consumes one answer. The OpenAI parser remains capable of recognizing multiple choices so this can be revisited without replacing the protocol layer, but implementation should wait for a concrete `n > 1` use case and an agreed blocking contract.
-
-### Normalized output events
-
-Content events are rebuilt instead of forwarding the raw upstream event. Metadata carried only on the original content event is not preserved. Finish-reason events are forwarded after the final buffered content is scanned.
-
-### Fixed character holdback
-
-The 256-character holdback is a safety boundary for local patterns, not an unlimited guarantee. A configured prohibited value or credential format longer than the holdback could be split across released and retained text. Changes to scanner behavior must be evaluated against this boundary.
-
-### Fail-closed parsing
-
-Malformed OpenAI SSE events produce the configured refusal. This prevents unparsed content from bypassing guardrails, but means protocol extensions must be added to `openai.py` before they can pass through this pipeline.
+Sanitized text must replace held text before any matching bytes are emitted.
 
 ## Policy Example
 
@@ -133,44 +74,18 @@ action: block
 blockMessage: "The model output was blocked by policy."
 scanners:
   - type: invisible_text
-    action: block
   - type: secrets
-    action: block
   - type: sensitive
-    action: block
-    detectors:
-      - email
-      - phone
-      - credit_card
-      - ip_address
+    detectors: [email, phone, credit_card, ip_address]
   - type: ban_substrings
-    action: block
-    substrings:
-      - prohibited phrase
+    substrings: [prohibited phrase]
     match_type: str
 ```
 
-The exact enclosing policy structure is owned by the RAG Engine output guardrails configuration. The important streaming constraints are that every scanner uses `block` and every scanner type appears in the streaming allowlist.
-
-## Tests
-
-Streaming-specific tests are under `presets/ragengine/tests/streaming/`.
-
-Run the focused suite from the repository root:
+## Validation
 
 ```bash
 .venv/bin/python -m pytest presets/ragengine/tests/streaming -v
+.venv/bin/ruff check presets/ragengine/streaming presets/ragengine/tests/streaming
+.venv/bin/ruff format --check presets/ragengine/streaming presets/ragengine/tests/streaming
 ```
-
-Run lint and formatting checks for this package and its tests:
-
-```bash
-.venv/bin/ruff check --output-format=github \
-  presets/ragengine/streaming \
-  presets/ragengine/tests/streaming
-.venv/bin/ruff format --check \
-  presets/ragengine/streaming \
-  presets/ragengine/tests/streaming
-```
-
-SSE test fixtures must include an integer `index` in every OpenAI choice object. Omitting it exercises the malformed-event refusal path instead of the intended scanner path.

--- a/presets/ragengine/streaming/README.md
+++ b/presets/ragengine/streaming/README.md
@@ -54,7 +54,6 @@ Not supported in streaming:
 
 - Content events are rebuilt with choice index `0`; original content-event metadata is not preserved.
 - Patterns longer than the 256-character holdback may cross the release boundary.
-- Multi-choice requires per-choice windows and defined partial-block semantics.
 
 ## Future Redaction
 

--- a/presets/ragengine/streaming/guardrails.py
+++ b/presets/ragengine/streaming/guardrails.py
@@ -30,7 +30,9 @@ from ragengine.streaming.openai import (
 from ragengine.streaming.sse import iter_sse_events
 
 STREAMING_GUARDRAILS_HOLDBACK_LEN = 256
-STREAMING_GUARDRAILS_SUPPORTED_SCANNERS = frozenset({"ban_substrings"})
+STREAMING_GUARDRAILS_SUPPORTED_SCANNERS = frozenset(
+    {"ban_substrings", "invisible_text", "secrets", "sensitive"}
+)
 
 
 @dataclass(frozen=True)
@@ -58,8 +60,8 @@ def validate_streaming_guardrails(
                 supported=False,
                 detail=(
                     "stream=true with output guardrails only supports "
-                    "ban_substrings scanners. Unsupported scanner: "
-                    f"{scanner_config.type}."
+                    f"{sorted(STREAMING_GUARDRAILS_SUPPORTED_SCANNERS)} scanners. "
+                    f"Unsupported scanner: {scanner_config.type}."
                 ),
             )
 
@@ -96,6 +98,13 @@ async def apply_streaming_guardrails(
                 return
 
             if parse_result.status != OpenAIChatChunkParseStatus.PARSED:
+                async for chunk in _emit_refusal(guardrails):
+                    yield chunk
+                return
+
+            if len(parse_result.parsed_choices) > 1 or any(
+                choice.choice_index != 0 for choice in parse_result.parsed_choices
+            ):
                 async for chunk in _emit_refusal(guardrails):
                     yield chunk
                 return

--- a/presets/ragengine/tests/api/test_chat_completions.py
+++ b/presets/ragengine/tests/api/test_chat_completions.py
@@ -27,6 +27,7 @@ from ragengine.guardrails.scanner_schemas import (
     ParsedScannerConfig,
     RegexConfig,
 )
+from ragengine.streaming.guardrails import STREAMING_GUARDRAILS_SUPPORTED_SCANNERS
 
 
 @pytest.fixture(autouse=True)
@@ -325,8 +326,8 @@ async def test_chat_completions_stream_with_unsupported_output_guardrails_is_rej
 
     assert response.status_code == 400
     assert (
-        response.json()["detail"]
-        == "stream=true with output guardrails only supports ban_substrings scanners. "
+        response.json()["detail"] == "stream=true with output guardrails only supports "
+        f"{sorted(STREAMING_GUARDRAILS_SUPPORTED_SCANNERS)} scanners. "
         "Unsupported scanner: json."
     )
 
@@ -339,6 +340,7 @@ async def test_chat_completions_rejects_multi_choice(async_client):
             "model": "mock-model",
             "messages": [{"role": "user", "content": "Hello"}],
             "n": 2,
+            "stream": True,
         },
     )
 

--- a/presets/ragengine/tests/streaming/test_guardrails.py
+++ b/presets/ragengine/tests/streaming/test_guardrails.py
@@ -21,10 +21,14 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../.
 from ragengine.guardrails import OutputGuardrails  # noqa: E402
 from ragengine.guardrails.scanner_schemas import (  # noqa: E402
     BanSubstringsConfig,
+    InvisibleTextConfig,
     JSONConfig,
     ParsedScannerConfig,
+    SecretsConfig,
+    SensitiveConfig,
 )
 from ragengine.streaming.guardrails import (  # noqa: E402
+    STREAMING_GUARDRAILS_SUPPORTED_SCANNERS,
     apply_streaming_guardrails,
     validate_streaming_guardrails,
 )
@@ -88,9 +92,39 @@ def test_validate_streaming_guardrails_rejects_streaming_unsafe_scanner():
 
     assert support.supported is False
     assert support.detail == (
-        "stream=true with output guardrails only supports ban_substrings scanners. "
+        "stream=true with output guardrails only supports "
+        f"{sorted(STREAMING_GUARDRAILS_SUPPORTED_SCANNERS)} scanners. "
         "Unsupported scanner: json."
     )
+
+
+@pytest.mark.parametrize(
+    "scanner_type,config",
+    [
+        ("invisible_text", InvisibleTextConfig()),
+        ("secrets", SecretsConfig()),
+        ("sensitive", SensitiveConfig(detectors=["email"])),
+    ],
+)
+def test_validate_streaming_guardrails_accepts_newly_supported_scanners(
+    scanner_type, config
+):
+    support = validate_streaming_guardrails(
+        OutputGuardrails(
+            enabled=True,
+            action_on_hit="block",
+            scanner_configs=(
+                ParsedScannerConfig(
+                    type=scanner_type,
+                    action_on_hit="block",
+                    config=config,
+                ),
+            ),
+        )
+    )
+
+    assert support.supported is True
+    assert support.detail is None
 
 
 @pytest.mark.asyncio
@@ -132,3 +166,195 @@ async def test_apply_streaming_guardrails_emits_refusal_for_malformed_sse_event(
         "data: [DONE]\n\n",
     ]
     assert closed is True
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "event",
+    [
+        (
+            'data: {"choices":['
+            '{"index":0,"delta":{"content":"first"}},'
+            '{"index":1,"delta":{"content":"second"}}]}\n\n'
+        ),
+        'data: {"choices":[{"index":1,"delta":{"content":"second"}}]}\n\n',
+    ],
+)
+async def test_apply_streaming_guardrails_rejects_non_single_choice_event(event):
+    async def upstream_chunks():
+        yield event
+        yield "data: [DONE]\n\n"
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        fail_open=False,
+        action_on_hit="block",
+        block_message="blocked-by-policy",
+        scanner_configs=(
+            ParsedScannerConfig(
+                type="ban_substrings",
+                action_on_hit="block",
+                config=BanSubstringsConfig(substrings=["unsafe"], match_type="str"),
+            ),
+        ),
+    )
+
+    chunks = [
+        chunk
+        async for chunk in apply_streaming_guardrails(
+            upstream_chunks(), guardrails, {"messages": [], "n": 1}
+        )
+    ]
+
+    assert chunks == [
+        'data: {"choices":[{"index":0,"delta":{"content":"blocked-by-policy"},"finish_reason":null}]}\n\n',
+        'data: {"choices":[{"index":0,"delta":{},"finish_reason":"content_filter"}]}\n\n',
+        "data: [DONE]\n\n",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apply_streaming_guardrails_blocks_secrets_scanner_hit():
+    async def upstream_chunks():
+        yield (
+            'data: {"choices":[{"index":0,"delta":{"content":'
+            '"Contact me at AKIA1234567890ABCDEF for access."}}]}\n\n'
+        )
+        yield 'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
+        yield "data: [DONE]\n\n"
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        fail_open=False,
+        action_on_hit="block",
+        block_message="blocked-by-policy",
+        scanner_configs=(
+            ParsedScannerConfig(
+                type="secrets",
+                action_on_hit="block",
+                config=SecretsConfig(),
+            ),
+        ),
+    )
+
+    chunks = [
+        chunk
+        async for chunk in apply_streaming_guardrails(
+            upstream_chunks(), guardrails, {"messages": []}
+        )
+    ]
+
+    assert chunks == [
+        'data: {"choices":[{"index":0,"delta":{"content":"blocked-by-policy"},"finish_reason":null}]}\n\n',
+        'data: {"choices":[{"index":0,"delta":{},"finish_reason":"content_filter"}]}\n\n',
+        "data: [DONE]\n\n",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apply_streaming_guardrails_blocks_sensitive_scanner_hit():
+    async def upstream_chunks():
+        yield (
+            'data: {"choices":[{"index":0,"delta":{"content":'
+            '"Reach me at leaked@example.com anytime."}}]}\n\n'
+        )
+        yield 'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
+        yield "data: [DONE]\n\n"
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        fail_open=False,
+        action_on_hit="block",
+        block_message="blocked-by-policy",
+        scanner_configs=(
+            ParsedScannerConfig(
+                type="sensitive",
+                action_on_hit="block",
+                config=SensitiveConfig(detectors=["email"]),
+            ),
+        ),
+    )
+
+    chunks = [
+        chunk
+        async for chunk in apply_streaming_guardrails(
+            upstream_chunks(), guardrails, {"messages": []}
+        )
+    ]
+
+    assert chunks == [
+        'data: {"choices":[{"index":0,"delta":{"content":"blocked-by-policy"},"finish_reason":null}]}\n\n',
+        'data: {"choices":[{"index":0,"delta":{},"finish_reason":"content_filter"}]}\n\n',
+        "data: [DONE]\n\n",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apply_streaming_guardrails_blocks_invisible_text_scanner_hit():
+    async def upstream_chunks():
+        yield 'data: {"choices":[{"index":0,"delta":{"content":"hello\\u200bworld"}}]}\n\n'
+        yield 'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
+        yield "data: [DONE]\n\n"
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        fail_open=False,
+        action_on_hit="block",
+        block_message="blocked-by-policy",
+        scanner_configs=(
+            ParsedScannerConfig(
+                type="invisible_text",
+                action_on_hit="block",
+                config=InvisibleTextConfig(),
+            ),
+        ),
+    )
+
+    chunks = [
+        chunk
+        async for chunk in apply_streaming_guardrails(
+            upstream_chunks(), guardrails, {"messages": []}
+        )
+    ]
+
+    assert chunks == [
+        'data: {"choices":[{"index":0,"delta":{"content":"blocked-by-policy"},"finish_reason":null}]}\n\n',
+        'data: {"choices":[{"index":0,"delta":{},"finish_reason":"content_filter"}]}\n\n',
+        "data: [DONE]\n\n",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_apply_streaming_guardrails_passes_through_safe_invisible_text_content():
+    async def upstream_chunks():
+        yield 'data: {"choices":[{"index":0,"delta":{"content":"hello "}}]}\n\n'
+        yield 'data: {"choices":[{"index":0,"delta":{"content":"world"}}]}\n\n'
+        yield 'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
+        yield "data: [DONE]\n\n"
+
+    guardrails = OutputGuardrails(
+        enabled=True,
+        fail_open=False,
+        action_on_hit="block",
+        scanner_configs=(
+            ParsedScannerConfig(
+                type="invisible_text",
+                action_on_hit="block",
+                config=InvisibleTextConfig(),
+            ),
+        ),
+    )
+
+    chunks = [
+        chunk
+        async for chunk in apply_streaming_guardrails(
+            upstream_chunks(), guardrails, {"messages": []}
+        )
+    ]
+
+    assert "".join(chunks) == (
+        'data: {"choices":[{"index":0,"delta":{"content":"hello world"},'
+        '"finish_reason":null}]}\n\n'
+        'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
+        "data: [DONE]\n\n"
+    )

--- a/presets/workspace/dependencies/requirements-test.txt
+++ b/presets/workspace/dependencies/requirements-test.txt
@@ -3,5 +3,5 @@
 
 # Test dependencies
 pytest==8.3.4
-httpx==0.27.0
+httpx>=0.27.0,<1.0
 requests==2.32.4


### PR DESCRIPTION
**Reason for Change**:
Streaming output guardrails currently allow only `ban_substrings`. Extend the block-only streaming path to support `invisible_text`, `secrets`, and `sensitive` while explicitly enforcing the existing single-choice (`n=1`, choice index `0`) contract. Add review-facing documentation for the streaming pipeline, safety model, and limitations.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:

N/A

**Notes for Reviewers**:
- Streaming remains `action: block` only.
- The API rejects `n > 1`; the guardrails pipeline also fails closed on multi-choice or nonzero-choice upstream events.
- Supported streaming scanners are `ban_substrings`, `invisible_text`, `secrets`, and `sensitive`.
- Validation: `.venv/bin/python -m pytest presets/ragengine/tests/streaming -q` (42 passed).
- Ruff check and format validation passed for the streaming package and affected tests.
- GPU E2E is not applicable to this change and was not run locally.