### PR TITLE
ci: harden e2e test

### DIFF
--- a/.github/actions/e2e-base-setup/action.yaml
+++ b/.github/actions/e2e-base-setup/action.yaml
@@ -239,10 +239,27 @@ runs:
           local location="$1"
           local vm_size="$2"
           az aks create --name "$AZURE_CLUSTER_NAME" --resource-group "$AZURE_RESOURCE_GROUP" \
-            --location "$location" --attach-acr "$AZURE_ACR_NAME" --node-vm-size "$vm_size" \
+            --location "$location" --node-vm-size "$vm_size" \
             --kubernetes-version "$AKS_K8S_VERSION" --generate-ssh-keys \
             --network-plugin azure --network-plugin-mode overlay --network-dataplane cilium \
             --enable-managed-identity --enable-oidc-issuer --enable-workload-identity -o none
+        }
+
+        # Attach ACR separately from create: the AcrPull role assignment can transiently
+        # fail on AAD role propagation, which must not force an expensive cluster recreate.
+        attach_acr_with_retry() {
+          local attempts=8 delay=15
+          for i in $(seq 1 $attempts); do
+            if az aks update --name "$AZURE_CLUSTER_NAME" --resource-group "$AZURE_RESOURCE_GROUP" \
+                --attach-acr "$AZURE_ACR_NAME" -o none; then
+              echo "ACR attached on attempt $i/$attempts"
+              return 0
+            fi
+            echo "::warning::attach-acr attempt $i/$attempts failed (AAD role propagation); retrying in ${delay}s"
+            sleep "$delay"
+          done
+          echo "::error::failed to attach ACR after $attempts attempts"
+          return 1
         }
 
         set +e
@@ -253,6 +270,7 @@ runs:
           echo "::warning::$AZURE_LOCATION AKS creation failed (rc=$rc); retrying in polandcentral with Standard_NV12ads_A10_v5"
           create_karpenter_cluster polandcentral Standard_NV12ads_A10_v5
         fi
+        attach_acr_with_retry
         az aks get-credentials --name "$AZURE_CLUSTER_NAME" --resource-group "$AZURE_RESOURCE_GROUP" --overwrite-existing
       env:
         AZURE_ACR_NAME: ${{ env.CLUSTER_NAME }}
@@ -269,10 +287,27 @@ runs:
           local location="$1"
           local vm_size="$2"
           az aks create --name "$AZURE_CLUSTER_NAME" --resource-group "$AZURE_RESOURCE_GROUP" \
-            --location "$location" --attach-acr "$AZURE_ACR_NAME" \
+            --location "$location" \
             --kubernetes-version "$AKS_K8S_VERSION" --generate-ssh-keys \
             --enable-managed-identity --enable-workload-identity --enable-oidc-issuer \
             --node-vm-size "$vm_size" -o none
+        }
+
+        # Attach ACR separately from create: the AcrPull role assignment can transiently
+        # fail on AAD role propagation, which must not force an expensive cluster recreate.
+        attach_acr_with_retry() {
+          local attempts=8 delay=15
+          for i in $(seq 1 $attempts); do
+            if az aks update --name "$AZURE_CLUSTER_NAME" --resource-group "$AZURE_RESOURCE_GROUP" \
+                --attach-acr "$AZURE_ACR_NAME" -o none; then
+              echo "ACR attached on attempt $i/$attempts"
+              return 0
+            fi
+            echo "::warning::attach-acr attempt $i/$attempts failed (AAD role propagation); retrying in ${delay}s"
+            sleep "$delay"
+          done
+          echo "::error::failed to attach ACR after $attempts attempts"
+          return 1
         }
 
         set +e
@@ -283,6 +318,7 @@ runs:
           echo "::warning::$AZURE_LOCATION AKS creation failed (rc=$rc); retrying in polandcentral with Standard_NV12ads_A10_v5"
           create_gpu_cluster polandcentral Standard_NV12ads_A10_v5
         fi
+        attach_acr_with_retry
         az aks get-credentials --name "$AZURE_CLUSTER_NAME" --resource-group "$AZURE_RESOURCE_GROUP" --overwrite-existing
       env:
         AZURE_ACR_NAME: ${{ env.CLUSTER_NAME }}

--- a/.github/actions/e2e-base-setup/action.yaml
+++ b/.github/actions/e2e-base-setup/action.yaml
@@ -78,6 +78,17 @@ runs:
       shell: bash
       run: |
         az login --identity
+        if [ -z "${E2E_SUBSCRIPTION_ID:-}" ]; then
+          echo "::error::E2E_SUBSCRIPTION_ID is not configured"
+          exit 1
+        fi
+        az account set --subscription "$E2E_SUBSCRIPTION_ID"
+        ACTIVE_SUBSCRIPTION_ID=$(az account show --query id -o tsv)
+        if [ "$ACTIVE_SUBSCRIPTION_ID" != "$E2E_SUBSCRIPTION_ID" ]; then
+          echo "::error::Failed to select E2E subscription $E2E_SUBSCRIPTION_ID; active subscription is $ACTIVE_SUBSCRIPTION_ID"
+          exit 1
+        fi
+        echo "Using E2E subscription $ACTIVE_SUBSCRIPTION_ID"
 
     - name: Install Helm
       uses: azure/setup-helm@v4


### PR DESCRIPTION
**Reason for Change**:

Harden E2E cluster setup against transient ACR role propagation failures and inconsistent Azure subscription defaults on self-hosted runners:
- Separates ACR attachment from AKS creation and retries ACR attachment up to eight times to tolerate AAD role propagation delays.
- Explicitly selects and verifies `E2E_SUBSCRIPTION_ID` after managed-identity login. Fails early when the E2E subscription is missing or cannot be selected.

**Requirements**

- [ ] added unit tests and e2e tests (not applicable; workflow-only change).

**Issue Fixed**:

N/A

**Notes for Reviewers**: