### PR TITLE
fix: prefetch SAS model assets before Ray workers start

### DIFF
--- a/pkg/workspace/inference/modelstreaming/azure/fetch_sas.py
+++ b/pkg/workspace/inference/modelstreaming/azure/fetch_sas.py
@@ -21,8 +21,9 @@ script resolves everything else at pod runtime using the workload identity:
   3. Derive the storage account and container from the blobUri.
   4. Mint a SAS at the mint endpoint with {blobUri[, assetId]} -> SAS token.
   5. List the container with the SAS to discover the safetensors subpath -> model streaming URI.
-  6. Write AZURE_STORAGE_SAS_TOKEN, AZURE_STORAGE_ACCOUNT_NAME, and STREAM_MODEL_URI to the
-     shared env file so the main container's entrypoint wrapper can source them.
+  6. Prefetch non-weight model files into the shared volume's vLLM asset cache.
+  7. Write credentials, STREAM_MODEL_URI, and cache settings to the shared env file
+     so the main container's entrypoint wrapper can source them.
 
 Required environment variables:
     STREAM_DATAREFS_URL       - model endpoint URL. For public: the datarefs (mint) URL. For byo:
@@ -32,18 +33,23 @@ Required environment variables:
     STREAM_ENV_FILE           - file path to write the env file (KEY=value lines)
 """
 
+import hashlib
 import json
 import os
-import re
+import shutil
 import sys
+import tempfile
 import urllib.parse
 import urllib.request
-import xml.sax.saxutils
+import xml.etree.ElementTree as ET
 
 from azure.identity import WorkloadIdentityCredential
 
 SOURCE_PUBLIC = "public"
 SOURCE_BYO = "byo"
+
+# Match vLLM ModelConfig.maybe_pull_model_tokenizer_for_runai.
+WEIGHT_SUFFIXES = (".pt", ".safetensors", ".bin", ".tensors", ".pth")
 
 # Token audience per source type (fixed Azure AAD resource identifiers).
 AUDIENCE_BY_TYPE = {
@@ -131,34 +137,92 @@ def account_and_container(blob_uri: str) -> "tuple[str, str]":
     return account, container
 
 
-def discover_subpath(sas_uri: str) -> str:
-    """List the container via the SAS and return the common directory prefix of the
-    safetensors files (empty string when they are at the container root).
-
-    Pages through the full listing (Azure returns at most 5000 blobs per page plus a
-    NextMarker) and unescapes XML entities in blob names so paths with '&' etc. are correct.
-    """
+def list_blobs(sas_uri: str) -> list[str]:
+    """List blob names across all pages, decoding XML entities in names and markers."""
     base = sas_uri + "&restype=container&comp=list&include=metadata"
-    names: list = []
+    names: list[str] = []
     marker = ""
     while True:
-        url = base + ("&marker=" + urllib.parse.quote(marker) if marker else "")
-        with urllib.request.urlopen(url, timeout=30) as resp:
-            body = resp.read().decode("utf-8", errors="replace")
-        names.extend(
-            xml.sax.saxutils.unescape(n)
-            for n in re.findall(r"<Name>(.*?)</Name>", body)
+        url = base + (
+            "&marker=" + urllib.parse.quote(marker, safe="") if marker else ""
         )
-        m = re.search(r"<NextMarker>(.*?)</NextMarker>", body)
-        marker = xml.sax.saxutils.unescape(m.group(1)) if m and m.group(1) else ""
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            page = ET.fromstring(resp.read())
+        for name in page.findall("./Blobs/Blob/Name"):
+            if not name.text:
+                raise ValueError("Blob listing contains an empty name")
+            names.append(name.text)
+        marker = page.findtext("NextMarker") or ""
         if not marker:
             break
+    return names
+
+
+def discover_subpath(names: list[str]) -> str:
+    """Return the common safetensors directory, or empty for the container root."""
     safetensors = [n for n in names if n.endswith(".safetensors")]
     if not safetensors:
         return ""
     if len(safetensors) == 1:
         return os.path.dirname(safetensors[0])
     return os.path.commonpath(safetensors)
+
+
+# TODO: Remove this prefetch workaround and its cache env exports once KAITO's
+# vLLM version includes the upstream fix for worker-side auxiliary-file downloads:
+# https://github.com/vllm-project/vllm/issues/50616
+def download_model_assets(
+    sas_uri: str, model_uri: str, subpath: str, names: list[str], cache_dir: str
+) -> None:
+    """Populate this pod's vLLM cache without downloading tensor files."""
+    model_hash = hashlib.sha256(model_uri.encode()).hexdigest()[:8]
+    destination = os.path.realpath(
+        os.path.join(cache_dir, "model_streamer", model_hash)
+    )
+    prefix = subpath + "/" if subpath else ""
+    source = urllib.parse.urlsplit(sas_uri)
+    downloaded = 0
+    for name in names:
+        if not name.startswith(prefix) or name.endswith(WEIGHT_SUFFIXES):
+            continue
+        relative_name = name[len(prefix) :]
+        if (
+            any(part in ("", ".", "..") for part in name.split("/"))
+            or "\\" in name
+            or "\x00" in name
+        ):
+            raise ValueError(f"Unsafe model asset path: {name!r}")
+        path = os.path.realpath(os.path.join(destination, relative_name))
+        if os.path.commonpath((destination, path)) != destination:
+            raise ValueError(f"Model asset escapes cache directory: {name!r}")
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        url = urllib.parse.urlunsplit(
+            (
+                source.scheme,
+                source.netloc,
+                source.path.rstrip("/") + "/" + urllib.parse.quote(name, safe="/"),
+                source.query,
+                "",
+            )
+        )
+        # Always re-download on init retries; never trust a partially populated cache.
+        with tempfile.TemporaryDirectory(dir=os.path.dirname(path)) as staging:
+            temporary_path = os.path.join(staging, "download")
+            with (
+                urllib.request.urlopen(url, timeout=30) as resp,
+                open(temporary_path, "wb") as output,
+            ):
+                shutil.copyfileobj(resp, output)
+                expected_size = resp.headers.get("Content-Length")
+                if expected_size is not None and output.tell() != int(expected_size):
+                    raise OSError(f"Incomplete model asset download: {name!r}")
+            os.replace(temporary_path, path)
+        downloaded += 1
+    if not downloaded:
+        raise ValueError(
+            "No non-weight model assets found at the streaming model prefix"
+        )
+    print(f"Downloaded {downloaded} model assets to {destination}")
 
 
 def write_env_file(out_path: str, values: dict) -> None:
@@ -214,8 +278,12 @@ def main() -> int:
     sas_token = sas_uri.split("?", 1)[1]
 
     # Discover the safetensors subpath and build the az:// model URI.
-    subpath = discover_subpath(sas_uri)
+    names = list_blobs(sas_uri)
+    subpath = discover_subpath(names)
     model_uri = f"az://{container}/{subpath}" if subpath else f"az://{container}"
+
+    cache_dir = os.path.join(os.path.dirname(os.path.abspath(out_path)), "assets")
+    download_model_assets(sas_uri, model_uri, subpath, names, cache_dir)
 
     write_env_file(
         out_path,
@@ -223,6 +291,8 @@ def main() -> int:
             "AZURE_STORAGE_SAS_TOKEN": sas_token,
             "AZURE_STORAGE_ACCOUNT_NAME": account,
             "STREAM_MODEL_URI": model_uri,
+            "VLLM_ASSETS_CACHE": cache_dir,
+            "VLLM_ASSETS_CACHE_MODEL_CLEAN": "0",
         },
     )
     print(f"SAS env file written to {out_path} (model_uri={model_uri})")

--- a/pkg/workspace/inference/modelstreaming/azure/fetch_sas_test.py
+++ b/pkg/workspace/inference/modelstreaming/azure/fetch_sas_test.py
@@ -11,19 +11,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""Unit tests for fetch_sas.py pure helpers.
+"""Unit tests for fetch_sas.py helpers and asset-prefetch startup.
 
 NOTE: this file is under a Go package dir, so CI pytest globs (which target presets/)
 do NOT run it automatically. Run manually during development:
-    python3 pkg/workspace/inference/modelstreaming/azure/fetch_sas_test.py
+    .venv/bin/python pkg/workspace/inference/modelstreaming/azure/fetch_sas_test.py
 It stubs azure.identity so azure-identity need not be installed locally.
 """
 
+import hashlib
 import importlib.util
+import io
 import os
+import subprocess
 import sys
 import tempfile
 import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
 
 # Stub azure.identity BEFORE loading fetch_sas (its module-level import would otherwise fail).
 _azure = types.ModuleType("azure")
@@ -167,7 +173,8 @@ def test_discover_subpath_paginates_and_unescapes():
     orig = fetch_sas.urllib.request.urlopen
     fetch_sas.urllib.request.urlopen = lambda url, timeout=30: _FakeResp(pages.pop(0))
     try:
-        got = fetch_sas.discover_subpath("https://blob/c?sig=x")
+        names = fetch_sas.list_blobs("https://blob/c?sig=x")
+        got = fetch_sas.discover_subpath(names)
     finally:
         fetch_sas.urllib.request.urlopen = orig
     # entity unescaped ('a&b') and the second page was fetched via the marker.
@@ -175,22 +182,14 @@ def test_discover_subpath_paginates_and_unescapes():
 
 
 def _assert_subpath(expected):
-    got = fetch_sas.discover_subpath("https://blob/c?sig=x")
+    got = fetch_sas.discover_subpath(fetch_sas.list_blobs("https://blob/c?sig=x"))
     assert got == expected, f"got {got!r} want {expected!r}"
 
 
-class _FakeResp:
-    def __init__(self, data):
-        self._data = data
-
-    def read(self):
-        return self._data.encode("utf-8")
-
-    def __enter__(self):
-        return self
-
-    def __exit__(self, *a):
-        return False
+class _FakeResp(io.BytesIO):
+    def __init__(self, data, headers=None):
+        super().__init__(data.encode("utf-8") if isinstance(data, str) else data)
+        self.headers = headers or {}
 
 
 def _with_stub_urlopen(xml, fn):
@@ -221,9 +220,281 @@ def test_write_env_file():
     assert "sv=1&sig=ab'\\''cd" in content, content
 
 
+class TestAssetPrefetch(unittest.TestCase):
+    def setUp(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        self.root = Path(temporary.name)
+        self.cache = self.root / "assets"
+        self.model_uri = "az://c/model"
+        self.sas_uri = "https://acct.blob.core.windows.net/c?sv=1&sig=a%2Bb"
+        self.destination = (
+            self.cache
+            / "model_streamer"
+            / hashlib.sha256(self.model_uri.encode()).hexdigest()[:8]
+        )
+
+    def download(self, names, model_uri=None, subpath="model"):
+        fetch_sas.download_model_assets(
+            self.sas_uri, model_uri or self.model_uri, subpath, names, str(self.cache)
+        )
+
+    def test_downloads_all_non_weight_assets_under_model_prefix(self):
+        assets = [
+            "config.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "preprocessor_config.json",
+            "tiktoken.model",
+            "tokenization_custom.py",
+            "merges.txt",
+            "vocab.txt",
+            "chat_template.jinja",
+            "templates/chat.jinja",
+            "model.safetensors.index.json",
+        ]
+        names = [f"model/{name}" for name in assets]
+        names += [
+            "model/pytorch_model.bin",
+            "model/consolidated.safetensors",
+            "model/weights.pt",
+            "model/weights.pth",
+            "model/weights.tensors",
+        ]
+        names += ["other/config.json", "model-other/config.json", "config.json"]
+        with patch.object(
+            fetch_sas.urllib.request,
+            "urlopen",
+            side_effect=lambda url, timeout: _FakeResp(b"asset"),
+        ) as request:
+            self.download(names)
+        self.assertEqual(request.call_count, len(assets))
+        for name in assets:
+            self.assertEqual((self.destination / name).read_bytes(), b"asset")
+        self.assertEqual(
+            sorted(
+                str(p.relative_to(self.destination))
+                for p in self.destination.rglob("*")
+                if p.is_file()
+            ),
+            sorted(assets),
+        )
+
+    def test_container_root_uses_exact_uri_hash(self):
+        model_uri = "az://c"
+        with patch.object(
+            fetch_sas.urllib.request, "urlopen", return_value=_FakeResp("{}")
+        ):
+            self.download(["config.json", "model.safetensors"], model_uri, subpath="")
+        destination = (
+            self.cache
+            / "model_streamer"
+            / hashlib.sha256(model_uri.encode()).hexdigest()[:8]
+        )
+        self.assertEqual((destination / "config.json").read_text(), "{}")
+
+    def test_blob_url_encodes_names_and_preserves_sas(self):
+        name = "tokenizer a&b#c?d%2F.json"
+        with patch.object(
+            fetch_sas.urllib.request, "urlopen", return_value=_FakeResp("{}")
+        ) as request:
+            self.download([f"model/{name}"])
+        request.assert_called_once_with(
+            "https://acct.blob.core.windows.net/c/model/"
+            "tokenizer%20a%26b%23c%3Fd%252F.json?sv=1&sig=a%2Bb",
+            timeout=30,
+        )
+        self.assertTrue((self.destination / name).is_file())
+
+    def test_rejects_unsafe_paths(self):
+        names = [
+            "model/../env",
+            "model/sub/../../env",
+            "model//config.json",
+            "model/./config.json",
+            "model/a\\b.json",
+            "model/config\x00.json",
+        ]
+        for name in names:
+            with (
+                self.subTest(name=name),
+                patch.object(fetch_sas.urllib.request, "urlopen") as request,
+                self.assertRaisesRegex(ValueError, "Unsafe model asset path"),
+            ):
+                self.download([name])
+            request.assert_not_called()
+
+    def test_rejects_symlink_outside_cache(self):
+        self.destination.mkdir(parents=True)
+        (self.destination / "outside").symlink_to(self.root, target_is_directory=True)
+        with (
+            patch.object(fetch_sas.urllib.request, "urlopen") as request,
+            self.assertRaisesRegex(ValueError, "escapes cache directory"),
+        ):
+            self.download(["model/outside/env"])
+        request.assert_not_called()
+
+    def test_failure_propagates_and_retry_redownloads(self):
+        class InterruptedResponse(_FakeResp):
+            def read(self, size=-1):
+                if self.tell():
+                    raise OSError("download interrupted")
+                return super().read(size)
+
+        names = ["model/config.json", "model/tokenizer.json"]
+        with (
+            patch.object(
+                fetch_sas.urllib.request,
+                "urlopen",
+                side_effect=[_FakeResp("old config"), InterruptedResponse("partial")],
+            ),
+            self.assertRaisesRegex(OSError, "download interrupted"),
+        ):
+            self.download(names)
+        self.assertEqual(
+            list(self.destination.iterdir()), [self.destination / "config.json"]
+        )
+        with patch.object(
+            fetch_sas.urllib.request,
+            "urlopen",
+            side_effect=[_FakeResp("new config"), _FakeResp("complete tokenizer")],
+        ) as request:
+            self.download(names)
+        self.assertEqual(request.call_count, 2)
+        self.assertEqual((self.destination / "config.json").read_text(), "new config")
+        self.assertEqual(
+            (self.destination / "tokenizer.json").read_text(), "complete tokenizer"
+        )
+
+    def test_truncated_response_is_not_published(self):
+        with (
+            patch.object(
+                fetch_sas.urllib.request,
+                "urlopen",
+                return_value=_FakeResp("partial", {"Content-Length": "100"}),
+            ),
+            self.assertRaisesRegex(OSError, "Incomplete model asset download"),
+        ):
+            self.download(["model/config.json"])
+        self.assertEqual(list(self.destination.iterdir()), [])
+
+    def test_rejects_missing_assets(self):
+        with (
+            patch.object(fetch_sas.urllib.request, "urlopen") as request,
+            self.assertRaisesRegex(ValueError, "No non-weight model assets"),
+        ):
+            self.download(["model/a.safetensors", "other/config.json"])
+        request.assert_not_called()
+
+    def test_listing_decodes_entities_and_paginates(self):
+        pages = [
+            _FakeResp(
+                "<EnumerationResults><Blobs><Blob>"
+                "<Name>model/chat&#32;template.jinja</Name>"
+                "</Blob></Blobs><NextMarker>a+/=&amp;b</NextMarker></EnumerationResults>"
+            ),
+            _FakeResp(
+                "<EnumerationResults><Blobs><Blob>"
+                "<Name>model/a.safetensors</Name>"
+                "</Blob></Blobs></EnumerationResults>"
+            ),
+        ]
+        with patch.object(
+            fetch_sas.urllib.request, "urlopen", side_effect=pages
+        ) as request:
+            names = fetch_sas.list_blobs(self.sas_uri)
+        self.assertEqual(names, ["model/chat template.jinja", "model/a.safetensors"])
+        self.assertTrue(request.call_args.args[0].endswith("&marker=a%2B%2F%3D%26b"))
+        self.assertEqual(fetch_sas.discover_subpath(names), "model")
+
+    def run_main(self):
+        env_file = self.root / "env"
+        env = {
+            "STREAM_DATAREFS_URL": "https://a/models/m/versions/1",
+            "STREAM_IDENTITY_CLIENT_ID": "test-client",
+            "STREAM_SOURCE_TYPE": fetch_sas.SOURCE_BYO,
+            "STREAM_ENV_FILE": str(env_file),
+        }
+        responses = [
+            {"blobReference": {"blobUri": "https://acct.blob.core.windows.net/c"}},
+            {"blobReference": {"credential": {"sasUri": self.sas_uri}}},
+        ]
+        with (
+            patch.dict(os.environ, env),
+            patch.object(fetch_sas, "WorkloadIdentityCredential"),
+            patch.object(fetch_sas, "http_json", side_effect=responses),
+        ):
+            self.assertEqual(fetch_sas.main(), 0)
+        return env_file
+
+    def test_main_prefetches_before_exporting_cache_and_credentials(self):
+        listing = (
+            "<EnumerationResults><Blobs>"
+            "<Blob><Name>model/a.safetensors</Name></Blob>"
+            "<Blob><Name>model/config.json</Name></Blob>"
+            "<Blob><Name>model/tokenizer.json</Name></Blob>"
+            "</Blobs></EnumerationResults>"
+        )
+
+        def respond(url, timeout):
+            self.assertFalse((self.root / "env").exists())
+            if "comp=list" in url:
+                return _FakeResp(listing)
+            return _FakeResp("{}")
+
+        with patch.object(
+            fetch_sas.urllib.request, "urlopen", side_effect=respond
+        ) as request:
+            env_file = self.run_main()
+        self.assertEqual(request.call_count, 3)  # one listing, two non-weight files
+        self.assertTrue((self.destination / "config.json").is_file())
+        self.assertTrue((self.destination / "tokenizer.json").is_file())
+        wrapper = (
+            Path(_here).parents[4]
+            / "presets/workspace/inference/vllm/export_sas_token_for_streaming.sh"
+        )
+        # The real wrapper must export the cache settings to either Ray launch branch.
+        result = subprocess.run(
+            [
+                "/bin/sh",
+                str(wrapper),
+                "/bin/sh",
+                "-c",
+                'printf "%s\\n" "$STREAM_MODEL_URI" "$VLLM_ASSETS_CACHE" '
+                '"$VLLM_ASSETS_CACHE_MODEL_CLEAN" "$AZURE_STORAGE_SAS_TOKEN"',
+            ],
+            env={**os.environ, "STREAM_ENV_FILE": str(env_file)},
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        self.assertEqual(
+            result.stdout.splitlines(),
+            [self.model_uri, str(self.cache), "0", "sv=1&sig=a%2Bb"],
+        )
+
+    def test_main_does_not_publish_env_on_download_failure(self):
+        with (
+            patch.object(
+                fetch_sas,
+                "list_blobs",
+                return_value=["model/a.safetensors", "model/config.json"],
+            ),
+            patch.object(
+                fetch_sas.urllib.request, "urlopen", side_effect=OSError("offline")
+            ),
+            self.assertRaisesRegex(OSError, "offline"),
+        ):
+            self.run_main()
+        self.assertFalse((self.root / "env").exists())
+
+
 if __name__ == "__main__":
     for name, fn in sorted(globals().items()):
         if name.startswith("test_") and callable(fn):
             fn()
             print(f"PASS {name}")
-    print("all fetch_sas helper tests passed")
+    result = unittest.TextTestRunner().run(
+        unittest.defaultTestLoader.loadTestsFromTestCase(TestAssetPrefetch)
+    )
+    sys.exit(0 if result.wasSuccessful() else 1)


### PR DESCRIPTION


**Reason for Change**:

Run:ai downloads non-weight model files only where vLLM constructs its model configuration. It then distributes the resolved node-local path to remote workers without populating their filesystems. Multi-node models that initialize tokenizers, multimodal processors, or custom code on workers therefore fail at startup, even when requests are text-only. See https://github.com/vllm-project/vllm/issues/50616.

KAITO runs inference_api.py only on the leader, so downloading there would leave the same gap. Instead, extend the SAS-fetch init container, which runs in every pod before the Ray head or workers start, to download the complete non-weight asset set under the resolved model prefix.

Reuse the existing pod-local shared volume and populate vLLM's model_streamer cache using the SHA256-derived directory for the exact remote model URI. Export VLLM_ASSETS_CACHE and disable cache cleanup through the existing SAS env-file wrapper. Every worker consequently starts with the assets at the path it receives from the driver. Keep the remote model URI unchanged and exclude tensor files so Run:ai weight streaming retains its startup benefits.

Reuse the paginated blob listing, preserve SAS query encoding, reject unsafe destination paths, and publish each file only after its download completes. Failed or truncated downloads stop initialization; retries re-download files instead of trusting a partial cache. Add regression coverage for filtering, cache paths, pagination, failed downloads and retries, and the actual entrypoint env handoff.

This is a temporary SAS-path workaround, not a vLLM modification or a shared-PVC requirement. Separate remote tokenizers and draft models are out of scope. Leave a TODO to remove the prefetch and cache exports once KAITO ships the upstream fix.

Validation: .venv/bin/python pkg/workspace/inference/modelstreaming/azure/fetch_sas_test.py (16 existing helper tests and 11 prefetch tests passed); targeted SAS provider and pod-wiring Go tests passed; ruff check and format checks passed. A live multi-node deployment was not exercised.

AI assistance was used to implement this change.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**: