### PR TITLE
chore: Update NVIDIA device plugin image version

### DIFF
--- a/charts/kaito/workspace/values.yaml
+++ b/charts/kaito/workspace/values.yaml
@@ -74,7 +74,7 @@ karpenterProviders:
 nvidiaDevicePlugin:
   enabled: true
   daemonsetName: "nvidia-device-plugin-daemonset"
-  image: "mcr.microsoft.com/oss/v2/nvidia/k8s-device-plugin:v0.18.2-1"
+  image: "mcr.microsoft.com/oss/v2/nvidia/k8s-device-plugin:v0.18.2-12"
   imagePullPolicy: "IfNotPresent"
 
 # Spot instance support for Azure GPU node pools.


### PR DESCRIPTION
**Reason for Change**:
Bump the device plugin image tag which contains the cve fixes. 