### PR TITLE
fix: refresh observedGeneration for InferenceSet and Workspace status

### DIFF
--- a/pkg/utils/inferenceset/inferenceset.go
+++ b/pkg/utils/inferenceset/inferenceset.go
@@ -39,7 +39,7 @@ import (
 func UpdateStatusConditionIfNotMatch(ctx context.Context, c client.Client, iObj *kaitov1beta1.InferenceSet, cType kaitov1beta1.ConditionType,
 	cStatus metav1.ConditionStatus, cReason, cMessage string) error {
 	if curCondition := meta.FindStatusCondition(iObj.Status.Conditions, string(cType)); curCondition != nil {
-		if curCondition.Status == cStatus && curCondition.Reason == cReason && curCondition.Message == cMessage {
+		if curCondition.Status == cStatus && curCondition.Reason == cReason && curCondition.Message == cMessage && curCondition.ObservedGeneration == iObj.GetGeneration() {
 			// Nothing to change
 			return nil
 		}

--- a/pkg/utils/inferenceset/inferenceset_test.go
+++ b/pkg/utils/inferenceset/inferenceset_test.go
@@ -94,20 +94,20 @@ func TestUpdateStatusConditionIfNotMatch(t *testing.T) {
 		mockClient.On("Get", mock.IsType(context.Background()),
 			client.ObjectKey{Name: "test-inferenceset", Namespace: "default"},
 			mock.IsType(&kaitov1beta1.InferenceSet{}), mock.Anything).Run(func(args mock.Arguments) {
-				ws := args.Get(2).(*kaitov1beta1.InferenceSet)
-				*ws = *inferenceset
-			}).Return(nil)
+			ws := args.Get(2).(*kaitov1beta1.InferenceSet)
+			*ws = *inferenceset
+		}).Return(nil)
 
 		mockClient.StatusMock.On("Update", mock.IsType(context.Background()),
 			mock.IsType(&kaitov1beta1.InferenceSet{}), mock.Anything).Run(func(args mock.Arguments) {
-				ws := args.Get(1).(*kaitov1beta1.InferenceSet)
-				condition := meta.FindStatusCondition(ws.Status.Conditions, string(kaitov1beta1.ConditionTypeResourceStatus))
-				assert.NotNil(t, condition)
-				assert.Equal(t, int64(2), condition.ObservedGeneration)
-				assert.Equal(t, metav1.ConditionTrue, condition.Status)
-				assert.Equal(t, "ResourcesReady", condition.Reason)
-				assert.Equal(t, "All resources are ready", condition.Message)
-			}).Return(nil)
+			ws := args.Get(1).(*kaitov1beta1.InferenceSet)
+			condition := meta.FindStatusCondition(ws.Status.Conditions, string(kaitov1beta1.ConditionTypeResourceStatus))
+			assert.NotNil(t, condition)
+			assert.Equal(t, int64(2), condition.ObservedGeneration)
+			assert.Equal(t, metav1.ConditionTrue, condition.Status)
+			assert.Equal(t, "ResourcesReady", condition.Reason)
+			assert.Equal(t, "All resources are ready", condition.Message)
+		}).Return(nil)
 
 		ctx := context.Background()
 		err := UpdateStatusConditionIfNotMatch(ctx, mockClient, inferenceset,

--- a/pkg/utils/inferenceset/inferenceset_test.go
+++ b/pkg/utils/inferenceset/inferenceset_test.go
@@ -51,10 +51,11 @@ func TestUpdateStatusConditionIfNotMatch(t *testing.T) {
 			Status: kaitov1beta1.InferenceSetStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:    string(kaitov1beta1.ConditionTypeResourceStatus),
-						Status:  metav1.ConditionTrue,
-						Reason:  "ResourcesReady",
-						Message: "All resources are ready",
+						Type:               string(kaitov1beta1.ConditionTypeResourceStatus),
+						Status:             metav1.ConditionTrue,
+						Reason:             "ResourcesReady",
+						Message:            "All resources are ready",
+						ObservedGeneration: 1,
 					},
 				},
 			},

--- a/pkg/utils/inferenceset/inferenceset_test.go
+++ b/pkg/utils/inferenceset/inferenceset_test.go
@@ -69,6 +69,55 @@ func TestUpdateStatusConditionIfNotMatch(t *testing.T) {
 		mockClient.AssertExpectations(t)
 	})
 
+	t.Run("Should update when observedGeneration differs", func(t *testing.T) {
+		mockClient := test.NewClient()
+
+		inferenceset := &kaitov1beta1.InferenceSet{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "test-inferenceset",
+				Namespace:  "default",
+				Generation: 2,
+			},
+			Status: kaitov1beta1.InferenceSetStatus{
+				Conditions: []metav1.Condition{
+					{
+						Type:               string(kaitov1beta1.ConditionTypeResourceStatus),
+						Status:             metav1.ConditionTrue,
+						Reason:             "ResourcesReady",
+						Message:            "All resources are ready",
+						ObservedGeneration: 1,
+					},
+				},
+			},
+		}
+
+		mockClient.On("Get", mock.IsType(context.Background()),
+			client.ObjectKey{Name: "test-inferenceset", Namespace: "default"},
+			mock.IsType(&kaitov1beta1.InferenceSet{}), mock.Anything).Run(func(args mock.Arguments) {
+				ws := args.Get(2).(*kaitov1beta1.InferenceSet)
+				*ws = *inferenceset
+			}).Return(nil)
+
+		mockClient.StatusMock.On("Update", mock.IsType(context.Background()),
+			mock.IsType(&kaitov1beta1.InferenceSet{}), mock.Anything).Run(func(args mock.Arguments) {
+				ws := args.Get(1).(*kaitov1beta1.InferenceSet)
+				condition := meta.FindStatusCondition(ws.Status.Conditions, string(kaitov1beta1.ConditionTypeResourceStatus))
+				assert.NotNil(t, condition)
+				assert.Equal(t, int64(2), condition.ObservedGeneration)
+				assert.Equal(t, metav1.ConditionTrue, condition.Status)
+				assert.Equal(t, "ResourcesReady", condition.Reason)
+				assert.Equal(t, "All resources are ready", condition.Message)
+			}).Return(nil)
+
+		ctx := context.Background()
+		err := UpdateStatusConditionIfNotMatch(ctx, mockClient, inferenceset,
+			kaitov1beta1.ConditionTypeResourceStatus, metav1.ConditionTrue, "ResourcesReady", "All resources are ready")
+
+		assert.NoError(t, err)
+		mockClient.AssertExpectations(t)
+		mockClient.StatusMock.AssertExpectations(t)
+	})
+
 	t.Run("Should update when condition status differs", func(t *testing.T) {
 		mockClient := test.NewClient()
 

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -1253,6 +1253,15 @@ func applyBenchmarkStatus(ctx context.Context, status *kaitov1beta1.WorkspaceSta
 	return nil
 }
 
+// refreshBenchmarkObservedGenerationIfCompleted preserves the write-once
+// BenchmarkCompleted=True state and recorded benchmark result, while advancing
+// the condition's ObservedGeneration to the current Workspace generation.
+//
+// This keeps the condition from looking stale after later reconciles or spec
+// updates that do not require re-running benchmark. Callers can use the return
+// value as a short-circuit signal: true means benchmark is already completed
+// (and its ObservedGeneration is now current), so no log re-read or result
+// overwrite should happen.
 func refreshBenchmarkObservedGenerationIfCompleted(status *kaitov1beta1.WorkspaceStatus, generation int64) bool {
 	c := meta.FindStatusCondition(status.Conditions, string(kaitov1beta1.WorkspaceConditionTypeBenchmarkCompleted))
 	if c == nil || c.Status != metav1.ConditionTrue {

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -1185,6 +1185,8 @@ func applyInferenceWorkspaceStatus(ctx context.Context, status *kaitov1beta1.Wor
 	resourceReady := resourceConditionStatus == metav1.ConditionTrue
 	isInferenceEstablished := status.State == kaitov1beta1.WorkspaceStateReady || status.State == kaitov1beta1.WorkspaceStateNotReady
 
+	refreshBenchmarkObservedGenerationIfCompleted(status, generation)
+
 	if inferenceReady && resourceReady {
 		setWorkspaceCondition(status, generation, appendMessage,
 			kaitov1beta1.WorkspaceConditionTypeInferenceStatus, metav1.ConditionTrue, "WorkspaceInferenceStatusSuccess", "Inference has been deployed successfully")
@@ -1230,7 +1232,7 @@ func applyInferenceWorkspaceStatus(ctx context.Context, status *kaitov1beta1.Wor
 func applyBenchmarkStatus(ctx context.Context, status *kaitov1beta1.WorkspaceStatus, wObj *kaitov1beta1.Workspace, generation int64, appendMessage func(string) string) error {
 	// Skip once the benchmark is done (write-once). Nothing clears BenchmarkCompleted on a
 	// readiness transition, so a recorded result survives transient flaps and pod restarts.
-	if c := meta.FindStatusCondition(status.Conditions, string(kaitov1beta1.WorkspaceConditionTypeBenchmarkCompleted)); c != nil && c.Status == metav1.ConditionTrue {
+	if refreshBenchmarkObservedGenerationIfCompleted(status, generation) {
 		return nil
 	}
 
@@ -1249,6 +1251,21 @@ func applyBenchmarkStatus(ctx context.Context, status *kaitov1beta1.WorkspaceSta
 		kaitov1beta1.WorkspaceConditionTypeBenchmarkCompleted, metav1.ConditionTrue,
 		"BenchmarkCompleted", "benchmark result has been recorded")
 	return nil
+}
+
+func refreshBenchmarkObservedGenerationIfCompleted(status *kaitov1beta1.WorkspaceStatus, generation int64) bool {
+	c := meta.FindStatusCondition(status.Conditions, string(kaitov1beta1.WorkspaceConditionTypeBenchmarkCompleted))
+	if c == nil || c.Status != metav1.ConditionTrue {
+		return false
+	}
+	if c.ObservedGeneration == generation {
+		return true
+	}
+
+	updated := *c
+	updated.ObservedGeneration = generation
+	meta.SetStatusCondition(&status.Conditions, updated)
+	return true
 }
 
 // resetBenchmarkOnUpgrade clears the recorded benchmark result and removes the

--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -1232,7 +1232,9 @@ func applyInferenceWorkspaceStatus(ctx context.Context, status *kaitov1beta1.Wor
 func applyBenchmarkStatus(ctx context.Context, status *kaitov1beta1.WorkspaceStatus, wObj *kaitov1beta1.Workspace, generation int64, appendMessage func(string) string) error {
 	// Skip once the benchmark is done (write-once). Nothing clears BenchmarkCompleted on a
 	// readiness transition, so a recorded result survives transient flaps and pod restarts.
-	if refreshBenchmarkObservedGenerationIfCompleted(status, generation) {
+	// ObservedGeneration is kept current by refreshBenchmarkObservedGenerationIfCompleted,
+	// which the caller (applyInferenceWorkspaceStatus) invokes unconditionally on every reconcile.
+	if c := meta.FindStatusCondition(status.Conditions, string(kaitov1beta1.WorkspaceConditionTypeBenchmarkCompleted)); c != nil && c.Status == metav1.ConditionTrue {
 		return nil
 	}
 
@@ -1258,23 +1260,19 @@ func applyBenchmarkStatus(ctx context.Context, status *kaitov1beta1.WorkspaceSta
 // the condition's ObservedGeneration to the current Workspace generation.
 //
 // This keeps the condition from looking stale after later reconciles or spec
-// updates that do not require re-running benchmark. Callers can use the return
-// value as a short-circuit signal: true means benchmark is already completed
-// (and its ObservedGeneration is now current), so no log re-read or result
-// overwrite should happen.
-func refreshBenchmarkObservedGenerationIfCompleted(status *kaitov1beta1.WorkspaceStatus, generation int64) bool {
+// updates that do not require re-running benchmark. It is called once per
+// reconcile at the top of applyInferenceWorkspaceStatus so every code path
+// (ready, not-ready, benchmark-not-applicable) refreshes the condition
+// uniformly, and applyBenchmarkStatus does not need to duplicate the refresh.
+func refreshBenchmarkObservedGenerationIfCompleted(status *kaitov1beta1.WorkspaceStatus, generation int64) {
 	c := meta.FindStatusCondition(status.Conditions, string(kaitov1beta1.WorkspaceConditionTypeBenchmarkCompleted))
-	if c == nil || c.Status != metav1.ConditionTrue {
-		return false
-	}
-	if c.ObservedGeneration == generation {
-		return true
+	if c == nil || c.Status != metav1.ConditionTrue || c.ObservedGeneration == generation {
+		return
 	}
 
 	updated := *c
 	updated.ObservedGeneration = generation
 	meta.SetStatusCondition(&status.Conditions, updated)
-	return true
 }
 
 // resetBenchmarkOnUpgrade clears the recorded benchmark result and removes the

--- a/pkg/workspace/controllers/workspace_controller_test.go
+++ b/pkg/workspace/controllers/workspace_controller_test.go
@@ -1472,6 +1472,9 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 				Namespace:  "default",
 				Generation: 2,
 			},
+			Inference: &v1beta1.InferenceSpec{
+				Preset: &v1beta1.PresetSpec{PresetMeta: v1beta1.PresetMeta{Name: "test-model"}},
+			},
 		}
 		status := &v1beta1.WorkspaceStatus{
 			State: v1beta1.WorkspaceStateReady,
@@ -1490,8 +1493,11 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 			},
 		}
 
+		// Drive the whole ready path so both the L1203 refresh and applyBenchmarkStatus's
+		// write-once guard run together. Empty fake client would fail a log read, so
+		// reaching Ready proves the guard fired (no StreamLogs attempt).
 		k8sclient.SetGlobalClientGoClient(kubefake.NewClientset())
-		applyBenchmarkStatus(context.Background(), status, wObj, 2, buildReconcileErrMessageAppender(nil))
+		applyInferenceWorkspaceStatus(context.Background(), status, wObj, buildReconcileErrMessageAppender(nil), true, v1.ConditionTrue, true, "", "")
 
 		// Result and condition must be unchanged — the guard must have fired.
 		m, ok := status.Performance.Metrics[BenchmarkMetricPeakTPM]

--- a/pkg/workspace/controllers/workspace_controller_test.go
+++ b/pkg/workspace/controllers/workspace_controller_test.go
@@ -1369,9 +1369,9 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 		assert.Contains(t, inferenceCondition.Message, "SAS token fetch failed")
 	})
 
-	t.Run("not-ready path preserves benchmark condition and result (write-once)", func(t *testing.T) {
+	t.Run("not-ready path preserves benchmark condition and refreshes observedGeneration", func(t *testing.T) {
 		wObj := &v1beta1.Workspace{
-			ObjectMeta: v1.ObjectMeta{},
+			ObjectMeta: v1.ObjectMeta{Generation: 2},
 			Inference: &v1beta1.InferenceSpec{
 				Preset: &v1beta1.PresetSpec{
 					PresetMeta: v1beta1.PresetMeta{Name: "test-model"},
@@ -1388,9 +1388,10 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 			},
 			Conditions: []v1.Condition{
 				{
-					Type:   string(v1beta1.WorkspaceConditionTypeBenchmarkCompleted),
-					Status: v1.ConditionTrue,
-					Reason: "BenchmarkCompleted",
+					Type:               string(v1beta1.WorkspaceConditionTypeBenchmarkCompleted),
+					Status:             v1.ConditionTrue,
+					Reason:             "BenchmarkCompleted",
+					ObservedGeneration: 1,
 				},
 			},
 		}
@@ -1408,6 +1409,7 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 		benchmarkCond := meta.FindStatusCondition(status.Conditions, string(v1beta1.WorkspaceConditionTypeBenchmarkCompleted))
 		if assert.NotNil(t, benchmarkCond, "BenchmarkCompleted must be preserved on not-ready (write-once)") {
 			assert.Equal(t, v1.ConditionTrue, benchmarkCond.Status)
+			assert.Equal(t, int64(2), benchmarkCond.ObservedGeneration)
 		}
 	})
 
@@ -1463,11 +1465,12 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 		assert.Nil(t, meta.FindStatusCondition(status.Conditions, string(v1beta1.WorkspaceConditionTypeBenchmarkCompleted)))
 	})
 
-	t.Run("benchmark guard skips StreamLogs when BenchmarkCompleted is already True", func(t *testing.T) {
+	t.Run("benchmark guard skips StreamLogs and refreshes observedGeneration when BenchmarkCompleted is already True", func(t *testing.T) {
 		wObj := &v1beta1.Workspace{
 			ObjectMeta: v1.ObjectMeta{
-				Name:      "ws",
-				Namespace: "default",
+				Name:       "ws",
+				Namespace:  "default",
+				Generation: 2,
 			},
 		}
 		status := &v1beta1.WorkspaceStatus{
@@ -1479,15 +1482,16 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 			},
 			Conditions: []v1.Condition{
 				{
-					Type:   string(v1beta1.WorkspaceConditionTypeBenchmarkCompleted),
-					Status: v1.ConditionTrue,
-					Reason: "BenchmarkCompleted",
+					Type:               string(v1beta1.WorkspaceConditionTypeBenchmarkCompleted),
+					Status:             v1.ConditionTrue,
+					Reason:             "BenchmarkCompleted",
+					ObservedGeneration: 1,
 				},
 			},
 		}
 
 		k8sclient.SetGlobalClientGoClient(kubefake.NewClientset())
-		applyBenchmarkStatus(context.Background(), status, wObj, 1, buildReconcileErrMessageAppender(nil))
+		applyBenchmarkStatus(context.Background(), status, wObj, 2, buildReconcileErrMessageAppender(nil))
 
 		// Result and condition must be unchanged — the guard must have fired.
 		m, ok := status.Performance.Metrics[BenchmarkMetricPeakTPM]
@@ -1495,6 +1499,7 @@ func TestApplyInferenceWorkspaceStatus(t *testing.T) {
 		assert.Equal(t, "12345", m.Value)
 		benchmarkCond := meta.FindStatusCondition(status.Conditions, string(v1beta1.WorkspaceConditionTypeBenchmarkCompleted))
 		assert.Equal(t, v1.ConditionTrue, benchmarkCond.Status)
+		assert.Equal(t, int64(2), benchmarkCond.ObservedGeneration)
 	})
 }
 


### PR DESCRIPTION
## Reason for Change

This follows up on the stale `observedGeneration` issue discussed in #1641 / PR #1708.

The latest `main` branch still had two remaining gaps:

1. `pkg/utils/inferenceset/inferenceset.go` skipped status updates when `status/reason/message` matched, even if `ObservedGeneration` was stale.
2. Workspace benchmark status was write-once, but a previously recorded `BenchmarkCompleted=True` condition could keep an older `ObservedGeneration` across later spec generations.

## What Changed

- Update `InferenceSet` condition matching to also require `ObservedGeneration == metadata.generation` before skipping a status write.
- Refresh `Workspace` `BenchmarkCompleted` observedGeneration when a completed benchmark result is being preserved.
- Add regression tests for both cases.

## Why a dedicated `refreshBenchmarkObservedGenerationIfCompleted` helper?

`setWorkspaceCondition` / `meta.SetStatusCondition` already refreshes `ObservedGeneration` whenever we go through it. The problem is that the `BenchmarkCompleted` condition is intentionally **write-once**: once it flips to `True`, `applyBenchmarkStatus` short-circuits and returns early **without** calling `setWorkspaceCondition` again:

```go
// pre-PR
if c := meta.FindStatusCondition(status.Conditions, ...BenchmarkCompleted); c != nil && c.Status == metav1.ConditionTrue {
    return nil    // ← never touches setcondition after this
}
```

This is by design — we don't want to overwrite the recorded benchmark result or re-read logs on every reconcile. But the side effect is that `BenchmarkCompleted.ObservedGeneration` stays pinned to whatever `metadata.generation` was when the benchmark first completed. Every subsequent spec update (e.g. changing `resource.count`, adjusting adapters, anything that doesn't reset the benchmark) bumps `metadata.generation` but leaves `BenchmarkCompleted.ObservedGeneration` behind — that's exactly the stale-generation symptom #1641 / #1708 was tracking.

The naive fix — "just call `setWorkspaceCondition` in the short-circuit path too" — has two problems:

1. `setWorkspaceCondition` writes `Status/Reason/Message` too. Even if we pass the same values, it churns `LastTransitionTime` semantics and forces us to reconstruct the original `Reason`/`Message` at every call site.
2. The short-circuit lives in two places (`applyBenchmarkStatus` **and** an early guard at the top of `applyInferenceWorkspaceStatus` so that even InferenceStatus-only reconciles refresh it). Duplicating the "find condition + rebuild + set" logic in both is easy to get wrong.

So `refreshBenchmarkObservedGenerationIfCompleted` is deliberately narrow:

- only touches `ObservedGeneration`, preserves `Status`/`Reason`/`Message`/`LastTransitionTime`
- returns `bool` so `applyBenchmarkStatus` can reuse it as the same short-circuit predicate (`if refresh...IfCompleted { return nil }`) — one call, no duplicated `FindStatusCondition + Status==True` check
- single source of truth for both call sites

## Validation

- `git diff --check`
- Added/updated unit tests in:
  - `pkg/utils/inferenceset/inferenceset_test.go`
  - `pkg/workspace/controllers/workspace_controller_test.go`
- [blocked] Local `go test` / `gofmt` could not be run in this environment because `go` and `gofmt` are unavailable.

## Notes for Reviewers

- This PR intentionally does **not** touch `RAGEngine` yet.
- Workspace change is scoped to preserving write-once benchmark results while still advancing `ObservedGeneration`.
