### PR TITLE
fix: race in upgrade test

### DIFF
--- a/.github/workflows/mig-e2e-test.yaml
+++ b/.github/workflows/mig-e2e-test.yaml
@@ -29,6 +29,7 @@ on:
       - "pkg/model/interface.go"
       - "examples/mig/**"
       - "examples/inference/kaito_inferenceset_mig_*.yaml"
+      - "charts/kaito/workspace/**"
       - ".github/workflows/mig-e2e-test.yaml"
   workflow_dispatch:
     inputs:

--- a/.github/workflows/upgrade-test.yaml
+++ b/.github/workflows/upgrade-test.yaml
@@ -109,20 +109,10 @@ jobs:
       - name: Verify migration to StatefulSet
         shell: bash
         run: |
-          # Wait for workspace to be ready again if needed
+          kubectl wait --for=create statefulset/workspace-mistral-7b-instruct --timeout=300s
+          kubectl wait --for=delete deployment/workspace-mistral-7b-instruct --timeout=300s
+          kubectl rollout status statefulset/workspace-mistral-7b-instruct --timeout=1000s
           kubectl wait --for=condition=InferenceReady workspace/workspace-mistral-7b-instruct --timeout=1000s
-
-          # Verify it is now using a StatefulSet
-          if ! kubectl get statefulset workspace-mistral-7b-instruct; then
-            echo "Error: StatefulSet not found for workspace after upgrade"
-            exit 1
-          fi
-
-          # Verify Deployment is gone
-          if kubectl get deployment workspace-mistral-7b-instruct 2>/dev/null; then
-            echo "Error: Old Deployment still exists"
-            exit 1
-          fi
 
       - name: Cleanup
         if: always()
@@ -291,19 +281,10 @@ jobs:
       - name: Verify migration to StatefulSet (BYO)
         shell: bash
         run: |
+          kubectl wait --for=create statefulset/workspace-mistral-7b-instruct --timeout=300s
+          kubectl wait --for=delete deployment/workspace-mistral-7b-instruct --timeout=300s
+          kubectl rollout status statefulset/workspace-mistral-7b-instruct --timeout=1200s
           kubectl wait --for=condition=InferenceReady workspace/workspace-mistral-7b-instruct --timeout=1200s
-
-          # Verify it is now using a StatefulSet
-          if ! kubectl get statefulset workspace-mistral-7b-instruct; then
-            echo "Error: StatefulSet not found for workspace after upgrade"
-            exit 1
-          fi
-
-          # Verify Deployment is gone
-          if kubectl get deployment workspace-mistral-7b-instruct 2>/dev/null; then
-            echo "Error: Old Deployment still exists"
-            exit 1
-          fi
 
       - name: Delete workspace and verify cleanup (BYO)
         shell: bash


### PR DESCRIPTION
**Reason for Change**:

Fixes a race in the Helm chart upgrade tests for both standard and BYO node configurations.

Before the upgrade, the Workspace has `InferenceReady=True` from its legacy Deployment. After Helm installs the new controller, that condition can remain true until the controller reconciles the existing Workspace. The test previously waited on `InferenceReady` first, which could return immediately using this stale status, and then checked for the new StatefulSet before migration had started.

The updated test synchronizes on the resources that represent the migration:

1. Wait for the StatefulSet to be created.
2. Wait for the legacy Deployment to be deleted.
3. Wait for the StatefulSet rollout to complete.
4. Verify the Workspace reports `InferenceReady=True`.

**Requirements**

**Issue Fixed**:

**Notes for Reviewers**: