### PR TITLE
fix: stop overriding vLLM's dynamic gpu-memory-utilization default

### DIFF
--- a/pkg/model/interface.go
+++ b/pkg/model/interface.go
@@ -362,29 +362,60 @@ func (p *PresetParam) buildHuggingfaceInferenceCommand() []string {
 	return utils.ShellCmd(torchCommand + " " + modelCommand)
 }
 
-// defaultGPUMemoryUtilization is the --gpu-memory-utilization value KAITO passes
-// to vLLM unless the GPU model overrides it in gpuMemoryUtilizationByGPUModel.
+// defaultGPUMemoryUtilization is the --gpu-memory-utilization value the node
+// estimator plans capacity with for GPU models that have no safety cap in
+// gpuMemoryUtilizationByGPUModel. It is not passed to vLLM: the launcher's own
+// free-memory-based default (get_max_gpu_memory_utilization() in
+// inference_api.py) governs those runs, so this is a conservative planning
+// assumption only, sized below what the runtime default typically resolves to.
 const defaultGPUMemoryUtilization = "0.92"
 
 // gpuMemoryUtilizationByGPUModel overrides --gpu-memory-utilization for specific
 // GPU models that need extra headroom. Keyed by the exact sku.GPUConfig.GPUModel
-// string (as defined in the SKU table, e.g. "NVIDIA A10").
+// string (as defined in the SKU table, e.g. "NVIDIA A10"). Unlike
+// defaultGPUMemoryUtilization, these values ARE passed to vLLM: they are hard
+// safety caps that must win over the runtime's free-memory-based default.
 var gpuMemoryUtilizationByGPUModel = map[string]string{
 	// On the 24 GiB A10, vLLM's KV-pool profiling under-counts the
 	// prompt-logprobs warmup + CUDA-graph-capture transients for some models
-	// (e.g. gemma-4's huge-vocab final_logit_softcapping copy), so the default
-	// 0.84 leaves too little headroom and OOMs. 0.82 leaves enough slack.
+	// (e.g. gemma-4's huge-vocab final_logit_softcapping copy), so the runtime
+	// default leaves too little headroom and OOMs. 0.82 leaves enough slack.
 	"NVIDIA A10": "0.82",
 }
 
-// ResolveGPUMemoryUtilization returns the --gpu-memory-utilization vLLM should be
-// launched with for the given GPU. A per-GPU-model safety cap (clamps down for
-// tight-VRAM GPUs) wins over the default.
+// ResolveGPUMemoryUtilization returns the --gpu-memory-utilization value the
+// node estimator should plan capacity with for the given GPU. A per-GPU-model
+// safety cap (clamps down for tight-VRAM GPUs) wins over the default planning
+// assumption. This does not necessarily match what vLLM is launched with: see
+// gpuMemoryUtilizationOverride.
 func ResolveGPUMemoryUtilization(gpuModel string) string {
 	if util, ok := gpuMemoryUtilizationByGPUModel[gpuModel]; ok {
 		return util
 	}
 	return defaultGPUMemoryUtilization
+}
+
+// gpuMemoryUtilizationOverride returns the --gpu-memory-utilization value that
+// must be forced on the vLLM command line for the given GPU, if any. Full GPUs
+// with no per-model safety cap get no override, leaving vLLM's own
+// free-memory-based default (get_max_gpu_memory_utilization() in
+// inference_api.py) in effect. MIG slices always get a forced value: they have
+// no GPUModel to key a safety cap off (see GetMIGGPUConfig), and small
+// profiles (e.g. 1g.5gb) can resolve a runtime default below what the node
+// estimator assumed when it planned capacity, so the estimator's planning
+// value must also be what vLLM actually runs with.
+func gpuMemoryUtilizationOverride(gpuConfig *sku.GPUConfig) (string, bool) {
+	gpuModel := ""
+	if gpuConfig != nil {
+		gpuModel = gpuConfig.GPUModel
+	}
+	if util, ok := gpuMemoryUtilizationByGPUModel[gpuModel]; ok {
+		return util, true
+	}
+	if gpuConfig != nil && gpuConfig.IsMIG {
+		return ResolveGPUMemoryUtilization(gpuModel), true
+	}
+	return "", false
 }
 
 func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
@@ -413,11 +444,12 @@ func (p *PresetParam) buildVLLMInferenceCommand(rc RuntimeContext) []string {
 		p.VLLM.ModelRunParams["max-model-len"] = strconv.Itoa(rc.MaxModelLen)
 	}
 
-	gpuModel := ""
-	if rc.GPUConfig != nil {
-		gpuModel = rc.GPUConfig.GPUModel
+	// Only force a value for GPUs with a known safety cap or MIG slices;
+	// otherwise let vLLM's free-memory-based default apply
+	// (get_max_gpu_memory_utilization() in inference_api.py).
+	if util, ok := gpuMemoryUtilizationOverride(rc.GPUConfig); ok {
+		p.VLLM.ModelRunParams["gpu-memory-utilization"] = util
 	}
-	p.VLLM.ModelRunParams["gpu-memory-utilization"] = ResolveGPUMemoryUtilization(gpuModel)
 
 	// Enable KV cache events by default so in-cluster subscribers can consume
 	// BlockStored / BlockRemoved / AllBlocksCleared events over ZMQ on the port

--- a/pkg/model/interface_test.go
+++ b/pkg/model/interface_test.go
@@ -257,7 +257,22 @@ func TestGetInferenceCommandVLLMGpuMemoryUtilization(t *testing.T) {
 	require.Len(t, cmdA10, 3)
 	assert.Contains(t, cmdA10[2], "--gpu-memory-utilization=0.82")
 
-	// A100 and nil GPUConfig fall back to the default 0.92.
+	// MIG slices have no GPUModel to key a safety cap off, so the controller
+	// must keep forcing the estimator's planning value (0.92): small profiles
+	// (e.g. 1g.5gb) can resolve a runtime default below what the estimator
+	// assumed was available, which would under-provision the node.
+	cmdMIG := p.GetInferenceCommand(RuntimeContext{
+		RuntimeName: RuntimeNameVLLM,
+		SKUNumGPUs:  1,
+		NumNodes:    1,
+		GPUConfig:   &sku.GPUConfig{IsMIG: true},
+	})
+	require.Len(t, cmdMIG, 3)
+	assert.Contains(t, cmdMIG[2], "--gpu-memory-utilization=0.92")
+
+	// A100 and nil GPUConfig have no safety cap: the controller must not inject
+	// --gpu-memory-utilization at all, leaving vLLM's own free-memory-based
+	// default in effect.
 	p2 := &PresetParam{RuntimeParam: RuntimeParam{VLLM: VLLMParam{BaseCommand: "vllm serve", ModelRunParams: map[string]string{}}}}
 	cmdA100 := p2.GetInferenceCommand(RuntimeContext{
 		RuntimeName: RuntimeNameVLLM,
@@ -266,7 +281,7 @@ func TestGetInferenceCommandVLLMGpuMemoryUtilization(t *testing.T) {
 		GPUConfig:   &sku.GPUConfig{GPUModel: "NVIDIA A100"},
 	})
 	require.Len(t, cmdA100, 3)
-	assert.Contains(t, cmdA100[2], "--gpu-memory-utilization=0.92")
+	assert.NotContains(t, cmdA100[2], "--gpu-memory-utilization")
 
 	p3 := &PresetParam{RuntimeParam: RuntimeParam{VLLM: VLLMParam{BaseCommand: "vllm serve", ModelRunParams: map[string]string{}}}}
 	cmdNil := p3.GetInferenceCommand(RuntimeContext{
@@ -275,7 +290,20 @@ func TestGetInferenceCommandVLLMGpuMemoryUtilization(t *testing.T) {
 		NumNodes:    1,
 	})
 	require.Len(t, cmdNil, 3)
-	assert.Contains(t, cmdNil[2], "--gpu-memory-utilization=0.92")
+	assert.NotContains(t, cmdNil[2], "--gpu-memory-utilization")
+
+	// An explicit user override (e.g. via preset ModelRunParams) is preserved.
+	p4 := &PresetParam{RuntimeParam: RuntimeParam{VLLM: VLLMParam{BaseCommand: "vllm serve", ModelRunParams: map[string]string{
+		"gpu-memory-utilization": "0.75",
+	}}}}
+	cmdOverride := p4.GetInferenceCommand(RuntimeContext{
+		RuntimeName: RuntimeNameVLLM,
+		SKUNumGPUs:  1,
+		NumNodes:    1,
+		GPUConfig:   &sku.GPUConfig{GPUModel: "NVIDIA A100"},
+	})
+	require.Len(t, cmdOverride, 3)
+	assert.Contains(t, cmdOverride[2], "--gpu-memory-utilization=0.75")
 }
 
 func TestGetInferenceCommandVLLMKVCacheEventsDefault(t *testing.T) {

--- a/pkg/workspace/estimator/nodesestimator/estimator.go
+++ b/pkg/workspace/estimator/nodesestimator/estimator.go
@@ -69,9 +69,12 @@ var baseOverheadGiBByGPUModel = map[string]float64{
 	"NVIDIA A10": 1.5,
 }
 
-// resolveGPUMemoryUtilization returns the --gpu-memory-utilization the launcher
-// runs vLLM with for the given GPU model (see ResolveGPUMemoryUtilization in
-// pkg/model), so the estimator predicts the same per-GPU budget vLLM will have.
+// resolveGPUMemoryUtilization returns the --gpu-memory-utilization the
+// estimator plans capacity with for the given GPU model (see
+// ResolveGPUMemoryUtilization in pkg/model). For GPU models with a hard safety
+// cap (e.g. A10) this matches what the launcher actually runs vLLM with; for
+// other GPU models it is a conservative planning assumption, since the
+// launcher instead lets vLLM pick its own free-memory-based value at runtime.
 func resolveGPUMemoryUtilization(gpuModel string) float64 {
 	v, err := strconv.ParseFloat(pkgmodel.ResolveGPUMemoryUtilization(gpuModel), 64)
 	if err != nil {

--- a/pkg/workspace/inference/preset_inferences_test.go
+++ b/pkg/workspace/inference/preset_inferences_test.go
@@ -91,7 +91,7 @@ func TestGeneratePresetInference(t *testing.T) {
 			},
 			// No BaseCommand, AccelerateParams, or ModelRunParams
 			// So expected cmd consists of shell command and inference file
-			expectedCmd:     "/bin/sh -c python3 /workspace/vllm/inference_api.py --gpu-memory-utilization=0.92 --max-model-len=auto --tensor-parallel-size=1 --served-model-name=mymodel",
+			expectedCmd:     "/bin/sh -c python3 /workspace/vllm/inference_api.py --max-model-len=auto --tensor-parallel-size=1 --served-model-name=mymodel",
 			hasAdapters:     false,
 			expectedEnvVars: []corev1.EnvVar{flashInferSamplerEnvVar},
 		},
@@ -107,7 +107,7 @@ func TestGeneratePresetInference(t *testing.T) {
 			// User-provided Inference.Config should mount the configmap and append
 			// --kaito-config-file pointing at the in-pod mount path.
 			inferenceConfig: "my-inference-config",
-			expectedCmd:     "/bin/sh -c python3 /workspace/vllm/inference_api.py --gpu-memory-utilization=0.92 --max-model-len=auto --tensor-parallel-size=1 --served-model-name=mymodel --kaito-config-file=/mnt/config/inference_config.yaml",
+			expectedCmd:     "/bin/sh -c python3 /workspace/vllm/inference_api.py --max-model-len=auto --tensor-parallel-size=1 --served-model-name=mymodel --kaito-config-file=/mnt/config/inference_config.yaml",
 			hasAdapters:     false,
 			expectedEnvVars: []corev1.EnvVar{flashInferSamplerEnvVar},
 		},
@@ -122,7 +122,7 @@ func TestGeneratePresetInference(t *testing.T) {
 			},
 			// No BaseCommand, AccelerateParams, or ModelRunParams
 			// So expected cmd consists of shell command and inference file
-			expectedCmd:     "/bin/sh -c python3 /workspace/vllm/inference_api.py --gpu-memory-utilization=0.92 --max-model-len=auto --tensor-parallel-size=1",
+			expectedCmd:     "/bin/sh -c python3 /workspace/vllm/inference_api.py --max-model-len=auto --tensor-parallel-size=1",
 			hasAdapters:     false,
 			expectedEnvVars: []corev1.EnvVar{flashInferSamplerEnvVar},
 		},
@@ -137,7 +137,7 @@ func TestGeneratePresetInference(t *testing.T) {
 			},
 			// No BaseCommand, AccelerateParams, or ModelRunParams
 			// So expected cmd consists of shell command and inference file
-			expectedCmd:     "/bin/sh -c python3 /workspace/vllm/inference_api.py --gpu-memory-utilization=0.92 --max-model-len=auto --tensor-parallel-size=1",
+			expectedCmd:     "/bin/sh -c python3 /workspace/vllm/inference_api.py --max-model-len=auto --tensor-parallel-size=1",
 			hasAdapters:     false,
 			expectedEnvVars: []corev1.EnvVar{flashInferSamplerEnvVar},
 		},
@@ -150,7 +150,7 @@ func TestGeneratePresetInference(t *testing.T) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
 			},
-			expectedCmd:    "/bin/sh -c python3 /workspace/vllm/inference_api.py --enable-lora --gpu-memory-utilization=0.92 --max-model-len=auto --tensor-parallel-size=1 --served-model-name=mymodel",
+			expectedCmd:    "/bin/sh -c python3 /workspace/vllm/inference_api.py --enable-lora --max-model-len=auto --tensor-parallel-size=1 --served-model-name=mymodel",
 			hasAdapters:    true,
 			expectedVolume: "adapter-volume",
 			expectedEnvVars: []corev1.EnvVar{flashInferSamplerEnvVar, {
@@ -198,7 +198,7 @@ func TestGeneratePresetInference(t *testing.T) {
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&corev1.ConfigMap{}), mock.Anything).Return(nil)
 				c.On("Get", mock.IsType(context.TODO()), mock.Anything, mock.IsType(&storagev1.StorageClass{}), mock.Anything).Return(nil)
 			},
-			expectedCmd: `/bin/sh -c python3 /workspace/vllm/inference_api.py --gpu-memory-utilization=0.92 --max-model-len=auto --tensor-parallel-size=2 --model=test-repo/test-model-a100 --code-revision=test-revision --download-dir=/workspace/weights`,
+			expectedCmd: `/bin/sh -c python3 /workspace/vllm/inference_api.py --max-model-len=auto --tensor-parallel-size=2 --model=test-repo/test-model-a100 --code-revision=test-revision --download-dir=/workspace/weights`,
 			expectedEnvVars: []corev1.EnvVar{flashInferSamplerEnvVar, {
 				Name: "HF_TOKEN",
 				ValueFrom: &corev1.EnvVarSource{


### PR DESCRIPTION
**Reason for Change**:
The vLLM launcher computes `gpu_memory_utilization` from the GPU's actual free memory (`get_max_gpu_memory_utilization()` in `inference_api.py`), sized to avoid OOM while still using available headroom. The workspace controller unconditionally injects an explicit `--gpu-memory-utilization` flag onto every vLLM command in `buildVLLMInferenceCommand` (`pkg/model/interface.go`). An explicit CLI argument always beats an argparse default, so the free-memory probe runs, logs its result, and is then discarded — every standard preset launches with the controller's static value instead.

**Approach**:
- The controller now only forces `--gpu-memory-utilization` for GPUs that need a hard safety cap (currently just NVIDIA A10, which OOMs under the runtime default for some models) or for MIG slices (which have no `GPUModel` to key a cap off, and whose node-estimator planning value must match what actually runs, since small profiles can otherwise resolve a runtime default below the estimator's assumption). For every other GPU, no flag is injected, so vLLM's own free-memory-based default takes effect.
- `defaultGPUMemoryUtilization` / `ResolveGPUMemoryUtilization` are kept as the node estimator's capacity-planning inputs (`pkg/workspace/estimator/nodesestimator/estimator.go`), decoupled from what is actually passed to vLLM for non-capped, non-MIG GPUs. Comments were updated to reflect this; the estimator's MIG math is unchanged since MIG still gets the forced value.
- An explicit user-supplied `gpu-memory-utilization` (e.g. via preset `ModelRunParams`) is still preserved for GPUs with no forced override.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:

**Notes for Reviewers**:
- Validation: `go vet ./...` (full repo) and `go build`/`go test` for the three touched packages (`pkg/model`, `pkg/workspace/estimator/nodesestimator`, `pkg/workspace/inference`) all pass; `gofmt -l` on changed files is clean. `./hack/tools/bin/golangci-lint run` (the repo's pinned v1.64.8, per `make golangci-lint`) is clean on `pkg/model/...` and `pkg/workspace/estimator/...`. I could not get it to complete on `pkg/workspace/inference/...` — my local sandbox is disk-constrained and repeatedly hit "no space left on device" mid-lint on that package's larger dependency tree; `go vet`/`go test` did pass cleanly for it, and the repo's own CI (`Go Lint`, `Unit Tests` on `main`) is green as of the current base tip, so I don't expect this to be a real issue, but flagging the gap honestly.
- No live GPU/cluster was used; the fix is provable from the code path and is covered by targeted unit tests: `TestGetInferenceCommandVLLMGpuMemoryUtilization` in `pkg/model/interface_test.go` now asserts (a) A10 still gets the forced `0.82` safety cap, (b) a MIG `GPUConfig` still gets the forced `0.92` estimator-matching value, (c) a full GPU with no cap (A100) and a nil `GPUConfig` get no `--gpu-memory-utilization` flag at all (so vLLM's dynamic default governs), and (d) an explicit user override is preserved. `pkg/workspace/inference/preset_inferences_test.go`'s fixture strings were updated accordingly (the two MIG/A10 distributed-inference fixtures, which still expect `--gpu-memory-utilization=0.82`, are unchanged).
- The Python launcher (`presets/workspace/inference/vllm/inference_api.py`) is unmodified — this is a Go-only controller-side fix.

Fixes #2191