### PR TITLE
[POC] feat: allow custom storage class for downloaded model weights

### DIFF
--- a/api/v1beta1/labels.go
+++ b/api/v1beta1/labels.go
@@ -101,6 +101,12 @@ const (
 	// skipping the HuggingFace download entirely.
 	AnnotationUseLocalWeights = KAITOPrefix + "use-local-weights"
 
+	// AnnotationModelWeightsStorageClass overrides the StorageClass used for the
+	// downloaded model-weights PVC when the workspace pulls weights from HuggingFace
+	// at runtime. When unset, KAITO keeps its default behavior: prefer the local NVMe
+	// StorageClass when available and otherwise fall back to an emptyDir volume.
+	AnnotationModelWeightsStorageClass = KAITOPrefix + "model-weights-storage-class"
+
 	// LocalWeightsHostPathPrefix is the node directory under which baked model
 	// weights live, one subdirectory per preset (see GetLocalWeightsPath). Used
 	// when kaito.sh/use-local-weights is enabled.
@@ -194,6 +200,19 @@ func GetLocalWeightsPath(ws *Workspace) string {
 		return ""
 	}
 	return path.Join(LocalWeightsHostPathPrefix, segment)
+}
+
+// GetModelWeightsStorageClass returns the explicit StorageClass override for the
+// downloaded model-weights PVC, falling back to defaultStorageClass when the
+// workspace annotation is absent.
+func GetModelWeightsStorageClass(ws *Workspace, defaultStorageClass string) string {
+	if ws == nil {
+		return defaultStorageClass
+	}
+	if v := ws.Annotations[AnnotationModelWeightsStorageClass]; v != "" {
+		return v
+	}
+	return defaultStorageClass
 }
 
 // sanitizePresetName maps a preset model id to a single path segment: lowercased

--- a/api/v1beta1/workspace_validation.go
+++ b/api/v1beta1/workspace_validation.go
@@ -157,6 +157,12 @@ func (w *Workspace) validateAnnotations() (errs *apis.FieldError) {
 			))
 		}
 	}
+	if v, ok := annotations[AnnotationModelWeightsStorageClass]; ok && strings.TrimSpace(v) == "" {
+		errs = errs.Also(apis.ErrInvalidValue(
+			"must be a non-empty StorageClass name",
+			fmt.Sprintf("metadata.annotations[%s]", AnnotationModelWeightsStorageClass),
+		))
+	}
 	return errs
 }
 

--- a/api/v1beta1/workspace_validation_test.go
+++ b/api/v1beta1/workspace_validation_test.go
@@ -2037,6 +2037,16 @@ func TestWorkspaceValidatePerformanceModeAnnotation(t *testing.T) {
 			annotations: map[string]string{AnnotationUseLocalWeights: "yes"},
 			wantErr:     true,
 		},
+		{
+			name:        "model weights storage class is valid",
+			annotations: map[string]string{AnnotationModelWeightsStorageClass: "managed-csi"},
+			wantErr:     false,
+		},
+		{
+			name:        "empty model weights storage class is invalid",
+			annotations: map[string]string{AnnotationModelWeightsStorageClass: "   "},
+			wantErr:     true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/charts/kaito/workspace/templates/deployment.yaml
+++ b/charts/kaito/workspace/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
             {{- if .Values.defaultModelMirrorStorageClass }}
             - --default-model-mirror-storage-class={{ .Values.defaultModelMirrorStorageClass }}
             {{- end }}
+            {{- if .Values.defaultModelWeightsStorageClass }}
+            - --default-model-weights-storage-class={{ .Values.defaultModelWeightsStorageClass }}
+            {{- end }}
             {{- if .Values.defaultStreamingServiceAccount }}
             - --default-streaming-service-account={{ .Values.defaultStreamingServiceAccount }}
             {{- end }}

--- a/charts/kaito/workspace/values.yaml
+++ b/charts/kaito/workspace/values.yaml
@@ -48,6 +48,7 @@ featureGates:
   ModelStreaming: false
   enableBaseImageAutoUpgrade: false
 defaultModelMirrorStorageClass: ""
+defaultModelWeightsStorageClass: ""
 defaultStreamingServiceAccount: ""
 # CPU/memory request==limit for the ModelMirror download Job. Empty uses the controller
 # defaults (3 CPU / 8Gi). Lower for resource-constrained clusters (e.g. e2e on small nodes).

--- a/cmd/workspace/main.go
+++ b/cmd/workspace/main.go
@@ -61,6 +61,7 @@ import (
 	karpenterutils "github.com/kaito-project/kaito/pkg/utils/karpenter"
 	"github.com/kaito-project/kaito/pkg/version"
 	"github.com/kaito-project/kaito/pkg/workspace/controllers"
+	"github.com/kaito-project/kaito/pkg/workspace/inference"
 	"github.com/kaito-project/kaito/pkg/workspace/inference/modelstreaming"
 	"github.com/kaito-project/kaito/pkg/workspace/inference/modelstreaming/registry"
 	"github.com/kaito-project/kaito/pkg/workspace/webhooks"
@@ -114,6 +115,7 @@ func main() {
 	var kubeClientBurst int = 50
 	var printVersionAndExit bool
 	var defaultModelMirrorStorageClass string
+	var defaultModelWeightsStorageClass string
 	var defaultStreamingServiceAccount string
 	var modelMirrorDownloadCPU string
 	var modelMirrorDownloadMemory string
@@ -136,6 +138,7 @@ func main() {
 	flag.StringVar(&karpenterNodeClasses, "karpenter-node-classes", "", `JSON array of NodeClasses KAITO creates and lets Workspaces select, e.g. [{"name":"image-family-ubuntu","default":true,"spec":{...}}]. "spec" is passed through to the provider's NodeClass unchanged. Exactly one entry must be default. Required when node-provisioner=karpenter.`)
 	flag.BoolVar(&printVersionAndExit, "version", false, "Print version and exit.")
 	flag.StringVar(&defaultModelMirrorStorageClass, "default-model-mirror-storage-class", "", "StorageClass for ModelMirror PVCs.")
+	flag.StringVar(&defaultModelWeightsStorageClass, "default-model-weights-storage-class", "", "Default StorageClass for downloaded model-weights PVCs on the classic HuggingFace download path.")
 	flag.StringVar(&defaultStreamingServiceAccount, "default-streaming-service-account", "", "Default ServiceAccount for streaming inference pods.")
 	flag.StringVar(&modelMirrorDownloadCPU, "model-mirror-download-cpu", "", "CPU request==limit for the ModelMirror download Job container. Empty uses the built-in default (3).")
 	flag.StringVar(&modelMirrorDownloadMemory, "model-mirror-download-memory", "", "Memory request==limit for the ModelMirror download Job container. Empty uses the built-in default (8Gi).")
@@ -284,6 +287,9 @@ func main() {
 		klog.ErrorS(err, "failed to start node provisioner")
 		exitWithErrorFunc()
 	}
+
+	// Set classic download-path defaults once at startup.
+	inference.DownloadedWeightsDefaults.StorageClass = defaultModelWeightsStorageClass
 
 	// Set streaming defaults once at startup (read by the modelstreaming package via StreamingDefaults).
 	if featuregates.FeatureGates[consts.FeatureFlagModelStreaming] {

--- a/pkg/workspace/inference/preset_inferences.go
+++ b/pkg/workspace/inference/preset_inferences.go
@@ -67,6 +67,12 @@ const (
 )
 
 var (
+	// DownloadedWeightsDefaults holds cluster-wide defaults for the classic
+	// download-at-runtime path (non-streaming, non-local-hostpath).
+	DownloadedWeightsDefaults = struct {
+		StorageClass string
+	}{}
+
 	containerPorts = []corev1.ContainerPort{
 		{
 			Name:          "http",
@@ -150,12 +156,10 @@ func GetInferenceImageInfo(ctx context.Context, workspaceObj *v1beta1.Workspace)
 }
 
 // GenerateModelFileCacheVolume generates a volume for caching model files.
-// These files would be stored in the local pv and its lifetime is tied to the pod.
-// Use NVMe for storage acceleration if it's available.
-//
-// notes: no capacity check here because NVMe is typically a TiB level storage,
-// which is sufficient for almost all models. check it if this assumption is not true.
-func GenerateModelWeightsCacheVolume(ctx context.Context, workspaceObj *v1beta1.Workspace, model pkgmodel.Model) corev1.PersistentVolumeClaim {
+// These files are stored in a PVC whose lifetime is tied to the pod. The
+// caller resolves the StorageClass: explicit workspace/controller override wins;
+// otherwise KAITO falls back to the local NVMe StorageClass when available.
+func GenerateModelWeightsCacheVolume(ctx context.Context, workspaceObj *v1beta1.Workspace, model pkgmodel.Model, storageClassName string) corev1.PersistentVolumeClaim {
 	return corev1.PersistentVolumeClaim{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "model-weights-volume",
@@ -165,7 +169,7 @@ func GenerateModelWeightsCacheVolume(ctx context.Context, workspaceObj *v1beta1.
 		},
 		Spec: corev1.PersistentVolumeClaimSpec{
 			AccessModes:      []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce},
-			StorageClassName: &consts.LocalNVMeStorageClass,
+			StorageClassName: ptr.To(storageClassName),
 			Resources: corev1.VolumeResourceRequirements{
 				Requests: corev1.ResourceList{
 					// place model files in this volume
@@ -254,8 +258,12 @@ func GeneratePresetInference(ctx context.Context, workspaceObj *v1beta1.Workspac
 	// are mounted via hostPath (both handled in GenerateInferencePodSpec), so
 	// neither needs the default download/cache weights volume.
 	if shouldDownloadWeightsFromHF {
-		if checkIfNVMeAvailable(ctx, gpuConfig, kubeClient) {
-			ssOpts = append(ssOpts, manifests.AddStatefulSetVolumeClaimTemplates(GenerateModelWeightsCacheVolume(ctx, workspaceObj, model)))
+		weightsStorageClass, usePVC, resolveErr := resolveDownloadedWeightsStorageClass(ctx, workspaceObj, gpuConfig, kubeClient)
+		if resolveErr != nil {
+			return nil, resolveErr
+		}
+		if usePVC {
+			ssOpts = append(ssOpts, manifests.AddStatefulSetVolumeClaimTemplates(GenerateModelWeightsCacheVolume(ctx, workspaceObj, model, weightsStorageClass)))
 		} else {
 			podOpts = append(podOpts, SetDefaultModelWeightsVolume)
 		}
@@ -351,6 +359,21 @@ func checkIfNVMeAvailable(ctx context.Context, gpuConfig *sku.GPUConfig, kubeCli
 		klog.ErrorS(err, "Failed to check for NVMe storage class. Assuming it's available.")
 	}
 	return true
+}
+
+func resolveDownloadedWeightsStorageClass(ctx context.Context, workspaceObj *v1beta1.Workspace, gpuConfig *sku.GPUConfig, kubeClient client.Client) (string, bool, error) {
+	if storageClass := v1beta1.GetModelWeightsStorageClass(workspaceObj, DownloadedWeightsDefaults.StorageClass); storageClass != "" {
+		sc := &storagev1.StorageClass{}
+		if err := kubeClient.Get(ctx, client.ObjectKey{Name: storageClass}, sc); err != nil {
+			return "", false, fmt.Errorf("downloaded model weights storage class %q not found: %w", storageClass, err)
+		}
+		return storageClass, true, nil
+	}
+
+	if checkIfNVMeAvailable(ctx, gpuConfig, kubeClient) {
+		return consts.LocalNVMeStorageClass, true, nil
+	}
+	return "", false, nil
 }
 
 // getDistributedInferenceProbe returns a container probe configuration for the distributed inference workload.

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -1720,6 +1720,133 @@ func TestGeneratePresetInferenceNodeImageWeights(t *testing.T) {
 	}
 }
 
+func TestResolveDownloadedWeightsStorageClass(t *testing.T) {
+	workspace := test.MockWorkspaceWithPresetVLLM.DeepCopy()
+
+	t.Run("workspace annotation overrides controller default", func(t *testing.T) {
+		prev := DownloadedWeightsDefaults.StorageClass
+		DownloadedWeightsDefaults.StorageClass = "managed-csi"
+		defer func() { DownloadedWeightsDefaults.StorageClass = prev }()
+
+		workspace := workspace.DeepCopy()
+		workspace.Annotations = map[string]string{v1beta1.AnnotationModelWeightsStorageClass: "fast-disk"}
+
+		mockClient := test.NewClient()
+		mockClient.CreateOrUpdateObjectInMap(&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "fast-disk"}})
+		mockClient.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
+
+		sc, usePVC, err := resolveDownloadedWeightsStorageClass(context.TODO(), workspace, &sku.GPUConfig{NVMeDiskEnabled: true}, mockClient)
+		if err != nil {
+			t.Fatalf("resolveDownloadedWeightsStorageClass returned error: %v", err)
+		}
+		if !usePVC || sc != "fast-disk" {
+			t.Fatalf("expected annotation override fast-disk with PVC=true, got sc=%q usePVC=%v", sc, usePVC)
+		}
+	})
+
+	t.Run("controller default is used when annotation is absent", func(t *testing.T) {
+		prev := DownloadedWeightsDefaults.StorageClass
+		DownloadedWeightsDefaults.StorageClass = "managed-csi"
+		defer func() { DownloadedWeightsDefaults.StorageClass = prev }()
+
+		workspace := workspace.DeepCopy()
+		workspace.Annotations = nil
+
+		mockClient := test.NewClient()
+		mockClient.CreateOrUpdateObjectInMap(&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "managed-csi"}})
+		mockClient.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
+
+		sc, usePVC, err := resolveDownloadedWeightsStorageClass(context.TODO(), workspace, &sku.GPUConfig{NVMeDiskEnabled: false}, mockClient)
+		if err != nil {
+			t.Fatalf("resolveDownloadedWeightsStorageClass returned error: %v", err)
+		}
+		if !usePVC || sc != "managed-csi" {
+			t.Fatalf("expected controller default managed-csi with PVC=true, got sc=%q usePVC=%v", sc, usePVC)
+		}
+	})
+
+	t.Run("missing configured storage class returns error", func(t *testing.T) {
+		prev := DownloadedWeightsDefaults.StorageClass
+		DownloadedWeightsDefaults.StorageClass = ""
+		defer func() { DownloadedWeightsDefaults.StorageClass = prev }()
+
+		workspace := workspace.DeepCopy()
+		workspace.Annotations = map[string]string{v1beta1.AnnotationModelWeightsStorageClass: "missing-sc"}
+
+		mockClient := test.NewClient()
+		mockClient.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(fmt.Errorf("not found"))
+
+		_, _, err := resolveDownloadedWeightsStorageClass(context.TODO(), workspace, &sku.GPUConfig{NVMeDiskEnabled: false}, mockClient)
+		if err == nil || !strings.Contains(err.Error(), "missing-sc") {
+			t.Fatalf("expected missing storage class error mentioning missing-sc, got %v", err)
+		}
+	})
+
+	t.Run("falls back to emptyDir when no override and no nvme", func(t *testing.T) {
+		prev := DownloadedWeightsDefaults.StorageClass
+		DownloadedWeightsDefaults.StorageClass = ""
+		defer func() { DownloadedWeightsDefaults.StorageClass = prev }()
+
+		workspace := workspace.DeepCopy()
+		workspace.Annotations = nil
+
+		mockClient := test.NewClient()
+		sc, usePVC, err := resolveDownloadedWeightsStorageClass(context.TODO(), workspace, &sku.GPUConfig{NVMeDiskEnabled: false}, mockClient)
+		if err != nil {
+			t.Fatalf("resolveDownloadedWeightsStorageClass returned error: %v", err)
+		}
+		if usePVC || sc != "" {
+			t.Fatalf("expected emptyDir fallback, got sc=%q usePVC=%v", sc, usePVC)
+		}
+	})
+}
+
+func TestGeneratePresetInferenceUsesConfiguredModelWeightsStorageClass(t *testing.T) {
+	t.Setenv("CLOUD_PROVIDER", consts.AzureCloudName)
+	t.Setenv("PRESET_REGISTRY_NAME", "test-registry")
+	t.Setenv("RELEASE_NAMESPACE", "kaito")
+	test.RegisterTestModel()
+
+	prev := DownloadedWeightsDefaults.StorageClass
+	DownloadedWeightsDefaults.StorageClass = "managed-csi"
+	defer func() { DownloadedWeightsDefaults.StorageClass = prev }()
+
+	mockClient := test.NewClient()
+	mockClient.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
+	mockClient.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
+	mockClient.CreateOrUpdateObjectInMap(&storagev1.StorageClass{ObjectMeta: metav1.ObjectMeta{Name: "managed-csi"}})
+
+	workspace := test.MockWorkspaceWithPresetVLLM.DeepCopy()
+	nodeCount := 1
+	workspace.Resource.Count = &nodeCount
+	workspace.Status.WorkerNodes = []string{"test-node-1"}
+	workspace.Status.TargetNodeCount = 1
+	workspace.Inference.Adapters = nil
+	workspace.Inference.Config = ""
+	workspace.Annotations = nil
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{Name: workspace.Name, Namespace: workspace.Namespace},
+		Spec:       corev1.ServiceSpec{ClusterIP: "10.0.0.1"},
+	}
+	mockClient.CreateOrUpdateObjectInMap(svc)
+
+	model := plugin.KaitoModelRegister.MustGet("test-model")
+	createdObject, err := GeneratePresetInference(context.TODO(), workspace, test.MockWorkspaceWithPresetHash, model, mockClient, nil)
+	if err != nil {
+		t.Fatalf("GeneratePresetInference returned error: %v", err)
+	}
+
+	ss := createdObject.(*appsv1.StatefulSet)
+	if len(ss.Spec.VolumeClaimTemplates) != 1 {
+		t.Fatalf("expected 1 volumeClaimTemplate, got %d", len(ss.Spec.VolumeClaimTemplates))
+	}
+	got := ss.Spec.VolumeClaimTemplates[0].Spec.StorageClassName
+	if got == nil || *got != "managed-csi" {
+		t.Fatalf("expected model-weights PVC StorageClass managed-csi, got %v", got)
+	}
+}
+
 // TestGeneratePresetInferenceCUDAToolkitProvisioner verifies that CUDA toolkit
 // provisioning is gated on models that require DeepGEMM: such a model gets a
 // cuda-toolkit-provisioner init container and a read-write hostPath at the


### PR DESCRIPTION
## Summary
- add a workspace annotation to override the StorageClass used by the classic HuggingFace download path for model weights
- add a controller flag / Helm value to set a cluster-wide default model-weights StorageClass
- preserve the current fallback behavior when no override is set: prefer local NVMe when available, otherwise use emptyDir

## API
- workspace annotation: `kaito.sh/model-weights-storage-class`
- controller flag: `--default-model-weights-storage-class`
- Helm value: `defaultModelWeightsStorageClass`

## Why
This makes it possible to place downloaded model weights on a non-NVMe PVC such as an Azure Disk StorageClass (for example `managed-csi`) instead of being limited to the local NVMe StorageClass or emptyDir fallback.

## Validation
- `git diff --check`
- added unit/integration-style tests for StorageClass resolution and StatefulSet PVC generation

## Notes
- explicit workspace annotation wins over the controller default
- if the configured StorageClass does not exist, inference generation now fails early with a clear error instead of silently falling back
- this change only affects the classic download-at-runtime path; ModelMirror / ModelStreaming behavior is unchanged
