### PR TITLE
[WIP] chore: switch default registry to oss/v2/kaito

### DIFF
--- a/charts/kaito/ragengine/values.yaml
+++ b/charts/kaito/ragengine/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 1
 image:
   repository: mcr.microsoft.com/oss/v2/kaito/ragengine
   pullPolicy: IfNotPresent
-  tag: 0.11.0
+  tag: v0.11.0
 imagePullSecrets: []
 podAnnotations: {}
 podSecurityContext:
@@ -34,4 +34,4 @@ affinity: {}
 cloudProviderName: "azure"
 presetRagRegistryName: "mcr.microsoft.com/oss/v2/kaito"
 presetRagImageName: "kaito-rag-service"
-presetRagImageTag: 0.11.0
+presetRagImageTag: v0.11.0

--- a/charts/kaito/ragengine/values.yaml
+++ b/charts/kaito/ragengine/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 replicaCount: 1
 image:
-  repository: mcr.microsoft.com/aks/kaito/ragengine
+  repository: mcr.microsoft.com/oss/v2/kaito/ragengine
   pullPolicy: IfNotPresent
   tag: 0.11.0
 imagePullSecrets: []
@@ -32,6 +32,6 @@ tolerations: []
 affinity: {}
 # Values can be "azure" or "aws"
 cloudProviderName: "azure"
-presetRagRegistryName: "mcr.microsoft.com/aks/kaito"
+presetRagRegistryName: "mcr.microsoft.com/oss/v2/kaito"
 presetRagImageName: "kaito-rag-service"
 presetRagImageTag: 0.11.0

--- a/charts/kaito/workspace/values.yaml
+++ b/charts/kaito/workspace/values.yaml
@@ -18,7 +18,7 @@ deploymentStrategy:
   rollingUpdate:
     maxUnavailable: 1
 image:
-  repository: mcr.microsoft.com/aks/kaito/workspace
+  repository: mcr.microsoft.com/oss/v2/kaito/workspace
   pullPolicy: IfNotPresent
   tag: 0.11.0
 imagePullSecrets: []
@@ -91,7 +91,7 @@ webhook:
 # Knative logging configuration
 logging:
   level: "error"
-presetRegistryName: mcr.microsoft.com/aks/kaito
+presetRegistryName: mcr.microsoft.com/oss/v2/kaito
 resources:
   limits:
     cpu: 500m

--- a/charts/kaito/workspace/values.yaml
+++ b/charts/kaito/workspace/values.yaml
@@ -20,7 +20,7 @@ deploymentStrategy:
 image:
   repository: mcr.microsoft.com/oss/v2/kaito/workspace
   pullPolicy: IfNotPresent
-  tag: 0.11.0
+  tag: v0.11.0
 imagePullSecrets: []
 podAnnotations: {}
 podSecurityContext:


### PR DESCRIPTION
## Summary
- replace mcr.microsoft.com/aks/kaito with mcr.microsoft.com/oss/v2/kaito in workspace values
- replace mcr.microsoft.com/aks/kaito with mcr.microsoft.com/oss/v2/kaito in ragengine values
- update related image tags to v0.11.0

## Note
Starting from v0.11.0, KAITO supports the mcr.microsoft.com/oss/v2/kaito image path. This PR updates the default chart values to use that supported registry path.

## Files changed
- charts/kaito/workspace/values.yaml
- charts/kaito/ragengine/values.yaml