### PR TITLE
test: add BBR (Body-Based Routing) e2e validation

### DIFF
--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -460,7 +460,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 				podList := &corev1.PodList{}
 				err = utils.TestingCluster.KubeClient.List(ctx, podList,
 					client.InNamespace(ws.Namespace),
-					client.MatchingLabels{"app": ws.Name})
+					client.MatchingLabels{kaitov1beta1.LabelWorkspaceName: ws.Name})
 				if err != nil || len(podList.Items) == 0 {
 					return false
 				}

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -514,6 +514,61 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 // validateBBRRouting installs BBR, creates an HTTPRoute with model-name header matching,
 // and validates both positive (correct model → success) and negative (wrong model → error) routing.
 func validateBBRRouting(inferenceSetObj *kaitov1beta1.InferenceSet, modelName, inferencePoolName string, findWorkspacePod func() (string, string, string)) {
+	// Ensure a DestinationRule exists for the EPP service so Istio Gateway's
+	// ext_proc gRPC uses the right TLS mode. Current EPP image is
+	// llm-d-inference-scheduler:v0.8.0 which listens on TLS by default
+	// (--secure-serving=true). Without SIMPLE + insecureSkipVerify=true, Envoy
+	// sends plaintext and the connection is terminated -> Gateway returns
+	// HTTP 500 empty body on every BBR request. When we bump EPP to v0.9.x
+	// (plaintext by default), switch this to mode: DISABLE.
+	By("Ensuring DestinationRule for EPP service (BBR)", func() {
+		eppServiceName := inferencePoolName + "-epp"
+		dr := &unstructured.Unstructured{}
+		dr.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "networking.istio.io",
+			Version: "v1",
+			Kind:    "DestinationRule",
+		})
+		dr.SetName(eppServiceName)
+		dr.SetNamespace(inferenceSetObj.Namespace)
+		dr.Object["spec"] = map[string]interface{}{
+			"host": eppServiceName,
+			"trafficPolicy": map[string]interface{}{
+				"tls": map[string]interface{}{
+					"mode":               "SIMPLE",
+					"insecureSkipVerify": true,
+				},
+			},
+		}
+		Eventually(func() error {
+			err := utils.TestingCluster.KubeClient.Create(ctx, dr)
+			if err != nil && apierrors.IsAlreadyExists(err) {
+				existing := &unstructured.Unstructured{}
+				existing.SetGroupVersionKind(dr.GroupVersionKind())
+				if getErr := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+					Namespace: dr.GetNamespace(), Name: dr.GetName(),
+				}, existing); getErr != nil {
+					return getErr
+				}
+				dr.SetResourceVersion(existing.GetResourceVersion())
+				return utils.TestingCluster.KubeClient.Update(ctx, dr)
+			}
+			return err
+		}, 2*time.Minute, utils.PollInterval).Should(Succeed(),
+			"Failed to create DestinationRule for EPP service %s", eppServiceName)
+		GinkgoWriter.Printf("Created/updated DestinationRule (mode=SIMPLE) for EPP service %s\n", eppServiceName)
+
+		DeferCleanup(func() {
+			cleanupDR := &unstructured.Unstructured{}
+			cleanupDR.SetGroupVersionKind(schema.GroupVersionKind{
+				Group: "networking.istio.io", Version: "v1", Kind: "DestinationRule",
+			})
+			cleanupDR.SetName(eppServiceName)
+			cleanupDR.SetNamespace(inferenceSetObj.Namespace)
+			_ = utils.TestingCluster.KubeClient.Delete(ctx, cleanupDR)
+		})
+	})
+
 	// Install BBR helm chart using a dedicated tool pod (alpine/helm)
 	By("Installing Body-Based Routing (BBR) helm chart", func() {
 		coreClient, err := utils.GetK8sClientset()

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -30,6 +30,7 @@ import (
 	"github.com/samber/lo"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -531,6 +532,40 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 			coreClient, err := utils.GetK8sClientset()
 			Expect(err).NotTo(HaveOccurred())
 
+			// Create a ServiceAccount + ClusterRoleBinding so the tool pod can install helm charts
+			sa := &corev1.ServiceAccount{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bbr-helm-installer",
+					Namespace: "default",
+				},
+			}
+			_, err = coreClient.CoreV1().ServiceAccounts("default").Create(ctx, sa, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to create service account")
+
+			crb := &rbacv1.ClusterRoleBinding{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "bbr-helm-installer-admin",
+				},
+				RoleRef: rbacv1.RoleRef{
+					APIGroup: "rbac.authorization.k8s.io",
+					Kind:     "ClusterRole",
+					Name:     "cluster-admin",
+				},
+				Subjects: []rbacv1.Subject{{
+					Kind:      "ServiceAccount",
+					Name:      "bbr-helm-installer",
+					Namespace: "default",
+				}},
+			}
+			_, err = coreClient.RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
+
+			DeferCleanup(func() {
+				_ = coreClient.RbacV1().ClusterRoleBindings().Delete(ctx, crb.Name, metav1.DeleteOptions{})
+				_ = coreClient.CoreV1().ServiceAccounts("default").Delete(ctx, sa.Name, metav1.DeleteOptions{})
+				GinkgoWriter.Printf("Deleted helm RBAC resources\n")
+			})
+
 			// Create a short-lived tool pod with helm pre-installed
 			toolPod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -539,7 +574,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 				},
 				Spec: corev1.PodSpec{
 					RestartPolicy:      corev1.RestartPolicyNever,
-					ServiceAccountName: "default",
+					ServiceAccountName: "bbr-helm-installer",
 					Containers: []corev1.Container{{
 						Name:    "helm",
 						Image:   "alpine/helm:3.17.3",

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -472,6 +472,346 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateModelsEndpoint(workspaceObj)
 		validateChatCompletionsEndpoint(workspaceObj)
 	})
+
+	It("should route requests via Body-Based Routing (BBR) based on model name in request body", Serial, utils.GinkgoLabelFastCheck, func() {
+		Expect(isIstioCRDAvailable()).To(BeTrue(), "Istio CRDs must be available for BBR routing validation")
+
+		numOfReplicas := 1
+		inferenceSetObj := createGemma3InferenceSetWithPresetPublicModeAndVLLM(numOfReplicas)
+		defer cleanupResourcesForInferenceSet(inferenceSetObj)
+		time.Sleep(120 * time.Second)
+
+		validateInferenceSetStatus(inferenceSetObj)
+		validateGatewayAPIInferenceExtensionResources(inferenceSetObj)
+
+		modelName := getModelName(string(PresetGemma3_4BInstructModel))
+		inferencePoolName := kaitoutils.InferencePoolName(inferenceSetObj.Name)
+
+		// Install BBR helm chart
+		By("Installing Body-Based Routing (BBR) helm chart", func() {
+			coreClient, err := utils.GetK8sClientset()
+			Expect(err).NotTo(HaveOccurred())
+
+			k8sConfig, err := utils.GetK8sConfig()
+			Expect(err).NotTo(HaveOccurred())
+
+			// Find a pod to exec helm install from (use inference pod)
+			podList := &corev1.PodList{}
+			Eventually(func() bool {
+				err = utils.TestingCluster.KubeClient.List(ctx, podList,
+					client.InNamespace(inferenceSetObj.Namespace),
+					client.MatchingLabels{"app": inferenceSetObj.Name})
+				return err == nil && len(podList.Items) > 0
+			}, 5*time.Minute, utils.PollInterval).Should(BeTrue())
+
+			execPodName := podList.Items[0].Name
+			execContainer := podList.Items[0].Spec.Containers[0].Name
+
+			// Install helm and BBR chart in the pod
+			installCmd := `command -v helm > /dev/null 2>&1 || (curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash > /dev/null 2>&1); ` +
+				`helm upgrade --install body-based-routing oci://registry.k8s.io/gateway-api-inference-extension/charts/body-based-routing ` +
+				`--version v1.3.0 --set provider.name=istio --namespace default --wait --timeout 3m`
+
+			execOption := corev1.PodExecOptions{
+				Command:   []string{"sh", "-c", installCmd},
+				Container: execContainer,
+				Stdout:    true,
+				Stderr:    true,
+			}
+
+			execCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+			stdout, execErr := utils.ExecSync(execCtx, k8sConfig, coreClient, inferenceSetObj.Namespace, execPodName, execOption)
+			cancel()
+			GinkgoWriter.Printf("BBR helm install output: %s\n", stdout)
+			Expect(execErr).NotTo(HaveOccurred(), "Failed to install BBR helm chart")
+
+			DeferCleanup(func() {
+				uninstallCmd := `helm uninstall body-based-routing --namespace default 2>/dev/null || true`
+				uninstallOption := corev1.PodExecOptions{
+					Command:   []string{"sh", "-c", uninstallCmd},
+					Container: execContainer,
+					Stdout:    true,
+					Stderr:    true,
+				}
+				uninstallCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+				utils.ExecSync(uninstallCtx, k8sConfig, coreClient, inferenceSetObj.Namespace, execPodName, uninstallOption)
+				cancel()
+				GinkgoWriter.Printf("Uninstalled BBR helm chart\n")
+			})
+		})
+
+		// Create HTTPRoute with X-Gateway-Model-Name header matching
+		By("Creating HTTPRoute with BBR model-name header matching", func() {
+			httpRoute := &unstructured.Unstructured{}
+			httpRoute.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "gateway.networking.k8s.io",
+				Version: "v1",
+				Kind:    "HTTPRoute",
+			})
+			httpRoute.SetName(inferenceSetObj.Name + "-bbr-route")
+			httpRoute.SetNamespace(inferenceSetObj.Namespace)
+			httpRoute.Object["spec"] = map[string]interface{}{
+				"parentRefs": []interface{}{
+					map[string]interface{}{
+						"group":     "gateway.networking.k8s.io",
+						"kind":      "Gateway",
+						"name":      "inference-gateway",
+						"namespace": "default",
+					},
+				},
+				"rules": []interface{}{
+					map[string]interface{}{
+						"matches": []interface{}{
+							map[string]interface{}{
+								"headers": []interface{}{
+									map[string]interface{}{
+										"type":  "Exact",
+										"name":  "X-Gateway-Model-Name",
+										"value": modelName,
+									},
+								},
+								"path": map[string]interface{}{
+									"type":  "PathPrefix",
+									"value": "/",
+								},
+							},
+						},
+						"backendRefs": []interface{}{
+							map[string]interface{}{
+								"group": "inference.networking.k8s.io",
+								"kind":  "InferencePool",
+								"name":  inferencePoolName,
+							},
+						},
+					},
+					// Rule for non-existent model - should fail routing
+					map[string]interface{}{
+						"matches": []interface{}{
+							map[string]interface{}{
+								"headers": []interface{}{
+									map[string]interface{}{
+										"type":  "Exact",
+										"name":  "X-Gateway-Model-Name",
+										"value": "nonexistent-model-xyz",
+									},
+								},
+								"path": map[string]interface{}{
+									"type":  "PathPrefix",
+									"value": "/",
+								},
+							},
+						},
+						"backendRefs": []interface{}{
+							map[string]interface{}{
+								"group": "inference.networking.k8s.io",
+								"kind":  "InferencePool",
+								"name":  "nonexistent-pool",
+							},
+						},
+					},
+				},
+			}
+
+			Eventually(func() error {
+				err := utils.TestingCluster.KubeClient.Create(ctx, httpRoute)
+				if err != nil && apierrors.IsAlreadyExists(err) {
+					existing := &unstructured.Unstructured{}
+					existing.SetGroupVersionKind(httpRoute.GroupVersionKind())
+					if getErr := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+						Namespace: httpRoute.GetNamespace(),
+						Name:      httpRoute.GetName(),
+					}, existing); getErr != nil {
+						return getErr
+					}
+					httpRoute.SetResourceVersion(existing.GetResourceVersion())
+					return utils.TestingCluster.KubeClient.Update(ctx, httpRoute)
+				}
+				return err
+			}, 2*time.Minute, utils.PollInterval).Should(Succeed(), "Failed to create BBR HTTPRoute")
+
+			DeferCleanup(func() {
+				cleanup := &unstructured.Unstructured{}
+				cleanup.SetGroupVersionKind(httpRoute.GroupVersionKind())
+				cleanup.SetName(httpRoute.GetName())
+				cleanup.SetNamespace(httpRoute.GetNamespace())
+				_ = utils.TestingCluster.KubeClient.Delete(ctx, cleanup)
+			})
+			GinkgoWriter.Printf("Created BBR HTTPRoute %s\n", httpRoute.GetName())
+
+			// Wait for HTTPRoute to be accepted
+			Eventually(func() bool {
+				route := &unstructured.Unstructured{}
+				route.SetGroupVersionKind(httpRoute.GroupVersionKind())
+				if err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+					Namespace: httpRoute.GetNamespace(),
+					Name:      httpRoute.GetName(),
+				}, route); err != nil {
+					return false
+				}
+				status, _ := route.Object["status"].(map[string]interface{})
+				parents, _ := status["parents"].([]interface{})
+				for _, p := range parents {
+					parent, ok := p.(map[string]interface{})
+					if !ok {
+						continue
+					}
+					conditions, _ := parent["conditions"].([]interface{})
+					for _, c := range conditions {
+						cond, ok := c.(map[string]interface{})
+						if !ok {
+							continue
+						}
+						ctype, _ := cond["type"].(string)
+						cstatus, _ := cond["status"].(string)
+						if ctype == "Accepted" && cstatus == "True" {
+							return true
+						}
+					}
+				}
+				return false
+			}, 2*time.Minute, 5*time.Second).Should(BeTrue(), "BBR HTTPRoute should be accepted by the gateway")
+		})
+
+		// Patch Gateway to allow routes from test namespace
+		By("Patching Gateway to allow routes from test namespace", func() {
+			gw := &unstructured.Unstructured{}
+			gw.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "gateway.networking.k8s.io",
+				Version: "v1",
+				Kind:    "Gateway",
+			})
+			Eventually(func() error {
+				if err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+					Namespace: "default",
+					Name:      "inference-gateway",
+				}, gw); err != nil {
+					return err
+				}
+				spec, ok := gw.Object["spec"].(map[string]interface{})
+				if !ok || spec == nil {
+					spec = map[string]interface{}{}
+					gw.Object["spec"] = spec
+				}
+				existingListeners, _ := spec["listeners"].([]interface{})
+				updatedListeners := make([]interface{}, 0, len(existingListeners))
+				for _, l := range existingListeners {
+					listener, ok := l.(map[string]interface{})
+					if !ok {
+						updatedListeners = append(updatedListeners, l)
+						continue
+					}
+					if proto, _ := listener["protocol"].(string); proto == "HTTP" {
+						listener["allowedRoutes"] = map[string]interface{}{
+							"namespaces": map[string]interface{}{"from": "All"},
+						}
+					}
+					updatedListeners = append(updatedListeners, listener)
+				}
+				spec["listeners"] = updatedListeners
+				return utils.TestingCluster.KubeClient.Update(ctx, gw)
+			}, 2*time.Minute, utils.PollInterval).Should(Succeed(), "Failed to patch Gateway")
+		})
+
+		// Send request with correct model name - should succeed
+		By("Sending request with correct model name through BBR gateway", func() {
+			coreClient, err := utils.GetK8sClientset()
+			Expect(err).NotTo(HaveOccurred())
+
+			k8sConfig, err := utils.GetK8sConfig()
+			Expect(err).NotTo(HaveOccurred())
+
+			podList := &corev1.PodList{}
+			Eventually(func() bool {
+				err = utils.TestingCluster.KubeClient.List(ctx, podList,
+					client.InNamespace(inferenceSetObj.Namespace),
+					client.MatchingLabels{"app": inferenceSetObj.Name})
+				return err == nil && len(podList.Items) > 0
+			}, 5*time.Minute, utils.PollInterval).Should(BeTrue())
+
+			execPodName := podList.Items[0].Name
+			execContainer := podList.Items[0].Spec.Containers[0].Name
+			gatewayEndpoint := "http://inference-gateway-istio.default.svc.cluster.local/v1/chat/completions"
+
+			// Request with correct model name - BBR should extract from body and set X-Gateway-Model-Name header
+			curlCmd := fmt.Sprintf(
+				`command -v curl > /dev/null 2>&1 || (apt-get update -qq > /dev/null 2>&1 && apt-get install -y -qq curl > /dev/null 2>&1); `+
+					`curl -sf --max-time 120 -X POST -H "Content-Type: application/json" `+
+					`-d '{"model":"%s","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}' `+
+					`%s && echo ''`,
+				modelName, gatewayEndpoint)
+
+			var stdout string
+			Eventually(func() bool {
+				execOption := corev1.PodExecOptions{
+					Command:   []string{"sh", "-c", curlCmd},
+					Container: execContainer,
+					Stdout:    true,
+					Stderr:    true,
+				}
+				execCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+				stdout, err = utils.ExecSync(execCtx, k8sConfig, coreClient, inferenceSetObj.Namespace, execPodName, execOption)
+				cancel()
+				if err != nil {
+					GinkgoWriter.Printf("BBR request failed: %v\n", err)
+					return false
+				}
+				return strings.Contains(stdout, "choices")
+			}, 5*time.Minute, 15*time.Second).Should(BeTrue(),
+				"BBR should route request with correct model name to inference pool")
+			GinkgoWriter.Printf("BBR routing with correct model succeeded: %s\n", stdout[:min(len(stdout), 200)])
+		})
+
+		// Send request with non-existent model name - should fail (no matching route/pool)
+		By("Sending request with non-existent model name through BBR gateway", func() {
+			coreClient, err := utils.GetK8sClientset()
+			Expect(err).NotTo(HaveOccurred())
+
+			k8sConfig, err := utils.GetK8sConfig()
+			Expect(err).NotTo(HaveOccurred())
+
+			podList := &corev1.PodList{}
+			Eventually(func() bool {
+				err = utils.TestingCluster.KubeClient.List(ctx, podList,
+					client.InNamespace(inferenceSetObj.Namespace),
+					client.MatchingLabels{"app": inferenceSetObj.Name})
+				return err == nil && len(podList.Items) > 0
+			}, 5*time.Minute, utils.PollInterval).Should(BeTrue())
+
+			execPodName := podList.Items[0].Name
+			execContainer := podList.Items[0].Spec.Containers[0].Name
+			gatewayEndpoint := "http://inference-gateway-istio.default.svc.cluster.local/v1/chat/completions"
+
+			// Request with wrong model name - BBR should extract "nonexistent-model-xyz" and route to nonexistent pool
+			curlCmd := fmt.Sprintf(
+				`command -v curl > /dev/null 2>&1 || (apt-get update -qq > /dev/null 2>&1 && apt-get install -y -qq curl > /dev/null 2>&1); `+
+					`curl -s --max-time 30 -o /dev/null -w "%%{http_code}" -X POST -H "Content-Type: application/json" `+
+					`-d '{"model":"nonexistent-model-xyz","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}' `+
+					`%s`,
+				gatewayEndpoint)
+
+			Eventually(func() bool {
+				execOption := corev1.PodExecOptions{
+					Command:   []string{"sh", "-c", curlCmd},
+					Container: execContainer,
+					Stdout:    true,
+					Stderr:    true,
+				}
+				execCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+				stdout, execErr := utils.ExecSync(execCtx, k8sConfig, coreClient, inferenceSetObj.Namespace, execPodName, execOption)
+				cancel()
+				if execErr != nil {
+					// Connection error is expected - nonexistent pool has no backends
+					GinkgoWriter.Printf("Request with wrong model failed as expected: %v\n", execErr)
+					return true
+				}
+				// HTTP error codes (404, 503, etc.) indicate the request was not routed successfully
+				httpCode := strings.TrimSpace(stdout)
+				GinkgoWriter.Printf("Request with wrong model returned HTTP %s\n", httpCode)
+				return httpCode != "200"
+			}, 2*time.Minute, 10*time.Second).Should(BeTrue(),
+				"BBR should not successfully route request with non-existent model name")
+		})
+	})
 })
 
 func createPhi4WorkspaceWithAdapterAndVLLM(numOfNode int, validAdapters []kaitov1beta1.AdapterSpec) *kaitov1beta1.Workspace {

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -776,6 +776,75 @@ func validateBBRRouting(inferenceSetObj *kaitov1beta1.InferenceSet, modelName, i
 			modelName, gatewayEndpoint)
 
 		var stdout string
+		diagDumped := false
+		dumpDiag := func(reason string) {
+			if diagDumped {
+				return
+			}
+			diagDumped = true
+			GinkgoWriter.Printf("\n===== BBR diagnostics (%s) =====\n", reason)
+			diagCtx, diagCancel := context.WithTimeout(context.Background(), 90*time.Second)
+			defer diagCancel()
+
+			dumpPodLogs := func(ns, selector string, tail int64) {
+				pods, listErr := coreClient.CoreV1().Pods(ns).List(diagCtx, metav1.ListOptions{LabelSelector: selector})
+				if listErr != nil {
+					GinkgoWriter.Printf("diag: list ns=%s selector=%q failed: %v\n", ns, selector, listErr)
+					return
+				}
+				if len(pods.Items) == 0 {
+					GinkgoWriter.Printf("diag: no pods matched ns=%s selector=%q\n", ns, selector)
+					return
+				}
+				for _, p := range pods.Items {
+					GinkgoWriter.Printf("diag: pod %s/%s phase=%s\n", p.Namespace, p.Name, p.Status.Phase)
+					for _, cs := range p.Status.ContainerStatuses {
+						GinkgoWriter.Printf("diag:   container %s ready=%v restarts=%d state=%+v\n", cs.Name, cs.Ready, cs.RestartCount, cs.State)
+					}
+					for _, c := range p.Spec.Containers {
+						tailLines := tail
+						req := coreClient.CoreV1().Pods(p.Namespace).GetLogs(p.Name, &corev1.PodLogOptions{Container: c.Name, TailLines: &tailLines})
+						if logs, lerr := req.DoRaw(diagCtx); lerr == nil {
+							GinkgoWriter.Printf("diag: logs %s/%s/%s:\n%s\n", p.Namespace, p.Name, c.Name, string(logs))
+						} else {
+							GinkgoWriter.Printf("diag: logs %s/%s/%s fetch failed: %v\n", p.Namespace, p.Name, c.Name, lerr)
+						}
+					}
+				}
+			}
+
+			dumpPodLogs("default", "app.kubernetes.io/name=body-based-routing", 200)
+			dumpPodLogs("default", "gateway.networking.k8s.io/gateway-name=inference-gateway", 150)
+			dumpPodLogs(inferenceSetObj.Namespace, "app="+inferencePoolName+"-epp", 200)
+			dumpPodLogs(inferenceSetObj.Namespace, "inferencepool="+inferencePoolName, 200)
+
+			// HTTPRoute status/spec
+			route := &unstructured.Unstructured{}
+			route.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+			if getErr := utils.TestingCluster.KubeClient.Get(diagCtx, client.ObjectKey{Namespace: inferenceSetObj.Namespace, Name: inferenceSetObj.Name + "-bbr-route"}, route); getErr == nil {
+				if b, mErr := json.MarshalIndent(route.Object["spec"], "", "  "); mErr == nil {
+					GinkgoWriter.Printf("diag: HTTPRoute spec:\n%s\n", string(b))
+				}
+				if b, mErr := json.MarshalIndent(route.Object["status"], "", "  "); mErr == nil {
+					GinkgoWriter.Printf("diag: HTTPRoute status:\n%s\n", string(b))
+				}
+			} else {
+				GinkgoWriter.Printf("diag: HTTPRoute get failed: %v\n", getErr)
+			}
+
+			// InferencePool status
+			pool := &unstructured.Unstructured{}
+			pool.SetGroupVersionKind(schema.GroupVersionKind{Group: "inference.networking.k8s.io", Version: "v1", Kind: "InferencePool"})
+			if getErr := utils.TestingCluster.KubeClient.Get(diagCtx, client.ObjectKey{Namespace: inferenceSetObj.Namespace, Name: inferencePoolName}, pool); getErr == nil {
+				if b, mErr := json.MarshalIndent(pool.Object["status"], "", "  "); mErr == nil {
+					GinkgoWriter.Printf("diag: InferencePool %s/%s status:\n%s\n", inferenceSetObj.Namespace, inferencePoolName, string(b))
+				}
+			} else {
+				GinkgoWriter.Printf("diag: InferencePool get failed: %v\n", getErr)
+			}
+			GinkgoWriter.Printf("===== end BBR diagnostics =====\n\n")
+		}
+
 		Eventually(func() bool {
 			execOption := corev1.PodExecOptions{Command: []string{"sh", "-c", curlCmd}, Container: execContainer, Stdout: true, Stderr: true}
 			execCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
@@ -787,6 +856,10 @@ func validateBBRRouting(inferenceSetObj *kaitov1beta1.InferenceSet, modelName, i
 			}
 			if !strings.Contains(stdout, "HTTP_STATUS=200") || !strings.Contains(stdout, "choices") {
 				GinkgoWriter.Printf("BBR request not yet successful (model=%s):\n%s\n", modelName, stdout)
+				// On the very first non-2xx, dump BBR/gateway/EPP diagnostics so
+				// we can see why (empty 500 body from Envoy usually means the EPP
+				// ExtProc gRPC failed or the InferencePool has no ready endpoints).
+				dumpDiag("non-2xx response")
 				return false
 			}
 			return true

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -478,7 +478,11 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 
 		numOfReplicas := 1
 		inferenceSetObj := createGemma3InferenceSetWithPresetPublicModeAndVLLM(numOfReplicas)
-		defer cleanupResourcesForInferenceSet(inferenceSetObj)
+		// Use DeferCleanup (LIFO) instead of defer so that the InferenceSet is
+		// cleaned up after BBR chart uninstall and HTTPRoute deletion.
+		DeferCleanup(func() {
+			cleanupResourcesForInferenceSet(inferenceSetObj)
+		})
 		time.Sleep(120 * time.Second)
 
 		validateInferenceSetStatus(inferenceSetObj)
@@ -487,40 +491,93 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		modelName := getModelName(string(PresetGemma3_4BInstructModel))
 		inferencePoolName := kaitoutils.InferencePoolName(inferenceSetObj.Name)
 
-		// Install BBR helm chart
+		// findWorkspacePod locates a running pod belonging to a child Workspace
+		// created by the InferenceSet, using the correct label selector.
+		findWorkspacePod := func() (string, string, string) {
+			wsList := &kaitov1beta1.WorkspaceList{}
+			var podName, containerName, namespace string
+			Eventually(func() bool {
+				err := utils.TestingCluster.KubeClient.List(ctx, wsList,
+					client.InNamespace(inferenceSetObj.Namespace),
+					client.MatchingLabels{consts.WorkspaceCreatedByInferenceSetLabel: inferenceSetObj.Name})
+				if err != nil || len(wsList.Items) == 0 {
+					return false
+				}
+				ws := &wsList.Items[0]
+				podList := &corev1.PodList{}
+				err = utils.TestingCluster.KubeClient.List(ctx, podList,
+					client.InNamespace(ws.Namespace),
+					client.MatchingLabels{"app": ws.Name})
+				if err != nil || len(podList.Items) == 0 {
+					return false
+				}
+				for _, pod := range podList.Items {
+					if pod.Status.Phase == corev1.PodRunning {
+						podName = pod.Name
+						containerName = pod.Spec.Containers[0].Name
+						namespace = pod.Namespace
+						return true
+					}
+				}
+				return false
+			}, 5*time.Minute, utils.PollInterval).Should(BeTrue(),
+				"Should find a running workspace pod for InferenceSet %s", inferenceSetObj.Name)
+			return podName, containerName, namespace
+		}
+
+		// Install BBR helm chart using a dedicated tool pod (alpine/helm) to
+		// avoid fragile curl|bash inside the inference workload pod.
 		By("Installing Body-Based Routing (BBR) helm chart", func() {
 			coreClient, err := utils.GetK8sClientset()
 			Expect(err).NotTo(HaveOccurred())
 
+			// Create a short-lived tool pod with helm pre-installed
+			toolPod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "bbr-helm-installer",
+					Namespace: "default",
+				},
+				Spec: corev1.PodSpec{
+					RestartPolicy:      corev1.RestartPolicyNever,
+					ServiceAccountName: "default",
+					Containers: []corev1.Container{{
+						Name:    "helm",
+						Image:   "alpine/helm:3.17.3",
+						Command: []string{"sleep", "600"},
+					}},
+				},
+			}
+
+			_, err = coreClient.CoreV1().Pods("default").Create(ctx, toolPod, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred(), "Failed to create helm tool pod")
+
+			DeferCleanup(func() {
+				_ = coreClient.CoreV1().Pods("default").Delete(ctx, toolPod.Name, metav1.DeleteOptions{})
+				GinkgoWriter.Printf("Deleted helm tool pod\n")
+			})
+
+			// Wait for the tool pod to be running
+			Eventually(func() bool {
+				p, err := coreClient.CoreV1().Pods("default").Get(ctx, toolPod.Name, metav1.GetOptions{})
+				return err == nil && p.Status.Phase == corev1.PodRunning
+			}, 3*time.Minute, utils.PollInterval).Should(BeTrue(), "Helm tool pod should be running")
+
 			k8sConfig, err := utils.GetK8sConfig()
 			Expect(err).NotTo(HaveOccurred())
 
-			// Find a pod to exec helm install from (use inference pod)
-			podList := &corev1.PodList{}
-			Eventually(func() bool {
-				err = utils.TestingCluster.KubeClient.List(ctx, podList,
-					client.InNamespace(inferenceSetObj.Namespace),
-					client.MatchingLabels{"app": inferenceSetObj.Name})
-				return err == nil && len(podList.Items) > 0
-			}, 5*time.Minute, utils.PollInterval).Should(BeTrue())
-
-			execPodName := podList.Items[0].Name
-			execContainer := podList.Items[0].Spec.Containers[0].Name
-
-			// Install helm and BBR chart in the pod
-			installCmd := `command -v helm > /dev/null 2>&1 || (curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash > /dev/null 2>&1); ` +
-				`helm upgrade --install body-based-routing oci://registry.k8s.io/gateway-api-inference-extension/charts/body-based-routing ` +
+			installCmd := `helm upgrade --install body-based-routing ` +
+				`oci://registry.k8s.io/gateway-api-inference-extension/charts/body-based-routing ` +
 				`--version v1.3.0 --set provider.name=istio --namespace default --wait --timeout 3m`
 
 			execOption := corev1.PodExecOptions{
 				Command:   []string{"sh", "-c", installCmd},
-				Container: execContainer,
+				Container: "helm",
 				Stdout:    true,
 				Stderr:    true,
 			}
 
 			execCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			stdout, execErr := utils.ExecSync(execCtx, k8sConfig, coreClient, inferenceSetObj.Namespace, execPodName, execOption)
+			stdout, execErr := utils.ExecSync(execCtx, k8sConfig, coreClient, "default", toolPod.Name, execOption)
 			cancel()
 			GinkgoWriter.Printf("BBR helm install output: %s\n", stdout)
 			Expect(execErr).NotTo(HaveOccurred(), "Failed to install BBR helm chart")
@@ -529,14 +586,110 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 				uninstallCmd := `helm uninstall body-based-routing --namespace default 2>/dev/null || true`
 				uninstallOption := corev1.PodExecOptions{
 					Command:   []string{"sh", "-c", uninstallCmd},
-					Container: execContainer,
+					Container: "helm",
 					Stdout:    true,
 					Stderr:    true,
 				}
 				uninstallCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-				utils.ExecSync(uninstallCtx, k8sConfig, coreClient, inferenceSetObj.Namespace, execPodName, uninstallOption)
+				utils.ExecSync(uninstallCtx, k8sConfig, coreClient, "default", toolPod.Name, uninstallOption)
 				cancel()
 				GinkgoWriter.Printf("Uninstalled BBR helm chart\n")
+			})
+		})
+
+		// Patch Gateway BEFORE creating HTTPRoute so cross-namespace routes are admitted.
+		// Without this, the Gateway rejects the HTTPRoute and it never becomes Accepted.
+		By("Patching Gateway to allow routes from test namespace", func() {
+			var originalListeners []interface{}
+			originalCaptured := false
+
+			gw := &unstructured.Unstructured{}
+			gw.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "gateway.networking.k8s.io",
+				Version: "v1",
+				Kind:    "Gateway",
+			})
+			Eventually(func() error {
+				if err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+					Namespace: "default",
+					Name:      "inference-gateway",
+				}, gw); err != nil {
+					return err
+				}
+				spec, ok := gw.Object["spec"].(map[string]interface{})
+				if !ok || spec == nil {
+					spec = map[string]interface{}{}
+					gw.Object["spec"] = spec
+				}
+				// Snapshot the original listeners exactly once for restoration.
+				if !originalCaptured {
+					if existing, ok := spec["listeners"].([]interface{}); ok {
+						if b, err := json.Marshal(existing); err == nil {
+							var cloned []interface{}
+							if err := json.Unmarshal(b, &cloned); err == nil {
+								originalListeners = cloned
+							}
+						}
+					}
+					originalCaptured = true
+				}
+				existingListeners, _ := spec["listeners"].([]interface{})
+				updatedListeners := make([]interface{}, 0, len(existingListeners))
+				httpListenerFound := false
+				for _, l := range existingListeners {
+					listener, ok := l.(map[string]interface{})
+					if !ok {
+						updatedListeners = append(updatedListeners, l)
+						continue
+					}
+					if proto, _ := listener["protocol"].(string); proto == "HTTP" {
+						listener["allowedRoutes"] = map[string]interface{}{
+							"namespaces": map[string]interface{}{"from": "All"},
+						}
+						httpListenerFound = true
+					}
+					updatedListeners = append(updatedListeners, listener)
+				}
+				if !httpListenerFound {
+					updatedListeners = append(updatedListeners, map[string]interface{}{
+						"name":     "http",
+						"port":     int64(80),
+						"protocol": "HTTP",
+						"allowedRoutes": map[string]interface{}{
+							"namespaces": map[string]interface{}{"from": "All"},
+						},
+					})
+				}
+				spec["listeners"] = updatedListeners
+				return utils.TestingCluster.KubeClient.Update(ctx, gw)
+			}, 2*time.Minute, utils.PollInterval).Should(Succeed(), "Failed to patch Gateway")
+			GinkgoWriter.Printf("Patched Gateway inference-gateway to allow routes from namespace %s\n", inferenceSetObj.Namespace)
+
+			// Restore original listeners after the test.
+			DeferCleanup(func() {
+				restoreGW := &unstructured.Unstructured{}
+				restoreGW.SetGroupVersionKind(schema.GroupVersionKind{
+					Group:   "gateway.networking.k8s.io",
+					Version: "v1",
+					Kind:    "Gateway",
+				})
+				if err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+					Namespace: "default",
+					Name:      "inference-gateway",
+				}, restoreGW); err != nil {
+					GinkgoWriter.Printf("WARNING: could not restore Gateway: %v\n", err)
+					return
+				}
+				if originalListeners != nil {
+					spec, _ := restoreGW.Object["spec"].(map[string]interface{})
+					if spec != nil {
+						spec["listeners"] = originalListeners
+						if err := utils.TestingCluster.KubeClient.Update(ctx, restoreGW); err != nil {
+							GinkgoWriter.Printf("WARNING: could not restore Gateway listeners: %v\n", err)
+						}
+					}
+				}
+				GinkgoWriter.Printf("Restored Gateway listeners\n")
 			})
 		})
 
@@ -672,46 +825,6 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 			}, 2*time.Minute, 5*time.Second).Should(BeTrue(), "BBR HTTPRoute should be accepted by the gateway")
 		})
 
-		// Patch Gateway to allow routes from test namespace
-		By("Patching Gateway to allow routes from test namespace", func() {
-			gw := &unstructured.Unstructured{}
-			gw.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "gateway.networking.k8s.io",
-				Version: "v1",
-				Kind:    "Gateway",
-			})
-			Eventually(func() error {
-				if err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
-					Namespace: "default",
-					Name:      "inference-gateway",
-				}, gw); err != nil {
-					return err
-				}
-				spec, ok := gw.Object["spec"].(map[string]interface{})
-				if !ok || spec == nil {
-					spec = map[string]interface{}{}
-					gw.Object["spec"] = spec
-				}
-				existingListeners, _ := spec["listeners"].([]interface{})
-				updatedListeners := make([]interface{}, 0, len(existingListeners))
-				for _, l := range existingListeners {
-					listener, ok := l.(map[string]interface{})
-					if !ok {
-						updatedListeners = append(updatedListeners, l)
-						continue
-					}
-					if proto, _ := listener["protocol"].(string); proto == "HTTP" {
-						listener["allowedRoutes"] = map[string]interface{}{
-							"namespaces": map[string]interface{}{"from": "All"},
-						}
-					}
-					updatedListeners = append(updatedListeners, listener)
-				}
-				spec["listeners"] = updatedListeners
-				return utils.TestingCluster.KubeClient.Update(ctx, gw)
-			}, 2*time.Minute, utils.PollInterval).Should(Succeed(), "Failed to patch Gateway")
-		})
-
 		// Send request with correct model name - should succeed
 		By("Sending request with correct model name through BBR gateway", func() {
 			coreClient, err := utils.GetK8sClientset()
@@ -720,22 +833,12 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 			k8sConfig, err := utils.GetK8sConfig()
 			Expect(err).NotTo(HaveOccurred())
 
-			podList := &corev1.PodList{}
-			Eventually(func() bool {
-				err = utils.TestingCluster.KubeClient.List(ctx, podList,
-					client.InNamespace(inferenceSetObj.Namespace),
-					client.MatchingLabels{"app": inferenceSetObj.Name})
-				return err == nil && len(podList.Items) > 0
-			}, 5*time.Minute, utils.PollInterval).Should(BeTrue())
-
-			execPodName := podList.Items[0].Name
-			execContainer := podList.Items[0].Spec.Containers[0].Name
+			execPodName, execContainer, execNamespace := findWorkspacePod()
 			gatewayEndpoint := "http://inference-gateway-istio.default.svc.cluster.local/v1/chat/completions"
 
 			// Request with correct model name - BBR should extract from body and set X-Gateway-Model-Name header
 			curlCmd := fmt.Sprintf(
-				`command -v curl > /dev/null 2>&1 || (apt-get update -qq > /dev/null 2>&1 && apt-get install -y -qq curl > /dev/null 2>&1); `+
-					`curl -sf --max-time 120 -X POST -H "Content-Type: application/json" `+
+				`curl -sf --max-time 120 -X POST -H "Content-Type: application/json" `+
 					`-d '{"model":"%s","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}' `+
 					`%s && echo ''`,
 				modelName, gatewayEndpoint)
@@ -749,7 +852,7 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 					Stderr:    true,
 				}
 				execCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-				stdout, err = utils.ExecSync(execCtx, k8sConfig, coreClient, inferenceSetObj.Namespace, execPodName, execOption)
+				stdout, err = utils.ExecSync(execCtx, k8sConfig, coreClient, execNamespace, execPodName, execOption)
 				cancel()
 				if err != nil {
 					GinkgoWriter.Printf("BBR request failed: %v\n", err)
@@ -769,22 +872,13 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 			k8sConfig, err := utils.GetK8sConfig()
 			Expect(err).NotTo(HaveOccurred())
 
-			podList := &corev1.PodList{}
-			Eventually(func() bool {
-				err = utils.TestingCluster.KubeClient.List(ctx, podList,
-					client.InNamespace(inferenceSetObj.Namespace),
-					client.MatchingLabels{"app": inferenceSetObj.Name})
-				return err == nil && len(podList.Items) > 0
-			}, 5*time.Minute, utils.PollInterval).Should(BeTrue())
-
-			execPodName := podList.Items[0].Name
-			execContainer := podList.Items[0].Spec.Containers[0].Name
+			execPodName, execContainer, execNamespace := findWorkspacePod()
 			gatewayEndpoint := "http://inference-gateway-istio.default.svc.cluster.local/v1/chat/completions"
 
-			// Request with wrong model name - BBR should extract "nonexistent-model-xyz" and route to nonexistent pool
+			// Request with wrong model name - BBR should extract "nonexistent-model-xyz" and route to nonexistent pool.
+			// Use -w to capture the HTTP status code; -o /dev/null discards the body.
 			curlCmd := fmt.Sprintf(
-				`command -v curl > /dev/null 2>&1 || (apt-get update -qq > /dev/null 2>&1 && apt-get install -y -qq curl > /dev/null 2>&1); `+
-					`curl -s --max-time 30 -o /dev/null -w "%%{http_code}" -X POST -H "Content-Type: application/json" `+
+				`curl -s --max-time 30 -o /dev/null -w "%%{http_code}" -X POST -H "Content-Type: application/json" `+
 					`-d '{"model":"nonexistent-model-xyz","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}' `+
 					`%s`,
 				gatewayEndpoint)
@@ -797,16 +891,20 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 					Stderr:    true,
 				}
 				execCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-				stdout, execErr := utils.ExecSync(execCtx, k8sConfig, coreClient, inferenceSetObj.Namespace, execPodName, execOption)
+				stdout, execErr := utils.ExecSync(execCtx, k8sConfig, coreClient, execNamespace, execPodName, execOption)
 				cancel()
 				if execErr != nil {
-					// Connection error is expected - nonexistent pool has no backends
-					GinkgoWriter.Printf("Request with wrong model failed as expected: %v\n", execErr)
-					return true
+					// Exec failure (e.g., DNS, network) — retry rather than treating as success
+					GinkgoWriter.Printf("Request with wrong model exec failed (retrying): %v\n", execErr)
+					return false
 				}
-				// HTTP error codes (404, 503, etc.) indicate the request was not routed successfully
+				// Only pass when the gateway actually responds with a non-200 HTTP code
 				httpCode := strings.TrimSpace(stdout)
 				GinkgoWriter.Printf("Request with wrong model returned HTTP %s\n", httpCode)
+				// Codes like 000 (curl connection failure) should also retry
+				if httpCode == "000" || httpCode == "" {
+					return false
+				}
 				return httpCode != "200"
 			}, 2*time.Minute, 10*time.Second).Should(BeTrue(),
 				"BBR should not successfully route request with non-existent model name")

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -581,7 +581,7 @@ func validateBBRRouting(inferenceSetObj *kaitov1beta1.InferenceSet, modelName, i
 
 		installCmd := `helm upgrade --install body-based-routing ` +
 			`oci://registry.k8s.io/gateway-api-inference-extension/charts/body-based-routing ` +
-			`--version v1.3.0 --set provider.name=istio --namespace default --wait --timeout 3m`
+			`--version v1.3.0 --set provider.name=istio --namespace default --wait --timeout 3m 2>&1`
 
 		execOption := corev1.PodExecOptions{
 			Command:   []string{"sh", "-c", installCmd},

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -94,19 +94,6 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateMultiRoleInferencePDDisaggregation(mriObj)
 	})
 
-	It("should create a Gemma 3 InferenceSet with preset public mode successfully", utils.GinkgoLabelFastCheck, func() {
-		numOfReplicas := 1
-		inferenceSetObj := createGemma3InferenceSetWithPresetPublicModeAndVLLM(numOfReplicas)
-		defer cleanupResourcesForInferenceSet(inferenceSetObj)
-		time.Sleep(120 * time.Second)
-
-		validateInferenceSetStatus(inferenceSetObj)
-		validateInferenceSetReplicas(inferenceSetObj, int32(numOfReplicas))
-
-		validateInferenceSetBenchmarkCompleted(inferenceSetObj)
-		validateGatewayAPIInferenceExtensionResources(inferenceSetObj)
-	})
-
 	It("should create a qwen3-coder-30b-a3b-instruct two-node workspace with preset public mode successfully", utils.GinkgoLabelFastCheck, func() {
 		Skip("temporarily skip this multi-node test due to e2e env GPU quota issue, will re-enable it after the e2e env is fixed")
 		numOfNode := 2
@@ -433,11 +420,14 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateChatCompletionsEndpoint(workspaceObj)
 	})
 
-	It("should create a Gemma 3 InferenceSet with preset public mode successfully", utils.GinkgoLabelFastCheck, func() {
+	It("should create a Gemma 3 InferenceSet with preset public mode and validate BBR routing", Serial, utils.GinkgoLabelFastCheck, func() {
+		Expect(isIstioCRDAvailable()).To(BeTrue(), "Istio CRDs must be available for BBR routing validation")
+
 		numOfReplicas := 1
 		inferenceSetObj := createGemma3InferenceSetWithPresetPublicModeAndVLLM(numOfReplicas)
-		defer cleanupResourcesForInferenceSet(inferenceSetObj)
-		time.Sleep(120 * time.Second)
+		DeferCleanup(func() {
+			cleanupResourcesForInferenceSet(inferenceSetObj)
+		})
 
 		validateInferenceSetStatus(inferenceSetObj)
 		validateInferenceSetReplicas(inferenceSetObj, int32(numOfReplicas))
@@ -449,46 +439,8 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 
 		validateInferenceSetBenchmarkCompleted(inferenceSetObj)
 		validateGatewayAPIInferenceExtensionResources(inferenceSetObj)
-	})
 
-	It("should create a ministral-3-3b-instruct-2512 workspace with preset public mode successfully", func() {
-		numOfNode := 1
-		workspaceObj := createMinistral3_3BInstructWorkspaceWithPresetPublicModeAndVLLM(numOfNode)
-
-		defer cleanupResources(workspaceObj)
-		time.Sleep(30 * time.Second)
-
-		validateCreateNode(workspaceObj, numOfNode)
-		validateResourceStatus(workspaceObj)
-
-		time.Sleep(30 * time.Second)
-
-		validateAssociatedService(workspaceObj)
-		validateInferenceConfig(workspaceObj)
-
-		validateInferenceResource(workspaceObj, int32(numOfNode))
-
-		validateWorkspaceReadiness(workspaceObj)
-		validateWorkspaceBenchmarkCompleted(workspaceObj)
-		validateModelsEndpoint(workspaceObj)
-		validateChatCompletionsEndpoint(workspaceObj)
-	})
-
-	It("should route requests via Body-Based Routing (BBR) based on model name in request body", Serial, utils.GinkgoLabelFastCheck, func() {
-		Expect(isIstioCRDAvailable()).To(BeTrue(), "Istio CRDs must be available for BBR routing validation")
-
-		numOfReplicas := 1
-		inferenceSetObj := createGemma3InferenceSetWithPresetPublicModeAndVLLM(numOfReplicas)
-		// Use DeferCleanup (LIFO) instead of defer so that the InferenceSet is
-		// cleaned up after BBR chart uninstall and HTTPRoute deletion.
-		DeferCleanup(func() {
-			cleanupResourcesForInferenceSet(inferenceSetObj)
-		})
-		time.Sleep(120 * time.Second)
-
-		validateInferenceSetStatus(inferenceSetObj)
-		validateGatewayAPIInferenceExtensionResources(inferenceSetObj)
-
+		// --- BBR (Body-Based Routing) validation ---
 		modelName := getModelName(string(PresetGemma3_4BInstructModel))
 		inferencePoolName := kaitoutils.InferencePoolName(inferenceSetObj.Name)
 
@@ -526,426 +478,339 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 			return podName, containerName, namespace
 		}
 
-		// Install BBR helm chart using a dedicated tool pod (alpine/helm) to
-		// avoid fragile curl|bash inside the inference workload pod.
-		By("Installing Body-Based Routing (BBR) helm chart", func() {
-			coreClient, err := utils.GetK8sClientset()
-			Expect(err).NotTo(HaveOccurred())
+		validateBBRRouting(inferenceSetObj, modelName, inferencePoolName, findWorkspacePod)
+	})
 
-			// Create a ServiceAccount + ClusterRoleBinding so the tool pod can install helm charts
-			sa := &corev1.ServiceAccount{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "bbr-helm-installer",
-					Namespace: "default",
-				},
-			}
-			_, err = coreClient.CoreV1().ServiceAccounts("default").Create(ctx, sa, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred(), "Failed to create service account")
+	It("should create a ministral-3-3b-instruct-2512 workspace with preset public mode successfully", func() {
+		numOfNode := 1
+		workspaceObj := createMinistral3_3BInstructWorkspaceWithPresetPublicModeAndVLLM(numOfNode)
 
-			crb := &rbacv1.ClusterRoleBinding{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: "bbr-helm-installer-admin",
-				},
-				RoleRef: rbacv1.RoleRef{
-					APIGroup: "rbac.authorization.k8s.io",
-					Kind:     "ClusterRole",
-					Name:     "cluster-admin",
-				},
-				Subjects: []rbacv1.Subject{{
-					Kind:      "ServiceAccount",
-					Name:      "bbr-helm-installer",
-					Namespace: "default",
+		defer cleanupResources(workspaceObj)
+		time.Sleep(30 * time.Second)
+
+		validateCreateNode(workspaceObj, numOfNode)
+		validateResourceStatus(workspaceObj)
+
+		time.Sleep(30 * time.Second)
+
+		validateAssociatedService(workspaceObj)
+		validateInferenceConfig(workspaceObj)
+
+		validateInferenceResource(workspaceObj, int32(numOfNode))
+
+		validateWorkspaceReadiness(workspaceObj)
+		validateWorkspaceBenchmarkCompleted(workspaceObj)
+		validateModelsEndpoint(workspaceObj)
+		validateChatCompletionsEndpoint(workspaceObj)
+	})
+})
+
+// validateBBRRouting installs BBR, creates an HTTPRoute with model-name header matching,
+// and validates both positive (correct model → success) and negative (wrong model → error) routing.
+func validateBBRRouting(inferenceSetObj *kaitov1beta1.InferenceSet, modelName, inferencePoolName string, findWorkspacePod func() (string, string, string)) {
+	// Install BBR helm chart using a dedicated tool pod (alpine/helm)
+	By("Installing Body-Based Routing (BBR) helm chart", func() {
+		coreClient, err := utils.GetK8sClientset()
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a ServiceAccount + ClusterRoleBinding so the tool pod can install helm charts
+		sa := &corev1.ServiceAccount{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bbr-helm-installer",
+				Namespace: "default",
+			},
+		}
+		_, err = coreClient.CoreV1().ServiceAccounts("default").Create(ctx, sa, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred(), "Failed to create service account")
+
+		crb := &rbacv1.ClusterRoleBinding{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "bbr-helm-installer-admin",
+			},
+			RoleRef: rbacv1.RoleRef{
+				APIGroup: "rbac.authorization.k8s.io",
+				Kind:     "ClusterRole",
+				Name:     "cluster-admin",
+			},
+			Subjects: []rbacv1.Subject{{
+				Kind:      "ServiceAccount",
+				Name:      "bbr-helm-installer",
+				Namespace: "default",
+			}},
+		}
+		_, err = coreClient.RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
+
+		DeferCleanup(func() {
+			_ = coreClient.RbacV1().ClusterRoleBindings().Delete(ctx, crb.Name, metav1.DeleteOptions{})
+			_ = coreClient.CoreV1().ServiceAccounts("default").Delete(ctx, sa.Name, metav1.DeleteOptions{})
+			GinkgoWriter.Printf("Deleted helm RBAC resources\n")
+		})
+
+		toolPod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "bbr-helm-installer",
+				Namespace: "default",
+			},
+			Spec: corev1.PodSpec{
+				RestartPolicy:      corev1.RestartPolicyNever,
+				ServiceAccountName: "bbr-helm-installer",
+				Containers: []corev1.Container{{
+					Name:    "helm",
+					Image:   "alpine/helm:3.17.3",
+					Command: []string{"sleep", "600"},
 				}},
-			}
-			_, err = coreClient.RbacV1().ClusterRoleBindings().Create(ctx, crb, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred(), "Failed to create ClusterRoleBinding")
+			},
+		}
 
-			DeferCleanup(func() {
-				_ = coreClient.RbacV1().ClusterRoleBindings().Delete(ctx, crb.Name, metav1.DeleteOptions{})
-				_ = coreClient.CoreV1().ServiceAccounts("default").Delete(ctx, sa.Name, metav1.DeleteOptions{})
-				GinkgoWriter.Printf("Deleted helm RBAC resources\n")
-			})
+		_, err = coreClient.CoreV1().Pods("default").Create(ctx, toolPod, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred(), "Failed to create helm tool pod")
 
-			// Create a short-lived tool pod with helm pre-installed
-			toolPod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "bbr-helm-installer",
-					Namespace: "default",
-				},
-				Spec: corev1.PodSpec{
-					RestartPolicy:      corev1.RestartPolicyNever,
-					ServiceAccountName: "bbr-helm-installer",
-					Containers: []corev1.Container{{
-						Name:    "helm",
-						Image:   "alpine/helm:3.17.3",
-						Command: []string{"sleep", "600"},
-					}},
-				},
-			}
+		DeferCleanup(func() {
+			_ = coreClient.CoreV1().Pods("default").Delete(ctx, toolPod.Name, metav1.DeleteOptions{})
+			GinkgoWriter.Printf("Deleted helm tool pod\n")
+		})
 
-			_, err = coreClient.CoreV1().Pods("default").Create(ctx, toolPod, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred(), "Failed to create helm tool pod")
+		Eventually(func() bool {
+			p, err := coreClient.CoreV1().Pods("default").Get(ctx, toolPod.Name, metav1.GetOptions{})
+			return err == nil && p.Status.Phase == corev1.PodRunning
+		}, 3*time.Minute, utils.PollInterval).Should(BeTrue(), "Helm tool pod should be running")
 
-			DeferCleanup(func() {
-				_ = coreClient.CoreV1().Pods("default").Delete(ctx, toolPod.Name, metav1.DeleteOptions{})
-				GinkgoWriter.Printf("Deleted helm tool pod\n")
-			})
+		k8sConfig, err := utils.GetK8sConfig()
+		Expect(err).NotTo(HaveOccurred())
 
-			// Wait for the tool pod to be running
-			Eventually(func() bool {
-				p, err := coreClient.CoreV1().Pods("default").Get(ctx, toolPod.Name, metav1.GetOptions{})
-				return err == nil && p.Status.Phase == corev1.PodRunning
-			}, 3*time.Minute, utils.PollInterval).Should(BeTrue(), "Helm tool pod should be running")
+		installCmd := `helm upgrade --install body-based-routing ` +
+			`oci://registry.k8s.io/gateway-api-inference-extension/charts/body-based-routing ` +
+			`--version v1.3.0 --set provider.name=istio --namespace default --wait --timeout 3m`
 
-			k8sConfig, err := utils.GetK8sConfig()
-			Expect(err).NotTo(HaveOccurred())
+		execOption := corev1.PodExecOptions{
+			Command:   []string{"sh", "-c", installCmd},
+			Container: "helm",
+			Stdout:    true,
+			Stderr:    true,
+		}
 
-			installCmd := `helm upgrade --install body-based-routing ` +
-				`oci://registry.k8s.io/gateway-api-inference-extension/charts/body-based-routing ` +
-				`--version v1.3.0 --set provider.name=istio --namespace default --wait --timeout 3m`
+		execCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+		stdout, execErr := utils.ExecSync(execCtx, k8sConfig, coreClient, "default", toolPod.Name, execOption)
+		cancel()
+		GinkgoWriter.Printf("BBR helm install output: %s\n", stdout)
+		Expect(execErr).NotTo(HaveOccurred(), "Failed to install BBR helm chart")
 
-			execOption := corev1.PodExecOptions{
-				Command:   []string{"sh", "-c", installCmd},
+		DeferCleanup(func() {
+			uninstallCmd := `helm uninstall body-based-routing --namespace default 2>/dev/null || true`
+			uninstallOption := corev1.PodExecOptions{
+				Command:   []string{"sh", "-c", uninstallCmd},
 				Container: "helm",
 				Stdout:    true,
 				Stderr:    true,
 			}
-
-			execCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
-			stdout, execErr := utils.ExecSync(execCtx, k8sConfig, coreClient, "default", toolPod.Name, execOption)
+			uninstallCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			utils.ExecSync(uninstallCtx, k8sConfig, coreClient, "default", toolPod.Name, uninstallOption)
 			cancel()
-			GinkgoWriter.Printf("BBR helm install output: %s\n", stdout)
-			Expect(execErr).NotTo(HaveOccurred(), "Failed to install BBR helm chart")
-
-			DeferCleanup(func() {
-				uninstallCmd := `helm uninstall body-based-routing --namespace default 2>/dev/null || true`
-				uninstallOption := corev1.PodExecOptions{
-					Command:   []string{"sh", "-c", uninstallCmd},
-					Container: "helm",
-					Stdout:    true,
-					Stderr:    true,
-				}
-				uninstallCtx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-				utils.ExecSync(uninstallCtx, k8sConfig, coreClient, "default", toolPod.Name, uninstallOption)
-				cancel()
-				GinkgoWriter.Printf("Uninstalled BBR helm chart\n")
-			})
-		})
-
-		// Patch Gateway BEFORE creating HTTPRoute so cross-namespace routes are admitted.
-		// Without this, the Gateway rejects the HTTPRoute and it never becomes Accepted.
-		By("Patching Gateway to allow routes from test namespace", func() {
-			var originalListeners []interface{}
-			originalCaptured := false
-
-			gw := &unstructured.Unstructured{}
-			gw.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "gateway.networking.k8s.io",
-				Version: "v1",
-				Kind:    "Gateway",
-			})
-			Eventually(func() error {
-				if err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
-					Namespace: "default",
-					Name:      "inference-gateway",
-				}, gw); err != nil {
-					return err
-				}
-				spec, ok := gw.Object["spec"].(map[string]interface{})
-				if !ok || spec == nil {
-					spec = map[string]interface{}{}
-					gw.Object["spec"] = spec
-				}
-				// Snapshot the original listeners exactly once for restoration.
-				if !originalCaptured {
-					if existing, ok := spec["listeners"].([]interface{}); ok {
-						if b, err := json.Marshal(existing); err == nil {
-							var cloned []interface{}
-							if err := json.Unmarshal(b, &cloned); err == nil {
-								originalListeners = cloned
-							}
-						}
-					}
-					originalCaptured = true
-				}
-				existingListeners, _ := spec["listeners"].([]interface{})
-				updatedListeners := make([]interface{}, 0, len(existingListeners))
-				httpListenerFound := false
-				for _, l := range existingListeners {
-					listener, ok := l.(map[string]interface{})
-					if !ok {
-						updatedListeners = append(updatedListeners, l)
-						continue
-					}
-					if proto, _ := listener["protocol"].(string); proto == "HTTP" {
-						listener["allowedRoutes"] = map[string]interface{}{
-							"namespaces": map[string]interface{}{"from": "All"},
-						}
-						httpListenerFound = true
-					}
-					updatedListeners = append(updatedListeners, listener)
-				}
-				if !httpListenerFound {
-					updatedListeners = append(updatedListeners, map[string]interface{}{
-						"name":     "http",
-						"port":     int64(80),
-						"protocol": "HTTP",
-						"allowedRoutes": map[string]interface{}{
-							"namespaces": map[string]interface{}{"from": "All"},
-						},
-					})
-				}
-				spec["listeners"] = updatedListeners
-				return utils.TestingCluster.KubeClient.Update(ctx, gw)
-			}, 2*time.Minute, utils.PollInterval).Should(Succeed(), "Failed to patch Gateway")
-			GinkgoWriter.Printf("Patched Gateway inference-gateway to allow routes from namespace %s\n", inferenceSetObj.Namespace)
-
-			// Restore original listeners after the test.
-			DeferCleanup(func() {
-				restoreGW := &unstructured.Unstructured{}
-				restoreGW.SetGroupVersionKind(schema.GroupVersionKind{
-					Group:   "gateway.networking.k8s.io",
-					Version: "v1",
-					Kind:    "Gateway",
-				})
-				if err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
-					Namespace: "default",
-					Name:      "inference-gateway",
-				}, restoreGW); err != nil {
-					GinkgoWriter.Printf("WARNING: could not restore Gateway: %v\n", err)
-					return
-				}
-				if originalListeners != nil {
-					spec, _ := restoreGW.Object["spec"].(map[string]interface{})
-					if spec != nil {
-						spec["listeners"] = originalListeners
-						if err := utils.TestingCluster.KubeClient.Update(ctx, restoreGW); err != nil {
-							GinkgoWriter.Printf("WARNING: could not restore Gateway listeners: %v\n", err)
-						}
-					}
-				}
-				GinkgoWriter.Printf("Restored Gateway listeners\n")
-			})
-		})
-
-		// Create HTTPRoute with X-Gateway-Model-Name header matching
-		By("Creating HTTPRoute with BBR model-name header matching", func() {
-			httpRoute := &unstructured.Unstructured{}
-			httpRoute.SetGroupVersionKind(schema.GroupVersionKind{
-				Group:   "gateway.networking.k8s.io",
-				Version: "v1",
-				Kind:    "HTTPRoute",
-			})
-			httpRoute.SetName(inferenceSetObj.Name + "-bbr-route")
-			httpRoute.SetNamespace(inferenceSetObj.Namespace)
-			httpRoute.Object["spec"] = map[string]interface{}{
-				"parentRefs": []interface{}{
-					map[string]interface{}{
-						"group":     "gateway.networking.k8s.io",
-						"kind":      "Gateway",
-						"name":      "inference-gateway",
-						"namespace": "default",
-					},
-				},
-				"rules": []interface{}{
-					map[string]interface{}{
-						"matches": []interface{}{
-							map[string]interface{}{
-								"headers": []interface{}{
-									map[string]interface{}{
-										"type":  "Exact",
-										"name":  "X-Gateway-Model-Name",
-										"value": modelName,
-									},
-								},
-								"path": map[string]interface{}{
-									"type":  "PathPrefix",
-									"value": "/",
-								},
-							},
-						},
-						"backendRefs": []interface{}{
-							map[string]interface{}{
-								"group": "inference.networking.k8s.io",
-								"kind":  "InferencePool",
-								"name":  inferencePoolName,
-							},
-						},
-					},
-					// Rule for non-existent model - should fail routing
-					map[string]interface{}{
-						"matches": []interface{}{
-							map[string]interface{}{
-								"headers": []interface{}{
-									map[string]interface{}{
-										"type":  "Exact",
-										"name":  "X-Gateway-Model-Name",
-										"value": "nonexistent-model-xyz",
-									},
-								},
-								"path": map[string]interface{}{
-									"type":  "PathPrefix",
-									"value": "/",
-								},
-							},
-						},
-						"backendRefs": []interface{}{
-							map[string]interface{}{
-								"group": "inference.networking.k8s.io",
-								"kind":  "InferencePool",
-								"name":  "nonexistent-pool",
-							},
-						},
-					},
-				},
-			}
-
-			Eventually(func() error {
-				err := utils.TestingCluster.KubeClient.Create(ctx, httpRoute)
-				if err != nil && apierrors.IsAlreadyExists(err) {
-					existing := &unstructured.Unstructured{}
-					existing.SetGroupVersionKind(httpRoute.GroupVersionKind())
-					if getErr := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
-						Namespace: httpRoute.GetNamespace(),
-						Name:      httpRoute.GetName(),
-					}, existing); getErr != nil {
-						return getErr
-					}
-					httpRoute.SetResourceVersion(existing.GetResourceVersion())
-					return utils.TestingCluster.KubeClient.Update(ctx, httpRoute)
-				}
-				return err
-			}, 2*time.Minute, utils.PollInterval).Should(Succeed(), "Failed to create BBR HTTPRoute")
-
-			DeferCleanup(func() {
-				cleanup := &unstructured.Unstructured{}
-				cleanup.SetGroupVersionKind(httpRoute.GroupVersionKind())
-				cleanup.SetName(httpRoute.GetName())
-				cleanup.SetNamespace(httpRoute.GetNamespace())
-				_ = utils.TestingCluster.KubeClient.Delete(ctx, cleanup)
-			})
-			GinkgoWriter.Printf("Created BBR HTTPRoute %s\n", httpRoute.GetName())
-
-			// Wait for HTTPRoute to be accepted
-			Eventually(func() bool {
-				route := &unstructured.Unstructured{}
-				route.SetGroupVersionKind(httpRoute.GroupVersionKind())
-				if err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
-					Namespace: httpRoute.GetNamespace(),
-					Name:      httpRoute.GetName(),
-				}, route); err != nil {
-					return false
-				}
-				status, _ := route.Object["status"].(map[string]interface{})
-				parents, _ := status["parents"].([]interface{})
-				for _, p := range parents {
-					parent, ok := p.(map[string]interface{})
-					if !ok {
-						continue
-					}
-					conditions, _ := parent["conditions"].([]interface{})
-					for _, c := range conditions {
-						cond, ok := c.(map[string]interface{})
-						if !ok {
-							continue
-						}
-						ctype, _ := cond["type"].(string)
-						cstatus, _ := cond["status"].(string)
-						if ctype == "Accepted" && cstatus == "True" {
-							return true
-						}
-					}
-				}
-				return false
-			}, 2*time.Minute, 5*time.Second).Should(BeTrue(), "BBR HTTPRoute should be accepted by the gateway")
-		})
-
-		// Send request with correct model name - should succeed
-		By("Sending request with correct model name through BBR gateway", func() {
-			coreClient, err := utils.GetK8sClientset()
-			Expect(err).NotTo(HaveOccurred())
-
-			k8sConfig, err := utils.GetK8sConfig()
-			Expect(err).NotTo(HaveOccurred())
-
-			execPodName, execContainer, execNamespace := findWorkspacePod()
-			gatewayEndpoint := "http://inference-gateway-istio.default.svc.cluster.local/v1/chat/completions"
-
-			// Request with correct model name - BBR should extract from body and set X-Gateway-Model-Name header
-			curlCmd := fmt.Sprintf(
-				`curl -sf --max-time 120 -X POST -H "Content-Type: application/json" `+
-					`-d '{"model":"%s","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}' `+
-					`%s && echo ''`,
-				modelName, gatewayEndpoint)
-
-			var stdout string
-			Eventually(func() bool {
-				execOption := corev1.PodExecOptions{
-					Command:   []string{"sh", "-c", curlCmd},
-					Container: execContainer,
-					Stdout:    true,
-					Stderr:    true,
-				}
-				execCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
-				stdout, err = utils.ExecSync(execCtx, k8sConfig, coreClient, execNamespace, execPodName, execOption)
-				cancel()
-				if err != nil {
-					GinkgoWriter.Printf("BBR request failed: %v\n", err)
-					return false
-				}
-				return strings.Contains(stdout, "choices")
-			}, 5*time.Minute, 15*time.Second).Should(BeTrue(),
-				"BBR should route request with correct model name to inference pool")
-			GinkgoWriter.Printf("BBR routing with correct model succeeded: %s\n", stdout[:min(len(stdout), 200)])
-		})
-
-		// Send request with non-existent model name - should fail (no matching route/pool)
-		By("Sending request with non-existent model name through BBR gateway", func() {
-			coreClient, err := utils.GetK8sClientset()
-			Expect(err).NotTo(HaveOccurred())
-
-			k8sConfig, err := utils.GetK8sConfig()
-			Expect(err).NotTo(HaveOccurred())
-
-			execPodName, execContainer, execNamespace := findWorkspacePod()
-			gatewayEndpoint := "http://inference-gateway-istio.default.svc.cluster.local/v1/chat/completions"
-
-			// Request with wrong model name - BBR should extract "nonexistent-model-xyz" and route to nonexistent pool.
-			// Use -w to capture the HTTP status code; -o /dev/null discards the body.
-			curlCmd := fmt.Sprintf(
-				`curl -s --max-time 30 -o /dev/null -w "%%{http_code}" -X POST -H "Content-Type: application/json" `+
-					`-d '{"model":"nonexistent-model-xyz","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}' `+
-					`%s`,
-				gatewayEndpoint)
-
-			Eventually(func() bool {
-				execOption := corev1.PodExecOptions{
-					Command:   []string{"sh", "-c", curlCmd},
-					Container: execContainer,
-					Stdout:    true,
-					Stderr:    true,
-				}
-				execCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
-				stdout, execErr := utils.ExecSync(execCtx, k8sConfig, coreClient, execNamespace, execPodName, execOption)
-				cancel()
-				if execErr != nil {
-					// Exec failure (e.g., DNS, network) — retry rather than treating as success
-					GinkgoWriter.Printf("Request with wrong model exec failed (retrying): %v\n", execErr)
-					return false
-				}
-				// Only pass when the gateway actually responds with a non-200 HTTP code
-				httpCode := strings.TrimSpace(stdout)
-				GinkgoWriter.Printf("Request with wrong model returned HTTP %s\n", httpCode)
-				// Codes like 000 (curl connection failure) should also retry
-				if httpCode == "000" || httpCode == "" {
-					return false
-				}
-				return httpCode != "200"
-			}, 2*time.Minute, 10*time.Second).Should(BeTrue(),
-				"BBR should not successfully route request with non-existent model name")
+			GinkgoWriter.Printf("Uninstalled BBR helm chart\n")
 		})
 	})
-})
+
+	// Patch Gateway to allow cross-namespace routes
+	By("Patching Gateway to allow routes from test namespace", func() {
+		var originalListeners []interface{}
+		originalCaptured := false
+
+		gw := &unstructured.Unstructured{}
+		gw.SetGroupVersionKind(schema.GroupVersionKind{
+			Group:   "gateway.networking.k8s.io",
+			Version: "v1",
+			Kind:    "Gateway",
+		})
+		Eventually(func() error {
+			if err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{
+				Namespace: "default",
+				Name:      "inference-gateway",
+			}, gw); err != nil {
+				return err
+			}
+			spec, ok := gw.Object["spec"].(map[string]interface{})
+			if !ok || spec == nil {
+				spec = map[string]interface{}{}
+				gw.Object["spec"] = spec
+			}
+			if !originalCaptured {
+				if existing, ok := spec["listeners"].([]interface{}); ok {
+					if b, err := json.Marshal(existing); err == nil {
+						var cloned []interface{}
+						if err := json.Unmarshal(b, &cloned); err == nil {
+							originalListeners = cloned
+						}
+					}
+				}
+				originalCaptured = true
+			}
+			existingListeners, _ := spec["listeners"].([]interface{})
+			updatedListeners := make([]interface{}, 0, len(existingListeners))
+			httpListenerFound := false
+			for _, l := range existingListeners {
+				listener, ok := l.(map[string]interface{})
+				if !ok {
+					updatedListeners = append(updatedListeners, l)
+					continue
+				}
+				if proto, _ := listener["protocol"].(string); proto == "HTTP" {
+					listener["allowedRoutes"] = map[string]interface{}{
+						"namespaces": map[string]interface{}{"from": "All"},
+					}
+					httpListenerFound = true
+				}
+				updatedListeners = append(updatedListeners, listener)
+			}
+			if !httpListenerFound {
+				updatedListeners = append(updatedListeners, map[string]interface{}{
+					"name": "http", "port": int64(80), "protocol": "HTTP",
+					"allowedRoutes": map[string]interface{}{"namespaces": map[string]interface{}{"from": "All"}},
+				})
+			}
+			spec["listeners"] = updatedListeners
+			return utils.TestingCluster.KubeClient.Update(ctx, gw)
+		}, 2*time.Minute, utils.PollInterval).Should(Succeed(), "Failed to patch Gateway")
+
+		DeferCleanup(func() {
+			restoreGW := &unstructured.Unstructured{}
+			restoreGW.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "Gateway"})
+			if err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{Namespace: "default", Name: "inference-gateway"}, restoreGW); err == nil && originalListeners != nil {
+				if spec, ok := restoreGW.Object["spec"].(map[string]interface{}); ok {
+					spec["listeners"] = originalListeners
+					_ = utils.TestingCluster.KubeClient.Update(ctx, restoreGW)
+				}
+			}
+		})
+	})
+
+	// Create HTTPRoute with BBR header matching
+	By("Creating HTTPRoute with BBR model-name header matching", func() {
+		httpRoute := &unstructured.Unstructured{}
+		httpRoute.SetGroupVersionKind(schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "HTTPRoute"})
+		httpRoute.SetName(inferenceSetObj.Name + "-bbr-route")
+		httpRoute.SetNamespace(inferenceSetObj.Namespace)
+		httpRoute.Object["spec"] = map[string]interface{}{
+			"parentRefs": []interface{}{map[string]interface{}{"group": "gateway.networking.k8s.io", "kind": "Gateway", "name": "inference-gateway", "namespace": "default"}},
+			"rules": []interface{}{
+				map[string]interface{}{
+					"matches":     []interface{}{map[string]interface{}{"headers": []interface{}{map[string]interface{}{"type": "Exact", "name": "X-Gateway-Model-Name", "value": modelName}}, "path": map[string]interface{}{"type": "PathPrefix", "value": "/"}}},
+					"backendRefs": []interface{}{map[string]interface{}{"group": "inference.networking.k8s.io", "kind": "InferencePool", "name": inferencePoolName}},
+				},
+				map[string]interface{}{
+					"matches":     []interface{}{map[string]interface{}{"headers": []interface{}{map[string]interface{}{"type": "Exact", "name": "X-Gateway-Model-Name", "value": "nonexistent-model-xyz"}}, "path": map[string]interface{}{"type": "PathPrefix", "value": "/"}}},
+					"backendRefs": []interface{}{map[string]interface{}{"group": "inference.networking.k8s.io", "kind": "InferencePool", "name": "nonexistent-pool"}},
+				},
+			},
+		}
+
+		Eventually(func() error {
+			err := utils.TestingCluster.KubeClient.Create(ctx, httpRoute)
+			if err != nil && apierrors.IsAlreadyExists(err) {
+				existing := &unstructured.Unstructured{}
+				existing.SetGroupVersionKind(httpRoute.GroupVersionKind())
+				if getErr := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{Namespace: httpRoute.GetNamespace(), Name: httpRoute.GetName()}, existing); getErr != nil {
+					return getErr
+				}
+				httpRoute.SetResourceVersion(existing.GetResourceVersion())
+				return utils.TestingCluster.KubeClient.Update(ctx, httpRoute)
+			}
+			return err
+		}, 2*time.Minute, utils.PollInterval).Should(Succeed(), "Failed to create BBR HTTPRoute")
+
+		DeferCleanup(func() {
+			cleanup := &unstructured.Unstructured{}
+			cleanup.SetGroupVersionKind(httpRoute.GroupVersionKind())
+			cleanup.SetName(httpRoute.GetName())
+			cleanup.SetNamespace(httpRoute.GetNamespace())
+			_ = utils.TestingCluster.KubeClient.Delete(ctx, cleanup)
+		})
+
+		Eventually(func() bool {
+			route := &unstructured.Unstructured{}
+			route.SetGroupVersionKind(httpRoute.GroupVersionKind())
+			if err := utils.TestingCluster.KubeClient.Get(ctx, client.ObjectKey{Namespace: httpRoute.GetNamespace(), Name: httpRoute.GetName()}, route); err != nil {
+				return false
+			}
+			status, _ := route.Object["status"].(map[string]interface{})
+			parents, _ := status["parents"].([]interface{})
+			for _, p := range parents {
+				parent, _ := p.(map[string]interface{})
+				conditions, _ := parent["conditions"].([]interface{})
+				for _, c := range conditions {
+					cond, _ := c.(map[string]interface{})
+					if cond["type"] == "Accepted" && cond["status"] == "True" {
+						return true
+					}
+				}
+			}
+			return false
+		}, 2*time.Minute, 5*time.Second).Should(BeTrue(), "BBR HTTPRoute should be accepted")
+	})
+
+	// Positive: correct model name → successful inference
+	By("Sending request with correct model name through BBR gateway", func() {
+		coreClient, err := utils.GetK8sClientset()
+		Expect(err).NotTo(HaveOccurred())
+		k8sConfig, err := utils.GetK8sConfig()
+		Expect(err).NotTo(HaveOccurred())
+
+		execPodName, execContainer, execNamespace := findWorkspacePod()
+		gatewayEndpoint := "http://inference-gateway-istio.default.svc.cluster.local/v1/chat/completions"
+
+		curlCmd := fmt.Sprintf(
+			`curl -sf --max-time 120 -X POST -H "Content-Type: application/json" `+
+				`-d '{"model":"%s","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}' %s && echo ''`,
+			modelName, gatewayEndpoint)
+
+		var stdout string
+		Eventually(func() bool {
+			execOption := corev1.PodExecOptions{Command: []string{"sh", "-c", curlCmd}, Container: execContainer, Stdout: true, Stderr: true}
+			execCtx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+			stdout, err = utils.ExecSync(execCtx, k8sConfig, coreClient, execNamespace, execPodName, execOption)
+			cancel()
+			if err != nil {
+				GinkgoWriter.Printf("BBR request failed: %v\n", err)
+				return false
+			}
+			return strings.Contains(stdout, "choices")
+		}, 5*time.Minute, 15*time.Second).Should(BeTrue(), "BBR should route correct model to inference pool")
+		GinkgoWriter.Printf("BBR routing succeeded: %s\n", stdout[:min(len(stdout), 200)])
+	})
+
+	// Negative: non-existent model → error
+	By("Sending request with non-existent model name through BBR gateway", func() {
+		coreClient, err := utils.GetK8sClientset()
+		Expect(err).NotTo(HaveOccurred())
+		k8sConfig, err := utils.GetK8sConfig()
+		Expect(err).NotTo(HaveOccurred())
+
+		execPodName, execContainer, execNamespace := findWorkspacePod()
+		gatewayEndpoint := "http://inference-gateway-istio.default.svc.cluster.local/v1/chat/completions"
+
+		curlCmd := fmt.Sprintf(
+			`curl -s --max-time 30 -o /dev/null -w "%%{http_code}" -X POST -H "Content-Type: application/json" `+
+				`-d '{"model":"nonexistent-model-xyz","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}' %s`,
+			gatewayEndpoint)
+
+		Eventually(func() bool {
+			execOption := corev1.PodExecOptions{Command: []string{"sh", "-c", curlCmd}, Container: execContainer, Stdout: true, Stderr: true}
+			execCtx, cancel := context.WithTimeout(context.Background(), 1*time.Minute)
+			stdout, execErr := utils.ExecSync(execCtx, k8sConfig, coreClient, execNamespace, execPodName, execOption)
+			cancel()
+			if execErr != nil {
+				GinkgoWriter.Printf("Request with wrong model exec failed (retrying): %v\n", execErr)
+				return false
+			}
+			httpCode := strings.TrimSpace(stdout)
+			GinkgoWriter.Printf("Request with wrong model returned HTTP %s\n", httpCode)
+			if httpCode == "000" || httpCode == "" {
+				return false
+			}
+			return httpCode != "200"
+		}, 2*time.Minute, 10*time.Second).Should(BeTrue(), "BBR should not route non-existent model")
+	})
+}
 
 func createPhi4WorkspaceWithAdapterAndVLLM(numOfNode int, validAdapters []kaitov1beta1.AdapterSpec) *kaitov1beta1.Workspace {
 	workspaceObj := &kaitov1beta1.Workspace{}

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -441,7 +441,13 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateGatewayAPIInferenceExtensionResources(inferenceSetObj)
 
 		// --- BBR (Body-Based Routing) validation ---
-		modelName := getModelName(string(PresetGemma3_4BInstructModel))
+		// vLLM serves the InferenceSet name as the OpenAI-compatible model id
+		// (see pkg/model/interface.go buildVLLMInferenceCommand: when the
+		// workspace has WorkspaceCreatedByInferenceSetLabel, served-model-name
+		// is set to the InferenceSet name). BBR mirrors the request body's
+		// "model" field into the X-Gateway-Model-Name header, so both the
+		// HTTPRoute header match and the request payload must use this name.
+		modelName := inferenceSetObj.Name
 		inferencePoolName := kaitoutils.InferencePoolName(inferenceSetObj.Name)
 
 		// findWorkspacePod locates a running pod belonging to a child Workspace
@@ -758,9 +764,15 @@ func validateBBRRouting(inferenceSetObj *kaitov1beta1.InferenceSet, modelName, i
 		execPodName, execContainer, execNamespace := findWorkspacePod()
 		gatewayEndpoint := "http://inference-gateway-istio.default.svc.cluster.local/v1/chat/completions"
 
+		// Use `curl -s -w` to capture BOTH the response body and the HTTP status
+		// code, and drop `-f` so we don't blindly exit with 22 on 4xx/5xx. This
+		// makes failure logs actionable (previously curl exit 22 with an empty
+		// stderr told us nothing).
 		curlCmd := fmt.Sprintf(
-			`curl -sf --max-time 120 -X POST -H "Content-Type: application/json" `+
-				`-d '{"model":"%s","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}' %s && echo ''`,
+			`curl -s --max-time 120 -o /tmp/bbr-body -w "HTTP_STATUS=%%{http_code}\n" `+
+				`-X POST -H "Content-Type: application/json" `+
+				`-d '{"model":"%s","messages":[{"role":"user","content":"Hello"}],"max_tokens":10}' %s; `+
+				`echo '---body---'; cat /tmp/bbr-body 2>/dev/null | head -c 4096; echo`,
 			modelName, gatewayEndpoint)
 
 		var stdout string
@@ -770,12 +782,16 @@ func validateBBRRouting(inferenceSetObj *kaitov1beta1.InferenceSet, modelName, i
 			stdout, err = utils.ExecSync(execCtx, k8sConfig, coreClient, execNamespace, execPodName, execOption)
 			cancel()
 			if err != nil {
-				GinkgoWriter.Printf("BBR request failed: %v\n", err)
+				GinkgoWriter.Printf("BBR request exec failed (model=%s, endpoint=%s): %v\nstdout: %s\n", modelName, gatewayEndpoint, err, stdout)
 				return false
 			}
-			return strings.Contains(stdout, "choices")
+			if !strings.Contains(stdout, "HTTP_STATUS=200") || !strings.Contains(stdout, "choices") {
+				GinkgoWriter.Printf("BBR request not yet successful (model=%s):\n%s\n", modelName, stdout)
+				return false
+			}
+			return true
 		}, 5*time.Minute, 15*time.Second).Should(BeTrue(), "BBR should route correct model to inference pool")
-		GinkgoWriter.Printf("BBR routing succeeded: %s\n", stdout[:min(len(stdout), 200)])
+		GinkgoWriter.Printf("BBR routing succeeded: %s\n", stdout[:min(len(stdout), 400)])
 	})
 
 	// Negative: non-existent model → error


### PR DESCRIPTION
## Description

This PR adds Body-Based Routing (BBR) e2e validation to the existing Gemma 3 InferenceSet test case, reusing the same GPU node and InferenceSet instead of creating a separate test that provisions duplicate infrastructure.

### What's tested

The merged test validates the full InferenceSet + BBR flow:

1. **InferenceSet creation** — status, replicas, NodePool (karpenter), benchmark
2. **GWIE integration** — InferencePool + EPP deployment via Flux
3. **BBR Helm chart installation** (via dedicated `alpine/helm` tool pod with RBAC)
4. **HTTPRoute with header-based matching** using `X-Gateway-Model-Name` header injected by BBR
5. **Positive routing**: Request with correct model name in body → BBR extracts model → routes to correct InferencePool → returns successful completion
6. **Negative routing**: Request with non-existent model name → routes to non-existent pool → returns error (404/503)

### BBR Flow Validated
```
Client request (model in body) → BBR ext_proc → extracts model name →
injects X-Gateway-Model-Name header → HTTPRoute header match →
routes to correct InferencePool → EPP picks endpoint → inference response
```

### Design Decisions
- **Merged into existing test** — avoids ~10-15 min of duplicate GPU provisioning
- **`validateBBRRouting()` helper** — extracted for readability and potential reuse
- **Dedicated helm tool pod** with ServiceAccount + ClusterRoleBinding (cleaned up via DeferCleanup)
- **Gateway listener restore** via DeferCleanup to avoid leaking config
- **Serial label** — BBR install/uninstall is cluster-wide

### Prerequisites
- Istio CRDs must be available in the test cluster
- Gateway `inference-gateway` must exist in default namespace