### PR TITLE
fix: weight size and node estimation for gpt-oss models

### DIFF
--- a/pkg/workspace/estimator/nodesestimator/estimator_test.go
+++ b/pkg/workspace/estimator/nodesestimator/estimator_test.go
@@ -659,8 +659,7 @@ func TestNodeEstimator_EstimateNodeCount_RealCatalogModels_A100(t *testing.T) {
 		a100_2GPU = "Standard_NC48ads_A100_v4"
 	)
 	runRealCatalogModelCases(t, []realCatalogModelCase{
-		{"gpt-oss-120b/1xA100", "openai/gpt-oss-120b", a100_1GPU, 2},                          // 121.54Gi
-		{"gpt-oss-120b/2xA100", "openai/gpt-oss-120b", a100_2GPU, 1},                          // 121.54Gi
+		{"gpt-oss-120b/1xA100", "openai/gpt-oss-120b", a100_1GPU, 1},                          // 60.77Gi
 		{"DeepSeek-V4-Flash-0731/1xA100", "deepseek-ai/DeepSeek-V4-Flash-0731", a100_1GPU, 3}, // 155.43Gi
 		{"DeepSeek-V4-Flash-0731/2xA100", "deepseek-ai/DeepSeek-V4-Flash-0731", a100_2GPU, 2}, // 155.43Gi
 		{"Qwen3.8-27B/1xA100", "Qwen/Qwen3.8-27B", a100_1GPU, 1},                              // 51.75Gi
@@ -678,8 +677,7 @@ func TestNodeEstimator_EstimateNodeCount_RealCatalogModels_H100(t *testing.T) {
 		h100_2GPU = "Standard_NC80adis_H100_v5"
 	)
 	runRealCatalogModelCases(t, []realCatalogModelCase{
-		{"gpt-oss-120b/1xH100", "openai/gpt-oss-120b", h100_1GPU, 2},                          // 121.54Gi
-		{"gpt-oss-120b/2xH100", "openai/gpt-oss-120b", h100_2GPU, 1},                          // 121.54Gi
+		{"gpt-oss-120b/1xH100", "openai/gpt-oss-120b", h100_1GPU, 1},                          // 60.77Gi
 		{"DeepSeek-V4-Flash-0731/1xH100", "deepseek-ai/DeepSeek-V4-Flash-0731", h100_1GPU, 2}, // 155.43Gi
 		{"DeepSeek-V4-Flash-0731/2xH100", "deepseek-ai/DeepSeek-V4-Flash-0731", h100_2GPU, 1}, // 155.43Gi
 		{"Qwen3.8-27B/1xH100", "Qwen/Qwen3.8-27B", h100_1GPU, 1},                              // 51.75Gi
@@ -697,8 +695,7 @@ func TestNodeEstimator_EstimateNodeCount_RealCatalogModels_A10(t *testing.T) {
 		a10_2GPU = "Standard_NV72ads_A10_v5"
 	)
 	runRealCatalogModelCases(t, []realCatalogModelCase{
-		{"gpt-oss-20b/1xA10", "openai/gpt-oss-20b", a10_1GPU, 2},                        // 25.63Gi
-		{"gpt-oss-20b/2xA10", "openai/gpt-oss-20b", a10_2GPU, 1},                        // 25.63Gi
+		{"gpt-oss-20b/1xA10", "openai/gpt-oss-20b", a10_1GPU, 1},                        // 12.82Gi                      // 12.82Gi
 		{"gemma-4-12B-it/1xA10", "google/gemma-4-12B-it", a10_1GPU, 2},                  // 22.28Gi
 		{"gemma-4-12B-it/2xA10", "google/gemma-4-12B-it", a10_2GPU, 1},                  // 22.28Gi
 		{"granite-4.1-8b/1xA10", "ibm-granite/granite-4.1-8b", a10_1GPU, 1},             // 16.38Gi

--- a/presets/workspace/generator/generator.go
+++ b/presets/workspace/generator/generator.go
@@ -425,8 +425,8 @@ func (g *Generator) listRepoFiles() ([]FileInfo, error) {
 	return files, nil
 }
 
-// selectWeightFiles picks the model weight files to use and detects whether
-// the model uses Mistral format. For Mistral-format models (those with
+// selectWeightFiles picks root-level model weight files and detects whether the
+// model uses Mistral format. For Mistral-format models (those with
 // consolidated*.safetensors), it sets g.IsMistralModel and returns only the
 // consolidated files. For standard models, it prefers .safetensors over .bin
 // when both are present.
@@ -434,6 +434,9 @@ func (g *Generator) selectWeightFiles(files []FileInfo) []FileInfo {
 	var safetensors, bins, mistral []FileInfo
 
 	for _, f := range files {
+		if strings.Contains(f.Path, "/") {
+			continue
+		}
 		if mistralRegex.MatchString(f.Path) {
 			mistral = append(mistral, f)
 		}

--- a/presets/workspace/generator/generator_test.go
+++ b/presets/workspace/generator/generator_test.go
@@ -673,6 +673,30 @@ func TestSelectWeightFiles(t *testing.T) {
 			expectedIsMistral: false,
 		},
 		{
+			name: "prefers root weights over alternate safetensors in subdirectories",
+			files: []FileInfo{
+				{Path: "model-00001-of-00002.safetensors", Size: 5000},
+				{Path: "model-00002-of-00002.safetensors", Size: 5000},
+				{Path: "original/model-00001-of-00002.safetensors", Size: 5000},
+				{Path: "original/model-00002-of-00002.safetensors", Size: 5000},
+				{Path: "metal/model.bin", Size: 10000},
+			},
+			expectedPaths: []string{
+				"model-00001-of-00002.safetensors",
+				"model-00002-of-00002.safetensors",
+			},
+			expectedIsMistral: false,
+		},
+		{
+			name: "ignores nested safetensors when no root weights exist",
+			files: []FileInfo{
+				{Path: "weights/model-00001-of-00002.safetensors", Size: 5000},
+				{Path: "weights/model-00002-of-00002.safetensors", Size: 5000},
+			},
+			expectedPaths:     nil,
+			expectedIsMistral: false,
+		},
+		{
 			name: "no weight files returns empty",
 			files: []FileInfo{
 				{Path: "config.json", Size: 100},

--- a/presets/workspace/models/model_catalog.yaml
+++ b/presets/workspace/models/model_catalog.yaml
@@ -140,7 +140,7 @@ models:
   description: https://huggingface.co/openai/gpt-oss-20b
   license: apache-2.0
   pipelineTag: text-generation
-  modelFileSize: 25.63Gi
+  modelFileSize: 12.82Gi
   architectures:
   - GptOssForCausalLM
   modelTokenLimit: 131072
@@ -154,7 +154,7 @@ models:
   description: https://huggingface.co/openai/gpt-oss-120b
   license: apache-2.0
   pipelineTag: text-generation
-  modelFileSize: 121.54Gi
+  modelFileSize: 60.77Gi
   architectures:
   - GptOssForCausalLM
   modelTokenLimit: 131072

--- a/test/e2e/preset_test.go
+++ b/test/e2e/preset_test.go
@@ -45,7 +45,7 @@ const (
 	PresetPhi4Model                 = "phi-4"
 	PresetGemma3_4BInstructModel    = "google/gemma-3-4b-it"
 	PresetGemma3_27BInstructModel   = "google/gemma-3-27b-it"
-	PresetGemma4_E2BInstructModel   = "google/gemma-4-E2B-it"
+	PresetGemma4_12BInstructModel   = "google/gemma-4-12B-it"
 	PresetQwen3_8_27BModel          = "Qwen/Qwen3.8-27B"
 	PresetGPT_OSS_20BModel          = "gpt-oss-20b"
 	PresetGPT_OSS_120BModel         = "gpt-oss-120b"

--- a/test/e2e/preset_vllm_test.go
+++ b/test/e2e/preset_vllm_test.go
@@ -94,9 +94,9 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateMultiRoleInferencePDDisaggregation(mriObj)
 	})
 
-	It("should create a gpt-oss-20b two-node workspace with preset public mode successfully", utils.GinkgoLabelFastCheck, func() {
+	It("should create a gemma-4-12B-it two-node workspace with preset public mode successfully", utils.GinkgoLabelFastCheck, func() {
 		numOfNode := 2
-		workspaceObj := createGPTOss20BWorkspaceWithPresetPublicModeAndVLLM(numOfNode)
+		workspaceObj := createGemma4_12BInstructWorkspaceWithPresetPublicModeAndVLLM(numOfNode)
 
 		defer cleanupResources(workspaceObj)
 		time.Sleep(30 * time.Second)
@@ -117,9 +117,9 @@ var _ = Describe("Workspace Preset on vllm runtime", func() {
 		validateChatCompletionsEndpoint(workspaceObj)
 	})
 
-	It("should create a gemma-4-E2B-it workspace with preset public mode successfully", utils.GinkgoLabelFastCheck, func() {
+	It("should create a gpt-oss-20b workspace with preset public mode successfully", utils.GinkgoLabelFastCheck, func() {
 		numOfNode := 1
-		workspaceObj := createGemma4_E2BInstructWorkspaceWithPresetPublicModeAndVLLM(numOfNode)
+		workspaceObj := createGPTOss20BWorkspaceWithPresetPublicModeAndVLLM(numOfNode)
 
 		defer cleanupResources(workspaceObj)
 		time.Sleep(30 * time.Second)
@@ -1194,15 +1194,16 @@ func validateMultiRoleInferenceKVEvents(mriObj *kaitov1alpha1.MultiRoleInference
 	})
 }
 
-func createGemma4_E2BInstructWorkspaceWithPresetPublicModeAndVLLM(numOfNode int) *kaitov1beta1.Workspace {
+func createGemma4_12BInstructWorkspaceWithPresetPublicModeAndVLLM(numOfNode int) *kaitov1beta1.Workspace {
+	modelSecret := createAndValidateModelSecret()
 	workspaceObj := &kaitov1beta1.Workspace{}
 
-	By("Creating a workspace CR with Gemma 4 E2B preset public mode and vLLM", func() {
-		uniqueID := fmt.Sprint("preset-gemma-4-e2b-", rand.Intn(1000))
+	By("Creating a workspace CR with Gemma 4 12B preset public mode and vLLM", func() {
+		uniqueID := fmt.Sprint("preset-gemma-4-12b-", rand.Intn(1000))
 		workspaceObj = utils.GenerateInferenceWorkspaceManifestWithVLLM(uniqueID, namespaceName, "", numOfNode, "Standard_NV36ads_A10_v5",
 			&metav1.LabelSelector{
-				MatchLabels: map[string]string{"kaito-workspace": "public-preset-e2e-test-gemma-4-e2b-vllm"},
-			}, nil, PresetGemma4_E2BInstructModel, nil, nil, nil, "", "")
+				MatchLabels: map[string]string{"kaito-workspace": "public-preset-e2e-test-gemma-4-12b-vllm"},
+			}, nil, PresetGemma4_12BInstructModel, nil, nil, nil, modelSecret.Name, "")
 
 		workspaceObj.Annotations = utils.DisableModelStreaming(workspaceObj.Annotations)
 		createAndValidateWorkspace(workspaceObj)


### PR DESCRIPTION
**Reason for Change**:

Hugging Face gpt-oss repositories include duplicate weight representations under `original/`. The catalog generator counted both sets, causing model sizes and GPU requirements to be overestimated. This PR updates catalog generation tool to considers only root-level weight files and corrects gpt-oss models' weight size in model_catalog.yaml.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).
- [x] tested gpt-oss-120b on 1xA100 and gpt-oss-20b on 1xA10 

**Issue Fixed**:

Fixes #2308

**Notes for Reviewers**: