### PR TITLE
chore: bump ragengine python packages

### DIFF
--- a/presets/ragengine/requirements-test.txt
+++ b/presets/ragengine/requirements-test.txt
@@ -2,6 +2,6 @@
 -r requirements.txt
 
 # Test dependencies
-pytest==8.3.4
-pytest-asyncio==0.26.0
-respx==0.22.0
+pytest==9.1.1
+pytest-asyncio==1.4.0
+respx==0.23.1

--- a/presets/ragengine/requirements.txt
+++ b/presets/ragengine/requirements.txt
@@ -27,7 +27,7 @@ asyncio==3.4.3
 aiorwlock==1.5.0
 nest-asyncio==1.6.0
 httpx==0.27.0
-requests==2.32.4
+requests==2.33.0
 openai==1.108.1
 llm-guard==0.3.16
 PyYAML>=6.0.2

--- a/presets/ragengine/requirements.txt
+++ b/presets/ragengine/requirements.txt
@@ -1,28 +1,27 @@
 # RAG Library Requirements
-llama-index==0.14.15
-# Pin llama-index-core to 0.14.18 to avoid refresh_ref_docs regression in 0.14.19
-# that causes KeyError on document IDs after update_documents with FAISS backend.
-# See: https://github.com/kaito-project/kaito/issues/TBD
+llama-index==0.14.18
+# Pin llama-index-core to 0.14.18 to avoid the refresh_ref_docs regression in
+# newer releases that leaves FAISS node IDs out of sync with the index struct.
 llama-index-core==0.14.18
 # HF Embeddings
-llama-index-embeddings-huggingface==0.6.1
-llama-index-embeddings-huggingface-api==0.4.1
+llama-index-embeddings-huggingface==0.7.0
+llama-index-embeddings-huggingface-api==0.5.0
 # HF LLMs
-llama-index-llms-huggingface==0.6.1
-llama-index-llms-huggingface-api==0.6.2
+llama-index-llms-huggingface==0.7.0
+llama-index-llms-huggingface-api==0.7.0
 # BM25 keyword retriever for hybrid search (Python-side fallback for non-Qdrant backends)
-llama-index-retrievers-bm25==0.6.5
+llama-index-retrievers-bm25==0.7.1
 # fastembed: BM25 sparse tokenizer used by Qdrant native hybrid search
 fastembed>=0.4.0
 
 fastapi==0.141.1
 starlette>=1.3.1
-faiss-cpu==1.11.0
-llama-index-vector-stores-faiss==0.5.3
-llama-index-vector-stores-qdrant==0.9.1
-qdrant-client==1.16.2
+faiss-cpu==1.15.0
+llama-index-vector-stores-faiss==0.6.0
+llama-index-vector-stores-qdrant==0.10.3
+qdrant-client==1.19.0
 llama-index-vector-stores-chroma==0.5.5
-llama-index-vector-stores-azurecosmosmongo==0.7.1
+llama-index-vector-stores-azurecosmosmongo==0.8.0
 uvicorn==0.34.2
 asyncio==3.4.3
 aiorwlock==1.5.0
@@ -35,8 +34,8 @@ PyYAML>=6.0.2
 watchfiles>=0.21.0
 
 tiktoken==0.11.0
-tree-sitter==0.23.2
+tree-sitter==0.26.0
 tree_sitter_languages==1.10.2
-tree-sitter-language-pack==0.7.3
+tree-sitter-language-pack==1.14.3
 # Metrics collection
 prometheus-client>=0.17.0

--- a/presets/ragengine/tests/api/conftest.py
+++ b/presets/ragengine/tests/api/conftest.py
@@ -23,8 +23,6 @@ os.environ["MKL_NUM_THREADS"] = "1"  # Force MKL to use a single thread
 # Set LLM_INFERENCE_URL before importing ragengine modules
 os.environ["LLM_INFERENCE_URL"] = "http://localhost:5000/v1/chat/completions"
 
-import asyncio
-
 import aiorwlock
 import httpx
 import nest_asyncio
@@ -40,13 +38,6 @@ async def async_client():
     """Use an async HTTP client to interact with FastAPI app."""
     async with httpx.AsyncClient(app=app, base_url="http://localhost") as client:
         yield client
-
-
-@pytest_asyncio.fixture(scope="session")
-def event_loop():
-    loop = asyncio.new_event_loop()
-    yield loop
-    loop.close()
 
 
 @pytest_asyncio.fixture(autouse=True)

--- a/presets/ragengine/tests/vector_store/test_base_store.py
+++ b/presets/ragengine/tests/vector_store/test_base_store.py
@@ -337,8 +337,9 @@ func main() {}"""
                 "test_code_index", [unsupported_doc]
             )
             assert False, "Expected ValueError for unsupported language"
-        except LookupError:
-            assert True
+        except Exception as e:
+            print(str(e))
+            assert "Download error: Language 'invalid' not available for download" in str(e)
 
     @pytest.mark.asyncio
     @respx.mock

--- a/presets/ragengine/tests/vector_store/test_base_store.py
+++ b/presets/ragengine/tests/vector_store/test_base_store.py
@@ -339,7 +339,10 @@ func main() {}"""
             assert False, "Expected ValueError for unsupported language"
         except Exception as e:
             print(str(e))
-            assert "Download error: Language 'invalid' not available for download" in str(e)
+            assert (
+                "Download error: Language 'invalid' not available for download"
+                in str(e)
+            )
 
     @pytest.mark.asyncio
     @respx.mock

--- a/test/rage2e/rag_test.go
+++ b/test/rage2e/rag_test.go
@@ -486,6 +486,7 @@ func createPhi3WorkspaceWithPresetPublicModeAndVLLM(numOfReplica int) *kaitov1be
 			&metav1.LabelSelector{
 				MatchLabels: map[string]string{"kaito-workspace": "rag-e2e-test-phi-4-mini-instruct-vllm"},
 			}, nil, PresetPhi3Mini128kModel, nil, nil, nil, "", "")
+		workspaceObj.Annotations = utils.DisableModelStreaming(workspaceObj.Annotations)
 
 		createAndValidateWorkspace(workspaceObj)
 	})


### PR DESCRIPTION
**Reason for Change**:
Bumping available versions. We are blocked on llama-index for some regression with the faiss vectordb handling document updates but not updating document ids.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: