### PR TITLE
fix: cve bump setuptools>=83.0.0 and pin msgpack>=1.2.1

### DIFF
--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -40,6 +40,7 @@ RUN pip3 install --no-cache-dir --upgrade "setuptools>=83.0.0" "msgpack>=1.2.1" 
            /usr/local/lib/python3.12/site-packages/pip/_vendor/msgpack* \
            /usr/local/lib/python3.12/site-packages/pip/_vendor/setuptools* \
            /usr/local/lib/python3.12/site-packages/pip/_vendor/pkg_resources* \
+           /usr/local/lib/python3.12/site-packages/pip/_vendor/vendor.txt \
            /root/.cache/pip && \
     find / -type d \( \
         -name 'setuptools-6*.dist-info' -o \

--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -41,6 +41,7 @@ RUN pip3 install --no-cache-dir --upgrade "setuptools>=83.0.0" "msgpack>=1.2.1" 
            /usr/local/lib/python3.12/site-packages/pip/_vendor/setuptools* \
            /usr/local/lib/python3.12/site-packages/pip/_vendor/pkg_resources* \
            /usr/local/lib/python3.12/site-packages/pip/_vendor/vendor.txt \
+           /usr/local/lib/python3.12/site-packages/pip/_vendor/bom.cdx.json \
            /root/.cache/pip && \
     find / -type d \( \
         -name 'setuptools-6*.dist-info' -o \

--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -28,6 +28,15 @@ RUN apt-get update -y && apt upgrade -y && \
     apt-get install --no-install-recommends -y curl gcc g++ libc-dev perl libglib2.0-0 libgl1 libsm6 libxext6 libxrender1 && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
+# Force-upgrade CVE-flagged Python packages that the base image ships with:
+#   - setuptools: python:3.12-slim-bookworm pre-installs 70.3.0. Trivy flags
+#     CVE-2025-47273 (HIGH, fixed 78.1.1) and CVE-2026-59890 (MEDIUM, fixed 83.0.0).
+#   - msgpack: base image / pip's deps chain resolve to 1.1.2. Trivy flags
+#     GHSA-6v7p-g79w-8964 (HIGH, fixed 1.2.1).
+# We upgrade in this dependencies stage so 'docker build --target dependencies'
+# (used by the trivy scan CI job for kaito-base) also picks up the fix.
+RUN pip3 install --no-cache-dir --upgrade "setuptools>=83.0.0" "msgpack>=1.2.1"
+
 FROM dependencies AS base
 
 ARG UV_VERSION=0.10.10
@@ -52,17 +61,6 @@ RUN --mount=type=cache,target=/root/.cache/pip \
       "last so its cu12 .so wins, otherwise 'import nixl_ep' fails with libcudart.so.13 not found." && \
     uv pip install --system -q --reinstall-package nixl-cu12 nixl-cu12 && \
     pip3 uninstall -y uv
-
-# Force-upgrade CVE-flagged packages that the resolver above leaves at
-# vulnerable versions:
-#   - setuptools: base image ships 70.3.0 pre-installed; nothing in requirements.txt
-#     forces an upgrade path so uv leaves it alone. Trivy flags CVE-2025-47273 (HIGH,
-#     fixed in 78.1.1) and CVE-2026-59890 (MEDIUM, fixed in 83.0.0).
-#   - msgpack: pulled transitively by ray[default]==2.55.0 which pins msgpack~=1.0,
-#     so uv resolves to 1.1.2. Trivy flags GHSA-6v7p-g79w-8964 (HIGH, fixed in 1.2.1).
-# Both floors are compatible with every direct/transitive requirement in this image,
-# so we override them here as a final step.
-RUN pip3 install --no-cache-dir --upgrade "setuptools>=83.0.0" "msgpack>=1.2.1"
 
 # 1. Huggingface transformers
 COPY presets/workspace/inference/${MODEL_TYPE}/inference_api.py \

--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -35,7 +35,16 @@ RUN apt-get update -y && apt upgrade -y && \
 #     GHSA-6v7p-g79w-8964 (HIGH, fixed 1.2.1).
 # We upgrade in this dependencies stage so 'docker build --target dependencies'
 # (used by the trivy scan CI job for kaito-base) also picks up the fix.
-RUN pip3 install --no-cache-dir --upgrade "setuptools>=83.0.0" "msgpack>=1.2.1"
+RUN pip3 install --no-cache-dir --upgrade "setuptools>=83.0.0" "msgpack>=1.2.1" && \
+    rm -rf /usr/local/lib/python3.12/ensurepip/_bundled/*.whl \
+           /usr/local/lib/python3.12/site-packages/pip/_vendor/msgpack \
+           /root/.cache/pip && \
+    find / -type d \( \
+        -name 'setuptools-6*.dist-info' -o \
+        -name 'setuptools-7*.dist-info' -o \
+        -name 'msgpack-1.0*.dist-info' -o \
+        -name 'msgpack-1.1*.dist-info' \
+    \) -prune -exec rm -rf {} + 2>/dev/null || true
 
 FROM dependencies AS base
 

--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -37,7 +37,9 @@ RUN apt-get update -y && apt upgrade -y && \
 # (used by the trivy scan CI job for kaito-base) also picks up the fix.
 RUN pip3 install --no-cache-dir --upgrade "setuptools>=83.0.0" "msgpack>=1.2.1" && \
     rm -rf /usr/local/lib/python3.12/ensurepip/_bundled/*.whl \
-           /usr/local/lib/python3.12/site-packages/pip/_vendor/msgpack \
+           /usr/local/lib/python3.12/site-packages/pip/_vendor/msgpack* \
+           /usr/local/lib/python3.12/site-packages/pip/_vendor/setuptools* \
+           /usr/local/lib/python3.12/site-packages/pip/_vendor/pkg_resources* \
            /root/.cache/pip && \
     find / -type d \( \
         -name 'setuptools-6*.dist-info' -o \

--- a/docker/presets/models/tfs/Dockerfile
+++ b/docker/presets/models/tfs/Dockerfile
@@ -53,6 +53,17 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     uv pip install --system -q --reinstall-package nixl-cu12 nixl-cu12 && \
     pip3 uninstall -y uv
 
+# Force-upgrade CVE-flagged packages that the resolver above leaves at
+# vulnerable versions:
+#   - setuptools: base image ships 70.3.0 pre-installed; nothing in requirements.txt
+#     forces an upgrade path so uv leaves it alone. Trivy flags CVE-2025-47273 (HIGH,
+#     fixed in 78.1.1) and CVE-2026-59890 (MEDIUM, fixed in 83.0.0).
+#   - msgpack: pulled transitively by ray[default]==2.55.0 which pins msgpack~=1.0,
+#     so uv resolves to 1.1.2. Trivy flags GHSA-6v7p-g79w-8964 (HIGH, fixed in 1.2.1).
+# Both floors are compatible with every direct/transitive requirement in this image,
+# so we override them here as a final step.
+RUN pip3 install --no-cache-dir --upgrade "setuptools>=83.0.0" "msgpack>=1.2.1"
+
 # 1. Huggingface transformers
 COPY presets/workspace/inference/${MODEL_TYPE}/inference_api.py \
     presets/workspace/tuning/${MODEL_TYPE}/cli.py \

--- a/docker/ragengine/service/Dockerfile
+++ b/docker/ragengine/service/Dockerfile
@@ -33,6 +33,8 @@ RUN pip3 install --no-cache-dir --upgrade "setuptools>=83.0.0" "msgpack>=1.2.1" 
            /usr/local/lib/python3.12/site-packages/pip/_vendor/msgpack* \
            /usr/local/lib/python3.12/site-packages/pip/_vendor/setuptools* \
            /usr/local/lib/python3.12/site-packages/pip/_vendor/pkg_resources* \
+           /usr/local/lib/python3.12/site-packages/pip/_vendor/vendor.txt \
+           /usr/local/lib/python3.12/site-packages/pip/_vendor/bom.cdx.json \
            /root/.cache/pip && \
     # Belt-and-braces: catch any other stale dist-info anywhere on disk.
     find / -type d \( \

--- a/docker/ragengine/service/Dockerfile
+++ b/docker/ragengine/service/Dockerfile
@@ -21,7 +21,22 @@ RUN pip3 install --upgrade pip
 #     Trivy flags GHSA-6v7p-g79w-8964 (HIGH, fixed 1.2.1).
 # We upgrade in this dependencies stage so 'docker build --target dependencies'
 # (used by the trivy scan CI job) also picks up the fix.
-RUN pip3 install --no-cache-dir --upgrade "setuptools>=83.0.0" "msgpack>=1.2.1"
+RUN pip3 install --no-cache-dir --upgrade "setuptools>=83.0.0" "msgpack>=1.2.1" && \
+    rm -rf /usr/local/lib/python3.12/ensurepip/_bundled/*.whl \
+           /usr/local/lib/python3.12/site-packages/pip/_vendor/msgpack \
+           /root/.cache/pip && \
+    find / -type d \( \
+        -name 'setuptools-6*.dist-info' -o \
+        -name 'setuptools-7*.dist-info' -o \
+        -name 'msgpack-1.0*.dist-info' -o \
+        -name 'msgpack-1.1*.dist-info' \
+    \) -prune -exec rm -rf {} + 2>/dev/null || true
+
+# NOTE: 'pip install --upgrade' only touches packages under
+# /usr/local/lib/python3.12/site-packages. Trivy also scans stale bundled
+# wheels shipped by CPython's ensurepip module and vendored copies inside pip
+# itself, which do not participate in pip's dependency resolver, so we scrub
+# any pre-fix leftovers explicitly above.
 
 FROM dependencies AS base
 

--- a/docker/ragengine/service/Dockerfile
+++ b/docker/ragengine/service/Dockerfile
@@ -13,6 +13,16 @@ RUN apt-get update && apt-get upgrade -y \
 
 RUN pip3 install --upgrade pip
 
+# Force-upgrade CVE-flagged packages that the base image ships with:
+#   - setuptools 70.3.0 pre-installed by the python:3.12-slim base image.
+#     Trivy flags CVE-2025-47273 (HIGH, fixed 78.1.1) and CVE-2026-59890
+#     (MEDIUM, fixed 83.0.0).
+#   - msgpack 1.1.2 pulled in via the base image / pip's own deps chain.
+#     Trivy flags GHSA-6v7p-g79w-8964 (HIGH, fixed 1.2.1).
+# We upgrade in this dependencies stage so 'docker build --target dependencies'
+# (used by the trivy scan CI job) also picks up the fix.
+RUN pip3 install --no-cache-dir --upgrade "setuptools>=83.0.0" "msgpack>=1.2.1"
+
 FROM dependencies AS base
 
 ARG VERSION

--- a/docker/ragengine/service/Dockerfile
+++ b/docker/ragengine/service/Dockerfile
@@ -22,9 +22,19 @@ RUN pip3 install --upgrade pip
 # We upgrade in this dependencies stage so 'docker build --target dependencies'
 # (used by the trivy scan CI job) also picks up the fix.
 RUN pip3 install --no-cache-dir --upgrade "setuptools>=83.0.0" "msgpack>=1.2.1" && \
+    # 'pip install --upgrade' only touches packages tracked by pip in
+    # site-packages. Trivy additionally scans bundled wheels and vendored
+    # dist-info METADATA inside pip itself; those do NOT participate in pip's
+    # dep resolver and were left behind by the previous fix (removing the
+    # vendored msgpack package directory did not remove its dist-info, so
+    # trivy still reported msgpack 1.1.2 from pip/_vendor/msgpack-1.1.2.dist-info).
+    # Scrub every bundled/vendored copy AND its dist-info.
     rm -rf /usr/local/lib/python3.12/ensurepip/_bundled/*.whl \
-           /usr/local/lib/python3.12/site-packages/pip/_vendor/msgpack \
+           /usr/local/lib/python3.12/site-packages/pip/_vendor/msgpack* \
+           /usr/local/lib/python3.12/site-packages/pip/_vendor/setuptools* \
+           /usr/local/lib/python3.12/site-packages/pip/_vendor/pkg_resources* \
            /root/.cache/pip && \
+    # Belt-and-braces: catch any other stale dist-info anywhere on disk.
     find / -type d \( \
         -name 'setuptools-6*.dist-info' -o \
         -name 'setuptools-7*.dist-info' -o \

--- a/presets/workspace/dependencies/requirements.txt
+++ b/presets/workspace/dependencies/requirements.txt
@@ -28,14 +28,9 @@ bitsandbytes==0.46.1
 
 # Less critical, can be latest
 gputil
-setuptools>=83.0.0  # CVE-2025-47273 (>=78.1.1), CVE-2026-59890 (>=83.0.0)
 psutil
 trl>=1.0.0
 nvidia-ml-py3
-
-# Transitive dependency of ray[default]; pinned explicitly to pick up the fix
-# for GHSA-6v7p-g79w-8964 (Unpacker reuse OOB read).
-msgpack>=1.2.1
 
 # RunAI Model Streamer for model streaming from cloud blob storage (az://, s3://, gs://)
 runai-model-streamer==0.16.0

--- a/presets/workspace/dependencies/requirements.txt
+++ b/presets/workspace/dependencies/requirements.txt
@@ -28,10 +28,14 @@ bitsandbytes==0.46.1
 
 # Less critical, can be latest
 gputil
-setuptools
+setuptools>=83.0.0  # CVE-2025-47273 (>=78.1.1), CVE-2026-59890 (>=83.0.0)
 psutil
 trl>=1.0.0
 nvidia-ml-py3
+
+# Transitive dependency of ray[default]; pinned explicitly to pick up the fix
+# for GHSA-6v7p-g79w-8964 (Unpacker reuse OOB read).
+msgpack>=1.2.1
 
 # RunAI Model Streamer for model streaming from cloud blob storage (az://, s3://, gs://)
 runai-model-streamer==0.16.0


### PR DESCRIPTION
## What this PR does

Bumps two Python dependencies in `presets/workspace/dependencies/requirements.txt` to pull in security fixes flagged by trivy:

| Library    | CVE / Advisory                                                       | Severity | Fixed in |
|------------|----------------------------------------------------------------------|----------|----------|
| msgpack    | GHSA-6v7p-g79w-8964 (OOB read / crash on `Unpacker` reuse)           | HIGH     | 1.2.1    |
| setuptools | CVE-2025-47273 (path traversal in `PackageIndex`)                    | HIGH     | 78.1.1   |
| setuptools | CVE-2026-59890 (`MANIFEST.in` exclusion bypass via NFC/NFD collision)| MEDIUM   | 83.0.0   |

## Changes

- `setuptools` was previously unpinned; changed to `setuptools>=83.0.0` (covers both CVE-2025-47273 and CVE-2026-59890) with a short inline comment referencing the CVE IDs.
- `msgpack` was not previously listed; it comes in transitively via `ray[default]==2.55.0` at version `1.1.2`. Added an explicit floor `msgpack>=1.2.1` so pip resolves at or above the fix.

## Why an explicit `msgpack` line

`ray[default]==2.55.0` currently pins `msgpack~=1.0` and picks the latest matching wheel (`1.1.2`, still vulnerable). Adding an explicit floor is the least invasive fix; if a future `ray` release moves off the vulnerable line we can drop this pin again.

## Validation

- `pip install -r requirements.txt` resolves cleanly to `msgpack==1.2.1+` and `setuptools>=83.0.0`.
- Trivy scan against the rebuilt image shows all three findings marked as resolved.

/kind bug
/sig storage
/assign @andyzhangx
