### PR TITLE
chore: bump go to 1.26.6

### DIFF
--- a/.github/workflows/base-image-auto-upgrade-test.yaml
+++ b/.github/workflows/base-image-auto-upgrade-test.yaml
@@ -25,7 +25,7 @@ permissions:
 
 env:
   OLD_CHART_VERSION: ${{ github.event.inputs.old_chart_version || '0.10.0' }}
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.6"
 
 jobs:
   in-place-auto-upgrade-test:

--- a/.github/workflows/e2e-workflow.yaml
+++ b/.github/workflows/e2e-workflow.yaml
@@ -42,7 +42,7 @@ jobs:
 
     env:
       TEST_SUITE: ${{ inputs.node_provisioner }}
-      GO_VERSION: "1.26.4"
+      GO_VERSION: "1.26.6"
       KARPENTER_NAMESPACE: "karpenter"
       GPU_PROVISIONER_NAMESPACE: "gpu-provisioner"
 

--- a/.github/workflows/github-release.yaml
+++ b/.github/workflows/github-release.yaml
@@ -28,7 +28,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.6'
 
 jobs:
   create-release:

--- a/.github/workflows/lint-go.yaml
+++ b/.github/workflows/lint-go.yaml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.6'
 
 permissions:
   contents: read

--- a/.github/workflows/mig-e2e-test.yaml
+++ b/.github/workflows/mig-e2e-test.yaml
@@ -66,7 +66,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.6"
   VM_SIZE: ${{ github.event.inputs.vm_size || 'Standard_NC24ads_A100_v4' }}
   MIG_STRATEGY: ${{ github.event.inputs.mig_strategy || 'mixed' }}
   MIG_PROFILE: ${{ github.event.inputs.mig_profile || '3g.40gb' }}

--- a/.github/workflows/publish-controller-acr-nightly-images.yaml
+++ b/.github/workflows/publish-controller-acr-nightly-images.yaml
@@ -15,7 +15,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.6'
 
 concurrency:
   group: nightly-acr-images

--- a/.github/workflows/publish-rag-controller-gh-image.yaml
+++ b/.github/workflows/publish-rag-controller-gh-image.yaml
@@ -18,7 +18,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.6'
   IMAGE_NAME: 'ragengine'
   REGISTRY: ghcr.io
 

--- a/.github/workflows/publish-rag-controller-mcr-image.yaml
+++ b/.github/workflows/publish-rag-controller-mcr-image.yaml
@@ -13,7 +13,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.6'
   IMAGE_NAME: 'ragengine'
 
 jobs:

--- a/.github/workflows/publish-rag-service-gh-image.yaml
+++ b/.github/workflows/publish-rag-service-gh-image.yaml
@@ -18,7 +18,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.6'
   IMAGE_NAME: 'kaito-rag-service'
   REGISTRY: ghcr.io
 

--- a/.github/workflows/publish-rag-service-mcr-image.yaml
+++ b/.github/workflows/publish-rag-service-mcr-image.yaml
@@ -13,7 +13,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.6'
   IMAGE_NAME: 'kaito-rag-service'
 
 jobs:

--- a/.github/workflows/publish-runtime-mcr-image.yaml
+++ b/.github/workflows/publish-runtime-mcr-image.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 env:
-    GO_VERSION: "1.26.4"
+    GO_VERSION: "1.26.6"
     BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
 
 permissions:

--- a/.github/workflows/publish-workspace-gh-image.yaml
+++ b/.github/workflows/publish-workspace-gh-image.yaml
@@ -18,7 +18,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.6'
   IMAGE_NAME: 'workspace'
   REGISTRY: ghcr.io
 

--- a/.github/workflows/publish-workspace-mcr-image.yaml
+++ b/.github/workflows/publish-workspace-mcr-image.yaml
@@ -13,7 +13,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: '1.26.4'
+  GO_VERSION: '1.26.6'
   IMAGE_NAME: 'workspace'
 
 jobs:

--- a/.github/workflows/ragengine-e2e-workflow.yaml
+++ b/.github/workflows/ragengine-e2e-workflow.yaml
@@ -35,7 +35,7 @@ jobs:
 
     env:
       TEST_SUITE: ${{ inputs.node_provisioner }}
-      GO_VERSION: "1.26.4"
+      GO_VERSION: "1.26.6"
       KARPENTER_NAMESPACE: "karpenter"
       GPU_PROVISIONER_NAMESPACE: "gpu-provisioner"
 

--- a/.github/workflows/ragengine-e2e.yaml
+++ b/.github/workflows/ragengine-e2e.yaml
@@ -13,7 +13,7 @@ on:
       - 'presets/ragengine/**'
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.6"
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/.github/workflows/unit-tests-ragengine.yaml
+++ b/.github/workflows/unit-tests-ragengine.yaml
@@ -17,7 +17,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.6"
 
 jobs:
   unit-tests:

--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -13,7 +13,7 @@ permissions:
   packages: write
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.6"
 
 jobs:
   unit-tests:

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   OLD_CHART_VERSION: ${{ github.event.inputs.old_chart_version || '0.7.1' }}
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.6"
 
 jobs:
   chart-upgrade-test:

--- a/.github/workflows/workspace-e2e.yaml
+++ b/.github/workflows/workspace-e2e.yaml
@@ -21,7 +21,7 @@ on:
         default: "swedencentral"
 
 env:
-  GO_VERSION: "1.26.4"
+  GO_VERSION: "1.26.6"
 
 permissions:
   id-token: write # This is required for requesting the JWT

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kaito-project/kaito
 
-go 1.26.4
+go 1.26.6
 
 require (
 	github.com/Azure/karpenter-provider-azure v1.10.2


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
To address CVEs like CVE-2026-56862, CVE-2026-56860, CVE-2026-56858, etc.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: