### PR TITLE
ci: verify generated RBAC relationships

### DIFF
--- a/.github/workflows/iac-contract.yaml
+++ b/.github/workflows/iac-contract.yaml
@@ -1,0 +1,112 @@
+name: IaC contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".iac-guard-v/**"
+      - ".github/workflows/iac-contract.yaml"
+      - "config/rbac/**"
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
+
+      - name: Check out the code
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+
+      - name: Set up Python
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+        with:
+          python-version: "3.12"
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@829323503d1be3d00ca8346e5391ca0b07a9ab0d # v5.1.0
+        with:
+          version: "v1.36.1"
+
+      - name: Install IaC-Guard-V
+        run: |
+          python -m pip install \
+            --disable-pip-version-check \
+            --no-compile \
+            --only-binary=:all: \
+            iac-guard-v==0.1.0a10
+
+      - name: Render RBAC deterministically
+        run: |
+          mkdir -p "${RUNNER_TEMP}/rbac-first" "${RUNNER_TEMP}/rbac-second"
+          kubectl kustomize config/rbac > "${RUNNER_TEMP}/rbac-first/objects.yaml"
+          kubectl kustomize config/rbac > "${RUNNER_TEMP}/rbac-second/objects.yaml"
+          cmp "${RUNNER_TEMP}/rbac-first/objects.yaml" \
+            "${RUNNER_TEMP}/rbac-second/objects.yaml"
+
+      - name: Verify documented RBAC relationships
+        run: |
+          iac-guard contract lint \
+            --contract .iac-guard-v/contracts.yaml \
+            --format console
+          iac-guard contract plan \
+            --contract .iac-guard-v/contracts.yaml \
+            --project-root . \
+            --contract-root "${RUNNER_TEMP}/rbac-first" \
+            --contract-provenance SUGGESTED_CONTRACT \
+            --source-commit "${GITHUB_SHA}" \
+            --default-namespace system \
+            --format console
+          set +e
+          iac-guard verify \
+            --contract .iac-guard-v/contracts.yaml \
+            --project-root . \
+            --contract-root "${RUNNER_TEMP}/rbac-first" \
+            --contract-provenance SUGGESTED_CONTRACT \
+            --source-commit "${GITHUB_SHA}" \
+            --default-namespace system \
+            --format json \
+            --output "${RUNNER_TEMP}/iac-contract-report.json" \
+            --quiet
+          verify_status=$?
+          set -e
+
+          iac-guard explain "${RUNNER_TEMP}/iac-contract-report.json" \
+            --format console
+
+          if [ "${verify_status}" -ne 0 ]; then
+            python - "${RUNNER_TEMP}/iac-contract-report.json" <<'PY'
+          import json
+          import sys
+
+          report = json.load(open(sys.argv[1], encoding="utf-8"))
+          print("\nActionable violated relationships:")
+          for clause in report.get("clauses", []):
+              for observation in clause.get("native_observations", []):
+                  if observation.get("result") != "VIOLATED":
+                      continue
+                  request = observation["request"]
+                  witness = observation["witness"]["contents"]
+                  print(f"- binding: {request['subject_identity']}")
+                  print(f"  property: {request['property_id']}")
+                  print(f"  reason: {observation['reason_code']}")
+                  expected_role = witness.get("expected_target_identity")
+                  if expected_role:
+                      print(f"  expected roleRef target: {expected_role}")
+                  for subject in witness.get("service_account_subjects", []):
+                      if subject.get("resolved_target") is None:
+                          print(
+                              "  expected ServiceAccount subject: "
+                              f"{subject['expected_identity']}"
+                          )
+          PY
+          fi
+
+          exit "${verify_status}"

--- a/.iac-guard-v/contracts.yaml
+++ b/.iac-guard-v/contracts.yaml
@@ -1,0 +1,35 @@
+apiVersion: iac-guard-v.io/v1alpha1
+kind: InfrastructureContract
+metadata:
+  name: kaito-manager-rbac-relationships
+spec:
+  artifactClass: kubernetes_rendered
+  subjects:
+    include:
+      selector:
+        apiVersions: [rbac.authorization.k8s.io/v1]
+        kinds: [RoleBinding, ClusterRoleBinding]
+        namespaces: [system, _cluster]
+        labelSelector: {matchLabels: {}}
+    cardinality: {min: 7}
+  responsibility:
+    class: PROJECT_MANAGED
+    reason: The component-managed RBAC bindings must resolve their Roles and ServiceAccount with Kubernetes-consistent scope.
+  expect:
+    - id: subject-resolves
+      property:
+        namespace: iac_guard_v
+        id: IACGV_K8S_RBAC_SERVICEACCOUNT_SUBJECT_RESOLVES_V1
+        version: "1"
+      parameters: {complete_expected_domain: true}
+    - id: role-ref-resolves
+      property:
+        namespace: iac_guard_v
+        id: IACGV_K8S_RBAC_ROLE_REF_RESOLVES_V1
+        version: "1"
+      parameters: {complete_expected_domain: true}
+    - id: scope-consistent
+      property:
+        namespace: iac_guard_v
+        id: IACGV_K8S_RBAC_BINDING_SCOPE_CONSISTENT_V1
+        version: "1"


### PR DESCRIPTION
**Reason for Change**:

This adds a small static RBAC relationship regression check for the existing `config/rbac` invariant.

The committed Kustomization states that all bindings use the controller ServiceAccount and need to stay synchronized when that identity changes. The proposed IaC-Guard-V contract checks the generated component as a whole: ServiceAccount subject resolution, roleRef resolution, and scope consistency across all seven bindings.

Current main passes all 21 native relationship checks. I also tested three local mutations: a missing ServiceAccount, a missing Role, and a RoleBinding roleRef kind change. Each mutation is rejected by the contract.

The workflow is read-only. It pins IaC-Guard-V `0.1.0a10`, renders `config/rbac` twice to require deterministic output, and does not use a cluster, cloud credentials, scanners, or model APIs.

**Requirements**

- [ ] added unit tests and e2e tests (not applicable; this adds a static contract and its CI execution).

**Issue Fixed**:

N/A

**Notes for Reviewers**:

AI-use disclosure: AI assistance was used to prepare the contract, workflow, and PR description. The resulting two-file change was validated with the checks listed below.

The contract is submitted with `SUGGESTED_CONTRACT` provenance. If the project accepts and commits it, future executions can treat the repository-owned contract as `PROJECT_AUTHORED` under IaC-Guard-V's provenance model.

IaC-Guard-V 0.1.0a10: https://github.com/lokesh0186/iac-guard-v/releases/tag/v0.1.0-alpha.10

Validation performed:

- `kubectl kustomize config/rbac` rendered byte-identically twice.
- Contract lint, plan, and verify passed on current main with 7 selected bindings and 21 native requests.
- Removing the controller ServiceAccount returned `VIOLATED` with all affected binding identities.
- Removing the leader-election Role returned `VIOLATED` with the unresolved roleRef target.
- Changing the leader RoleBinding roleRef kind returned `VIOLATED` with the unresolved expected target.
- `actionlint` 1.7.12 reported no workflow findings.
