### PR TITLE
fix: deployment of MiniMax-M2.7 and Mistral-Small-4-119B-2603 on A100

### DIFF
--- a/charts/kaito/ragengine/templates/kaito.sh_ragengines.yaml
+++ b/charts/kaito/ragengine/templates/kaito.sh_ragengines.yaml
@@ -432,10 +432,10 @@ spec:
                         type: string
                       profile:
                         description: |-
-                          Profile is the MIG partition profile, e.g. "1g.10gb", "2g.20gb", "3g.40gb".
-                          Required and used only when Mode is "mig". Each workload is scheduled on
-                          exactly one partition; tensor parallelism across partitions is not supported.
-                          Use multiple Workspaces or an InferenceSet to run replicas.
+                          Profile is the partition profile, interpreted according to Mode. For MIG this
+                          is a profile name like "1g.10gb", "2g.20gb", "3g.40gb". Each workload is
+                          scheduled on exactly one partition; tensor parallelism across partitions is
+                          not supported. Use multiple Workspaces or an InferenceSet to run replicas.
                         type: string
                     required:
                     - mode

--- a/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
+++ b/charts/kaito/workspace/templates/kaito.sh_inferencesets.yaml
@@ -711,10 +711,10 @@ spec:
                             type: string
                           profile:
                             description: |-
-                              Profile is the MIG partition profile, e.g. "1g.10gb", "2g.20gb", "3g.40gb".
-                              Required and used only when Mode is "mig". Each workload is scheduled on
-                              exactly one partition; tensor parallelism across partitions is not supported.
-                              Use multiple Workspaces or an InferenceSet to run replicas.
+                              Profile is the partition profile, interpreted according to Mode. For MIG this
+                              is a profile name like "1g.10gb", "2g.20gb", "3g.40gb". Each workload is
+                              scheduled on exactly one partition; tensor parallelism across partitions is
+                              not supported. Use multiple Workspaces or an InferenceSet to run replicas.
                             type: string
                         required:
                         - mode

--- a/charts/kaito/workspace/templates/kaito.sh_workspaces.yaml
+++ b/charts/kaito/workspace/templates/kaito.sh_workspaces.yaml
@@ -626,10 +626,10 @@ spec:
                     type: string
                   profile:
                     description: |-
-                      Profile is the MIG partition profile, e.g. "1g.10gb", "2g.20gb", "3g.40gb".
-                      Required and used only when Mode is "mig". Each workload is scheduled on
-                      exactly one partition; tensor parallelism across partitions is not supported.
-                      Use multiple Workspaces or an InferenceSet to run replicas.
+                      Profile is the partition profile, interpreted according to Mode. For MIG this
+                      is a profile name like "1g.10gb", "2g.20gb", "3g.40gb". Each workload is
+                      scheduled on exactly one partition; tensor parallelism across partitions is
+                      not supported. Use multiple Workspaces or an InferenceSet to run replicas.
                     type: string
                 required:
                 - mode

--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -661,6 +661,25 @@ func (p *PresetParam) RequiresDeepGEMM() bool {
 	return false
 }
 
+// RequiresFlashInfer returns true for models which require JIT-compilation with nvcc at runtime.
+func (p *PresetParam) RequiresFlashInfer() bool {
+	switch p.Name {
+	case "mistral-small-4-119b-2603":
+		return true
+	}
+	return false
+}
+
+// RequiresCUDAToolkit returns true for models that need the runtime CUDA toolkit
+// (nvcc) available in the container. This covers DeepGEMM models plus models
+// whose other runtime JIT paths compile with nvcc (see RequiresFlashInfer).
+// The slim base image ships no nvcc, so these models get the
+// cuda-toolkit-provisioner init container and CUDA_HOME. Enabling the toolkit
+// does not enable DeepGEMM itself (that stays gated on RequiresDeepGEMM).
+func (p *PresetParam) RequiresCUDAToolkit() bool {
+	return p.RequiresDeepGEMM() || p.RequiresFlashInfer()
+}
+
 // modelFitsOnSingleGPU returns true when the model file size is smaller than
 // 50% of a single GPU's memory, meaning the entire model can be loaded onto
 // one GPU with headroom to spare.

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -702,10 +702,11 @@ func configureModelWeightsVolumes(streamingModelPath, localModelWeightsPath stri
 }
 
 // configureCUDAToolkitVolume mounts the node's CUDA toolkit into the pod for
-// models whose FP8 GEMMs require DeepGEMM's nvcc JIT (e.g. DeepSeek-V4), and
-// returns cudaHome — the toolkit path — or "" for models that don't need it.
+// models whose runtime JIT paths require nvcc (see RequiresCUDAToolkit — e.g.
+// DeepSeek-V4's DeepGEMM FP8 GEMMs, or Mistral-Small-4's FlashInfer CUTLASS MoE),
+// and returns cudaHome — the toolkit path — or "" for models that don't need it.
 //
-// Only DeepGEMM models get a toolkit. It lives at a fixed node path
+// Only models requiring the toolkit get one. It lives at a fixed node path
 // (defaultCudaHomePath) and is mounted read-only (the main container only
 // reads nvcc + headers/libs; the cuda-toolkit-provisioner init container mounts it
 // read-write to install). Because it lives on the node (hostPath, DirectoryOrCreate
@@ -715,7 +716,7 @@ func configureModelWeightsVolumes(streamingModelPath, localModelWeightsPath stri
 func configureCUDAToolkitVolume(model pkgmodel.Model,
 	volumes []corev1.Volume, volumeMounts []corev1.VolumeMount,
 ) ([]corev1.Volume, []corev1.VolumeMount, string) {
-	if !model.GetInferenceParameters().RequiresDeepGEMM() {
+	if !model.GetInferenceParameters().RequiresCUDAToolkit() {
 		return volumes, volumeMounts, ""
 	}
 

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -231,22 +231,11 @@ var (
 
 	// vllmAttentionBackendPrefixMap maps model name prefixes to their vLLM attention backend.
 	// source: https://docs.vllm.ai/en/latest/design/attention_backends/
-	vllmAttentionBackendPrefixMap = map[string]string{
-		// flashinfer attention backend is chosen by default for LLaMA 3 models, which requires the FlashInfer library to be installed lively.
-		// Pin to triton backend as a workaround.
-		"llama-3": "TRITON_ATTN",
-	}
+	vllmAttentionBackendPrefixMap = map[string]string{}
 
 	// vllmMoeBackendOverride maps exact model names to their vLLM MoE backend.
 	// source: https://docs.vllm.ai/en/latest/configuration/engine_args/#-moe-backend
-	vllmMoeBackendOverride = map[string]string{
-		// Mistral Small 4 FP8 defaults to FlashInfer CUTLASS MoE backend which requires
-		// JIT compilation with CUDA dev headers (nvcc, cublasLt, nvrtc).
-		// Pin to triton backend to avoid the JIT dependency for now.
-		"mistral-small-4-119b-2603": "triton",
-		// MiniMax-M2.7 FP8 MoE also defaults to FlashInfer CUTLASS which needs nvcc.
-		"minimax-m2.7": "triton",
-	}
+	vllmMoeBackendOverride = map[string]string{}
 
 	// vllmKVCacheDtypePrefixMap maps model name prefixes to their required vLLM
 	// kv-cache-dtype. Some architectures only support a specific KV cache format


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in KAITO? Why is it needed? -->
Currently KAITO pins MoE backend to `triton` for models MiniMax-M2.7 and Mistral-Small-4-119B-2603, which doesn't work on A100:
- MiniMax-M2.7: the pin is actually unnecessary -> remove
- Mistral-Small-4-119B-2603: the pin only works on H100 -> remove the pin and use FlashInfer kernels instead (require nvcc) which work for both H100 and A100.

Also removes the unnecessary attention backend pin for Llama-3.3-70B-Instruct.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).
- [x] tested MiniMax-M2.7,  Mistral-Small-4-119B-2603 and Llama-3.3-70B-Instruct on both H100 and A100.

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: