### PR TITLE
fix: default Karpenter capacity to on-demand and add spot opt-in

### DIFF
--- a/api/v1alpha1/multiroleinference_validation.go
+++ b/api/v1alpha1/multiroleinference_validation.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/klog/v2"
 	"knative.dev/pkg/apis"
 
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
@@ -44,10 +45,12 @@ func (m *MultiRoleInference) Validate(ctx context.Context) (errs *apis.FieldErro
 	if base == nil {
 		klog.InfoS("Validate creation", "multiroleinference", fmt.Sprintf("%s/%s", m.Namespace, m.Name))
 		errs = errs.Also(m.validateCreate().ViaField("spec"))
+		errs = errs.Also(m.validateCapacityTypeAnnotation())
 	} else {
 		klog.InfoS("Validate update", "multiroleinference", fmt.Sprintf("%s/%s", m.Namespace, m.Name))
 		old := base.(*MultiRoleInference)
 		errs = errs.Also(m.validateUpdate(old).ViaField("spec"))
+		errs = errs.Also(m.validateCapacityTypeAnnotationUpdate(old))
 	}
 	return errs
 }
@@ -84,6 +87,39 @@ func (m *MultiRoleInference) validateUpdate(old *MultiRoleInference) (errs *apis
 	errs = errs.Also(m.validateRoles())
 
 	return errs
+}
+
+func (m *MultiRoleInference) validateCapacityTypeAnnotation() *apis.FieldError {
+	if !consts.IsKarpenterProvisioner() {
+		return nil
+	}
+	capacityType := m.GetAnnotations()[kaitov1beta1.AnnotationCapacityType]
+	if consts.IsSupportedKarpenterCapacityType(capacityType) {
+		return nil
+	}
+	return apis.ErrInvalidValue(
+		fmt.Sprintf("%q is not a supported capacity type; choose one of: %s, %s",
+			capacityType, consts.KarpenterCapacityTypeOnDemand, consts.KarpenterCapacityTypeSpot),
+		fmt.Sprintf("metadata.annotations[%s]", kaitov1beta1.AnnotationCapacityType),
+	)
+}
+
+func (m *MultiRoleInference) validateCapacityTypeAnnotationUpdate(old *MultiRoleInference) *apis.FieldError {
+	if !consts.IsKarpenterProvisioner() {
+		return nil
+	}
+	oldValue := old.GetAnnotations()[kaitov1beta1.AnnotationCapacityType]
+	newValue := m.GetAnnotations()[kaitov1beta1.AnnotationCapacityType]
+	if oldValue == newValue {
+		return nil
+	}
+	if !consts.IsSupportedKarpenterCapacityType(oldValue) {
+		return m.validateCapacityTypeAnnotation()
+	}
+	return apis.ErrGeneric(
+		fmt.Sprintf("annotation %s is immutable after creation", kaitov1beta1.AnnotationCapacityType),
+		fmt.Sprintf("metadata.annotations[%s]", kaitov1beta1.AnnotationCapacityType),
+	)
 }
 
 func (m *MultiRoleInference) validateRoles() (errs *apis.FieldError) {

--- a/api/v1alpha1/multiroleinference_validation_test.go
+++ b/api/v1alpha1/multiroleinference_validation_test.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/pkg/apis"
 
+	kaitov1beta1 "github.com/kaito-project/kaito/api/v1beta1"
 	"github.com/kaito-project/kaito/pkg/utils/consts"
 )
 
@@ -271,4 +272,23 @@ func TestMultiRoleInference_validateUpdate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMultiRoleInferenceCapacityTypeAnnotation(t *testing.T) {
+	originalProvisioner := consts.ActiveNodeProvisioner
+	consts.ActiveNodeProvisioner = consts.NodeProvisionerKarpenter
+	t.Cleanup(func() { consts.ActiveNodeProvisioner = originalProvisioner })
+
+	makeMRI := func(value string) *MultiRoleInference {
+		return &MultiRoleInference{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{kaitov1beta1.AnnotationCapacityType: value},
+		}}
+	}
+
+	assert.Nil(t, makeMRI(consts.KarpenterCapacityTypeSpot).validateCapacityTypeAnnotation())
+	assert.NotNil(t, makeMRI("reserved").validateCapacityTypeAnnotation())
+	assert.NotNil(t, makeMRI(consts.KarpenterCapacityTypeSpot).
+		validateCapacityTypeAnnotationUpdate(makeMRI(consts.KarpenterCapacityTypeOnDemand)))
+	assert.Nil(t, makeMRI(consts.KarpenterCapacityTypeOnDemand).
+		validateCapacityTypeAnnotationUpdate(makeMRI("reserved")))
 }

--- a/api/v1beta1/inferenceset_validation.go
+++ b/api/v1beta1/inferenceset_validation.go
@@ -68,6 +68,7 @@ func (is *InferenceSet) validateCreate() (errs *apis.FieldError) {
 		errs = errs.Also(apis.ErrInvalidValue(*is.Spec.Replicas, "replicas", "must be non-negative"))
 	}
 	errs = errs.Also(is.validateInstanceType().ViaField("template"))
+	errs = errs.Also(is.validateCapacityTypeAnnotation().ViaField("template"))
 	errs = errs.Also(validateInferenceSetMaintenanceWindow(is.Spec.AutoUpgrade))
 	return errs
 }
@@ -79,7 +80,41 @@ func (is *InferenceSet) validateUpdate(old *InferenceSet) (errs *apis.FieldError
 	if !apiequality.Semantic.DeepEqual(is.Spec.Template.Resource.Partition, old.Spec.Template.Resource.Partition) {
 		errs = errs.Also(apis.ErrGeneric("field is immutable", "template", "resource", "partition"))
 	}
+	errs = errs.Also(is.validateCapacityTypeAnnotationUpdate(old))
 	return errs
+}
+
+func (is *InferenceSet) validateCapacityTypeAnnotation() *apis.FieldError {
+	if !consts.IsKarpenterProvisioner() {
+		return nil
+	}
+	capacityType := is.Spec.Template.Annotations[AnnotationCapacityType]
+	if consts.IsSupportedKarpenterCapacityType(capacityType) {
+		return nil
+	}
+	return apis.ErrInvalidValue(
+		fmt.Sprintf("%q is not a supported capacity type; choose one of: %s, %s",
+			capacityType, consts.KarpenterCapacityTypeOnDemand, consts.KarpenterCapacityTypeSpot),
+		fmt.Sprintf("metadata.annotations[%s]", AnnotationCapacityType),
+	)
+}
+
+func (is *InferenceSet) validateCapacityTypeAnnotationUpdate(old *InferenceSet) *apis.FieldError {
+	if !consts.IsKarpenterProvisioner() {
+		return nil
+	}
+	oldValue := old.Spec.Template.Annotations[AnnotationCapacityType]
+	newValue := is.Spec.Template.Annotations[AnnotationCapacityType]
+	if oldValue == newValue {
+		return nil
+	}
+	if !consts.IsSupportedKarpenterCapacityType(oldValue) {
+		return is.validateCapacityTypeAnnotation().ViaField("template")
+	}
+	return apis.ErrGeneric(
+		fmt.Sprintf("annotation %s is immutable after creation", AnnotationCapacityType),
+		"template", "metadata", "annotations", AnnotationCapacityType,
+	)
 }
 
 func validateInferenceSetMaintenanceWindow(autoUpgrade *AutoUpgradePolicy) (errs *apis.FieldError) {

--- a/api/v1beta1/inferenceset_validation_test.go
+++ b/api/v1beta1/inferenceset_validation_test.go
@@ -102,6 +102,27 @@ func TestInferenceSetMIGImmutable(t *testing.T) {
 	assert.Contains(t, errs.Error(), "field is immutable")
 }
 
+func TestInferenceSetCapacityTypeAnnotation(t *testing.T) {
+	originalProvisioner := consts.ActiveNodeProvisioner
+	consts.ActiveNodeProvisioner = consts.NodeProvisionerKarpenter
+	t.Cleanup(func() { consts.ActiveNodeProvisioner = originalProvisioner })
+
+	makeIS := func(value string) *InferenceSet {
+		return &InferenceSet{Spec: InferenceSetSpec{Template: InferenceSetTemplate{
+			ObjectMeta: metav1.ObjectMeta{
+				Annotations: map[string]string{AnnotationCapacityType: value},
+			},
+		}}}
+	}
+
+	assert.Nil(t, makeIS(consts.KarpenterCapacityTypeSpot).validateCapacityTypeAnnotation())
+	assert.NotNil(t, makeIS("reserved").validateCapacityTypeAnnotation())
+	assert.NotNil(t, makeIS(consts.KarpenterCapacityTypeSpot).
+		validateCapacityTypeAnnotationUpdate(makeIS(consts.KarpenterCapacityTypeOnDemand)))
+	assert.Nil(t, makeIS(consts.KarpenterCapacityTypeOnDemand).
+		validateCapacityTypeAnnotationUpdate(makeIS("reserved")))
+}
+
 func TestInferenceSetAcceleratorImmutable(t *testing.T) {
 	makeIS := func(count *int) *InferenceSet {
 		var p *PartitionSpec

--- a/api/v1beta1/labels.go
+++ b/api/v1beta1/labels.go
@@ -66,6 +66,10 @@ const (
 	// --karpenter-node-classes flag. When unset, the default NodeClass is used.
 	AnnotationNodeClassName = KAITOPrefix + "node-class-name"
 
+	// AnnotationCapacityType selects on-demand or spot capacity for a Karpenter NodePool.
+	// When unset or empty, on-demand capacity is used.
+	AnnotationCapacityType = KAITOPrefix + "capacity-type"
+
 	// AnnotationDisableBenchmark disables the post-load throughput benchmark stage.
 	// The benchmark is enabled by default. Set to "true" on a Workspace to
 	// disable it; when absent or any other value, the benchmark runs.

--- a/api/v1beta1/workspace_validation.go
+++ b/api/v1beta1/workspace_validation.go
@@ -85,6 +85,7 @@ func (w *Workspace) Validate(ctx context.Context) (errs *apis.FieldError) {
 		if w.GetAnnotations()[AnnotationNodeClassName] != old.GetAnnotations()[AnnotationNodeClassName] {
 			errs = errs.Also(w.validateNodeClassNameAnnotation())
 		}
+		errs = errs.Also(w.validateCapacityTypeAnnotationUpdate(old))
 		if featuregates.FeatureGates[consts.FeatureFlagModelStreaming] {
 			errs = errs.Also(w.validateModelStreamingAnnotationImmutable(old))
 		}
@@ -105,6 +106,7 @@ func (w *Workspace) ValidateCreate(ctx context.Context) (errs *apis.FieldError) 
 	errs = errs.Also(w.validateCreate().ViaField("spec"))
 	errs = errs.Also(w.validateAnnotations())
 	errs = errs.Also(w.validateNodeClassNameAnnotation())
+	errs = errs.Also(w.validateCapacityTypeAnnotation())
 	if w.Inference != nil {
 		bypassResourceChecks := false
 		if w.GetAnnotations() != nil {
@@ -231,6 +233,39 @@ func (w *Workspace) validateNodeClassNameAnnotation() *apis.FieldError {
 		)
 	}
 	return nil
+}
+
+func (w *Workspace) validateCapacityTypeAnnotation() *apis.FieldError {
+	if !consts.IsKarpenterProvisioner() {
+		return nil
+	}
+	capacityType := w.GetAnnotations()[AnnotationCapacityType]
+	if consts.IsSupportedKarpenterCapacityType(capacityType) {
+		return nil
+	}
+	return apis.ErrInvalidValue(
+		fmt.Sprintf("%q is not a supported capacity type; choose one of: %s, %s",
+			capacityType, consts.KarpenterCapacityTypeOnDemand, consts.KarpenterCapacityTypeSpot),
+		fmt.Sprintf("metadata.annotations[%s]", AnnotationCapacityType),
+	)
+}
+
+func (w *Workspace) validateCapacityTypeAnnotationUpdate(old *Workspace) *apis.FieldError {
+	if !consts.IsKarpenterProvisioner() {
+		return nil
+	}
+	oldValue := old.GetAnnotations()[AnnotationCapacityType]
+	newValue := w.GetAnnotations()[AnnotationCapacityType]
+	if oldValue == newValue {
+		return nil
+	}
+	if !consts.IsSupportedKarpenterCapacityType(oldValue) {
+		return w.validateCapacityTypeAnnotation()
+	}
+	return apis.ErrGeneric(
+		fmt.Sprintf("annotation %s is immutable after creation", AnnotationCapacityType),
+		fmt.Sprintf("metadata.annotations[%s]", AnnotationCapacityType),
+	)
 }
 
 func (w *Workspace) validateUpdate(old *Workspace) (errs *apis.FieldError) {

--- a/api/v1beta1/workspace_validation_test.go
+++ b/api/v1beta1/workspace_validation_test.go
@@ -2166,6 +2166,56 @@ func TestWorkspaceValidateNodeClassNameAnnotation(t *testing.T) {
 	})
 }
 
+func TestWorkspaceCapacityTypeAnnotation(t *testing.T) {
+	originalProvisioner := consts.ActiveNodeProvisioner
+	consts.ActiveNodeProvisioner = consts.NodeProvisionerKarpenter
+	t.Cleanup(func() { consts.ActiveNodeProvisioner = originalProvisioner })
+
+	for _, value := range []string{"", consts.KarpenterCapacityTypeOnDemand, consts.KarpenterCapacityTypeSpot} {
+		ws := &Workspace{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{AnnotationCapacityType: value},
+		}}
+		if errs := ws.validateCapacityTypeAnnotation(); errs != nil {
+			t.Errorf("validateCapacityTypeAnnotation() rejected %q: %v", value, errs)
+		}
+	}
+
+	invalid := &Workspace{ObjectMeta: metav1.ObjectMeta{
+		Annotations: map[string]string{AnnotationCapacityType: "reserved"},
+	}}
+	if errs := invalid.validateCapacityTypeAnnotation(); errs == nil {
+		t.Fatal("validateCapacityTypeAnnotation() accepted an unsupported value")
+	}
+
+	t.Run("valid value is immutable", func(t *testing.T) {
+		old := &Workspace{ObjectMeta: metav1.ObjectMeta{
+			Annotations: map[string]string{AnnotationCapacityType: consts.KarpenterCapacityTypeOnDemand},
+		}}
+		updated := old.DeepCopy()
+		updated.Annotations[AnnotationCapacityType] = consts.KarpenterCapacityTypeSpot
+		if errs := updated.validateCapacityTypeAnnotationUpdate(old); errs == nil {
+			t.Fatal("validateCapacityTypeAnnotationUpdate() allowed a valid capacity type to change")
+		}
+	})
+
+	t.Run("invalid legacy value can be repaired", func(t *testing.T) {
+		old := invalid.DeepCopy()
+		updated := old.DeepCopy()
+		updated.Annotations[AnnotationCapacityType] = consts.KarpenterCapacityTypeOnDemand
+		if errs := updated.validateCapacityTypeAnnotationUpdate(old); errs != nil {
+			t.Errorf("validateCapacityTypeAnnotationUpdate() rejected legacy repair: %v", errs)
+		}
+	})
+
+	t.Run("annotation is inert outside karpenter", func(t *testing.T) {
+		consts.ActiveNodeProvisioner = consts.NodeProvisionerBYO
+		defer func() { consts.ActiveNodeProvisioner = consts.NodeProvisionerKarpenter }()
+		if errs := invalid.validateCapacityTypeAnnotation(); errs != nil {
+			t.Errorf("validateCapacityTypeAnnotation() rejected inert annotation: %v", errs)
+		}
+	})
+}
+
 func TestWorkspaceValidateNAPFeatureGate(t *testing.T) {
 	RegisterValidationTestModels()
 

--- a/pkg/controllers/multiroleinference/controller_test.go
+++ b/pkg/controllers/multiroleinference/controller_test.go
@@ -38,8 +38,9 @@ func TestReconcileInferenceSetPropagatesAnnotations(t *testing.T) {
 			Name:      "mri-test",
 			Namespace: "default",
 			Annotations: map[string]string{
-				"kaito.sh/model-streaming":   "disabled",
-				"kaito.sh/disable-benchmark": "true",
+				"kaito.sh/model-streaming":          "disabled",
+				"kaito.sh/disable-benchmark":        "true",
+				kaitov1beta1.AnnotationCapacityType: "spot",
 			},
 		},
 		Spec: kaitov1alpha1.MultiRoleInferenceSpec{
@@ -63,4 +64,5 @@ func TestReconcileInferenceSetPropagatesAnnotations(t *testing.T) {
 
 	assert.Equal(t, "disabled", got.Spec.Template.Annotations["kaito.sh/model-streaming"])
 	assert.Equal(t, "true", got.Spec.Template.Annotations["kaito.sh/disable-benchmark"])
+	assert.Equal(t, "spot", got.Spec.Template.Annotations[kaitov1beta1.AnnotationCapacityType])
 }

--- a/pkg/inferenceset/inferenceset_controller.go
+++ b/pkg/inferenceset/inferenceset_controller.go
@@ -299,6 +299,25 @@ func (c *InferenceSetReconciler) selectWorkspacesToDelete(ctx context.Context, w
 	return toDelete, nil
 }
 
+func repairInvalidWorkspaceCapacityType(ws *kaitov1beta1.Workspace, desired string) bool {
+	if !consts.IsSupportedKarpenterCapacityType(desired) {
+		return false
+	}
+	current := ws.GetAnnotations()[kaitov1beta1.AnnotationCapacityType]
+	if consts.IsSupportedKarpenterCapacityType(current) {
+		return false
+	}
+	if desired == "" {
+		delete(ws.Annotations, kaitov1beta1.AnnotationCapacityType)
+		return true
+	}
+	if ws.Annotations == nil {
+		ws.Annotations = make(map[string]string)
+	}
+	ws.Annotations[kaitov1beta1.AnnotationCapacityType] = desired
+	return true
+}
+
 func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iObj *kaitov1beta1.InferenceSet) (reconcile.Result, error) {
 	if iObj == nil {
 		return reconcile.Result{}, nil
@@ -402,25 +421,28 @@ func (c *InferenceSetReconciler) addOrUpdateInferenceSet(ctx context.Context, iO
 	if mriParent, ok := iObj.Labels[kaitov1alpha1.LabelMultiRoleInferenceParent]; ok {
 		desiredLabels[kaitov1alpha1.LabelMultiRoleInferenceParent] = mriParent
 	}
-	if len(desiredLabels) > 0 {
-		for i := range wsList.Items {
-			ws := &wsList.Items[i]
-			needsUpdate := false
-			if ws.Labels == nil {
-				ws.Labels = make(map[string]string)
+	desiredCapacityType := iObj.Spec.Template.Annotations[kaitov1beta1.AnnotationCapacityType]
+	for i := range wsList.Items {
+		ws := &wsList.Items[i]
+		needsUpdate := false
+		if ws.Labels == nil {
+			ws.Labels = make(map[string]string)
+		}
+		for k, v := range desiredLabels {
+			if ws.Labels[k] != v {
+				ws.Labels[k] = v
+				needsUpdate = true
 			}
-			for k, v := range desiredLabels {
-				if ws.Labels[k] != v {
-					ws.Labels[k] = v
-					needsUpdate = true
-				}
-			}
-			if needsUpdate {
-				klog.InfoS("Reconciling workspace labels", "workspace", klog.KObj(ws))
-				if err := c.Client.Update(ctx, ws); err != nil {
-					klog.ErrorS(err, "failed to update workspace labels", "workspace", klog.KObj(ws))
-					return ctrl.Result{}, err
-				}
+		}
+		if consts.IsKarpenterProvisioner() &&
+			repairInvalidWorkspaceCapacityType(ws, desiredCapacityType) {
+			needsUpdate = true
+		}
+		if needsUpdate {
+			klog.InfoS("Reconciling workspace metadata", "workspace", klog.KObj(ws))
+			if err := c.Client.Update(ctx, ws); err != nil {
+				klog.ErrorS(err, "failed to update workspace metadata", "workspace", klog.KObj(ws))
+				return ctrl.Result{}, err
 			}
 		}
 	}

--- a/pkg/inferenceset/inferenceset_controller_test.go
+++ b/pkg/inferenceset/inferenceset_controller_test.go
@@ -44,6 +44,58 @@ import (
 	"github.com/kaito-project/kaito/pkg/workspace/manifests"
 )
 
+func TestRepairInvalidWorkspaceCapacityType(t *testing.T) {
+	tests := []struct {
+		name        string
+		current     string
+		desired     string
+		wantChanged bool
+		wantValue   string
+		wantPresent bool
+	}{
+		{
+			name:        "repair invalid value to spot",
+			current:     "reserved",
+			desired:     consts.KarpenterCapacityTypeSpot,
+			wantChanged: true,
+			wantValue:   consts.KarpenterCapacityTypeSpot,
+			wantPresent: true,
+		},
+		{
+			name:        "repair invalid value to default",
+			current:     "reserved",
+			wantChanged: true,
+		},
+		{
+			name:        "do not mutate valid value",
+			current:     consts.KarpenterCapacityTypeSpot,
+			desired:     consts.KarpenterCapacityTypeOnDemand,
+			wantValue:   consts.KarpenterCapacityTypeSpot,
+			wantPresent: true,
+		},
+		{
+			name:        "do not propagate invalid desired value",
+			current:     "reserved",
+			desired:     "unsupported",
+			wantValue:   "reserved",
+			wantPresent: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &v1beta1.Workspace{ObjectMeta: v1.ObjectMeta{Annotations: map[string]string{
+				v1beta1.AnnotationCapacityType: tt.current,
+			}}}
+			changed := repairInvalidWorkspaceCapacityType(ws, tt.desired)
+			assert.Equal(t, tt.wantChanged, changed)
+			value, present := ws.Annotations[v1beta1.AnnotationCapacityType]
+			assert.Equal(t, tt.wantPresent, present)
+			assert.Equal(t, tt.wantValue, value)
+		})
+	}
+}
+
 func TestInferenceSetSyncControllerRevision(t *testing.T) {
 	testcases := map[string]struct {
 		callMocks     func(c *test.MockClient)

--- a/pkg/nodeprovision/karpenter/nodepool.go
+++ b/pkg/nodeprovision/karpenter/nodepool.go
@@ -74,16 +74,38 @@ func isInferenceSetWorkspace(ws *kaitov1beta1.Workspace) bool {
 	return ok
 }
 
+func resolveCapacityType(ws *kaitov1beta1.Workspace) (string, error) {
+	capacityType := ws.Annotations[kaitov1beta1.AnnotationCapacityType]
+	if capacityType == "" {
+		return consts.KarpenterCapacityTypeOnDemand, nil
+	}
+	switch capacityType {
+	case consts.KarpenterCapacityTypeOnDemand, consts.KarpenterCapacityTypeSpot:
+		return capacityType, nil
+	default:
+		return "", fmt.Errorf("annotation %s=%q is invalid: supported values are %q and %q",
+			kaitov1beta1.AnnotationCapacityType,
+			capacityType,
+			consts.KarpenterCapacityTypeOnDemand,
+			consts.KarpenterCapacityTypeSpot)
+	}
+}
+
 // nodePoolRequirements builds the NodePool requirements list.
-// The instance-type requirement is always included. Provider-specific
+// The instance-type and capacity-type requirements are always included. Provider-specific
 // requirements (e.g. Azure placement scope) are added based on the
 // NodeClassConfig group.
-func nodePoolRequirements(ws *kaitov1beta1.Workspace, cfg NodeClassConfig) []karpenterv1.NodeSelectorRequirementWithMinValues {
+func nodePoolRequirements(ws *kaitov1beta1.Workspace, cfg NodeClassConfig, capacityType string) []karpenterv1.NodeSelectorRequirementWithMinValues {
 	reqs := []karpenterv1.NodeSelectorRequirementWithMinValues{
 		{
 			Key:      corev1.LabelInstanceTypeStable,
 			Operator: corev1.NodeSelectorOpIn,
 			Values:   []string{ws.Resource.InstanceType},
+		},
+		{
+			Key:      consts.KarpenterCapacityTypeLabel,
+			Operator: corev1.NodeSelectorOpIn,
+			Values:   []string{capacityType},
 		},
 	}
 	// Azure Karpenter requires regional placement scope.
@@ -98,7 +120,7 @@ func nodePoolRequirements(ws *kaitov1beta1.Workspace, cfg NodeClassConfig) []kar
 }
 
 // generateNodePool builds a karpenter NodePool manifest for the given Workspace.
-func generateNodePool(ws *kaitov1beta1.Workspace, cfg NodeClassConfig, nodeClassName string) *karpenterv1.NodePool {
+func generateNodePool(ws *kaitov1beta1.Workspace, cfg NodeClassConfig, nodeClassName, capacityType string) *karpenterv1.NodePool {
 	nodePoolName := NodePoolName(ws.Namespace, ws.Name)
 
 	// Drift budget: InferenceSet workspaces start with "0" (blocked),
@@ -156,7 +178,7 @@ func generateNodePool(ws *kaitov1beta1.Workspace, cfg NodeClassConfig, nodeClass
 						Kind:  cfg.Kind,
 						Name:  nodeClassName,
 					},
-					Requirements: nodePoolRequirements(ws, cfg),
+					Requirements: nodePoolRequirements(ws, cfg, capacityType),
 					Taints: []corev1.Taint{
 						{
 							Key:    consts.SKUString,

--- a/pkg/nodeprovision/karpenter/nodepool_test.go
+++ b/pkg/nodeprovision/karpenter/nodepool_test.go
@@ -162,6 +162,45 @@ func TestIsInferenceSetWorkspace_False(t *testing.T) {
 	assert.Assert(t, !isInferenceSetWorkspace(ws))
 }
 
+func TestResolveCapacityType(t *testing.T) {
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		want        string
+		wantErr     bool
+	}{
+		{name: "absent defaults to on-demand", want: consts.KarpenterCapacityTypeOnDemand},
+		{
+			name:        "empty defaults to on-demand",
+			annotations: map[string]string{kaitov1beta1.AnnotationCapacityType: ""},
+			want:        consts.KarpenterCapacityTypeOnDemand,
+		},
+		{
+			name:        "spot opt-in",
+			annotations: map[string]string{kaitov1beta1.AnnotationCapacityType: consts.KarpenterCapacityTypeSpot},
+			want:        consts.KarpenterCapacityTypeSpot,
+		},
+		{
+			name:        "invalid value",
+			annotations: map[string]string{kaitov1beta1.AnnotationCapacityType: "reserved"},
+			wantErr:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ws := &kaitov1beta1.Workspace{ObjectMeta: metav1.ObjectMeta{Annotations: tt.annotations}}
+			got, err := resolveCapacityType(ws)
+			if tt.wantErr {
+				assert.Assert(t, err != nil)
+				return
+			}
+			assert.NilError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
 // --- generateNodePool tests ---
 
 func newTestWorkspace(ns, name, instanceType string, targetNodeCount int32, labels, annotations map[string]string) *kaitov1beta1.Workspace {
@@ -189,7 +228,7 @@ func newTestWorkspace(ns, name, instanceType string, targetNodeCount int32, labe
 
 func TestGenerateNodePool_Standalone(t *testing.T) {
 	ws := newTestWorkspace("default", "llama-serve", "Standard_NC24ads_A100_v4", 2, nil, nil)
-	np := generateNodePool(ws, testConfig, testConfig.DefaultName)
+	np := generateNodePool(ws, testConfig, testConfig.DefaultName, consts.KarpenterCapacityTypeOnDemand)
 
 	// Name
 	assert.Equal(t, "default-llama-serve", np.Name)
@@ -212,12 +251,16 @@ func TestGenerateNodePool_Standalone(t *testing.T) {
 	assert.Equal(t, testConfig.DefaultName, ref.Name)
 
 	// Requirements
-	assert.Equal(t, 2, len(np.Spec.Template.Spec.Requirements))
+	assert.Equal(t, 3, len(np.Spec.Template.Spec.Requirements))
 	req := np.Spec.Template.Spec.Requirements[0]
 	assert.Equal(t, corev1.LabelInstanceTypeStable, req.Key)
 	assert.Equal(t, corev1.NodeSelectorOpIn, req.Operator)
 	assert.Equal(t, "Standard_NC24ads_A100_v4", req.Values[0])
-	placementReq := np.Spec.Template.Spec.Requirements[1]
+	capacityReq := np.Spec.Template.Spec.Requirements[1]
+	assert.Equal(t, consts.KarpenterCapacityTypeLabel, capacityReq.Key)
+	assert.Equal(t, corev1.NodeSelectorOpIn, capacityReq.Operator)
+	assert.Equal(t, consts.KarpenterCapacityTypeOnDemand, capacityReq.Values[0])
+	placementReq := np.Spec.Template.Spec.Requirements[2]
 	assert.Equal(t, consts.AzurePlacementScopeLabel, placementReq.Key)
 	assert.Equal(t, corev1.NodeSelectorOpIn, placementReq.Operator)
 	assert.Equal(t, consts.AzurePlacementRegional, placementReq.Values[0])
@@ -247,7 +290,7 @@ func TestGenerateNodePool_InferenceSet(t *testing.T) {
 		consts.WorkspaceCreatedByInferenceSetLabel: "my-infset",
 	}
 	ws := newTestWorkspace("prod", "llama-infset-0", "Standard_NC24ads_A100_v4", 1, labels, nil)
-	np := generateNodePool(ws, testConfig, testConfig.DefaultName)
+	np := generateNodePool(ws, testConfig, testConfig.DefaultName, consts.KarpenterCapacityTypeOnDemand)
 
 	// InferenceSet workspace gets budget "0"
 	assert.Equal(t, "0", np.Spec.Disruption.Budgets[0].Nodes)
@@ -267,7 +310,7 @@ func TestGenerateNodePool_WithAnnotation(t *testing.T) {
 	})
 	nodeClassName, err := resolveNodeClassName(ws, testConfig)
 	assert.NilError(t, err)
-	np := generateNodePool(ws, testConfig, nodeClassName)
+	np := generateNodePool(ws, testConfig, nodeClassName, consts.KarpenterCapacityTypeOnDemand)
 	assert.Equal(t, "image-family-azure-linux", np.Spec.Template.Spec.NodeClassRef.Name)
 }
 
@@ -278,14 +321,16 @@ func TestGenerateNodePool_CustomCloudConfig(t *testing.T) {
 		DefaultName: "default-ec2",
 	}
 	ws := newTestWorkspace("default", "ws1", "m5.xlarge", 1, nil, nil)
-	np := generateNodePool(ws, cfg, cfg.DefaultName)
+	np := generateNodePool(ws, cfg, cfg.DefaultName, consts.KarpenterCapacityTypeSpot)
 
 	ref := np.Spec.Template.Spec.NodeClassRef
 	assert.Equal(t, "karpenter.k8s.aws", ref.Group)
 	assert.Equal(t, "EC2NodeClass", ref.Kind)
 	assert.Equal(t, "default-ec2", ref.Name)
 
-	// Non-Azure providers should only have instance-type requirement (no placement scope).
-	assert.Equal(t, 1, len(np.Spec.Template.Spec.Requirements))
+	// Non-Azure providers should have portable instance and capacity requirements only.
+	assert.Equal(t, 2, len(np.Spec.Template.Spec.Requirements))
 	assert.Equal(t, corev1.LabelInstanceTypeStable, np.Spec.Template.Spec.Requirements[0].Key)
+	assert.Equal(t, consts.KarpenterCapacityTypeLabel, np.Spec.Template.Spec.Requirements[1].Key)
+	assert.Equal(t, consts.KarpenterCapacityTypeSpot, np.Spec.Template.Spec.Requirements[1].Values[0])
 }

--- a/pkg/nodeprovision/karpenter/provisioner.go
+++ b/pkg/nodeprovision/karpenter/provisioner.go
@@ -348,7 +348,11 @@ func (p *KarpenterProvisioner) ProvisionNodes(ctx context.Context, ws *kaitov1be
 		if !apierrors.IsNotFound(err) {
 			return fmt.Errorf("getting NodePool %q: %w", nodePoolName, err)
 		}
-		np := generateNodePool(ws, p.nodeClassConfig, nodeClassName)
+		capacityType, err := resolveCapacityType(ws)
+		if err != nil {
+			return err
+		}
+		np := generateNodePool(ws, p.nodeClassConfig, nodeClassName, capacityType)
 		np.Spec.Replicas = lo.ToPtr(desiredReplicas)
 		if err := p.client.Create(ctx, np); err != nil {
 			if apierrors.IsAlreadyExists(err) {

--- a/pkg/nodeprovision/karpenter/provisioner_test.go
+++ b/pkg/nodeprovision/karpenter/provisioner_test.go
@@ -285,6 +285,42 @@ func TestProvisionNodes_NoBYONodes_CreatesWithFullReplicas(t *testing.T) {
 	assert.Equal(t, int64(2), *np.Spec.Replicas)
 }
 
+func TestProvisionNodes_InvalidCapacityTypeFailsNewNodePool(t *testing.T) {
+	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
+	c := newFakeClient(nodeClass)
+	p := NewKarpenterProvisioner(c, testConfig)
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, map[string]string{
+		kaitov1beta1.AnnotationCapacityType: "reserved",
+	})
+
+	err := p.ProvisionNodes(context.Background(), ws)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), kaitov1beta1.AnnotationCapacityType)
+
+	np := &karpenterv1.NodePool{}
+	err = c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, np)
+	assert.True(t, apierrors.IsNotFound(err))
+}
+
+func TestProvisionNodes_DoesNotRepairExistingNodePoolCapacityType(t *testing.T) {
+	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
+	existingNP := &karpenterv1.NodePool{
+		ObjectMeta: metav1.ObjectMeta{Name: "default-ws1"},
+		Spec:       karpenterv1.NodePoolSpec{Replicas: lo.ToPtr(int64(1))},
+	}
+	c := newFakeClient(nodeClass, existingNP)
+	p := NewKarpenterProvisioner(c, testConfig)
+	ws := newTestWorkspace("default", "ws1", "Standard_NC24ads_A100_v4", 1, nil, map[string]string{
+		kaitov1beta1.AnnotationCapacityType: "reserved",
+	})
+
+	require.NoError(t, p.ProvisionNodes(context.Background(), ws))
+
+	np := &karpenterv1.NodePool{}
+	require.NoError(t, c.Get(context.Background(), client.ObjectKey{Name: "default-ws1"}, np))
+	assert.Len(t, np.Spec.Template.Spec.Requirements, 0)
+}
+
 func TestProvisionNodes_DeltaWithBYONodes(t *testing.T) {
 	nodeClass := makeNodeClassUnstructured("image-family-ubuntu")
 	byoNode := makeReadyNode("byo-1", "Standard_NC24ads_A100_v4", nil)

--- a/pkg/utils/consts/consts.go
+++ b/pkg/utils/consts/consts.go
@@ -98,6 +98,12 @@ func IsKarpenterProvisioner() bool {
 	return ActiveNodeProvisioner == NodeProvisionerKarpenter
 }
 
+// IsSupportedKarpenterCapacityType reports whether a Workspace annotation value
+// can be used as a Karpenter capacity-type requirement. Empty selects the default.
+func IsSupportedKarpenterCapacityType(value string) bool {
+	return value == "" || value == KarpenterCapacityTypeOnDemand || value == KarpenterCapacityTypeSpot
+}
+
 // allowedNodeClassNames is the sorted set of NodeClass names declared via
 // --karpenter-node-classes. Set once during startup in main.go; read by the Workspace
 // admission webhook to validate the node-class-name annotation. Unexported so callers
@@ -122,11 +128,14 @@ const (
 	NodeClassName                 = "default"
 
 	// Karpenter provisioner related consts
-	KarpenterLabelManagedBy    = "karpenter.kaito.sh/managed-by"
-	KarpenterManagedByValue    = "kaito"
-	AKSNodeClassUbuntuName     = "image-family-ubuntu"
-	AKSNodeClassAzureLinuxName = "image-family-azure-linux"
-	AKSNodeClassOSDiskSizeGB   = 300
+	KarpenterLabelManagedBy       = "karpenter.kaito.sh/managed-by"
+	KarpenterManagedByValue       = "kaito"
+	KarpenterCapacityTypeLabel    = "karpenter.sh/capacity-type"
+	KarpenterCapacityTypeOnDemand = "on-demand"
+	KarpenterCapacityTypeSpot     = "spot"
+	AKSNodeClassUbuntuName        = "image-family-ubuntu"
+	AKSNodeClassAzureLinuxName    = "image-family-azure-linux"
+	AKSNodeClassOSDiskSizeGB      = 300
 
 	// machine related consts
 	ProvisionerName           = "default"

--- a/pkg/utils/inferenceset/inferenceset_test.go
+++ b/pkg/utils/inferenceset/inferenceset_test.go
@@ -1012,6 +1012,22 @@ func TestListWorkspaces(t *testing.T) {
 	}
 }
 
+func TestNewWorkspaceForInferenceSetPropagatesCapacityType(t *testing.T) {
+	is := &kaitov1beta1.InferenceSet{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-is", Namespace: "default"},
+		Spec: kaitov1beta1.InferenceSetSpec{
+			Template: kaitov1beta1.InferenceSetTemplate{
+				ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+					kaitov1beta1.AnnotationCapacityType: consts.KarpenterCapacityTypeSpot,
+				}},
+			},
+		},
+	}
+
+	ws := NewWorkspaceForInferenceSet(is)
+	assert.Equal(t, consts.KarpenterCapacityTypeSpot, ws.Annotations[kaitov1beta1.AnnotationCapacityType])
+}
+
 func TestValidateWorkspaceForInferenceSet(t *testing.T) {
 	// BYO mode so an empty instanceType is valid and node-listing is skipped.
 	orig := featuregates.FeatureGates[consts.FeatureFlagDisableNodeAutoProvisioning]

--- a/website/docs/aws.md
+++ b/website/docs/aws.md
@@ -216,6 +216,23 @@ kubectl run -it --rm --restart=Never curl --image=curlimages/curl -- \
   -d '{"model":"phi-4-mini-instruct","messages":[{"role":"user","content":"Say hello in one short sentence."}],"max_tokens":40}'
 ```
 
+### Select a Capacity Type
+
+KAITO uses on-demand capacity for every new Karpenter `NodePool` by default. To opt a
+`Workspace` into Spot capacity, set the following annotation when creating it:
+
+```yaml
+metadata:
+  annotations:
+    kaito.sh/capacity-type: spot
+```
+
+The supported values are `on-demand` and `spot`. An absent or empty annotation means
+`on-demand`. The annotation is immutable after creation and does not modify existing
+NodePools. For an `InferenceSet`, place it under
+`spec.template.metadata.annotations`. For a `MultiRoleInference`, place it in the
+resource's top-level `metadata.annotations`; the selection applies to every role.
+
 ## Supported AWS GPU Instance Types
 
 KAITO supports various AWS GPU SKUs; see the [supported options here](https://github.com/kaito-project/kaito/blob/main/pkg/sku/aws_sku_handler.go).

--- a/website/docs/azure.md
+++ b/website/docs/azure.md
@@ -188,6 +188,23 @@ helm uninstall karpenter -n karpenter
 az identity delete --name azkarpenterIdentity -g $AZURE_RESOURCE_GROUP
 ```
 
+## Select a Capacity Type
+
+KAITO uses on-demand capacity for every new Karpenter `NodePool` by default. To opt a
+`Workspace` into Spot capacity, set the following annotation when creating it:
+
+```yaml
+metadata:
+  annotations:
+    kaito.sh/capacity-type: spot
+```
+
+The supported values are `on-demand` and `spot`. An absent or empty annotation means
+`on-demand`. The annotation is immutable after creation and does not modify existing
+NodePools. For an `InferenceSet`, place it under
+`spec.template.metadata.annotations`. For a `MultiRoleInference`, place it in the
+resource's top-level `metadata.annotations`; the selection applies to every role.
+
 ## Select a Node Class (Optional)
 
 When using Azure Karpenter, KAITO ships **two built-in `AKSNodeClass` definitions** and lets you choose which one a `Workspace` uses through an annotation.


### PR DESCRIPTION
**Reason for Change**:

New Karpenter NodePools previously inherited the provider default capacity type, which could place inference workloads on Spot nodes unexpectedly. Every generated NodePool now carries an explicit karpenter.sh/capacity-type requirement that defaults to on-demand.

Spot is opt-in via the kaito.sh/capacity-type annotation on a Workspace, InferenceSet pod template, or MultiRoleInference. Validation webhooks reject unsupported values and treat the annotation as immutable; existing NodePools are left untouched.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:

<img width="1087" height="70" alt="image" src="https://github.com/user-attachments/assets/084f08cc-ad4f-4988-99d3-d70e1693c8a0" />
