### PR TITLE
fix: allow pipeline parallelism > 3

### DIFF
--- a/pkg/workspace/controllers/workspace_controller.go
+++ b/pkg/workspace/controllers/workspace_controller.go
@@ -73,16 +73,6 @@ const (
 	WorkspaceHashAnnotation = "workspace.kaito.io/hash"
 	WorkspaceNameLabel      = "workspace.kaito.io/name"
 	revisionHashSuffix      = 5
-
-	// MaxAllowedNodeCount caps the per-replica node count produced by the node
-	// estimator for inference workspaces. vLLM's Ray executor has a known bug
-	// where pipeline_parallel_size > 3 fails to initialize the KV cache,
-	// producing a KeyError on layer lookup; see
-	// https://github.com/vllm-project/vllm/issues/30128. Until that is fixed
-	// upstream, we refuse to provision more than this many nodes per replica
-	// and ask the user to pick a larger GPU instance type (or shrink the
-	// model / context size) instead.
-	MaxAllowedNodeCount = 3
 )
 
 type WorkspaceReconciler struct {
@@ -309,11 +299,6 @@ func (c *WorkspaceReconciler) waitForModelMirror(ctx context.Context, wObj *kait
 }
 
 func (c *WorkspaceReconciler) reconcileNodes(ctx context.Context, wObj *kaitov1beta1.Workspace) (result *reconcile.Result, err error) {
-	// Refuse to provision when the persisted target node count is over the limit.
-	if err := c.guardTargetNodeCount(wObj); err != nil {
-		return &reconcile.Result{}, err
-	}
-
 	// Provision nodes via the NodeProvisioner interface.
 	// GpuProvisioner creates NodeClaims; BYOProvisioner (BYO mode) is a no-op.
 	if err := c.nodeProvisioner.ProvisionNodes(ctx, wObj); err != nil {
@@ -1440,22 +1425,6 @@ func (c *WorkspaceReconciler) UpdateWorkspaceTargetNodeCount(ctx context.Context
 	}
 
 	return nil
-}
-
-// guardTargetNodeCount blocks provisioning when the persisted target node
-// count exceeds MaxAllowedNodeCount. Only enforced for inference; tuning
-// paths set Resource.Count directly and do not go through the estimator.
-func (c *WorkspaceReconciler) guardTargetNodeCount(wObj *kaitov1beta1.Workspace) error {
-	if wObj.Inference == nil || wObj.Status.TargetNodeCount <= MaxAllowedNodeCount {
-		return nil
-	}
-	msg := fmt.Sprintf("estimated node count %d exceeds the maximum allowed %d; "+
-		"node provisioning halted. Use a larger GPU instance type or reduce model/context size.",
-		wObj.Status.TargetNodeCount, MaxAllowedNodeCount)
-	if c.Recorder != nil {
-		c.Recorder.Eventf(wObj, corev1.EventTypeWarning, "NodeCountExceedsLimit", msg)
-	}
-	return fmt.Errorf("%s", msg)
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/pkg/workspace/controllers/workspace_controller_test.go
+++ b/pkg/workspace/controllers/workspace_controller_test.go
@@ -917,14 +917,14 @@ func TestUpdateWorkspaceTargetNodeCount(t *testing.T) {
 			expectedError:  true,
 			expectedTarget: 0,
 		},
-		"should persist over-limit estimate without error (guard lives in reconcileNodes)": {
+		"should persist estimate without error": {
 			workspace: &v1beta1.Workspace{
 				ObjectMeta: v1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
 				Inference:  &v1beta1.InferenceSpec{Preset: &v1beta1.PresetSpec{PresetMeta: v1beta1.PresetMeta{Name: "test-preset"}}},
 				Status:     v1beta1.WorkspaceStatus{TargetNodeCount: 0},
 			},
 			setupMocks: func(c *test.MockClient, e *mockEstimator, updatedTarget *int32) {
-				e.On("EstimateNodeCount", mock.Anything, mock.IsType(estimator.NodeEstimateRequest{}), mock.Anything).Return(int32(MaxAllowedNodeCount+1), nil)
+				e.On("EstimateNodeCount", mock.Anything, mock.IsType(estimator.NodeEstimateRequest{}), mock.Anything).Return(int32(4), nil)
 				c.On("Get", mock.Anything, mock.Anything, mock.IsType(&v1beta1.Workspace{}), mock.Anything).
 					Run(func(args mock.Arguments) {
 						ws := args.Get(2).(*v1beta1.Workspace)
@@ -938,7 +938,7 @@ func TestUpdateWorkspaceTargetNodeCount(t *testing.T) {
 					}).Return(nil)
 			},
 			expectedError:  false,
-			expectedTarget: MaxAllowedNodeCount + 1,
+			expectedTarget: 4,
 		},
 	}
 
@@ -968,47 +968,6 @@ func TestUpdateWorkspaceTargetNodeCount(t *testing.T) {
 
 			mockClient.AssertExpectations(t)
 			mockEst.AssertExpectations(t)
-		})
-	}
-}
-
-func TestGuardTargetNodeCount(t *testing.T) {
-	tests := map[string]struct {
-		workspace   *v1beta1.Workspace
-		expectError bool
-	}{
-		"no inference => allowed": {
-			workspace: &v1beta1.Workspace{
-				ObjectMeta: v1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
-				Status:     v1beta1.WorkspaceStatus{TargetNodeCount: MaxAllowedNodeCount + 10},
-			},
-		},
-		"inference at the limit => allowed": {
-			workspace: &v1beta1.Workspace{
-				ObjectMeta: v1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
-				Inference:  &v1beta1.InferenceSpec{Preset: &v1beta1.PresetSpec{PresetMeta: v1beta1.PresetMeta{Name: "test-preset"}}},
-				Status:     v1beta1.WorkspaceStatus{TargetNodeCount: MaxAllowedNodeCount},
-			},
-		},
-		"inference above the limit => blocked": {
-			workspace: &v1beta1.Workspace{
-				ObjectMeta: v1.ObjectMeta{Name: "test-workspace", Namespace: "default"},
-				Inference:  &v1beta1.InferenceSpec{Preset: &v1beta1.PresetSpec{PresetMeta: v1beta1.PresetMeta{Name: "test-preset"}}},
-				Status:     v1beta1.WorkspaceStatus{TargetNodeCount: MaxAllowedNodeCount + 1},
-			},
-			expectError: true,
-		},
-	}
-
-	for name, tt := range tests {
-		t.Run(name, func(t *testing.T) {
-			reconciler := &WorkspaceReconciler{}
-			err := reconciler.guardTargetNodeCount(tt.workspace)
-			if tt.expectError {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
 		})
 	}
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
The pp > 3 regression was fixed alongside with a RayExecutor refactor in vLLM: https://github.com/vllm-project/vllm/pull/36836.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).
- [x] verified PP=5 working on A10s

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: