### PR TITLE
fix: cap NodePool name at 63 chars to satisfy label-value limit

### DIFF
--- a/pkg/nodeprovision/karpenter/nodepool.go
+++ b/pkg/nodeprovision/karpenter/nodepool.go
@@ -27,7 +27,9 @@ import (
 )
 
 const (
-	maxNodePoolNameLen = 253
+	// Bounded by the Kubernetes label-value limit: the name is stored in the
+	// karpenter.sh/nodepool label on NodeClaims and Nodes.
+	maxNodePoolNameLen = 63
 	hashSuffixLen      = 9
 )
 
@@ -43,10 +45,9 @@ func truncatedName(workspaceNamespace, workspaceName string, maxLen int) string 
 	return full[:truncLen] + "-" + hex.EncodeToString(h[:])[:hashSuffixLen]
 }
 
-// NodePoolName returns a deterministic, DNS-safe name for the NodePool
-// derived from the workspace namespace and name.
-// If the result exceeds 253 characters, it is truncated and a 9-char
-// SHA-256 hex suffix is appended for uniqueness.
+// NodePoolName returns a deterministic, label-safe name for the NodePool
+// derived from the workspace namespace and name, with a hash suffix appended
+// when truncation is needed.
 func NodePoolName(workspaceNamespace, workspaceName string) string {
 	return truncatedName(workspaceNamespace, workspaceName, maxNodePoolNameLen)
 }

--- a/pkg/nodeprovision/karpenter/nodepool_test.go
+++ b/pkg/nodeprovision/karpenter/nodepool_test.go
@@ -33,25 +33,25 @@ func TestNodePoolName_Normal(t *testing.T) {
 	assert.Equal(t, "default-myworkspace", name)
 }
 
-func TestNodePoolName_Exactly253(t *testing.T) {
-	ws := strings.Repeat("a", 250)
+func TestNodePoolName_Exactly63(t *testing.T) {
+	ws := strings.Repeat("a", 60)
 	name := NodePoolName("ns", ws)
-	assert.Equal(t, 253, len(name))
+	assert.Equal(t, 63, len(name))
 	assert.Equal(t, "ns-"+ws, name)
 }
 
-func TestNodePoolName_Over253_Truncated(t *testing.T) {
-	ws := strings.Repeat("b", 251)
+func TestNodePoolName_Over63_Truncated(t *testing.T) {
+	ws := strings.Repeat("b", 61)
 	name := NodePoolName("ns", ws)
-	assert.Assert(t, len(name) == 253, "expected length 253, got %d", len(name))
+	assert.Assert(t, len(name) == 63, "expected length 63, got %d", len(name))
 	assert.Assert(t, name[maxNodePoolNameLen-1-hashSuffixLen] == '-', "expected dash at truncation point")
 	suffix := name[maxNodePoolNameLen-hashSuffixLen:]
 	assert.Equal(t, hashSuffixLen, len(suffix))
 }
 
 func TestNodePoolName_Deterministic(t *testing.T) {
-	name1 := NodePoolName("ns", strings.Repeat("c", 300))
-	name2 := NodePoolName("ns", strings.Repeat("c", 300))
+	name1 := NodePoolName("ns", strings.Repeat("c", 100))
+	name2 := NodePoolName("ns", strings.Repeat("c", 100))
 	assert.Equal(t, name1, name2)
 }
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->

The NodePool name is used as the value of the karpenter.sh/nodepool label on Nodes and NodeClaims. Kubernetes label values are limited to 63 characters, but NodePoolName was truncating to 253 (DNS-subdomain limit). When namespace + "-" + name exceeded 63 chars, listing NodeClaims by that label failed webhook validation and the workspace controller could not sync status.

Observed error:

  E0806 01:56:05.499624       1 workspace_controller.go:129] "failed to sync workspace status"
  err="listing NodeClaims for NodePool \"aimns-nt65pxruu4dzng6vmdu6xvhijl-aimmd-lfrdpzxsxhxisz6rohhi5x5hta-9tkvt\":
  unable to parse requirement: values[0][karpenter.sh/nodepool]: Invalid value:
  \"aimns-nt65pxruu4dzng6vmdu6xvhijl-aimmd-lfrdpzxsxhxisz6rohhi5x5hta-9tkvt\":
  must be no more than 63 bytes"
  workspace="aimns-nt65pxruu4dzng6vmdu6xvhijl/aimmd-lfrdpzxsxhxisz6rohhi5x5hta-9tkvt"

Lower maxNodePoolNameLen from 253 to 63. The existing truncatedName helper appends a 9-char SHA-256 suffix when the combined name would overflow, so long namespaces/names still produce a deterministic, unique, and label-safe name. Tests updated for the new boundary.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: