### PR TITLE
feat: support invisible-text redaction in streaming guardrails

### DIFF
--- a/presets/ragengine/streaming/README.md
+++ b/presets/ragengine/streaming/README.md
@@ -5,12 +5,11 @@ Incremental output scanning for OpenAI-compatible chat completion SSE streams.
 ## Scope
 
 - single choice only (`n=1`, choice index `0`)
-- `action: block` only
 - supported scanners: `ban_substrings`, `invisible_text`, `secrets`, `sensitive`
 
 The API rejects `n > 1`. The pipeline also fails closed on multiple choices, a nonzero choice index, or malformed SSE.
 
-Streaming redaction is not supported because emitted bytes cannot be withdrawn. Text is held and scanned before release so a scanner hit can safely block the response.
+Text is held and scanned before release so a scanner can safely block or redact the response. Streaming redaction is currently limited to `invisible_text`.
 
 ## Flow
 
@@ -43,6 +42,9 @@ The default holdback is 256 characters. The window keeps only the pending tail, 
 | `secrets` | Common credentials and secret formats |
 | `sensitive` | Email, phone, credit card, and IPv4 patterns |
 
+Streaming supports `block` for all listed scanners and `redact` for `invisible_text` only.
+Redaction scanners sanitize held text before block scanners validate the final text.
+
 Not supported in streaming:
 
 - `json`: requires the complete document
@@ -55,16 +57,13 @@ Not supported in streaming:
 - Content events are rebuilt with choice index `0`; original content-event metadata is not preserved.
 - Patterns longer than the 256-character holdback may cross the release boundary.
 
-## Future Redaction
+## Remaining Redaction Work
 
 Implement separately in this order:
 
-1. `invisible_text`
-2. `sensitive`
-3. `secrets`
-4. `ban_substrings`
-
-Sanitized text must replace held text before any matching bytes are emitted.
+1. `sensitive`
+2. `secrets`
+3. `ban_substrings`
 
 ## Policy Example
 
@@ -73,6 +72,7 @@ action: block
 blockMessage: "The model output was blocked by policy."
 scanners:
   - type: invisible_text
+    action: redact
   - type: secrets
   - type: sensitive
     detectors: [email, phone, credit_card, ip_address]

--- a/presets/ragengine/streaming/buffer_window.py
+++ b/presets/ragengine/streaming/buffer_window.py
@@ -26,6 +26,7 @@ from typing import Protocol
 
 @dataclass(frozen=True)
 class WindowScanResult:
+    sanitized_text: str | None = None
     blocked: bool = False
 
 
@@ -53,10 +54,15 @@ class StreamingBufferWindow:
         self._holdback_len = holdback_len
         self._pending_buffer = ""
         self._blocked = False
+        self._redacted = False
 
     @property
     def blocked(self) -> bool:
         return self._blocked
+
+    @property
+    def redacted(self) -> bool:
+        return self._redacted
 
     def feed(self, text: str) -> WindowEmitResult:
         if self._blocked:
@@ -69,7 +75,7 @@ class StreamingBufferWindow:
 
         return self._scan_and_emit(
             self._pending_buffer,
-            emit_len=emit_len,
+            flush=False,
         )
 
     def flush(self) -> WindowEmitResult:
@@ -80,7 +86,7 @@ class StreamingBufferWindow:
 
         return self._scan_and_emit(
             self._pending_buffer,
-            emit_len=len(self._pending_buffer),
+            flush=True,
         )
 
     def _calc_emit_len(self) -> int:
@@ -92,13 +98,21 @@ class StreamingBufferWindow:
         self,
         scan_text: str,
         *,
-        emit_len: int,
+        flush: bool,
     ) -> WindowEmitResult:
         scan_result = self._scanner.scan(scan_text)
         if scan_result.blocked:
             self._blocked = True
             self._pending_buffer = ""
             return WindowEmitResult(chunks=(), blocked=True)
+
+        if scan_result.sanitized_text is not None:
+            self._pending_buffer = scan_result.sanitized_text
+            self._redacted = True
+
+        emit_len = len(self._pending_buffer) if flush else self._calc_emit_len()
+        if emit_len == 0:
+            return WindowEmitResult(chunks=())
 
         emit_text = self._pending_buffer[:emit_len]
         self._pending_buffer = self._pending_buffer[emit_len:]

--- a/presets/ragengine/streaming/guardrails.py
+++ b/presets/ragengine/streaming/guardrails.py
@@ -30,9 +30,13 @@ from ragengine.streaming.openai import (
 from ragengine.streaming.sse import iter_sse_events
 
 STREAMING_GUARDRAILS_HOLDBACK_LEN = 256
-STREAMING_GUARDRAILS_SUPPORTED_SCANNERS = frozenset(
-    {"ban_substrings", "invisible_text", "secrets", "sensitive"}
-)
+STREAMING_GUARDRAILS_CAPABILITIES = {
+    "ban_substrings": frozenset({"block"}),
+    "invisible_text": frozenset({"block", "redact"}),
+    "secrets": frozenset({"block"}),
+    "sensitive": frozenset({"block"}),
+}
+STREAMING_GUARDRAILS_SUPPORTED_SCANNERS = frozenset(STREAMING_GUARDRAILS_CAPABILITIES)
 
 
 @dataclass(frozen=True)
@@ -46,22 +50,23 @@ def validate_streaming_guardrails(
 ) -> StreamingGuardrailsSupport:
     for scanner_config in guardrails.scanner_configs:
         scanner_action = scanner_config.action_on_hit or guardrails.action_on_hit
-        if scanner_action != "block":
-            return StreamingGuardrailsSupport(
-                supported=False,
-                detail=(
-                    "stream=true with output guardrails only supports "
-                    "action=block. Unsupported action: "
-                    f"{scanner_action}."
-                ),
-            )
-        if scanner_config.type not in STREAMING_GUARDRAILS_SUPPORTED_SCANNERS:
+        supported_actions = STREAMING_GUARDRAILS_CAPABILITIES.get(scanner_config.type)
+        if supported_actions is None:
             return StreamingGuardrailsSupport(
                 supported=False,
                 detail=(
                     "stream=true with output guardrails only supports "
                     f"{sorted(STREAMING_GUARDRAILS_SUPPORTED_SCANNERS)} scanners. "
                     f"Unsupported scanner: {scanner_config.type}."
+                ),
+            )
+        if scanner_action not in supported_actions:
+            return StreamingGuardrailsSupport(
+                supported=False,
+                detail=(
+                    f"stream=true does not support action={scanner_action} for "
+                    f"scanner={scanner_config.type}. Supported actions: "
+                    f"{sorted(supported_actions)}."
                 ),
             )
 
@@ -81,7 +86,11 @@ async def apply_streaming_guardrails(
             return
 
         prompt = guardrails._extract_prompt(request)
-        scanner = _LLMGuardWindowScanner(prompt=prompt, built_scanners=built_scanners)
+        scanner = _LLMGuardWindowScanner(
+            prompt=prompt,
+            built_scanners=built_scanners,
+            default_action_on_hit=guardrails.action_on_hit,
+        )
         window = StreamingBufferWindow(
             scanner,
             holdback_len=STREAMING_GUARDRAILS_HOLDBACK_LEN,
@@ -94,6 +103,7 @@ async def apply_streaming_guardrails(
                     yield chunk
                 if window.blocked:
                     return
+                _record_successful_redaction(window, guardrails)
                 yield build_sse_done_chunk()
                 return
 
@@ -127,23 +137,56 @@ async def apply_streaming_guardrails(
 
         async for chunk in _flush_window_or_block(window, guardrails):
             yield chunk
+        if not window.blocked:
+            _record_successful_redaction(window, guardrails)
     finally:
         await _aclose(upstream_chunks)
 
 
 class _LLMGuardWindowScanner:
-    def __init__(self, *, prompt: str, built_scanners: list[tuple[Any, Any]]) -> None:
+    def __init__(
+        self,
+        *,
+        prompt: str,
+        built_scanners: list[tuple[Any, Any]],
+        default_action_on_hit: str,
+    ) -> None:
         self._prompt = prompt
         self._built_scanners = built_scanners
+        self._default_action_on_hit = default_action_on_hit
 
     def scan(self, text: str) -> WindowScanResult:
-        for _, scanner in self._built_scanners:
+        sanitized_text = text
+        for scanner_config, scanner in self._built_scanners:
+            scanner_action = scanner_config.action_on_hit or self._default_action_on_hit
+            if scanner_action != "redact":
+                continue
+
+            scanner_output, results_valid, _ = scan_output(
+                [scanner], self._prompt, sanitized_text, fail_fast=False
+            )
+            if not all(results_valid.values()):
+                if (
+                    not isinstance(scanner_output, str)
+                    or scanner_output == sanitized_text
+                ):
+                    return WindowScanResult(blocked=True)
+                sanitized_text = scanner_output
+
+        for scanner_config, scanner in self._built_scanners:
+            scanner_action = scanner_config.action_on_hit or self._default_action_on_hit
+            if scanner_action != "block":
+                continue
+
             _, results_valid, _ = scan_output(
-                [scanner], self._prompt, text, fail_fast=False
+                [scanner], self._prompt, sanitized_text, fail_fast=False
             )
             if not all(results_valid.values()):
                 return WindowScanResult(blocked=True)
-        return WindowScanResult()
+
+        if sanitized_text == text:
+            return WindowScanResult()
+        return WindowScanResult(sanitized_text=sanitized_text)
 
 
 async def _flush_window_or_block(
@@ -165,6 +208,14 @@ async def _emit_refusal(guardrails: OutputGuardrails) -> AsyncIterator[str]:
     yield build_openai_chat_delta_sse_chunk(guardrails.block_message)
     yield build_openai_chat_finish_reason_sse_chunk(finish_reason="content_filter")
     yield build_sse_done_chunk()
+
+
+def _record_successful_redaction(
+    window: StreamingBufferWindow,
+    guardrails: OutputGuardrails,
+) -> None:
+    if window.redacted:
+        guardrails._record_response_action("redact")
 
 
 async def _aclose(upstream_chunks: AsyncIterator[str]) -> None:

--- a/presets/ragengine/tests/streaming/test_buffer_window.py
+++ b/presets/ragengine/tests/streaming/test_buffer_window.py
@@ -41,6 +41,14 @@ class BadSubstringScanner:
         return WindowScanResult()
 
 
+class InvisibleTextRedactScanner:
+    def scan(self, text: str) -> WindowScanResult:
+        sanitized_text = text.replace("\u200b", "").replace("\u200c", "")
+        if sanitized_text == text:
+            return WindowScanResult()
+        return WindowScanResult(sanitized_text=sanitized_text)
+
+
 def test_safe_text_emits_as_single_confirmed_chunk():
     window = StreamingBufferWindow(AllowScanner(), holdback_len=0)
 
@@ -49,6 +57,34 @@ def test_safe_text_emits_as_single_confirmed_chunk():
 
     assert result.chunks == ("abcdefgh",)
     assert result.blocked is False
+    assert flush_result.chunks == ()
+
+
+def test_redaction_replaces_pending_text_before_emission():
+    window = StreamingBufferWindow(InvisibleTextRedactScanner(), holdback_len=0)
+
+    result = window.feed("hello\u200bworld")
+
+    assert result.chunks == ("helloworld",)
+
+
+def test_redaction_recalculates_emit_length_after_text_shrinks():
+    window = StreamingBufferWindow(InvisibleTextRedactScanner(), holdback_len=5)
+
+    result = window.feed("abc\u200b\u200cdef")
+    flush_result = window.flush()
+
+    assert result.chunks == ("a",)
+    assert flush_result.chunks == ("bcdef",)
+
+
+def test_redaction_can_remove_all_text_during_flush():
+    window = StreamingBufferWindow(InvisibleTextRedactScanner(), holdback_len=5)
+
+    result = window.feed("\u200b\u200c")
+    flush_result = window.flush()
+
+    assert result.chunks == ()
     assert flush_result.chunks == ()
 
 

--- a/presets/ragengine/tests/streaming/test_guardrails.py
+++ b/presets/ragengine/tests/streaming/test_guardrails.py
@@ -11,6 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import sys
 
@@ -32,6 +33,52 @@ from ragengine.streaming.guardrails import (  # noqa: E402
     apply_streaming_guardrails,
     validate_streaming_guardrails,
 )
+
+
+def _invisible_text_scanner(action="redact"):
+    return ParsedScannerConfig(
+        type="invisible_text",
+        action_on_hit=action,
+        config=InvisibleTextConfig(),
+    )
+
+
+def _ban_substrings_scanner():
+    return ParsedScannerConfig(
+        type="ban_substrings",
+        action_on_hit="block",
+        config=BanSubstringsConfig(substrings=["unsafe"], match_type="str"),
+    )
+
+
+def _streaming_guardrails(*scanner_configs):
+    return OutputGuardrails(
+        enabled=True,
+        fail_open=False,
+        action_on_hit="block",
+        block_message="blocked-by-policy",
+        scanner_configs=scanner_configs,
+    )
+
+
+async def _apply_text(text, guardrails, *, finish_reason=None):
+    payload = {"choices": [{"index": 0, "delta": {"content": text}}]}
+
+    async def upstream_chunks():
+        yield f"data: {json.dumps(payload, separators=(',', ':'))}\n\n"
+        if finish_reason is not None:
+            yield (
+                'data: {"choices":[{"index":0,"delta":{},'
+                f'"finish_reason":"{finish_reason}"}}]}}\n\n'
+            )
+        yield "data: [DONE]\n\n"
+
+    return [
+        chunk
+        async for chunk in apply_streaming_guardrails(
+            upstream_chunks(), guardrails, {"messages": []}
+        )
+    ]
 
 
 def test_validate_streaming_guardrails_accepts_block_ban_substrings_policy():
@@ -70,8 +117,8 @@ def test_validate_streaming_guardrails_rejects_scanner_action_override():
 
     assert support.supported is False
     assert support.detail == (
-        "stream=true with output guardrails only supports action=block. "
-        "Unsupported action: mask."
+        "stream=true does not support action=mask for scanner=ban_substrings. "
+        "Supported actions: ['block']."
     )
 
 
@@ -125,6 +172,43 @@ def test_validate_streaming_guardrails_accepts_newly_supported_scanners(
 
     assert support.supported is True
     assert support.detail is None
+
+
+def test_validate_streaming_guardrails_accepts_invisible_text_redaction():
+    support = validate_streaming_guardrails(
+        OutputGuardrails(
+            enabled=True,
+            action_on_hit="block",
+            scanner_configs=(
+                ParsedScannerConfig(
+                    type="invisible_text",
+                    action_on_hit="redact",
+                    config=InvisibleTextConfig(),
+                ),
+            ),
+        )
+    )
+
+    assert support.supported is True
+    assert support.detail is None
+
+
+def test_validate_streaming_guardrails_rejects_sensitive_redaction():
+    support = validate_streaming_guardrails(
+        OutputGuardrails(
+            enabled=True,
+            action_on_hit="block",
+            scanner_configs=(
+                ParsedScannerConfig(
+                    type="sensitive",
+                    action_on_hit="redact",
+                    config=SensitiveConfig(detectors=["email"]),
+                ),
+            ),
+        )
+    )
+
+    assert support.supported is False
 
 
 @pytest.mark.asyncio
@@ -325,36 +409,117 @@ async def test_apply_streaming_guardrails_blocks_invisible_text_scanner_hit():
 
 
 @pytest.mark.asyncio
-async def test_apply_streaming_guardrails_passes_through_safe_invisible_text_content():
-    async def upstream_chunks():
-        yield 'data: {"choices":[{"index":0,"delta":{"content":"hello "}}]}\n\n'
-        yield 'data: {"choices":[{"index":0,"delta":{"content":"world"}}]}\n\n'
-        yield 'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
-        yield "data: [DONE]\n\n"
-
-    guardrails = OutputGuardrails(
-        enabled=True,
-        fail_open=False,
-        action_on_hit="block",
-        scanner_configs=(
-            ParsedScannerConfig(
-                type="invisible_text",
-                action_on_hit="block",
-                config=InvisibleTextConfig(),
-            ),
-        ),
+@pytest.mark.parametrize(
+    ("input_text", "safe_text"),
+    [
+        ("hello\u200bworld", "helloworld"),
+        ("hello\u200b\u200cworld", "helloworld"),
+        ("hello world", "hello world"),
+    ],
+)
+async def test_apply_streaming_guardrails_preserves_or_redacts_text_during_flush(
+    input_text, safe_text
+):
+    chunks = await _apply_text(
+        input_text,
+        _streaming_guardrails(_invisible_text_scanner()),
+        finish_reason="stop",
     )
 
-    chunks = [
-        chunk
-        async for chunk in apply_streaming_guardrails(
-            upstream_chunks(), guardrails, {"messages": []}
-        )
+    assert chunks == [
+        f'data: {{"choices":[{{"index":0,"delta":{{"content":"{safe_text}"}},'
+        '"finish_reason":null}]}\n\n',
+        'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n',
+        "data: [DONE]\n\n",
     ]
+    assert "\u200b" not in "".join(chunks)
+    assert "\\u200b" not in "".join(chunks)
+    assert "\u200c" not in "".join(chunks)
 
-    assert "".join(chunks) == (
-        'data: {"choices":[{"index":0,"delta":{"content":"hello world"},'
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "scanner_configs",
+    [
+        (_invisible_text_scanner(), _ban_substrings_scanner()),
+        (_ban_substrings_scanner(), _invisible_text_scanner()),
+    ],
+)
+async def test_block_scanner_checks_final_redacted_text(scanner_configs):
+    chunks = await _apply_text("un\u200bsafe", _streaming_guardrails(*scanner_configs))
+
+    assert chunks == [
+        'data: {"choices":[{"index":0,"delta":{"content":"blocked-by-policy"},"finish_reason":null}]}\n\n',
+        'data: {"choices":[{"index":0,"delta":{},"finish_reason":"content_filter"}]}\n\n',
+        "data: [DONE]\n\n",
+    ]
+    assert "\u200b" not in "".join(chunks)
+    assert "\\u200b" not in "".join(chunks)
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("text", "scanner_configs", "expected_action"),
+    [
+        ("hello\u200bworld", (_invisible_text_scanner(),), "redact"),
+        (
+            "un\u200bsafe",
+            (_invisible_text_scanner(), _ban_substrings_scanner()),
+            "block",
+        ),
+    ],
+)
+async def test_records_only_final_response_action(
+    monkeypatch, text, scanner_configs, expected_action
+):
+    recorded_actions = []
+    monkeypatch.setattr(
+        OutputGuardrails,
+        "_record_response_action",
+        lambda self, action: recorded_actions.append(action),
+    )
+
+    chunks = await _apply_text(text, _streaming_guardrails(*scanner_configs))
+
+    assert chunks[-1] == "data: [DONE]\n\n"
+    assert recorded_actions == [expected_action]
+
+
+@pytest.mark.asyncio
+async def test_invisible_redaction_emits_sanitized_text_before_stream_finishes():
+    unsafe_text = "a" * 300 + "\u200b" + "tail"
+    sanitized_text = "a" * 300 + "tail"
+
+    chunks = await _apply_text(
+        unsafe_text, _streaming_guardrails(_invisible_text_scanner())
+    )
+    emitted_text = "".join(
+        chunk.split('"content":"', 1)[1].split('"', 1)[0]
+        for chunk in chunks
+        if '"content":"' in chunk
+    )
+
+    assert len(chunks[0].split('"content":"', 1)[1].split('"', 1)[0]) == 48
+    assert emitted_text == sanitized_text
+    assert "\u200b" not in "".join(chunks)
+    assert "\\u200b" not in "".join(chunks)
+    assert chunks[-1] == "data: [DONE]\n\n"
+
+
+@pytest.mark.asyncio
+async def test_invisible_redaction_without_modified_text_fails_closed(monkeypatch):
+    def scan_without_redaction(scanners, prompt, output, fail_fast):
+        return output, {"invisible_text": False}, {"invisible_text": 1.0}
+
+    monkeypatch.setattr(
+        "ragengine.streaming.guardrails.scan_output", scan_without_redaction
+    )
+
+    chunks = await _apply_text(
+        "hello\u200bworld", _streaming_guardrails(_invisible_text_scanner())
+    )
+
+    assert chunks[0] == (
+        'data: {"choices":[{"index":0,"delta":{"content":"blocked-by-policy"},'
         '"finish_reason":null}]}\n\n'
-        'data: {"choices":[{"index":0,"delta":{},"finish_reason":"stop"}]}\n\n'
-        "data: [DONE]\n\n"
     )


### PR DESCRIPTION
**Reason for Change**:

Support invisible-text redaction for streaming guardrails without exposing unsafe characters to clients.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:

N/A

**Notes for Reviewers**:

- Supports `invisible_text` with `block` and `redact`.
- Other streaming scanners remain block-only.
- Covers scanner ordering, flush redaction, fail-closed behavior, and leak prevention.
- All 55 streaming tests pass.